### PR TITLE
Change sidekiq job to vbms rather than succeed

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -36,6 +36,7 @@ class FormSubmissionAttempt < ApplicationRecord
       {
         name: 'Form Submissions Attempt State change',
         form_submission_id:,
+        benefits_intake_uuid: form_submission&.benefits_intake_uuid,
         from_state: aasm.from_state,
         to_state: aasm.to_state,
         event: aasm.current_event

--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -27,6 +27,7 @@ class FormSubmissionAttempt < ApplicationRecord
 
     event :vbms do
       transitions from: :pending, to: :vbms
+      transitions from: :success, to: :vbms
     end
   end
 

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -6,12 +6,15 @@ class BenefitsIntakeStatusJob
   include Sidekiq::Job
 
   def perform
+    Rails.logger.info('BenefitsIntakeStatusJob started')
     pending_form_submission_ids = FormSubmission
                                   .joins(:form_submission_attempts)
                                   .where(form_submission_attempts: { aasm_state: 'pending' })
                                   .map(&:benefits_intake_uuid)
     response = BenefitsIntakeService::Service.new.get_bulk_status_of_uploads(pending_form_submission_ids)
     handle_response(response)
+    submissions_handled = response.body['data'].count
+    Rails.logger.info({ name: 'BenefitsIntakeStatusJob ended', submissions_handled: })
   end
 
   private

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -43,6 +43,6 @@ class BenefitsIntakeStatusJob
                               .where(aasm_state: 'pending')
                               .order(created_at: :asc)
                               .last
-    form_submission_attempt.succeed!
+    form_submission_attempt.vbms!
   end
 end

--- a/spec/sidekiq/benefits_intake_status_job_spec.rb
+++ b/spec/sidekiq/benefits_intake_status_job_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe BenefitsIntakeStatusJob, type: :job do
     end
 
     describe 'updating the form submission status' do
-      it 'updates the status with success from the bulk status report endpoint' do
+      it 'updates the status with vbms from the bulk status report endpoint' do
         VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_bulk_status_report_success') do
           pending_form_submissions = create_list(:form_submission, 1, :pending)
 
           BenefitsIntakeStatusJob.new.perform
 
           pending_form_submissions.each do |form_submission|
-            expect(form_submission.form_submission_attempts.first.reload.aasm_state).to eq 'success'
+            expect(form_submission.form_submission_attempts.first.reload.aasm_state).to eq 'vbms'
           end
         end
       end


### PR DESCRIPTION
## Summary
This PR fixes a problem where a complete form submission would be marked `success` rather than `vbms` in our state machine. It also adds a transition from `success` to `vbms` (which we aren't using yet, but may someday).