### PR TITLE
72343 Adjust DMCs throttle for hitting VaNotify

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -129,8 +129,8 @@ mcp:
     mock_vista: false
     api_key: abcd1234abcd1234abcd1234abcd1234abcd1234
   notifications:
-    job_interval: 90
-    batch_size: 100
+    job_interval: 10
+    batch_size: 10
 
 fsr:
   prefill: true


### PR DESCRIPTION
## Summary
VA notify is receiving an excessive number of hits from the Debt team's API key. To better accommodate them I'm adjusting our throttle to send fewer requests per second.

## Related issue(s)
[72343](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/72343)


## Testing done
specs pass

## What areas of the site does it impact?
user email notifications for new copay statements

## Acceptance criteria
- The Debt team will hit VaNotify's api fewer that 15 times per second
