### PR TITLE
add docker-compose* to BE review group ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 
 Dangerfile @department-of-veterans-affairs/backend-review-group
 Dockerfile @department-of-veterans-affairs/backend-review-group
+docker-compose* @department-of-veterans-affairs/backend-review-group
 Gemfile @department-of-veterans-affairs/backend-review-group
 Gemfile.lock @department-of-veterans-affairs/backend-review-group
 Makefile @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
docker-compose files were missing from CODEOWNERS file.

Added `docker-compose* @department-of-veterans-affairs/backend-review-group`

This CODEOWNERS file is valid.