### PR TITLE
API-32277-fed-act-delete-error

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -618,8 +618,11 @@ module ClaimsApi
         @pdf_data[:data][:attributes][:serviceInformation][:federalActivation][:anticipatedSeparationDate] =
           regex_date_conversion(anticipated_sep_date)
         @pdf_data[:data][:attributes][:serviceInformation][:activatedOnFederalOrders] = activation_date ? 'YES' : 'NO'
-        @pdf_data[:data][:attributes][:serviceInformation][:reservesNationalGuardService].delete(:federalActivation)
-
+        if @pdf_data&.dig(
+          'data', 'attributes', 'serviceInformation', 'reservesNationalGuardService', 'federalActivation'
+        ).present?
+          @pdf_data[:data][:attributes][:serviceInformation][:reservesNationalGuardService].delete(:federalActivation)
+        end
         @pdf_data
       end
 


### PR DESCRIPTION
## Summary

- Adds check to see if we have reserves/fed activation info before trying to delete it.

## Related issue(s)
[API-32277](https://jira.devops.va.gov/browse/API-32277)


## Testing done

- Postman
- rspec

Test by removing the following section:
```               
 "reservesNationalGuardService": {
                    "obligationTermsOfService": {
                        "beginDate": "2016-11-24",
                        "endDate": "2017-11-17"
                    },
                    "unitName": "National Guard Unit Name",
                    "unitAddress": "1243 pine court",
                    "component": "National Guard",
                    "unitPhone": {
                        "areaCode": "555",
                        "phoneNumber": "5555555"
                    },
                    "receivingInactiveDutyTrainingPay": "YES"
                },
```

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature