### PR TITLE
POA v2: respond with 404 if POA is not found

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -12,7 +12,7 @@ module ClaimsApi
 
         def show
           poa_code = BGS::PowerOfAttorneyVerifier.new(target_veteran).current_poa_code
-          head(:no_content) && return if poa_code.blank?
+          raise ::Common::Exceptions::ResourceNotFound.new(detail: 'POA not found') if poa_code.blank?
 
           render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyBlueprint.render(
             representative(poa_code).merge({ code: poa_code })

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8346,11 +8346,11 @@
               }
             }
           },
-          "204": {
-            "description": "Successful response with no current Power of Attorney",
+          "404": {
+            "description": "POA not found",
             "content": {
               "application/json": {
-                "example": ""
+                "example": "{\"errors\":[{\"title\":\"Resource not found\",\"detail\":\"POA not found\"}]}"
               }
             }
           },

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe 'Power Of Attorney', type: :request do
         context 'when provided' do
           context 'when valid' do
             context 'when current poa code does not exist' do
-              it 'returns a 204' do
+              it 'returns a 404' do
                 mock_ccg(scopes) do |auth_header|
                   allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(OpenStruct.new(current_poa_code: nil))
 
                   get get_poa_path, headers: auth_header
 
-                  expect(response.status).to eq(204)
+                  expect(response).to have_http_status(:not_found)
                 end
               end
             end
@@ -49,7 +49,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             it 'returns a 401' do
               get get_poa_path, headers: { 'Authorization' => 'Bearer HelloWorld' }
 
-              expect(response.status).to eq(401)
+              expect(response).to have_http_status(:unauthorized)
             end
           end
         end
@@ -80,7 +80,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
                 .and_return({ person_poa_history: nil })
 
               put appoint_individual_path, params: data, headers: auth_header
-              expect(response.status).to eq(200)
+              expect(response).to have_http_status(:ok)
             end
           end
         end
@@ -88,7 +88,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
         context 'when not provided' do
           it 'returns a 401 error code' do
             put appoint_individual_path, params: data
-            expect(response.status).to eq(401)
+            expect(response).to have_http_status(:unauthorized)
           end
         end
       end
@@ -99,7 +99,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             data[:serviceOrganization] = nil
 
             put appoint_individual_path, params: data, headers: auth_header
-            expect(response.status).to eq(400)
+            expect(response).to have_http_status(:bad_request)
           end
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             data[:signatures] = nil
 
             put appoint_individual_path, params: data, headers: auth_header
-            expect(response.status).to eq(400)
+            expect(response).to have_http_status(:bad_request)
           end
         end
       end
@@ -121,7 +121,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             data[:signatures][:veteran] = nil
 
             put appoint_individual_path, params: data, headers: auth_header
-            expect(response.status).to eq(400)
+            expect(response).to have_http_status(:bad_request)
           end
         end
       end
@@ -132,7 +132,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             data[:signatures][:representative] = nil
 
             put appoint_individual_path, params: data, headers: auth_header
-            expect(response.status).to eq(400)
+            expect(response).to have_http_status(:bad_request)
           end
         end
       end
@@ -143,7 +143,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             data[:serviceOrganization][:poaCode] = organization_poa_code.to_s
 
             put appoint_individual_path, params: data, headers: auth_header
-            expect(response.status).to eq(422)
+            expect(response).to have_http_status(:unprocessable_entity)
           end
         end
       end
@@ -155,7 +155,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
           mock_ccg(scopes) do |auth_header|
             put appoint_individual_path, params: data, headers: auth_header
-            expect(response.status).to eq(500)
+            expect(response).to have_http_status(:internal_server_error)
           end
         end
       end
@@ -172,7 +172,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
                 put appoint_individual_path, params: data, headers: auth_header
 
-                expect(response.status).to eq(200)
+                expect(response).to have_http_status(:ok)
               end
             end
           end
@@ -181,7 +181,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             it 'returns a 401' do
               put appoint_individual_path, params: data, headers: { 'Authorization' => 'Bearer HelloWorld' }
 
-              expect(response.status).to eq(401)
+              expect(response).to have_http_status(:unauthorized)
             end
           end
         end
@@ -212,7 +212,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
                 .and_return({ person_poa_history: nil })
 
               put appoint_organization_path, params: data, headers: auth_header
-              expect(response.status).to eq(200)
+              expect(response).to have_http_status(:ok)
             end
           end
         end
@@ -220,7 +220,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
         context 'when not provided' do
           it 'returns a 401 error code' do
             put appoint_organization_path, params: data
-            expect(response.status).to eq(401)
+            expect(response).to have_http_status(:unauthorized)
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
               data[:serviceOrganization][:poaCode] = individual_poa_code.to_s
 
               put appoint_organization_path, params: data, headers: auth_header
-              expect(response.status).to eq(422)
+              expect(response).to have_http_status(:unprocessable_entity)
             end
           end
         end
@@ -248,7 +248,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
                 put appoint_organization_path, params: data, headers: auth_header
 
-                expect(response.status).to eq(200)
+                expect(response).to have_http_status(:ok)
               end
             end
           end
@@ -257,7 +257,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
             it 'returns a 401' do
               put appoint_organization_path, params: data, headers: { 'Authorization' => 'Bearer HelloWorld' }
 
-              expect(response.status).to eq(401)
+              expect(response).to have_http_status(:unauthorized)
             end
           end
         end

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -77,7 +77,7 @@ describe 'PowerOfAttorney',
       describe 'No POA assigned to Veteran' do
         let(:bgs_poa) { { person_org_name: nil } }
 
-        response '204', 'Successful response with no current Power of Attorney' do
+        response '404', 'POA not found' do
           before do |example|
             expect_any_instance_of(local_bgs).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
             allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
@@ -96,7 +96,7 @@ describe 'PowerOfAttorney',
             }
           end
 
-          it 'returns a valid 200 response' do |example|
+          it 'returns a 404 response' do |example|
             assert_response_matches_metadata(example.metadata)
           end
         end


### PR DESCRIPTION
Respond with a 404 when the POA for a veteran doesn't exist

## Summary

- Raise `::Common::Exceptions::ResourceNotFound` instead of `head(:no_content)`
- Updates specs to use status code symbols instead of response numbers

## Related issue(s)

- [API-32087](https://jira.devops.va.gov/browse/API-32087)

## Testing done

- RSpec request spec updated

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature