### PR TITLE
Modify STATSD_KEY_PREFIX

### DIFF
--- a/app/sidekiq/bgs/flash_updater.rb
+++ b/app/sidekiq/bgs/flash_updater.rb
@@ -15,7 +15,7 @@ module BGS
     # A max retry attempt of 10 will result in a run time of ~8 hours
     # This job is invoked from 526 background job
     sidekiq_options retry: 10
-    STATSD_KEY_PREFIX = 'worker.bgs.flash_updater.exhausted'
+    STATSD_KEY_PREFIX = 'worker.bgs.flash_updater'
 
     wrap_with_logging(
       :add_flashes,
@@ -50,7 +50,7 @@ module BGS
         bgjob_errors: bgjob_errors.merge(new_error)
       )
 
-      StatsD.increment(STATSD_KEY_PREFIX)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
       ::Rails.logger.warn(
         'Flash Updater Retries exhausted',

--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -21,7 +21,7 @@ module CentralMail
       }
     )
 
-    STATSD_KEY_PREFIX = 'worker.evss.submit_form4142.exhausted'
+    STATSD_KEY_PREFIX = 'worker.evss.submit_form4142'
 
     # Sidekiq has built in exponential back-off functionality for retries
     # A max retry attempt of 10 will result in a run time of ~8 hours
@@ -56,7 +56,7 @@ module CentralMail
         bgjob_errors: bgjob_errors.merge(new_error)
       )
 
-      StatsD.increment(STATSD_KEY_PREFIX)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
       ::Rails.logger.warn(
         'Submit Form 4142 Retries exhausted',

--- a/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
@@ -32,7 +32,7 @@ module EVSS
         FORM_ID_0781A => { docType: 'L229' }
       }.freeze
 
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form0781.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form0781'
 
       # Sidekiq has built in exponential back-off functionality for retries
       # A max retry attempt of 10 will result in a run time of ~8 hours
@@ -64,7 +64,7 @@ module EVSS
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
-        StatsD.increment(STATSD_KEY_PREFIX)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
         ::Rails.logger.warn(
           'Submit Form 0781 Retries exhausted',

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -18,7 +18,7 @@ module EVSS
       # Changed from 15 -> 14 ~ Jan 19, 2023
       # This change reduces the run-time from ~36 hours to ~24 hours
       RETRY = 14
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526'
 
       wrap_with_logging(
         :submit_complete_form,

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526_cleanup.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526_cleanup.rb
@@ -6,7 +6,7 @@ module EVSS
   module DisabilityCompensationForm
     class SubmitForm526Cleanup < Job
       include Sidekiq::Job
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_cleanup.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_cleanup'
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']
@@ -31,7 +31,7 @@ module EVSS
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
-        StatsD.increment(STATSD_KEY_PREFIX)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
         ::Rails.logger.warn(
           'Submit Form 526 Cleanup Retries exhausted',

--- a/app/sidekiq/evss/disability_compensation_form/submit_form8940.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form8940.rb
@@ -7,7 +7,7 @@ module EVSS
     class SubmitForm8940 < Job
       extend Logging::ThirdPartyTransaction::MethodWrapper
 
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form8940.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form8940'
 
       # Sidekiq has built in exponential back-off functionality for retries
       # A max retry attempt of 10 will result in a run time of ~8 hours
@@ -39,7 +39,7 @@ module EVSS
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
-        StatsD.increment(STATSD_KEY_PREFIX)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
         ::Rails.logger.warn(
           'Submit Form 8940 Retries exhausted',

--- a/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
@@ -3,7 +3,7 @@
 module EVSS
   module DisabilityCompensationForm
     class SubmitUploads < Job
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_upload.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_upload'
 
       # retry for one day
       sidekiq_options retry: 14
@@ -31,7 +31,7 @@ module EVSS
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
-        StatsD.increment(STATSD_KEY_PREFIX)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
         ::Rails.logger.warn(
           'Submit Form 526 Upload Retries exhausted',

--- a/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
+++ b/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
@@ -7,7 +7,7 @@ module EVSS
     class UploadBddInstructions < Job
       extend Logging::ThirdPartyTransaction::MethodWrapper
 
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_bdd_instructions.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_bdd_instructions'
 
       # retry for one day
       sidekiq_options retry: 14
@@ -35,7 +35,7 @@ module EVSS
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
-        StatsD.increment(STATSD_KEY_PREFIX)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
         ::Rails.logger.warn(
           'Submit Form 526 Upload BDD Instructions Retries exhausted',

--- a/lib/logging/third_party_transaction.rb
+++ b/lib/logging/third_party_transaction.rb
@@ -15,7 +15,7 @@ module Logging
       #     log data
       #   - scoped to the class, will be available at instantiation
       #   - [ KEY ]: log identifier, [ VALUE ]: method chain to access desired instance value
-      #     - passed as an array, e.g. [:foo, :bar] will be calles as <instance>.foo.bar
+      #     - passed as an array, e.g. [:foo, :bar] will be called as <instance>.foo.bar
       #     - will fail silently and return nil if methods or values are not available
       def wrap_with_logging(*method_names, additional_class_logs: {}, additional_instance_logs: {})
         # including the instance method helpers inside this method makes them

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -21,7 +21,7 @@ module Sidekiq
       include Sidekiq::Job
 
       sidekiq_options retry: 14
-      STATSD_KEY_PREFIX = 'worker.evss.form526_backup_submission_process.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.form526_backup_submission_process'
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']
@@ -46,7 +46,7 @@ module Sidekiq
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
-        StatsD.increment(STATSD_KEY_PREFIX)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
         ::Rails.logger.warn(
           'Form 526 Backup Submission Retries exhausted',

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/bgs/flash_updater_spec.rb
+++ b/spec/sidekiq/bgs/flash_updater_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe BGS::FlashUpdater, type: :job do
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
+++ b/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_cleanup_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_cleanup_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526Cleanup, type: :jo
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm8940, type: :job do
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload


### PR DESCRIPTION
## Summary

Revise `STATSD_KEY_PREFIX`, appending `exhausted` suffix within `sidekiq_retries_exhausted` block

## Related issue(s)
- [ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/67288)

## Testing done

- updated RSpec tests
- manual click through and instantiation

## What areas of the site does it impact?
- 526 Async submission

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
