### PR TITLE
Log the form_type with FormSubmissionAttempt

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -35,6 +35,7 @@ class FormSubmissionAttempt < ApplicationRecord
     log_hash = {
       form_submission_id:,
       benefits_intake_uuid: form_submission&.benefits_intake_uuid,
+      form_type: form_submission&.form_type,
       from_state: aasm.from_state,
       to_state: aasm.to_state,
       event: aasm.current_event


### PR DESCRIPTION
## Summary
We want to know which form we're attempting to submit. This will be useful for a DD Dashboard to aggregate over all form types and see if there are trends.
