### PR TITLE
Create a new FormSubmission every time we submit a Simple Form

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -111,12 +111,13 @@ module SimpleFormsApi
       def upload_pdf_to_benefits_intake(file_path, metadata)
         lighthouse_service = SimpleFormsApiSubmission::Service.new
         uuid_and_location = get_upload_location_and_uuid(lighthouse_service)
-        FormSubmission.create(
+        form_submission = FormSubmission.create(
           form_type: params[:form_number],
           benefits_intake_uuid: uuid_and_location[:uuid],
           form_data: params.to_json,
-          user_account_id: @current_user&.id
+          user_account: @current_user
         )
+        FormSubmissionAttempt.create(form_submission:)
 
         Datadog::Tracing.active_trace&.set_tag('uuid', uuid_and_location[:uuid])
         Rails.logger.info(

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -111,6 +111,12 @@ module SimpleFormsApi
       def upload_pdf_to_benefits_intake(file_path, metadata)
         lighthouse_service = SimpleFormsApiSubmission::Service.new
         uuid_and_location = get_upload_location_and_uuid(lighthouse_service)
+        FormSubmission.create(
+          form_type: params[:form_number],
+          benefits_intake_uuid: uuid_and_location[:uuid],
+          form_data: params.to_json,
+          user_account_id: @current_user&.id
+        )
 
         Datadog::Tracing.active_trace&.set_tag('uuid', uuid_and_location[:uuid])
         Rails.logger.info(

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
           end
         end
       end
+
+      it 'saves a FormSubmission' do
+        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+            fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', test_payload)
+            data = JSON.parse(fixture_path.read)
+            allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
+
+            expect { post '/simple_forms_api/v1/simple_forms', params: data }.to change { FormSubmission.count }.by(1)
+          ensure
+            metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
+            Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)
+          end
+        end
+      end
     end
 
     test_submit_request 'vha_10_10d.json'

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
             data = JSON.parse(fixture_path.read)
             allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
 
-            expect { post '/simple_forms_api/v1/simple_forms', params: data }.to change(FormSubmissionAttempt, :count).by(1)
+            expect {
+              post '/simple_forms_api/v1/simple_forms', params: data
+            }.to change(FormSubmissionAttempt, :count).by(1)
           ensure
             metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
             Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
             data = JSON.parse(fixture_path.read)
             allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
 
-            expect {
+            expect do
               post '/simple_forms_api/v1/simple_forms', params: data
-            }.to change(FormSubmissionAttempt, :count).by(1)
+            end.to change(FormSubmissionAttempt, :count).by(1)
           ensure
             metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
             Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -44,15 +44,15 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
     test_submit_request 'vba_21_0966.json'
     test_submit_request 'vba_20_10206.json'
 
-    def self.test_saves_form_submission(test_payload)
-      it 'saves a FormSubmission' do
+    def self.test_saves_form_submission_attempt(test_payload)
+      it 'saves a FormSubmissionAttempt' do
         VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
           VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
             fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', test_payload)
             data = JSON.parse(fixture_path.read)
             allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
 
-            expect { post '/simple_forms_api/v1/simple_forms', params: data }.to change(FormSubmission, :count).by(1)
+            expect { post '/simple_forms_api/v1/simple_forms', params: data }.to change(FormSubmissionAttempt, :count).by(1)
           ensure
             metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
             Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)
@@ -61,16 +61,16 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
       end
     end
 
-    test_saves_form_submission 'vha_10_10d.json'
-    test_saves_form_submission 'vba_26_4555.json'
-    test_saves_form_submission 'vba_21_4142.json'
-    test_saves_form_submission 'vba_21_10210.json'
-    test_saves_form_submission 'vba_21p_0847.json'
-    test_saves_form_submission 'vba_21_0972.json'
-    test_saves_form_submission 'vba_21_0845.json'
-    test_saves_form_submission 'vba_40_0247.json'
-    test_saves_form_submission 'vba_21_0966.json'
-    test_saves_form_submission 'vba_20_10206.json'
+    test_saves_form_submission_attempt 'vha_10_10d.json'
+    test_saves_form_submission_attempt 'vba_26_4555.json'
+    test_saves_form_submission_attempt 'vba_21_4142.json'
+    test_saves_form_submission_attempt 'vba_21_10210.json'
+    test_saves_form_submission_attempt 'vba_21p_0847.json'
+    test_saves_form_submission_attempt 'vba_21_0972.json'
+    test_saves_form_submission_attempt 'vba_21_0845.json'
+    test_saves_form_submission_attempt 'vba_40_0247.json'
+    test_saves_form_submission_attempt 'vba_21_0966.json'
+    test_saves_form_submission_attempt 'vba_20_10206.json'
 
     describe 'request with intent to file unauthenticated' do
       let(:expiration_date) { Time.zone.now }

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -31,21 +31,6 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
           end
         end
       end
-
-      it 'saves a FormSubmission' do
-        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
-          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
-            fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', test_payload)
-            data = JSON.parse(fixture_path.read)
-            allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
-
-            expect { post '/simple_forms_api/v1/simple_forms', params: data }.to change { FormSubmission.count }.by(1)
-          ensure
-            metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
-            Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)
-          end
-        end
-      end
     end
 
     test_submit_request 'vha_10_10d.json'
@@ -58,6 +43,34 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
     test_submit_request 'vba_40_0247.json'
     test_submit_request 'vba_21_0966.json'
     test_submit_request 'vba_20_10206.json'
+
+    def self.test_saves_form_submission(test_payload)
+      it 'saves a FormSubmission' do
+        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+            fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', test_payload)
+            data = JSON.parse(fixture_path.read)
+            allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
+
+            expect { post '/simple_forms_api/v1/simple_forms', params: data }.to change(FormSubmission, :count).by(1)
+          ensure
+            metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
+            Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)
+          end
+        end
+      end
+    end
+
+    test_saves_form_submission 'vha_10_10d.json'
+    test_saves_form_submission 'vba_26_4555.json'
+    test_saves_form_submission 'vba_21_4142.json'
+    test_saves_form_submission 'vba_21_10210.json'
+    test_saves_form_submission 'vba_21p_0847.json'
+    test_saves_form_submission 'vba_21_0972.json'
+    test_saves_form_submission 'vba_21_0845.json'
+    test_saves_form_submission 'vba_40_0247.json'
+    test_saves_form_submission 'vba_21_0966.json'
+    test_saves_form_submission 'vba_20_10206.json'
 
     describe 'request with intent to file unauthenticated' do
       let(:expiration_date) { Time.zone.now }


### PR DESCRIPTION
## Summary
This PR will create a new `FormSubmission` every time we submit a form through the Simple Forms controller.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/71835


## Testing done

Tests written and passing.
