### PR TITLE
Adding document_type to list of allowed params for DataDog

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -23,6 +23,7 @@ ALLOWLIST = %w[
   showCompleted
   excludeProvidedMessage
   document_id
+  document_type
   category
   cookie_id
   reply_id


### PR DESCRIPTION
## Summary
Adds `document_type` to the list of parameters that won't be filtered in DataDog logs. My team is interested in being able to add a query parameter to calls to the V0::ClaimLetterController (/v0/claim_letters) to record the docType (a numeric value such as 184) that is being requested by va.gov

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#72469


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
