### PR TITLE
dbex/69391: gate submission job for certain users with Feature Toggle

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -51,8 +51,18 @@ module V0
       saved_claim = SavedClaim::DisabilityCompensation::Form526AllClaim.from_hash(form_content)
       saved_claim.save ? log_success(saved_claim) : log_failure(saved_claim)
       submission = create_submission(saved_claim)
+      # if jid = 0 then the submission was prevented from going any further in the process
+      jid = 0
 
-      jid = submission.start
+      # Feature flag to stop submission from being submitted to third-party service
+      # With this on, the submission will NOT be processed by EVSS or Lighthouse,
+      # nor will it go to VBMS,
+      # but the line of code before this one creates the submission in the vets-api database
+      if Flipper.enabled?(:disability_compensation_prevent_submission_job, @current_user)
+        Rails.logger.info("Submission ID: #{submission.id} prevented from sending to third party service.")
+      else
+        jid = submission.start
+      end
 
       render json: { data: { attributes: { job_id: jid } } },
              status: :ok

--- a/config/features.yml
+++ b/config/features.yml
@@ -1223,6 +1223,9 @@ features:
   disability_compensation_lighthouse_ppiu_direct_deposit_provider:
     actor_type: user
     description: If enabled uses the lighthouse ppiu/direct deposit endpoint in the form526 submission workflow
+  disability_compensation_prevent_submission_job:
+    actor_type: user
+    description: If enabled, the submission form526 record will be created, but there will be submission job
   virtual_agent_fetch_jwt_token:
     actor_type: user
     description: Enable the fetching of a JWT token to access MAP environment

--- a/spec/requests/disability_compensation_form_request_spec.rb
+++ b/spec/requests/disability_compensation_form_request_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Disability compensation form' do
 
   before do
     Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_PPIU_DIRECT_DEPOSIT)
+    Flipper.disable('disability_compensation_prevent_submission_job')
     sign_in_as(user)
   end
 

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -967,6 +967,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
         create(:in_progress_form, form_id: FormProfiles::VA526ez::FORM_ID, user_uuid: mhv_user.uuid)
         # TODO: remove Flipper feature toggle when lighthouse provider is implemented
         Flipper.disable('disability_compensation_lighthouse_rated_disabilities_provider_foreground')
+        Flipper.disable('disability_compensation_prevent_submission_job')
       end
 
       let(:form526v2) do


### PR DESCRIPTION
## Summary

- Add  'disability_compensation_prevent_submission_job' feature flag to prevent submission job per user

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#69391


## Testing done

- hit the endpoint /submit_all_claim with this feature flag turned on and no submission job will be created
- response will have `"jid": 0`

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
- Form526 /submit_all_claim endpoint

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
