### PR TITLE
Rename form_data to form_data_ciphertext

### DIFF
--- a/db/migrate/20231213145347_rename_form_data_to_form_data_ciphertext.rb
+++ b/db/migrate/20231213145347_rename_form_data_to_form_data_ciphertext.rb
@@ -1,0 +1,6 @@
+class RenameFormDataToFormDataCiphertext < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :form_submissions, :form_data, :jsonb }
+    add_column :form_submissions, :form_data_ciphertext, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_07_022820) do
+ActiveRecord::Schema.define(version: 2023_12_13_145347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -637,13 +637,13 @@ ActiveRecord::Schema.define(version: 2023_12_07_022820) do
     t.string "form_type", null: false
     t.uuid "benefits_intake_uuid"
     t.uuid "submitted_claim_uuid"
-    t.jsonb "form_data", default: {}
     t.uuid "user_account_id"
     t.bigint "saved_claim_id"
     t.bigint "in_progress_form_id"
     t.text "encrypted_kms_key"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "form_data_ciphertext"
     t.index ["benefits_intake_uuid"], name: "index_form_submissions_on_benefits_intake_uuid"
     t.index ["in_progress_form_id"], name: "index_form_submissions_on_in_progress_form_id"
     t.index ["saved_claim_id"], name: "index_form_submissions_on_saved_claim_id"


### PR DESCRIPTION
## Summary

This PR fixes a little mistake I made earlier when I neglected to name the KMS encrypted field `form_data_ciphertext` in the `form_submissions` table.

We have no `form_submissions` saved to the database yet so dropping the column should be no problem.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/71835

