### PR TITLE
Fix Service Name for Veteran Status Redis

### DIFF
--- a/lib/va_profile/veteran_status/configuration.rb
+++ b/lib/va_profile/veteran_status/configuration.rb
@@ -12,7 +12,7 @@ module VAProfile
       end
 
       def service_name
-        'VAProfileVeteranStatus'
+        'VAProfile/VeteranStatus'
       end
 
       def mock_enabled?


### PR DESCRIPTION
## Summary

Fixes a veteran_status Redis EMIS deprecation error that was noticed in production.

## Related issue(s)
[Slack thread](https://dsva.slack.com/archives/C03LT909K1A/p1702492075679549)

