### PR TITLE
API-32243 Validate zipCode in Benefits Intake metadata

### DIFF
--- a/modules/vba_documents/lib/vba_documents/upload_validator.rb
+++ b/modules/vba_documents/lib/vba_documents/upload_validator.rb
@@ -116,7 +116,7 @@ module VBADocuments
     def validate_zip_code(zip_code)
       unless VALID_ZIP_CODE_REGEX.match?(zip_code)
         # rubocop:disable Layout/LineLength
-        detail = 'Zip code must be a string of either five digits ("XXXXX") or five digits followed by a hyphen and four more digits ("XXXXX-XXXX"). Use "00000" for addresses outside the US.'
+        detail = 'Zip code must be a string of either five digits ("XXXXX") or five digits followed by a hyphen and four more digits ("XXXXX-XXXX"). Use "00000" for Veterans with non-US addresses.'
         # rubocop:enable Layout/LineLength
         raise VBADocuments::UploadError.new(code: 'DOC102', detail:)
       end

--- a/modules/vba_documents/lib/vba_documents/upload_validator.rb
+++ b/modules/vba_documents/lib/vba_documents/upload_validator.rb
@@ -115,9 +115,8 @@ module VBADocuments
 
     def validate_zip_code(zip_code)
       unless VALID_ZIP_CODE_REGEX.match?(zip_code)
-        # rubocop:disable Layout/LineLength
-        detail = 'Zip code must be a string of either five digits ("XXXXX") or five digits followed by a hyphen and four more digits ("XXXXX-XXXX"). Use "00000" for Veterans with non-US addresses.'
-        # rubocop:enable Layout/LineLength
+        detail = 'Zip code must be a string of either five digits ("XXXXX") or five digits followed by a hyphen ' \
+                 'and four more digits ("XXXXX-XXXX"). Use "00000" for Veterans with non-US addresses.'
         raise VBADocuments::UploadError.new(code: 'DOC102', detail:)
       end
     end

--- a/modules/vba_documents/lib/vba_documents/upload_validator.rb
+++ b/modules/vba_documents/lib/vba_documents/upload_validator.rb
@@ -86,7 +86,6 @@ module VBADocuments
       end
       metadata['businessLine'] = VALID_LOB[metadata['businessLine'].to_s.upcase] if metadata.key? 'businessLine'
       metadata['businessLine'] = AppealsApi::LineOfBusiness.new(model).value if model.appeals_consumer?
-      metadata['zipCode'] = metadata['zipCode'].to_s if metadata['zipCode'].is_a? Numeric
       metadata
     end
 

--- a/modules/vba_documents/spec/lib/upload_validator_spec.rb
+++ b/modules/vba_documents/spec/lib/upload_validator_spec.rb
@@ -30,22 +30,6 @@ RSpec.describe VBADocuments::UploadValidations do
       expect(subject).to have_key('ahash1')
       expect(subject['ahash1']).to eq(upload_submission.uploaded_pdf['content']['attachments'][0]['sha256_checksum'])
     end
-
-    describe 'when zipCode is a number' do
-      before do
-        json_parse = JSON.method(:parse)
-        allow(JSON).to receive(:parse) do |input|
-          output = json_parse.call(input)
-          output.merge!({ 'zipCode' => 12_345 }) if output.is_a?(Hash) && output['zipCode'].present?
-          output
-        end
-      end
-
-      it 'stringifies the zipCode' do
-        expect(subject).to have_key('zipCode')
-        expect(subject['zipCode']).to eq('12345')
-      end
-    end
   end
 
   describe '#validate_metadata' do


### PR DESCRIPTION
## Summary

- Adds validations for zip code metadata when uploading a document via the Benefits Intake API (any version)

## Related issue(s)
- [API-32243](https://jira.devops.va.gov/browse/API-32243)

## Testing done

- Updated and added specs


## What areas of the site does it impact?
All versions of the Benefits Intake API

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Do we need release notes for this? I'm leaning no because we're enforcing the metadata schema we already have, but I don't feel strongly.