### PR TITLE
API-32191 Use ICN from token in Appeals Status API

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/appeals_controller.rb
@@ -31,18 +31,24 @@ module AppealsApi
         @ssn ||= icn_to_ssn!(veteran_icn)
       end
 
+      def va_user
+        required_header('X-VA-User')
+      end
+
       def caseflow_request_headers
-        { 'Consumer' => request.headers['X-Consumer-Username'] }
+        { 'Consumer' => request.headers['X-Consumer-Username'], 'VA-User' => required_header('X-VA-User') }
       end
 
       def log_caseflow_request_details
-        Rails.logger.info('Caseflow Request', 'lookup_identifier' => Digest::SHA2.hexdigest(ssn))
+        hashed_ssn = Digest::SHA2.hexdigest(ssn)
+        Rails.logger.info('Caseflow Request', 'va_user' => va_user, 'lookup_identifier' => hashed_ssn)
       end
 
       def log_caseflow_response(res)
         Rails.logger.info(
           'Caseflow Response',
           {
+            'va_user' => va_user,
             'first_appeal_id' => res.body.dig('data', 0, 'id'),
             'appeal_count' => res.body['data'].length
           }

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/icn_parameter_validation.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/icn_parameter_validation.rb
@@ -3,7 +3,7 @@
 module AppealsApi
   module IcnParameterValidation
     extend ActiveSupport::Concern
-    # NOTE: Make sure to also include the AppealsApi::OpenidAuth concern when using this concern
+    include AppealsApi::OpenidAuth # This concern depends on `token_validation_result`
 
     ICN_REGEX = /^[0-9]{10}V[0-9]{6}$/
 
@@ -22,6 +22,12 @@ module AppealsApi
       elsif veteran_icn_from_token.blank? && params[:icn].blank?
         # If the auth token is a system or representative token, an ICN parameter is required
         raise(Common::Exceptions::ParameterMissing, 'icn')
+      end
+
+      if veteran_icn_from_token.present? && !ICN_REGEX.match?(veteran_icn_from_token)
+        # rubocop:disable Layout/LineLength
+        Rails.logger.error("The Veteran ICN '#{veteran_icn_from_token}', which was returned by the token validation server, has an invalid format. This should never happen.")
+        # rubocop:enable Layout/LineLength
       end
     end
 

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/icn_parameter_validation.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/icn_parameter_validation.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  module IcnParameterValidation
+    extend ActiveSupport::Concern
+    # NOTE: Make sure to also include the AppealsApi::OpenidAuth concern when using this concern
+
+    ICN_REGEX = /^[0-9]{10}V[0-9]{6}$/
+
+    def validate_icn_parameter!
+      if params[:icn] && !ICN_REGEX.match?(params[:icn])
+        raise(
+          Common::Exceptions::UnprocessableEntity,
+          detail: "'icn' parameter has an invalid format. Pattern: #{ICN_REGEX.inspect}"
+        )
+      end
+
+      if veteran_icn_from_token.present? && params[:icn].present? && veteran_icn_from_token != params[:icn]
+        # If both a veteran-scoped auth token and an ICN parameter are received, the ICNs must match
+        raise(Common::Exceptions::Forbidden,
+              detail: "Invalid 'icn' parameter: Veterans may access only their own records")
+      elsif veteran_icn_from_token.blank? && params[:icn].blank?
+        # If the auth token is a system or representative token, an ICN parameter is required
+        raise(Common::Exceptions::ParameterMissing, 'icn')
+      end
+    end
+
+    def veteran_icn
+      veteran_icn_from_token.presence || params[:icn]
+    end
+
+    private
+
+    def veteran_icn_from_token
+      token_validation_result&.veteran_icn # Will only be present on tokens with veteran/* scopes
+    end
+  end
+end

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/openid_auth.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/openid_auth.rb
@@ -50,11 +50,19 @@ module AppealsApi
       # modules_appeals_api.enable_unsafe_mode = true in settings.local.yml
       return if unsafe_mode?
 
-      token_validation_client.validate_token!(
+      @token_validation_result = token_validation_client.validate_token!(
         audience: audience_url,
         scopes: DEFAULT_OAUTH_SCOPES[request.method.to_sym] + self.class::OAUTH_SCOPES[request.method.to_sym],
         token: auth_token
       )
+    end
+
+    def token_validation_result
+      if @token_validation_result.blank? && !Rails.env.production?
+        raise 'You must call `validate_auth_token!` before accessing `token_validation_result`'
+      end
+
+      @token_validation_result
     end
 
     private

--- a/modules/appeals_api/app/swagger/appeals_status/v1/swagger.json
+++ b/modules/appeals_api/app/swagger/appeals_status/v1/swagger.json
@@ -944,7 +944,7 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "with a incorrectly formatted 'icn' parameter": {
+                  "with an incorrectly formatted 'icn' parameter": {
                     "value": {
                       "errors": [
                         {

--- a/modules/appeals_api/app/swagger/appeals_status/v1/swagger.json
+++ b/modules/appeals_api/app/swagger/appeals_status/v1/swagger.json
@@ -57,6 +57,16 @@
             },
             "in": "query",
             "required": false
+          },
+          {
+            "name": "X-VA-User",
+            "in": "header",
+            "required": true,
+            "example": "va.api.user+idme.025@gmail.com",
+            "schema": {
+              "type": "string"
+            },
+            "description": "VA username of the person making the request"
           }
         ],
         "responses": {

--- a/modules/appeals_api/app/swagger/appeals_status/v1/swagger.json
+++ b/modules/appeals_api/app/swagger/appeals_status/v1/swagger.json
@@ -47,7 +47,7 @@
         "parameters": [
           {
             "name": "icn",
-            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN)",
+            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN). Optional when using a veteran-scoped token. Required when using a representative- or system-scoped token.",
             "example": "1012832025V743496",
             "schema": {
               "type": "string",
@@ -56,24 +56,805 @@
               "maxLength": 17
             },
             "in": "query",
-            "required": true
-          },
-          {
-            "name": "X-VA-User",
-            "in": "header",
-            "required": true,
-            "example": "va.api.user+idme.025@gmail.com",
-            "schema": {
-              "type": "string"
-            },
-            "description": "VA username of the person making the request"
+            "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "Appeals retrieved successfully",
+            "description": "Successfully fetching appeals",
             "content": {
               "application/json": {
+                "examples": {
+                  "with a veteran-scoped token (no 'icn' parameter necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2002-09-23",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2003-01-06",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2003-06-18",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2003-09-30",
+                                "type": "ftr"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": false,
+                                "date": "2003-09-30",
+                                "description": "Service connection, lumbosacral strain",
+                                "diagnosticCode": "5295",
+                                "lastAction": "withdrawn"
+                              }
+                            ],
+                            "location": "bva",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "ftr"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "1196201",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": true,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2008-04-24",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2008-06-11",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2010-09-10",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2010-11-08",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-01-03",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-04-17",
+                                "type": "hearing_held"
+                              },
+                              {
+                                "date": "2015-07-24",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2015-10-06",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2016-05-03",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2018-01-16",
+                                "type": "ssoc"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, migraines",
+                                "diagnosticCode": "8100",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, limitation of leg motion",
+                                "diagnosticCode": "5260",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "100% rating for individual unemployability",
+                                "diagnosticCode": null,
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, ankylosis of hip",
+                                "diagnosticCode": "5250",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, hearing loss",
+                                "diagnosticCode": "6100",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, sciatic nerve paralysis",
+                                "diagnosticCode": "8520",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, arthritis due to trauma",
+                                "diagnosticCode": "5010",
+                                "lastAction": null
+                              },
+                              {
+                                "active": false,
+                                "date": "2015-07-24",
+                                "description": "New and material evidence for service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "allowed"
+                              }
+                            ],
+                            "location": "aoj",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "remand_ssoc"
+                            },
+                            "type": "post_remand",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "3294289",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "other",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2010-08-11",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2010-09-17",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2013-09-26",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2013-10-02",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-02-26",
+                                "type": "merged"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+
+                            ],
+                            "location": "bva",
+                            "programArea": null,
+                            "status": {
+                              "details": {
+                              },
+                              "type": "other_close"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "2348605",
+                          "type": "legacyAppeal"
+                        }
+                      ]
+                    }
+                  },
+                  "with a representative-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2002-09-23",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2003-01-06",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2003-06-18",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2003-09-30",
+                                "type": "ftr"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": false,
+                                "date": "2003-09-30",
+                                "description": "Service connection, lumbosacral strain",
+                                "diagnosticCode": "5295",
+                                "lastAction": "withdrawn"
+                              }
+                            ],
+                            "location": "bva",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "ftr"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "1196201",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": true,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2008-04-24",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2008-06-11",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2010-09-10",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2010-11-08",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-01-03",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-04-17",
+                                "type": "hearing_held"
+                              },
+                              {
+                                "date": "2015-07-24",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2015-10-06",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2016-05-03",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2018-01-16",
+                                "type": "ssoc"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, migraines",
+                                "diagnosticCode": "8100",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, limitation of leg motion",
+                                "diagnosticCode": "5260",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "100% rating for individual unemployability",
+                                "diagnosticCode": null,
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, ankylosis of hip",
+                                "diagnosticCode": "5250",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, hearing loss",
+                                "diagnosticCode": "6100",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, sciatic nerve paralysis",
+                                "diagnosticCode": "8520",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, arthritis due to trauma",
+                                "diagnosticCode": "5010",
+                                "lastAction": null
+                              },
+                              {
+                                "active": false,
+                                "date": "2015-07-24",
+                                "description": "New and material evidence for service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "allowed"
+                              }
+                            ],
+                            "location": "aoj",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "remand_ssoc"
+                            },
+                            "type": "post_remand",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "3294289",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "other",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2010-08-11",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2010-09-17",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2013-09-26",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2013-10-02",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-02-26",
+                                "type": "merged"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+
+                            ],
+                            "location": "bva",
+                            "programArea": null,
+                            "status": {
+                              "details": {
+                              },
+                              "type": "other_close"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "2348605",
+                          "type": "legacyAppeal"
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2002-09-23",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2003-01-06",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2003-06-18",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2003-09-30",
+                                "type": "ftr"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": false,
+                                "date": "2003-09-30",
+                                "description": "Service connection, lumbosacral strain",
+                                "diagnosticCode": "5295",
+                                "lastAction": "withdrawn"
+                              }
+                            ],
+                            "location": "bva",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "ftr"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "1196201",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": true,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2008-04-24",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2008-06-11",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2010-09-10",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2010-11-08",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-01-03",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-04-17",
+                                "type": "hearing_held"
+                              },
+                              {
+                                "date": "2015-07-24",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2015-10-06",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2016-05-03",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2018-01-16",
+                                "type": "ssoc"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, migraines",
+                                "diagnosticCode": "8100",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, limitation of leg motion",
+                                "diagnosticCode": "5260",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "100% rating for individual unemployability",
+                                "diagnosticCode": null,
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, ankylosis of hip",
+                                "diagnosticCode": "5250",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, hearing loss",
+                                "diagnosticCode": "6100",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, sciatic nerve paralysis",
+                                "diagnosticCode": "8520",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, arthritis due to trauma",
+                                "diagnosticCode": "5010",
+                                "lastAction": null
+                              },
+                              {
+                                "active": false,
+                                "date": "2015-07-24",
+                                "description": "New and material evidence for service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "allowed"
+                              }
+                            ],
+                            "location": "aoj",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "remand_ssoc"
+                            },
+                            "type": "post_remand",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "3294289",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "other",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2010-08-11",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2010-09-17",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2013-09-26",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2013-10-02",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-02-26",
+                                "type": "merged"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+
+                            ],
+                            "location": "bva",
+                            "programArea": null,
+                            "status": {
+                              "details": {
+                              },
+                              "type": "other_close"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "2348605",
+                          "type": "legacyAppeal"
+                        }
+                      ]
+                    }
+                  }
+                },
                 "schema": {
                   "type": "object",
                   "properties": {
@@ -89,9 +870,59 @@
             }
           },
           "400": {
-            "description": "Missing 'icn' parameter",
+            "description": "Missing parameters",
             "content": {
               "application/json": {
+                "examples": {
+                  "with a representative-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden requests",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "with a veteran-scoped token and an optional 'icn' parameter that does not match the Veteran's ICN": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Forbidden",
+                          "detail": "Invalid 'icn' parameter: Veterans may access only their own records",
+                          "code": "403",
+                          "status": "403"
+                        }
+                      ]
+                    }
+                  }
+                },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
                 }
@@ -99,9 +930,23 @@
             }
           },
           "422": {
-            "description": "Invalid ICN",
+            "description": "Invalid 'icn' parameter",
             "content": {
               "application/json": {
+                "examples": {
+                  "with a incorrectly formatted 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Unprocessable Entity",
+                          "detail": "'icn' parameter has an invalid format. Pattern: /^[0-9]{10}V[0-9]{6}$/",
+                          "code": "422",
+                          "status": "422"
+                        }
+                      ]
+                    }
+                  }
+                },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
                 }

--- a/modules/appeals_api/app/swagger/appeals_status/v1/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/appeals_status/v1/swagger_dev.json
@@ -944,7 +944,7 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "with a incorrectly formatted 'icn' parameter": {
+                  "with an incorrectly formatted 'icn' parameter": {
                     "value": {
                       "errors": [
                         {

--- a/modules/appeals_api/app/swagger/appeals_status/v1/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/appeals_status/v1/swagger_dev.json
@@ -57,6 +57,16 @@
             },
             "in": "query",
             "required": false
+          },
+          {
+            "name": "X-VA-User",
+            "in": "header",
+            "required": true,
+            "example": "va.api.user+idme.025@gmail.com",
+            "schema": {
+              "type": "string"
+            },
+            "description": "VA username of the person making the request"
           }
         ],
         "responses": {

--- a/modules/appeals_api/app/swagger/appeals_status/v1/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/appeals_status/v1/swagger_dev.json
@@ -47,7 +47,7 @@
         "parameters": [
           {
             "name": "icn",
-            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN)",
+            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN). Optional when using a veteran-scoped token. Required when using a representative- or system-scoped token.",
             "example": "1012832025V743496",
             "schema": {
               "type": "string",
@@ -56,24 +56,805 @@
               "maxLength": 17
             },
             "in": "query",
-            "required": true
-          },
-          {
-            "name": "X-VA-User",
-            "in": "header",
-            "required": true,
-            "example": "va.api.user+idme.025@gmail.com",
-            "schema": {
-              "type": "string"
-            },
-            "description": "VA username of the person making the request"
+            "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "Appeals retrieved successfully",
+            "description": "Successfully fetching appeals",
             "content": {
               "application/json": {
+                "examples": {
+                  "with a veteran-scoped token (no 'icn' parameter necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2002-09-23",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2003-01-06",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2003-06-18",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2003-09-30",
+                                "type": "ftr"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": false,
+                                "date": "2003-09-30",
+                                "description": "Service connection, lumbosacral strain",
+                                "diagnosticCode": "5295",
+                                "lastAction": "withdrawn"
+                              }
+                            ],
+                            "location": "bva",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "ftr"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "1196201",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": true,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2008-04-24",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2008-06-11",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2010-09-10",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2010-11-08",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-01-03",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-04-17",
+                                "type": "hearing_held"
+                              },
+                              {
+                                "date": "2015-07-24",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2015-10-06",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2016-05-03",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2018-01-16",
+                                "type": "ssoc"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, migraines",
+                                "diagnosticCode": "8100",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, limitation of leg motion",
+                                "diagnosticCode": "5260",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "100% rating for individual unemployability",
+                                "diagnosticCode": null,
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, ankylosis of hip",
+                                "diagnosticCode": "5250",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, hearing loss",
+                                "diagnosticCode": "6100",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, sciatic nerve paralysis",
+                                "diagnosticCode": "8520",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, arthritis due to trauma",
+                                "diagnosticCode": "5010",
+                                "lastAction": null
+                              },
+                              {
+                                "active": false,
+                                "date": "2015-07-24",
+                                "description": "New and material evidence for service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "allowed"
+                              }
+                            ],
+                            "location": "aoj",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "remand_ssoc"
+                            },
+                            "type": "post_remand",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "3294289",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "other",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2010-08-11",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2010-09-17",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2013-09-26",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2013-10-02",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-02-26",
+                                "type": "merged"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+
+                            ],
+                            "location": "bva",
+                            "programArea": null,
+                            "status": {
+                              "details": {
+                              },
+                              "type": "other_close"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "2348605",
+                          "type": "legacyAppeal"
+                        }
+                      ]
+                    }
+                  },
+                  "with a representative-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2002-09-23",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2003-01-06",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2003-06-18",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2003-09-30",
+                                "type": "ftr"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": false,
+                                "date": "2003-09-30",
+                                "description": "Service connection, lumbosacral strain",
+                                "diagnosticCode": "5295",
+                                "lastAction": "withdrawn"
+                              }
+                            ],
+                            "location": "bva",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "ftr"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "1196201",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": true,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2008-04-24",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2008-06-11",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2010-09-10",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2010-11-08",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-01-03",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-04-17",
+                                "type": "hearing_held"
+                              },
+                              {
+                                "date": "2015-07-24",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2015-10-06",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2016-05-03",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2018-01-16",
+                                "type": "ssoc"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, migraines",
+                                "diagnosticCode": "8100",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, limitation of leg motion",
+                                "diagnosticCode": "5260",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "100% rating for individual unemployability",
+                                "diagnosticCode": null,
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, ankylosis of hip",
+                                "diagnosticCode": "5250",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, hearing loss",
+                                "diagnosticCode": "6100",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, sciatic nerve paralysis",
+                                "diagnosticCode": "8520",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, arthritis due to trauma",
+                                "diagnosticCode": "5010",
+                                "lastAction": null
+                              },
+                              {
+                                "active": false,
+                                "date": "2015-07-24",
+                                "description": "New and material evidence for service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "allowed"
+                              }
+                            ],
+                            "location": "aoj",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "remand_ssoc"
+                            },
+                            "type": "post_remand",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "3294289",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "other",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2010-08-11",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2010-09-17",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2013-09-26",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2013-10-02",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-02-26",
+                                "type": "merged"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+
+                            ],
+                            "location": "bva",
+                            "programArea": null,
+                            "status": {
+                              "details": {
+                              },
+                              "type": "other_close"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "2348605",
+                          "type": "legacyAppeal"
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2002-09-23",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2003-01-06",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2003-06-18",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2003-09-30",
+                                "type": "ftr"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": false,
+                                "date": "2003-09-30",
+                                "description": "Service connection, lumbosacral strain",
+                                "diagnosticCode": "5295",
+                                "lastAction": "withdrawn"
+                              }
+                            ],
+                            "location": "bva",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "ftr"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "1196201",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": true,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "vba",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2008-04-24",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2008-06-11",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2010-09-10",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2010-11-08",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-01-03",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-04-17",
+                                "type": "hearing_held"
+                              },
+                              {
+                                "date": "2015-07-24",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2015-10-06",
+                                "type": "ssoc"
+                              },
+                              {
+                                "date": "2016-05-03",
+                                "type": "bva_decision"
+                              },
+                              {
+                                "date": "2018-01-16",
+                                "type": "ssoc"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, migraines",
+                                "diagnosticCode": "8100",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "Increased rating, limitation of leg motion",
+                                "diagnosticCode": "5260",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": true,
+                                "date": "2016-05-03",
+                                "description": "100% rating for individual unemployability",
+                                "diagnosticCode": null,
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, ankylosis of hip",
+                                "diagnosticCode": "5250",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, hearing loss",
+                                "diagnosticCode": "6100",
+                                "lastAction": null
+                              },
+                              {
+                                "active": true,
+                                "date": "2015-07-24",
+                                "description": "Service connection, sciatic nerve paralysis",
+                                "diagnosticCode": "8520",
+                                "lastAction": "remand"
+                              },
+                              {
+                                "active": false,
+                                "date": null,
+                                "description": "Service connection, arthritis due to trauma",
+                                "diagnosticCode": "5010",
+                                "lastAction": null
+                              },
+                              {
+                                "active": false,
+                                "date": "2015-07-24",
+                                "description": "New and material evidence for service connection, degenerative spinal arthritis",
+                                "diagnosticCode": "5242",
+                                "lastAction": "allowed"
+                              }
+                            ],
+                            "location": "aoj",
+                            "programArea": "compensation",
+                            "status": {
+                              "details": {
+                              },
+                              "type": "remand_ssoc"
+                            },
+                            "type": "post_remand",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "3294289",
+                          "type": "legacyAppeal"
+                        },
+                        {
+                          "attributes": {
+                            "appealIds": [
+
+                            ],
+                            "active": false,
+                            "alerts": [
+
+                            ],
+                            "aod": false,
+                            "aoj": "other",
+                            "description": "",
+                            "docket": null,
+                            "events": [
+                              {
+                                "date": "2010-08-11",
+                                "type": "claim_decision"
+                              },
+                              {
+                                "date": "2010-09-17",
+                                "type": "nod"
+                              },
+                              {
+                                "date": "2013-09-26",
+                                "type": "soc"
+                              },
+                              {
+                                "date": "2013-10-02",
+                                "type": "form9"
+                              },
+                              {
+                                "date": "2014-07-28",
+                                "type": "certified"
+                              },
+                              {
+                                "date": "2015-02-26",
+                                "type": "merged"
+                              }
+                            ],
+                            "evidence": [
+
+                            ],
+                            "incompleteHistory": false,
+                            "issues": [
+
+                            ],
+                            "location": "bva",
+                            "programArea": null,
+                            "status": {
+                              "details": {
+                              },
+                              "type": "other_close"
+                            },
+                            "type": "original",
+                            "updated": "2018-01-19T10:20:42-05:00"
+                          },
+                          "id": "2348605",
+                          "type": "legacyAppeal"
+                        }
+                      ]
+                    }
+                  }
+                },
                 "schema": {
                   "type": "object",
                   "properties": {
@@ -89,9 +870,59 @@
             }
           },
           "400": {
-            "description": "Missing 'icn' parameter",
+            "description": "Missing parameters",
             "content": {
               "application/json": {
+                "examples": {
+                  "with a representative-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden requests",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "with a veteran-scoped token and an optional 'icn' parameter that does not match the Veteran's ICN": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Forbidden",
+                          "detail": "Invalid 'icn' parameter: Veterans may access only their own records",
+                          "code": "403",
+                          "status": "403"
+                        }
+                      ]
+                    }
+                  }
+                },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
                 }
@@ -99,9 +930,23 @@
             }
           },
           "422": {
-            "description": "Invalid ICN",
+            "description": "Invalid 'icn' parameter",
             "content": {
               "application/json": {
+                "examples": {
+                  "with a incorrectly formatted 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Unprocessable Entity",
+                          "detail": "'icn' parameter has an invalid format. Pattern: /^[0-9]{10}V[0-9]{6}$/",
+                          "code": "422",
+                          "status": "422"
+                        }
+                      ]
+                    }
+                  }
+                },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
                 }

--- a/modules/appeals_api/lib/appeals_api/token_validation_client.rb
+++ b/modules/appeals_api/lib/appeals_api/token_validation_client.rb
@@ -4,7 +4,7 @@ require 'common/client/base'
 require 'token_validation/v2/configuration'
 
 module AppealsApi
-  # Represents the result of token validation
+  # Exposes a subset of the data received from the token validation server
   #
   # @attr [Array<String>] scopes the scopes included with this token
   # @attr [String|nil] veteran_icn the ICN of the target veteran, if any

--- a/modules/appeals_api/lib/appeals_api/token_validation_client.rb
+++ b/modules/appeals_api/lib/appeals_api/token_validation_client.rb
@@ -4,28 +4,39 @@ require 'common/client/base'
 require 'token_validation/v2/configuration'
 
 module AppealsApi
-  class TokenValidation
-    module V3
-      class Configuration < ::TokenValidation::V2::Configuration
-        def connection
-          Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-            conn.request :url_encoded # required for token validation service v3 (v2 accepted json)
-            conn.response :snakecase
-            conn.adapter Faraday.default_adapter
-          end
-        end
+  # Represents the result of token validation
+  #
+  # @attr [Array<String>] scopes the scopes included with this token
+  # @attr [String|nil] veteran_icn the ICN of the target veteran, if any
+  TokenValidationResult = Struct.new(:scopes, :veteran_icn)
+
+  class Configuration < ::TokenValidation::V2::Configuration
+    def connection
+      Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
+        conn.use :breakers
+        conn.request :url_encoded # required for token validation service v3 (v2 accepted json)
+        conn.response :snakecase
+        conn.adapter Faraday.default_adapter
       end
     end
   end
 
   # This is based on TokenValidation::V2::Client, but allows for more fine-grained status codes in failure responses
   class TokenValidationClient < ::Common::Client::Base
-    configuration TokenValidation::V3::Configuration
+    configuration Configuration
 
     def initialize(api_key:)
       @api_key = api_key
     end
 
+    # Validates an OAuth token
+    #
+    # @param audience [String] the audience URL to use when validating the token (via well-known OpenID config)
+    # @param token [String] the OAuth token provided by the user
+    # @param scopes [Array<String>] valid scopes: the token is considered valid if it has any one of these scopes
+    # @return [TokenValidationResult]
+    # @raise [::Common::Exceptions::Unauthorized] if the token is rejected by the auth server
+    # @raise [::Common::Exceptions::Forbidden] if the token has the wrong scope(s)
     def validate_token!(audience:, token:, scopes:)
       params = { 'aud': audience }
       headers = {
@@ -42,7 +53,16 @@ module AppealsApi
 
       matching_scope = scopes.find { |scope| permitted.include?(scope) }
 
-      raise ::Common::Exceptions::Forbidden unless matching_scope
+      raise ::Common::Exceptions::Forbidden if matching_scope.blank?
+
+      body = JSON.parse(response.body)
+
+      is_veteran_token = permitted.any? { |s| s.start_with? 'veteran/' }
+
+      TokenValidationResult.new(
+        scopes: permitted,
+        veteran_icn: is_veteran_token ? body.dig('data', 'attributes', 'act', 'icn') : nil
+      )
     end
 
     private

--- a/modules/appeals_api/spec/docs/appeals_status/v1_spec.rb
+++ b/modules/appeals_api/spec/docs/appeals_status/v1_spec.rb
@@ -26,6 +26,8 @@ describe 'Appeals Status', swagger_doc:, type: :request do
       consumes 'application/json'
       produces 'application/json'
 
+      example_va_user = 'va.api.user+idme.025@gmail.com'
+
       parameter(
         parameter_from_schema('shared/v0/icn.json', 'properties', 'icn').merge(
           {
@@ -36,6 +38,15 @@ describe 'Appeals Status', swagger_doc:, type: :request do
           }
         )
       )
+
+      parameter name: 'X-VA-User',
+                in: :header,
+                required: true,
+                example: example_va_user,
+                schema: { type: 'string' },
+                description: 'VA username of the person making the request'
+
+      let(:'X-VA-User') { example_va_user }
 
       cassette = %w[caseflow/appeals mpi/find_candidate/valid]
       expected_icn = '1012832025V743496'

--- a/modules/appeals_api/spec/docs/appeals_status/v1_spec.rb
+++ b/modules/appeals_api/spec/docs/appeals_status/v1_spec.rb
@@ -122,7 +122,7 @@ describe 'Appeals Status', swagger_doc:, type: :request do
         let(:cassette) { %w[caseflow/invalid_ssn mpi/find_candidate/valid] }
 
         it_behaves_like 'rswag example',
-                        desc: "with a incorrectly formatted 'icn' parameter",
+                        desc: "with an incorrectly formatted 'icn' parameter",
                         extract_desc: true,
                         cassette:,
                         scopes: %w[veteran/AppealsStatus.read]

--- a/modules/appeals_api/spec/docs/appeals_status/v1_spec.rb
+++ b/modules/appeals_api/spec/docs/appeals_status/v1_spec.rb
@@ -10,101 +10,115 @@ def swagger_doc
   "modules/appeals_api/app/swagger/appeals_status/v1/swagger#{DocHelpers.doc_suffix}.json"
 end
 
-# rubocop:disable RSpec/VariableName, Layout/LineLength, RSpec/RepeatedExample
+# rubocop:disable RSpec/VariableName, Layout/LineLength
 describe 'Appeals Status', swagger_doc:, type: :request do
   include DocHelpers
   let(:Authorization) { 'Bearer TEST_TOKEN' }
 
   path '/appeals' do
     get 'Retrieve appeals status for the Veteran with the supplied ICN' do
-      scopes = AppealsApi::V1::AppealsController::OAUTH_SCOPES[:GET]
       tags 'Appeals Status'
       operationId 'getAppealStatus'
 
       description "Returns a list of all known appeal records for the given Veteran. Includes details of each appeal's current status, priority, and history of updates."
 
-      security DocHelpers.oauth_security_config(scopes)
+      security DocHelpers.oauth_security_config(AppealsApi::V1::AppealsController::OAUTH_SCOPES[:GET])
       consumes 'application/json'
       produces 'application/json'
-
-      example_va_user = 'va.api.user+idme.025@gmail.com'
 
       parameter(
         parameter_from_schema('shared/v0/icn.json', 'properties', 'icn').merge(
           {
             name: :icn,
             in: :query,
-            required: true
+            description: "Veteran's Master Person Index (MPI) Integration Control Number (ICN). Optional when using a veteran-scoped token. Required when using a representative- or system-scoped token.",
+            required: false
           }
         )
       )
 
-      let(:icn) { '1012832025V743496' }
+      cassette = %w[caseflow/appeals mpi/find_candidate/valid]
+      expected_icn = '1012832025V743496'
+      success_response_schema = {
+        type: 'object',
+        properties: { data: { '$ref': '#/components/schemas/appeals' } },
+        required: ['data']
+      }
 
-      parameter name: 'X-VA-User',
-                in: :header,
-                required: true,
-                example: example_va_user,
-                schema: { type: 'string' },
-                description: 'VA username of the person making the request'
+      response '200', 'Successfully fetching appeals' do
+        schema success_response_schema
 
-      let(:'X-VA-User') { example_va_user }
+        describe 'success with veteran-scoped token' do
+          it_behaves_like 'rswag example',
+                          desc: "with a veteran-scoped token (no 'icn' parameter necessary)",
+                          extract_desc: true,
+                          cassette:,
+                          scopes: %w[veteran/AppealsStatus.read]
+        end
 
-      let(:caseflow_cassette_name) { 'caseflow/appeals' }
-      let(:mpi_cassette_name) { 'mpi/find_candidate/valid' }
+        describe 'success with representative-scoped token' do
+          let(:icn) { expected_icn }
 
-      before do |example|
-        VCR.use_cassette(caseflow_cassette_name) do
-          VCR.use_cassette(mpi_cassette_name) do
-            with_rswag_auth(scopes) { submit_request(example.metadata) }
-          end
+          it_behaves_like 'rswag example',
+                          desc: "with a representative-scoped token ('icn' parameter is necessary)",
+                          extract_desc: true,
+                          cassette:,
+                          scopes: %w[representative/AppealsStatus.read]
+        end
+
+        describe 'success with system-scoped token' do
+          let(:icn) { expected_icn }
+
+          it_behaves_like 'rswag example',
+                          desc: "with a system-scoped token ('icn' parameter is necessary)",
+                          extract_desc: true,
+                          cassette:,
+                          scopes: %w[system/AppealsStatus.read]
         end
       end
 
-      response '200', 'Appeals retrieved successfully' do
-        response_schema = {
-          type: 'object',
-          properties: { data: { '$ref': '#/components/schemas/appeals' } },
-          required: ['data']
-        }
-        schema response_schema
-
-        it 'returns a 200 response' do |example|
-          assert_response_matches_metadata(example.metadata)
-        end
-      end
-
-      response '400', "Missing 'icn' parameter" do
-        let(:icn) { nil }
-
+      response '400', 'Missing parameters' do
         schema '$ref' => '#/components/schemas/errorModel'
 
-        it 'returns a 400 response' do |example|
-          assert_response_matches_metadata(example.metadata)
-        end
+        it_behaves_like 'rswag example',
+                        desc: "with a representative-scoped token and no 'icn' parameter",
+                        extract_desc: true,
+                        cassette:,
+                        scopes: %w[representative/AppealsStatus.read]
+
+        it_behaves_like 'rswag example',
+                        desc: "with a system-scoped token and no 'icn' parameter",
+                        extract_desc: true,
+                        cassette:,
+                        scopes: %w[system/AppealsStatus.read]
       end
 
-      response '422', 'Invalid ICN' do
+      response '403', 'Forbidden requests' do
         schema '$ref' => '#/components/schemas/errorModel'
+        let(:icn) { '1234567890V123456' }
+
+        it_behaves_like 'rswag example',
+                        desc: "with a veteran-scoped token and an optional 'icn' parameter that does not match the Veteran's ICN",
+                        extract_desc: true,
+                        cassette:,
+                        scopes: %w[veteran/AppealsStatus.read]
+      end
+
+      response '422', "Invalid 'icn' parameter" do
+        schema '$ref' => '#/components/schemas/errorModel'
+        let(:scopes) { %w[representative/AppealsStatus.read] }
         let(:icn) { '000000000V00000' }
+        let(:cassette) { %w[caseflow/invalid_ssn mpi/find_candidate/valid] }
 
-        context 'with caseflow error response' do
-          before do |example|
-            VCR.use_cassette('caseflow/invalid_ssn') do
-              with_rswag_auth(scopes) do
-                submit_request(example.metadata)
-              end
-            end
-          end
-
-          it 'returns a 422 response' do |example|
-            assert_response_matches_metadata(example.metadata)
-          end
-        end
+        it_behaves_like 'rswag example',
+                        desc: "with a incorrectly formatted 'icn' parameter",
+                        extract_desc: true,
+                        cassette:,
+                        scopes: %w[veteran/AppealsStatus.read]
       end
 
       it_behaves_like 'rswag 500 response'
     end
   end
 end
-# rubocop:enable RSpec/VariableName, Layout/LineLength, RSpec/RepeatedExample
+# rubocop:enable RSpec/VariableName, Layout/LineLength

--- a/modules/appeals_api/spec/lib/token_validation_client_spec.rb
+++ b/modules/appeals_api/spec/lib/token_validation_client_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'appeals_api/token_validation_client'
+require_relative '../spec_helper'
+
+describe AppealsApi::TokenValidationClient do
+  let(:audience) { 'https://dev-api.va.gov/services/some-api' }
+  let(:token) { 'ABC123' }
+  let(:api_key) { 'abcd1234abcd1234abcd1234abcd1234abcd1234' }
+  let(:client) { described_class.new(api_key:) }
+  let(:veteran_icn) { '1012667145V762142' }
+  let(:expected_scopes) { %w[veteran/something.read] }
+  let(:token_scopes) { expected_scopes }
+  let(:valid) { true }
+
+  describe '#validate_token!' do
+    let(:result) do
+      with_openid_auth(token_scopes, valid:) do
+        client.validate_token!(audience:, token:, scopes: expected_scopes)
+      end
+    end
+
+    context 'with a valid veteran token' do
+      it 'indicates the token is valid and returns correct details' do
+        expect(result.scopes).to eq token_scopes
+        expect(result.veteran_icn).to eq veteran_icn
+      end
+    end
+
+    context 'with a valid representative token' do
+      let(:expected_scopes) { %w[representative/something.read] }
+
+      it 'indicates the token is valid and returns correct details' do
+        expect(result.scopes).to eq token_scopes
+        expect(result.veteran_icn).to be_nil
+      end
+    end
+
+    context 'with a valid system token' do
+      let(:expected_scopes) { %w[system/something.read] }
+
+      it 'indicates the token is valid and returns correct details' do
+        expect(result.scopes).to eq token_scopes
+        expect(result.veteran_icn).to be_nil
+      end
+    end
+
+    context 'with an invalid token' do
+      let(:valid) { false }
+
+      it 'raises an Unauthorized error' do
+        expect { result }.to raise_error Common::Exceptions::Unauthorized
+      end
+    end
+
+    context 'without the expected scope(s)' do
+      let(:token_scopes) { %w[not-the-right-scope] }
+
+      it 'raises a Forbidden error' do
+        expect { result }.to raise_error Common::Exceptions::Forbidden
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/requests/v1/appeals_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/appeals_controller_spec.rb
@@ -9,86 +9,125 @@ describe AppealsApi::V1::AppealsController, type: :request do
 
     let(:caseflow_cassette_name) { 'caseflow/appeals' }
     let(:mpi_cassette_name) { 'mpi/find_candidate/valid' }
-    let(:icn) { '1008714701V416111' }
+    let(:icn) { '1012667145V762142' }
     let(:ssn) { '796122306' }
     let(:consumer_username) { 'TestConsumer' }
-    let(:va_user) { 'text.user' }
-    let(:headers) { { 'X-Consumer-Username' => consumer_username, 'X-VA-User' => va_user } }
+    let(:headers) { { 'X-Consumer-Username' => consumer_username } }
+    let(:scopes) { described_class::OAUTH_SCOPES[:GET] }
+    let(:params) { {} }
 
     describe '#index' do
       let(:path) { '/services/appeals/v1/appeals' }
 
-      before { allow(Rails.logger).to receive(:info) }
+      before do
+        allow(Rails.logger).to receive(:info)
+        VCR.use_cassette(caseflow_cassette_name) do
+          VCR.use_cassette(mpi_cassette_name) do
+            with_openid_auth(scopes) do |auth_header|
+              get(path, params:, headers: auth_header.merge(headers))
+            end
+          end
+        end
+      end
 
-      describe 'success' do
-        before do
-          VCR.use_cassette(caseflow_cassette_name) do
-            VCR.use_cassette(mpi_cassette_name) do
-              with_openid_auth(described_class::OAUTH_SCOPES[:GET]) do |auth_header|
-                get(path, params: { icn: }, headers: auth_header.merge(headers))
-              end
+      describe 'successes' do
+        context 'with veteran scope' do
+          let(:scopes) { %w[veteran/AppealsStatus.read] }
+
+          context 'without ICN parameter' do
+            it 'returns appeals' do
+              expect(response).to have_http_status(:ok)
+              expect(response).to match_response_schema('appeals')
+            end
+
+            it 'logs the caseflow request and response' do
+              expect(Rails.logger).to have_received(:info).with(
+                'Caseflow Request',
+                { 'lookup_identifier' => Digest::SHA2.hexdigest(ssn) }
+              )
+              expect(Rails.logger).to have_received(:info).with(
+                'Caseflow Response',
+                { 'first_appeal_id' => '1196201', 'appeal_count' => 3 }
+              )
+            end
+          end
+
+          context 'with correct, optional ICN parameter' do
+            let(:params) { { icn: } }
+
+            it 'returns appeals' do
+              expect(response).to have_http_status(:ok)
+              expect(response).to match_response_schema('appeals')
             end
           end
         end
 
-        it 'returns appeals' do
-          expect(response).to have_http_status(:ok)
-          expect(response.body).to be_a(String)
-          expect(response).to match_response_schema('appeals')
+        context 'with system scope' do
+          let(:scopes) { %w[system/AppealsStatus.read] }
+          let(:params) { { icn: } }
+
+          it 'returns appeals' do
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_response_schema('appeals')
+          end
         end
 
-        it 'logs the caseflow request and response' do
-          expect(Rails.logger).to have_received(:info).with(
-            'Caseflow Request',
-            { 'va_user' => va_user, 'lookup_identifier' => Digest::SHA2.hexdigest(ssn) }
-          )
-          expect(Rails.logger).to have_received(:info).with(
-            'Caseflow Response',
-            { 'va_user' => va_user, 'first_appeal_id' => '1196201', 'appeal_count' => 3 }
-          )
+        context 'with representative scope' do
+          let(:scopes) { %w[representative/AppealsStatus.read] }
+          let(:params) { { icn: } }
+
+          it 'returns appeals' do
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_response_schema('appeals')
+          end
         end
       end
 
       describe 'errors' do
-        let(:error) { JSON.parse(response.body)['errors'].first }
+        let(:error) { JSON.parse(response.body).dig('errors', 0) }
 
-        before do
-          VCR.use_cassette(caseflow_cassette_name) do
-            VCR.use_cassette(mpi_cassette_name) do
-              with_openid_auth(described_class::OAUTH_SCOPES[:GET]) do |auth_header|
-                get '/services/appeals/v1/appeals', params: { icn: }, headers: auth_header.merge(headers)
-              end
+        describe 'with veteran scope' do
+          describe 'with incorrect ICN parameter' do
+            let(:params) { { icn: '1234567890V123456' } }
+
+            it 'returns a 403 error' do
+              expect(response).to have_http_status(:forbidden)
+              expect(error['detail']).to include('Veterans may access only their own records')
             end
           end
         end
 
-        describe 'with missing X-VA-User header' do
-          let(:headers) { { 'X-Consumer-Username' => consumer_username } }
+        describe 'with representative scope' do
+          let(:scopes) { %w[representative/AppealsStatus.read] }
 
-          it 'returns a 400 error' do
-            expect(response).to have_http_status(:bad_request)
-            expect(error['detail']).to include('X-VA-User')
+          describe 'with missing ICN parameter' do
+            it 'returns a 400 error' do
+              expect(response).to have_http_status(:bad_request)
+              expect(error['detail']).to include('required parameter "icn"')
+            end
           end
         end
 
-        describe 'with missing ICN parameter' do
-          let(:icn) {}
+        describe 'with system scope' do
+          describe 'with missing ICN parameter' do
+            let(:scopes) { %w[system/AppealsStatus.read] }
 
-          it 'returns a 400 error' do
-            expect(response).to have_http_status(:bad_request)
-            expect(error['detail']).to include("'icn'")
+            it 'returns a 400 error' do
+              expect(response).to have_http_status(:bad_request)
+              expect(error['detail']).to include('required parameter "icn"')
+            end
           end
         end
 
         describe 'with malformed ICN parameter' do
-          let(:icn) { 'not-an-icn' }
+          let(:params) { { icn: 'not-an-icn' } }
 
           it 'returns a 422 error' do
             expect(response).to have_http_status(:unprocessable_entity)
           end
         end
 
-        describe 'when veteran SSN is not found by ICN in MPI' do
+        describe 'when veteran SSN is not found in MPI based on the provided ICN' do
           let(:mpi_cassette_name) { 'mpi/find_candidate/icn_not_found' }
 
           it 'returns a 404 error with a message that does not reference SSN' do

--- a/modules/appeals_api/spec/requests/v1/appeals_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/appeals_controller_spec.rb
@@ -12,7 +12,8 @@ describe AppealsApi::V1::AppealsController, type: :request do
     let(:icn) { '1012667145V762142' }
     let(:ssn) { '796122306' }
     let(:consumer_username) { 'TestConsumer' }
-    let(:headers) { { 'X-Consumer-Username' => consumer_username } }
+    let(:va_user) { 'test.user@example.com' }
+    let(:headers) { { 'X-Consumer-Username' => consumer_username, 'X-VA-User' => va_user } }
     let(:scopes) { described_class::OAUTH_SCOPES[:GET] }
     let(:params) { {} }
 
@@ -43,11 +44,11 @@ describe AppealsApi::V1::AppealsController, type: :request do
             it 'logs the caseflow request and response' do
               expect(Rails.logger).to have_received(:info).with(
                 'Caseflow Request',
-                { 'lookup_identifier' => Digest::SHA2.hexdigest(ssn) }
+                { 'va_user' => va_user, 'lookup_identifier' => Digest::SHA2.hexdigest(ssn) }
               )
               expect(Rails.logger).to have_received(:info).with(
                 'Caseflow Response',
-                { 'first_appeal_id' => '1196201', 'appeal_count' => 3 }
+                { 'va_user' => va_user, 'first_appeal_id' => '1196201', 'appeal_count' => 3 }
               )
             end
           end

--- a/modules/appeals_api/spec/support/doc_helpers.rb
+++ b/modules/appeals_api/spec/support/doc_helpers.rb
@@ -65,7 +65,7 @@ module DocHelpers
   end
 
   # @param [Hash] opts
-  # @option opts [String] :cassette The name of the cassette to use, if any
+  # @option opts [String|String[]] :cassette The name(s) of the cassette(s) to use, if any
   # @option opts [String] :desc The description of the test. Required.
   # @option opts [Boolean] :extract_desc Whether to use the example name
   # @option opts [Symbol] :response_wrapper Method name to wrap the response, to modify the output of the example
@@ -77,9 +77,11 @@ module DocHelpers
       scopes = opts.fetch(:scopes, [])
       valid = opts.fetch(:token_valid, true)
       if opts[:cassette]
-        VCR.use_cassette(opts[:cassette]) do
-          with_rswag_auth(scopes, valid:) { submit_request(example.metadata) }
-        end
+        cassettes = opts[:cassette].is_a?(String) ? [opts[:cassette]] : opts[:cassette]
+
+        cassettes.each { |c| VCR.insert_cassette(c) }
+        with_rswag_auth(scopes, valid:) { submit_request(example.metadata) }
+        cassettes.each { |c| VCR.eject_cassette(c) }
       else
         with_rswag_auth(scopes, valid:) { submit_request(example.metadata) }
       end


### PR DESCRIPTION
## Summary

- This makes the following changes to the Appeals Status API v1:
  1. The `X-VA-User` header is no longer required or sent to Caseflow - this is not directly related to the other changes here, but we realized while discussing this ticket that this header may not actually be required at all, since results are returned regardless of whether we send it. If it turns out that this is not the case, we can revisit easily.
  2. **For requests made with tokens with `veteran/*` scopes only**, the ICN parameter is no longer required. Instead, by default, the ICN is read from the token validation result (the response from the validation server). If the user sends an `icn` parameter even though it's optional, it must match the ICN read from this token. If it doesn't match, the result will be a 403 (forbidden) error, since veterans may only access their own records.
  3. **For requests made with tokens with `representative/*` or `sysetm/*` scopes**, the ICN parameter is still required, and is used the same way as it was before.

## Related issue(s)
- [API-32191](https://jira.devops.va.gov/browse/API-32191)


## Testing done

- Added many new specs, updated docs

## What areas of the site does it impact?
- as-yet-unreleased Appeals Status API v1

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
