### PR TITLE
Change string to symbol so that logging works

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -40,10 +40,10 @@ class FormSubmissionAttempt < ApplicationRecord
       to_state: aasm.to_state,
       event: aasm.current_event
     }
-    if aasm.to_state == 'failure'
+    if aasm.to_state == :failure
       log_hash[:message] = 'Form Submission Attempt failed'
       Rails.logger.error(log_hash)
-    elsif aasm.to_state == 'vbms'
+    elsif aasm.to_state == :vbms
       log_hash[:message] = 'Form Submission Attempt went to vbms'
       Rails.logger.info(log_hash)
     else

--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -40,10 +40,10 @@ class FormSubmissionAttempt < ApplicationRecord
       to_state: aasm.to_state,
       event: aasm.current_event
     }
-    if aasm.to_state == :failure
+    if failure?
       log_hash[:message] = 'Form Submission Attempt failed'
       Rails.logger.error(log_hash)
-    elsif aasm.to_state == :vbms
+    elsif vbms?
       log_hash[:message] = 'Form Submission Attempt went to vbms'
       Rails.logger.info(log_hash)
     else


### PR DESCRIPTION
## Summary
This PR fixes a mistake I made in logging from the `FormSubmissionAttempt` model where I was looking for a string and it ought to have been a Ruby symbol.
