### PR TITLE
Transliterate form 4142 metadata name values

### DIFF
--- a/lib/evss/disability_compensation_form/form4142_processor.rb
+++ b/lib/evss/disability_compensation_form/form4142_processor.rb
@@ -73,8 +73,8 @@ module EVSS
         address = form['veteranAddress']
 
         {
-          'veteranFirstName' => veteran_full_name['first'],
-          'veteranLastName' => veteran_full_name['last'],
+          'veteranFirstName' => transliterate(veteran_full_name['first']),
+          'veteranLastName' => transliterate(veteran_full_name['last']),
           'fileNumber' => form['vaFileNumber'] || form['veteranSocialSecurityNumber'],
           'receiveDt' => received_date,
           'uuid' => jid,
@@ -91,6 +91,11 @@ module EVSS
         date = SavedClaim::DisabilityCompensation.find(@submission.saved_claim_id).created_at
         date = date.in_time_zone('Central Time (US & Canada)')
         date.strftime('%Y-%m-%d %H:%M:%S')
+      end
+
+      # Corrects or replaces with an empty string any characters not matching upstream validators
+      def transliterate(name)
+        I18n.transliterate(name).gsub(%r{[^A-Za-z'/ -]}, '')
       end
     end
   end

--- a/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
+++ b/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
           expect(jid).not_to be_empty
         end
       end
+
+      it 'corrects for invalid characters in generated metadata' do
+        submission.form[Form526Submission::FORM_4142]['veteranFullName']
+                  .update('first' => 'Beyoncé', 'last' => 'Knowle$')
+        subject.perform_async(submission.id)
+        jid = subject.jobs.last['jid']
+        processor = EVSS::DisabilityCompensationForm::Form4142Processor.new(submission, jid)
+        request_body = processor.request_body
+        metadata_hash = JSON.parse(request_body['metadata'])
+        veteran_first_name = metadata_hash['veteranFirstName']
+        veteran_last_name = metadata_hash['veteranLastName']
+        transliterated_chars_regex = /[^\x00-\x7F]/
+
+        expect(veteran_first_name).not_to match(transliterated_chars_regex)
+        expect(veteran_last_name).not_to match(transliterated_chars_regex)
+      end
     end
 
     context 'with a submission timeout' do


### PR DESCRIPTION
## Summary

The processing of 4142 forms, as part of the 526 form submission workflow, has experienced issues where special characters in a Veteran's first and/or last names would trigger a failure within the Central Mail EMMS API regex validation. The method implemented corrects for or removes any non-conforming characters in the generated metadata of a request body for a CentralMail submission. 

## Related issue(s)

Zenhub ticket [#72321](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/72321)

## Testing done

Test added to validate the conversion of accented characters into their respective equivalents (e.g., `é` => `e`) and removal of characters that are not letters (both uppercase and lowercase), apostrophes, spaces, or hyphens.

## What areas of the site does it impact?

Form 4142 processing as part of Form 526 async submission

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
