### PR TITLE
Strip upcased form data from error messages

### DIFF
--- a/modules/simple_forms_api/lib/simple_forms_api.rb
+++ b/modules/simple_forms_api/lib/simple_forms_api.rb
@@ -37,10 +37,10 @@ module SimpleFormsApi
                  'error message has been redacted to keep PII from getting leaked'
         end
 
-        remove_words(words_to_remove)
+        remove_words(message, words_to_remove)
       end
 
-      def remove_words(words_to_remove)
+      def remove_words(message, words_to_remove)
         words_to_remove.compact.each do |word|
           message.gsub!(word, '')
           message.gsub!(word.upcase, '')

--- a/modules/simple_forms_api/lib/simple_forms_api.rb
+++ b/modules/simple_forms_api/lib/simple_forms_api.rb
@@ -37,8 +37,13 @@ module SimpleFormsApi
                  'error message has been redacted to keep PII from getting leaked'
         end
 
+        remove_words(words_to_remove)
+      end
+
+      def remove_words(words_to_remove)
         words_to_remove.compact.each do |word|
           message.gsub!(word, '')
+          message.gsub!(word.upcase, '')
         end
 
         message


### PR DESCRIPTION
## Summary
We discovered that even though we are stripping entered form data that might contain PII, user first and last names were being entered and then upcased behind the scenes. This ensures that even if they are upcased, they should be deleted from the error message.
