### PR TITLE
Add more to the Remarks box for Simple Form 20-10206

### DIFF
--- a/modules/simple_forms_api/app/form_mappings/vba_20_10206.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_20_10206.json.erb
@@ -80,7 +80,7 @@
 
   "form1[0].#subform[8].TextField1[0]": "<%= data['va_regional_office_name'] %>",
 
-  "form1[0].#subform[8].TextField1[1]": "<%= data['additional_records_information'] %>",
+  "form1[0].#subform[8].TextField1[1]": "<%= data['additional_records_information'] + '\n' + (data['disability_exams'].length > 0 ? 'Disability exams:\n' + data['disability_exams'].map{ |e| e['disability_exam_date'] }.join(', ') : '') + '\n' + data['financial_record_details'] + '\n' + data['life_insurance_benefit_details'] %>",
 
   "form1[0].#subform[8].I_AM_WILLING_TO_PAY_THE_APPLICABLE_FEES_UP_TO_THE_AMOUNT_OF[0]": "<%= %>",
   "form1[0].#subform[8].IF_YOU_BELIEVE_YOU_ARE_ENTITLED_TO_A_FEE_WAIVER_OR_EXPEDITED_PROCESSING_INDICATE_HERE[0]": "<%= %>",

--- a/modules/simple_forms_api/app/form_mappings/vba_20_10206.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_20_10206.json.erb
@@ -80,7 +80,7 @@
 
   "form1[0].#subform[8].TextField1[0]": "<%= data['va_regional_office_name'] %>",
 
-  "form1[0].#subform[8].TextField1[1]": "<%= data['additional_records_information'] + '\n' + (data['disability_exams'].length > 0 ? 'Disability exams:\n' + data['disability_exams'].map{ |e| e['disability_exam_date'] }.join(', ') : '') + '\n' + data['financial_record_details'] + '\n' + data['life_insurance_benefit_details'] %>",
+  "form1[0].#subform[8].TextField1[1]": "<%= data['additional_records_information'] + '\n' + (data['disability_exams'].length > 0 ? 'Disability exams (YYYY-MM-DD):\n' + data['disability_exams'].map{ |e| e['disability_exam_date'] }.join(', ') : '') + '\n' + data['financial_record_details'] + '\n' + data['life_insurance_benefit_details'] %>",
 
   "form1[0].#subform[8].I_AM_WILLING_TO_PAY_THE_APPLICABLE_FEES_UP_TO_THE_AMOUNT_OF[0]": "<%= %>",
   "form1[0].#subform[8].IF_YOU_BELIEVE_YOU_ARE_ENTITLED_TO_A_FEE_WAIVER_OR_EXPEDITED_PROCESSING_INDICATE_HERE[0]": "<%= %>",


### PR DESCRIPTION
## Summary
This adds more content to the Remarks box of the pdf for Simple Forms 20-10206, which were previously not being reflected on the pdf.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/854


## Testing done
Tests pass

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/d2d0bb5e-4b3e-468b-a240-59a82bff063c)




## Requested Feedback
This tortured logic in an erb template is making very clear to me that we need to refactor these erb templates and allow us to use method calls to populate the pdf. That will be a new year goal because we need to get this form done!
