### PR TITLE
fix: remove toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -743,9 +743,6 @@ features:
       Toggle for the entire pre-entry covid 19 self-screener available at /covid19screener and to be used by visitors
       to VHA facilities in lieu of manual screening with a VHA employee.
       This toggle is owned by Patrick B. and the rest of the CTO Health Products team.
-  show_authenticated_menu_enhancements:
-    actor_type: user
-    description: Exposes new links for dependents and letters in the header dropdown for authenticated users
   profile_enhanced_military_info:
     actor_type: user
     description: When enabled, /v1/profile/military_info endpoint will return all military information for a user.


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- We have removed the usage of `show_authenticated_menu_enhancements` feature toggle on the FE, so now we need to remove it from the api code.

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/70769)

## Testing done

- tests pass, just removing a single toggle

## What areas of the site does it impact?
Profile

## Acceptance criteria

- [x]  Toggle removed
