### PR TITLE
Removing feature flag. No longer needed

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1264,9 +1264,6 @@ features:
   burial_form_enabled:
     actor_type: user
     description: Enable the burial form
-  burial_form_v2:
-    actor_type: user
-    description: Enable the burial form version 2
   pension_form_enabled:
     actor_type: user
     description: Enable the pension form


### PR DESCRIPTION
## Summary

- Removing the feature flag `burial_form_v2` as it is no longer needed

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#0000
- *Link to ticket created in va.gov-team repo*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*


## Testing done

- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *Describe the tests completed and the results*

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
