### PR TITLE
add default zipCode fallback for 20-10206

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -24,7 +24,7 @@ module SimpleFormsApi
           'non_citizen_id',
           'arn'
         ),
-        'zipCode' => @data.dig('address', 'postal_code'),
+        'zipCode' => @data.dig('address', 'postal_code') || '00000',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP'


### PR DESCRIPTION
## Summary

- Add fallback zipCode 00000 for 20-10206

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#844

## What areas of the site does it impact?
Form 20-10206

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
