### PR TITLE
Add summary stats to daily benefits intake status job

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -38,7 +38,7 @@ class BenefitsIntakeStatusJob
 
     {
       total_submissions_handled:,
-      pending_submissions_handled:
+      pending_submissions_handled:,
       failed_submissions_handled:,
       successful_submissions_handled:
     }

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -25,7 +25,7 @@ class BenefitsIntakeStatusJob
       failed_submissions_handled: 0,
       successful_submissions_handled: 0
     }
-    response.body['data'].each do |submission|
+    response.body['data']&.each do |submission|
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
         stats[:failed_submissions_handled] += 1
         handle_failure(submission)

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -13,16 +13,14 @@ class BenefitsIntakeStatusJob
                                   .map(&:benefits_intake_uuid)
     response = BenefitsIntakeService::Service.new.get_bulk_status_of_uploads(pending_form_submission_ids)
     stats = handle_response(response)
-    Rails.logger.info({ message: 'BenefitsIntakeStatusJob ended'}.merge(stats))
+    Rails.logger.info({ message: 'BenefitsIntakeStatusJob ended' }.merge(stats))
   end
 
   private
 
   def handle_response(response)
-    total_submissions_handled = 0
-    pending_submissions_handled = 0
-    failed_submissions_handled = 0
-    successful_submissions_handled = 0
+    total_submissions_handled, pending_submissions_handled, failed_submissions_handled, successful_submissions_handled =
+      0, 0, 0, 0
     response.body['data'].each do |submission|
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
         failed_submissions_handled += 1

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -19,26 +19,26 @@ class BenefitsIntakeStatusJob
   private
 
   def handle_response(response)
-    total_submissions_handled = 0
-    pending_submissions_handled = 0
-    failed_submissions_handled = 0
-    successful_submissions_handled = 0
+    stats = {
+      total_submissions_handled: 0,
+      pending_submissions_handled: 0,
+      failed_submissions_handled: 0,
+      successful_submissions_handled: 0
+    }
     response.body['data'].each do |submission|
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
-        failed_submissions_handled += 1
+        stats[:failed_submissions_handled] += 1
         handle_failure(submission)
       elsif submission.dig('attributes', 'status') == 'vbms'
-        successful_submissions_handled += 1
+        stats[:successful_submissions_handled] += 1
         handle_success(submission)
       else
-        pending_submissions_handled += 1
+        stats[:pending_submissions_handled] += 1
       end
-      total_submissions_handled += 1
+      stats[:total_submissions_handled] += 1
     end
-    {
-      total_submissions_handled:, pending_submissions_handled:,
-      failed_submissions_handled:, successful_submissions_handled:
-    }
+
+    stats
   end
 
   def handle_failure(submission)

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -19,8 +19,10 @@ class BenefitsIntakeStatusJob
   private
 
   def handle_response(response)
-    total_submissions_handled, pending_submissions_handled, failed_submissions_handled, successful_submissions_handled =
-      0, 0, 0, 0
+    total_submissions_handled = 0
+    pending_submissions_handled = 0
+    failed_submissions_handled = 0
+    successful_submissions_handled = 0
     response.body['data'].each do |submission|
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
         failed_submissions_handled += 1
@@ -33,12 +35,9 @@ class BenefitsIntakeStatusJob
       end
       total_submissions_handled += 1
     end
-
     {
-      total_submissions_handled:,
-      pending_submissions_handled:,
-      failed_submissions_handled:,
-      successful_submissions_handled:
+      total_submissions_handled:, pending_submissions_handled:,
+      failed_submissions_handled:, successful_submissions_handled:
     }
   end
 


### PR DESCRIPTION
## Summary
This PR adds some summary stats to our `BenefitsIntakeStatusJob`, which should make it easier to have our dashboard show counts of pending forms.
