### PR TITLE
Remove ability to sort "Find a Representative" results by distance_desc

### DIFF
--- a/modules/veteran/app/controllers/veteran/v0/accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/accredited_representatives_controller.rb
@@ -17,8 +17,8 @@ module Veteran
 
       PERMITTED_TYPES = %w[attorney claim_agents organization].freeze
 
-      PERMITTED_ORGANIZATION_SORTS = %w[distance_asc distance_desc name_asc name_desc].freeze
-      PERMITTED_REPRESENTATIVE_SORTS = %w[distance_asc distance_desc first_name_asc first_name_desc last_name_asc
+      PERMITTED_ORGANIZATION_SORTS = %w[distance_asc name_asc name_desc].freeze
+      PERMITTED_REPRESENTATIVE_SORTS = %w[distance_asc first_name_asc first_name_desc last_name_asc
                                           last_name_desc].freeze
       def index
         collection = Common::Collection.new(model_klass, data: accreditation_query)
@@ -104,9 +104,6 @@ module Veteran
         case sort_param
         when 'distance_asc'
           [Arel.sql('ST_Distance(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, location) ASC'),
-           search_params[:long], search_params[:lat]]
-        when 'distance_desc'
-          [Arel.sql('ST_Distance(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, location) DESC'),
            search_params[:long], search_params[:lat]]
         when 'name_asc' then 'name ASC'
         when 'name_desc' then 'name DESC'

--- a/modules/veteran/app/docs/veteran/v0/accreditation.yaml
+++ b/modules/veteran/app/docs/veteran/v0/accreditation.yaml
@@ -68,7 +68,7 @@ paths:
           schema:
             type: string
             default: 'distance_asc'
-            enum: ['distance_asc', 'distance_desc', 'first_name_asc', 'first_name_desc', 'last_name_asc',
+            enum: ['distance_asc', 'first_name_asc', 'first_name_desc', 'last_name_asc',
                    'last_name_desc', 'name_asc', 'name_desc']
         - name: type
           in: query

--- a/modules/veteran/spec/requests/v0/accredited_representatives_spec.rb
+++ b/modules/veteran/spec/requests/v0/accredited_representatives_spec.rb
@@ -181,15 +181,6 @@ RSpec.describe 'Find a Rep - Accredited Representatives spec', type: :request do
         expect(parsed_response['data'].pluck('id')).to eq(%w[123 234 345 456])
       end
 
-      it 'can sort by distance_desc' do
-        get '/services/veteran/v0/accredited_representatives',
-            params: { type: 'organization', lat: 38.9072, long: -77.0369, sort: 'distance_desc' }
-
-        parsed_response = JSON.parse(response.body)
-
-        expect(parsed_response['data'].pluck('id')).to eq(%w[456 345 234 123])
-      end
-
       it 'can sort by name_asc' do
         get '/services/veteran/v0/accredited_representatives',
             params: { type: 'organization', lat: 38.9072, long: -77.0369, sort: 'name_asc' }
@@ -293,15 +284,6 @@ RSpec.describe 'Find a Rep - Accredited Representatives spec', type: :request do
         parsed_response = JSON.parse(response.body)
 
         expect(parsed_response['data'].pluck('id')).to eq(%w[123 234 345 456])
-      end
-
-      it 'can sort by distance_desc' do
-        get '/services/veteran/v0/accredited_representatives',
-            params: { type: 'attorney', lat: 38.9072, long: -77.0369, sort: 'distance_desc' }
-
-        parsed_response = JSON.parse(response.body)
-
-        expect(parsed_response['data'].pluck('id')).to eq(%w[456 345 234 123])
       end
 
       it 'can sort by first_name_asc' do


### PR DESCRIPTION
## Summary
- As part of the new MVP path for Find a Representative, this PR removes the ability to sort results by `distance_desc` (farthest to closest).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/71824

## Testing done
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *Describe the tests completed and the results*

## Testing done
`distance_desc` is now an invalid field value in Postman. All other values remain valid
<img width="834" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/143013011/86eb992d-8ccb-4dcd-b8aa-2db18e146709">

## What areas of the site does it impact?
- "Find a Representative" is not yet live in production. This change will only impact staging + internal testing. 