### PR TITLE
Changes date for BDD to be dynamic instead of static so it stays outside of the range

### DIFF
--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -3186,7 +3186,7 @@ RSpec.describe 'Disability Claims', type: :request do
 
         context 'when anticipatedSeparationDate is not between 90 and 180 days in future' do
           let(:claim_process_type) { 'BDD_PROGRAM' }
-          let(:anticipated_separation_date) { '2024-06-16' }
+          let(:anticipated_separation_date) { claim_date + 81.days }
 
           it 'responds with bad request' do
             mock_ccg(scopes) do |auth_header|


### PR DESCRIPTION
## Summary
Fixes failing test that was checking a dynamic date vs. static date value which was no longer outside the range it needed to be.

## Related issue(s)
* Failing test on master

## Testing done
* RSpec

## What areas of the site does it impact?
* modified: modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

