### PR TITLE
Adding user_types attribute to representative serializer

### DIFF
--- a/modules/veteran/app/serializers/veteran/accreditation/representative_serializer.rb
+++ b/modules/veteran/app/serializers/veteran/accreditation/representative_serializer.rb
@@ -22,6 +22,7 @@ module Veteran
       attribute :lat
       attribute :long
       attribute :distance
+      attribute :user_types
 
       def distance
         object.distance / Veteran::Service::Constants::METERS_PER_MILE

--- a/modules/veteran/spec/serializers/accreditation/representative_serializer_spec.rb
+++ b/modules/veteran/spec/serializers/accreditation/representative_serializer_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe Veteran::Accreditation::RepresentativeSerializer do
            long: '-75',
            poa_codes: ['A123'],
            phone: '222-222-2222',
-           email: 'email@example.com')
+           email: 'email@example.com',
+           user_types: ['attorney']
+           )
   end
 
   it 'includes the specified model attributes' do
@@ -53,7 +55,9 @@ RSpec.describe Veteran::Accreditation::RepresentativeSerializer do
        phone
        email
        lat
-       long].each do |attr|
+       long
+       user_types
+      ].each do |attr|
       expect(attributes[attr]).to eq(representative.public_send(attr))
     end
   end
@@ -97,6 +101,8 @@ RSpec.describe Veteran::Accreditation::RepresentativeSerializer do
                                      email
                                      lat
                                      long
-                                     distance])
+                                     distance
+                                     user_types
+                                    ])
   end
 end

--- a/modules/veteran/spec/serializers/accreditation/representative_serializer_spec.rb
+++ b/modules/veteran/spec/serializers/accreditation/representative_serializer_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe Veteran::Accreditation::RepresentativeSerializer do
            poa_codes: ['A123'],
            phone: '222-222-2222',
            email: 'email@example.com',
-           user_types: ['attorney']
-           )
+           user_types: ['attorney'])
   end
 
   it 'includes the specified model attributes' do
@@ -56,8 +55,7 @@ RSpec.describe Veteran::Accreditation::RepresentativeSerializer do
        email
        lat
        long
-       user_types
-      ].each do |attr|
+       user_types].each do |attr|
       expect(attributes[attr]).to eq(representative.public_send(attr))
     end
   end
@@ -102,7 +100,6 @@ RSpec.describe Veteran::Accreditation::RepresentativeSerializer do
                                      lat
                                      long
                                      distance
-                                     user_types
-                                    ])
+                                     user_types])
   end
 end


### PR DESCRIPTION
## Summary

- Added user_types to representative serializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/69742

## Testing done

- Added user_types to specified model attributes expected in the representative serializer spec
