### PR TITLE
Improve logging for FormSubmissionAttempt state change

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -40,13 +40,13 @@ class FormSubmissionAttempt < ApplicationRecord
       event: aasm.current_event
     }
     if aasm.to_state == 'failure'
-      log_hash[:name] = 'Form Submission Attempt failed'
+      log_hash[:message] = 'Form Submission Attempt failed'
       Rails.logger.error(log_hash)
     elsif aasm.to_state == 'vbms'
-      log_hash[:name] = 'Form Submission Attempt went to vbms'
+      log_hash[:message] = 'Form Submission Attempt went to vbms'
       Rails.logger.info(log_hash)
     else
-      log_hash[:name] = 'Form Submission Attempt State change'
+      log_hash[:message] = 'Form Submission Attempt State change'
       Rails.logger.info(log_hash)
     end
   end

--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -32,15 +32,22 @@ class FormSubmissionAttempt < ApplicationRecord
   end
 
   def log_status_change
-    Rails.logger.info(
-      {
-        name: 'Form Submissions Attempt State change',
-        form_submission_id:,
-        benefits_intake_uuid: form_submission&.benefits_intake_uuid,
-        from_state: aasm.from_state,
-        to_state: aasm.to_state,
-        event: aasm.current_event
-      }
-    )
+    log_hash = {
+      form_submission_id:,
+      benefits_intake_uuid: form_submission&.benefits_intake_uuid,
+      from_state: aasm.from_state,
+      to_state: aasm.to_state,
+      event: aasm.current_event
+    }
+    if aasm.to_state == 'failure'
+      log_hash[:name] = 'Form Submission Attempt failed'
+      Rails.logger.error(log_hash)
+    elsif aasm.to_state == 'vbms'
+      log_hash[:name] = 'Form Submission Attempt went to vbms'
+      Rails.logger.info(log_hash)
+    else
+      log_hash[:name] = 'Form Submission Attempt State change'
+      Rails.logger.info(log_hash)
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR splits logging into error and non-error states so that we can more easily read the logs and determine where intervention might be needed. This will also help with reporting on DataDog, I believe.
