### PR TITLE
Use correct number for additional form number of certificates requested

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -66,6 +66,7 @@ module SimpleFormsApi
         'postal_code' => additional_form_data.dig('additional_address', 'postal_code'),
         'country' => additional_form_data.dig('additional_address', 'country')
       }
+      additional_form_data['certificates'] = additional_form_data['additional_copies']
       filler = SimpleFormsApi::PdfFiller.new(
         form_number: 'vba_40_0247',
         data: additional_form_data,

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_40_0247-min.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_40_0247-min.json
@@ -31,7 +31,7 @@
     "state": "NY",
     "postal_code": "12345"
   },
-  "additional_copies": "3",
+  "additional_copies": "5",
   "statement_of_truth_signature": "Joe Applicant",
   "statement_of_truth_certified": true
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_40_0247.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_40_0247.json
@@ -37,7 +37,7 @@
     "state": "NY",
     "postal_code": "12345"
   },
-  "additional_copies": "3",
+  "additional_copies": "5",
   "statement_of_truth_signature": "Joe Applicant",
   "statement_of_truth_certified": true
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_40_0247_with_supporting_document.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_40_0247_with_supporting_document.json
@@ -44,7 +44,7 @@
     "state": "NY",
     "postal_code": "12345"
   },
-  "additional_copies": "3",
+  "additional_copies": "5",
   "statement_of_truth_signature": "Joe Applicant",
   "statement_of_truth_certified": true
 }


### PR DESCRIPTION
## Summary
This PR updates the 40-0247 model so that when we submit two PDFs, the second one has the correct number for # of certificates requested. I also took the liberty of updating our test data so that the number of certificates requested and the additional number of certificates requested are different numbers, making testing easier.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/719
