### PR TITLE
Supply a user_account to FormSubmission instead of user

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -115,7 +115,7 @@ module SimpleFormsApi
           form_type: params[:form_number],
           benefits_intake_uuid: uuid_and_location[:uuid],
           form_data: params.to_json,
-          user_account: @current_user
+          user_account: @current_user&.user_account
         )
         FormSubmissionAttempt.create(form_submission:)
 


### PR DESCRIPTION
## Summary

This PR fixes a silly mistake I made where I sent `User` objects to `FormSubmission` instead of `UserAccount`s.
