### PR TITLE
API-32383 Handle duplicate poa entries

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -14,7 +14,6 @@ module ClaimsApi
 
         def show
           poa_code = BGS::PowerOfAttorneyVerifier.new(target_veteran).current_poa_code
-
           head(:no_content) && return if poa_code.blank?
 
           render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyBlueprint.render(

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -2,16 +2,19 @@
 
 require 'bgs/power_of_attorney_verifier'
 require 'claims_api/v2/params_validation/power_of_attorney'
+require 'claims_api/v2/error/lighthouse_error_handler'
 
 module ClaimsApi
   module V2
     module Veterans
       class PowerOfAttorneyController < ClaimsApi::V2::ApplicationController
         include ClaimsApi::PoaVerification
+        include ClaimsApi::V2::Error::LighthouseErrorHandler
         FORM_NUMBER = '2122'
 
         def show
           poa_code = BGS::PowerOfAttorneyVerifier.new(target_veteran).current_poa_code
+
           head(:no_content) && return if poa_code.blank?
 
           render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyBlueprint.render(
@@ -72,22 +75,33 @@ module ClaimsApi
 
         def representative(poa_code)
           organization = ::Veteran::Service::Organization.find_by(poa: poa_code)
-          if organization.present?
-            return {
-              name: organization.name,
-              phone_number: organization.phone,
-              type: 'organization'
-            }
-          end
+          return format_organization(organization) if organization.present?
 
-          individuals = ::Veteran::Service::Representative.where('? = ANY(poa_codes)', poa_code)
-          raise 'Ambiguous representative results' if individuals.count > 1
+          individuals = ::Veteran::Service::Representative.where('? = ANY(poa_codes)',
+                                                                 poa_code).order(created_at: :desc)
           return {} if individuals.blank?
 
-          individual = individuals.first
+          if individuals.pluck(:representative_id).uniq.count > 1
+            raise ::ClaimsApi::Common::Exceptions::Lighthouse::UnprocessableEntity.new(
+              detail: "Could not retrieve Power of Attorney due to multiple representatives with code: #{poa_code}"
+            )
+          end
+
+          format_representative(individuals.first)
+        end
+
+        def format_organization(organization)
           {
-            name: "#{individual.first_name} #{individual.last_name}",
-            phone_number: individual.phone,
+            name: organization.name,
+            phone_number: organization.phone,
+            type: 'organization'
+          }
+        end
+
+        def format_representative(representative)
+          {
+            name: "#{representative.first_name} #{representative.last_name}",
+            phone_number: representative.phone,
             type: 'individual'
           }
         end

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8423,7 +8423,7 @@
                       "status": "422",
                       "detail": "Could not retrieve Power of Attorney due to multiple representatives with code: A1Q",
                       "source": {
-                        "pointer": "data/attributes"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:85:in `representative'"
                       }
                     }
                   ]

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8362,6 +8362,7 @@
                   "errors": [
                     {
                       "title": "Not authorized",
+                      "status": "401",
                       "detail": "Not authorized"
                     }
                   ]
@@ -8387,6 +8388,71 @@
                           "detail": {
                             "type": "string",
                             "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Unprocessable entity",
+                      "status": "422",
+                      "detail": "Could not retrieve Power of Attorney due to multiple representatives with code: A1Q",
+                      "source": {
+                        "pointer": "data/attributes"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
                           },
                           "source": {
                             "type": "object",

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -43,6 +43,69 @@ RSpec.describe 'Power Of Attorney', type: :request do
                 end
               end
             end
+
+            context 'when the current poa is not associated with an organization' do
+              context 'when multiple representatives share the poa code' do
+                context 'when there is one unique representative_id' do
+                  before do
+                    create(:representative, representative_id: '12345', first_name: 'Bob', last_name: 'Law',
+                                            poa_codes: ['ABC'], phone: '123-456-7890')
+                    create(:representative, representative_id: '12345', first_name: 'Robert', last_name: 'Lawlaw',
+                                            poa_codes: ['ABC'], phone: '321-654-0987')
+                  end
+
+                  it 'returns the most recently created representative' do
+                    mock_ccg(scopes) do |auth_header|
+                      allow(BGS::PowerOfAttorneyVerifier)
+                        .to receive(:new)
+                        .and_return(OpenStruct.new(current_poa_code: 'ABC'))
+
+                      expected_response = {
+                        'code' => 'ABC',
+                        'name' => 'Robert Lawlaw',
+                        'phone' => {
+                          'number' => '321-654-0987'
+                        },
+                        'type' => 'individual'
+                      }
+
+                      get get_poa_path, headers: auth_header
+
+                      response_body = JSON.parse(response.body)
+
+                      expect(response).to have_http_status(:ok)
+                      expect(response_body).to eq(expected_response)
+                    end
+                  end
+                end
+
+                context 'when there are multiple unique representative_ids' do
+                  before do
+                    create(:representative, representative_id: '67890', poa_codes: ['EDF'])
+                    create(:representative, representative_id: '54321', poa_codes: ['EDF'])
+                  end
+
+                  it 'returns a meaningful 422' do
+                    mock_ccg(scopes) do |auth_header|
+                      allow(BGS::PowerOfAttorneyVerifier)
+                        .to receive(:new)
+                        .and_return(OpenStruct.new(current_poa_code: 'EDF'))
+
+                      detail = 'Could not retrieve Power of Attorney due to multiple representatives with code: EDF'
+
+                      get get_poa_path, headers: auth_header
+
+                      response_body = JSON.parse(response.body)['errors'][0]
+
+                      expect(response).to have_http_status(:unprocessable_entity)
+                      expect(response_body['title']).to eq('Unprocessable entity')
+                      expect(response_body['status']).to eq('422')
+                      expect(response_body['detail']).to eq(detail)
+                    end
+                  end
+                end
+              end
+            end
           end
 
           context 'when not valid' do

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -105,7 +105,7 @@ describe 'PowerOfAttorney',
       describe 'Getting a 401 response' do
         response '401', 'Unauthorized' do
           schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
-                                                      'default.json')))
+                                                      'power_of_attorney', 'default.json')))
 
           let(:Authorization) { nil }
 
@@ -122,6 +122,45 @@ describe 'PowerOfAttorney',
           end
 
           it 'returns a 401 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+          end
+        end
+      end
+
+      describe 'Getting a 422 response' do
+        response '422', 'Unprocessable Entity' do
+          schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
+                                                      'power_of_attorney', 'default.json')))
+
+          before do |example|
+            expect_any_instance_of(local_bgs).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
+            allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
+              .and_return({ person_poa_history: nil })
+            Veteran::Service::Representative.new(representative_id: '12345',
+                                                 poa_codes: [poa_code],
+                                                 first_name: 'Firstname',
+                                                 last_name: 'Lastname',
+                                                 phone: '555-555-5555').save!
+            Veteran::Service::Representative.new(representative_id: '54321',
+                                                 poa_codes: [poa_code],
+                                                 first_name: 'Another',
+                                                 last_name: 'Name',
+                                                 phone: '222-222-2222').save!
+            mock_ccg(scopes) do |auth_header|
+              Authorization = auth_header # rubocop:disable Naming/ConstantName
+              submit_request(example.metadata)
+            end
+          end
+
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end
+
+          it 'returns a 422 response' do |example|
             assert_response_matches_metadata(example.metadata)
           end
         end
@@ -211,7 +250,7 @@ describe 'PowerOfAttorney',
       xdescribe 'Getting a 401 response', document: false do
         response '401', 'Unauthorized' do
           schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
-                                                      'default.json')))
+                                                      'power_of_attorney', 'default.json')))
 
           let(:Authorization) { nil }
 
@@ -236,7 +275,7 @@ describe 'PowerOfAttorney',
       xdescribe 'Getting a 422 response', document: false do
         response '422', 'Unprocessable Entity' do
           schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
-                                                      'default.json')))
+                                                      'power_of_attorney', 'default.json')))
 
           before do |example|
             mock_ccg(scopes) do |auth_header|
@@ -353,7 +392,7 @@ describe 'PowerOfAttorney',
       xdescribe 'Getting a 401 response', document: false do
         response '401', 'Unauthorized' do
           schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
-                                                      'default.json')))
+                                                      'power_of_attorney', 'default.json')))
 
           let(:Authorization) { nil }
 
@@ -378,7 +417,7 @@ describe 'PowerOfAttorney',
       xdescribe 'Getting a 422 response', document: false do
         response '422', 'Unprocessable Entity' do
           schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
-                                                      'default.json')))
+                                                      'power_of_attorney', 'default.json')))
 
           before do |example|
             mock_ccg(scopes) do |auth_header|

--- a/spec/support/schemas/claims_api/v2/errors/power_of_attorney/default.json
+++ b/spec/support/schemas/claims_api/v2/errors/power_of_attorney/default.json
@@ -1,0 +1,37 @@
+{
+  "required": ["errors"],
+  "properties": {
+    "errors": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "required": ["title", "detail"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "HTTP error title"
+          },
+          "detail": {
+            "type": "string",
+            "description": "HTTP error detail"
+          },
+          "status": {
+            "type": "string",
+            "description": "HTTP error status code"
+          },
+          "source": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Source of error",
+            "properties": {
+              "pointer": {
+                "type": "string",
+                "description": "Pointer to source of error"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds new lighthouse error handling to V2 POA
- Adds check for multiple representative_ids when poa_code is not for an organization
- Updates rswag and swagger documentation


## Related issue(s)
- [API-32383](https://jira.devops.va.gov/browse/API-32383)

## Testing done

- Verified behavior in postman using `services/claims/v2/veterans/{veteranId}/power-of-attorney`:
  - create local representative (1) with a poa code returned from any BGS lookup
  - hit the endpoint and verify representative (1) is returned
  - create another representative (2) with the same poa code and representative id as (1) but with a different first name
  - hit the endpoint and verify representative (2) is returned
  - create another representative (3) with the same poa code as (1) and (2) but with a different representative id
  - hit the endpoint and verify a 422 is returned

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/fcf2fad1-4e74-40fa-97f4-a80d42100cc8)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature