### PR TITLE
67399 all streamlines are waivers

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -79,9 +79,7 @@ module DebtsApi
 
     def streamline_adjustments(form)
       if @streamlined_data
-        if @is_streamlined
-          form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver'
-        end
+        form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver' if @is_streamlined
         form['streamlined'] = @is_streamlined
       end
     end

--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -80,10 +80,7 @@ module DebtsApi
     def streamline_adjustments(form)
       if @streamlined_data
         if @is_streamlined
-          reasons = form.dig('personalIdentification', 'fsrReason')
-          reasons_array = reasons.nil? ? [] : reasons.split(',').map(&:strip)
-          reasons = reasons_array.push('Automatically Approved').uniq.join(', ')
-          form['personalIdentification']['fsrReason'] = reasons
+          form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver'
         end
         form['streamlined'] = @is_streamlined
       end

--- a/modules/debts_api/spec/fixtures/fsr_forms/streamlined_fsr_form.json
+++ b/modules/debts_api/spec/fixtures/fsr_forms/streamlined_fsr_form.json
@@ -2,7 +2,7 @@
     "personal_identification": {
         "ssn": "1234",
         "file_number": "5678",
-        "fsr_reason": ""
+        "fsr_reason": "waiver, monthly"
     },
     "personal_data": {
         "veteran_full_name": {
@@ -208,21 +208,24 @@
         {
             "debt_type": "COPAY",
             "p_h_amt_due": "100",
-            "station": {"facilit_y_num": "123"}
+            "station": {"facilit_y_num": "123"},
+            "resolution_option": "waiver"
         },
         {
             "debt_type": "COPAY",
             "p_h_amt_due": "200",
             "station": {
                 "facilit_y_num": "123"
-            }
+            },
+            "resolution_option": "waiver"
         },
         {
             "debt_type": "COPAY",
             "p_h_amt_due": "300",
             "station": {
                 "facilit_y_num": "999"
-            }
+            },
+            "resolution_option": "monthly"
         }
     ],
     "streamlined":{

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe DebtsApi::V0::FsrFormBuilder, type: :service do
       it 'updates fsrReason' do
         vha_form = form_builder.vha_forms.first.form_data
         reasons = vha_form['personalIdentification']['fsrReason']
-        expect(reasons.include?('Automatically Approved')).to eq(true)
+        expect(reasons).to eq('Automatically Approved, Waiver')
       end
 
       it 'does not change fsrReason for non-streamlined waivers' do


### PR DESCRIPTION
## Summary
VHA has asked that all streamlined FSRs be given the `fsrReason` of waiver. 

## Related issue(s)
[67399](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/67399)


## Testing done
- Specs green

## What areas of the site does it impact?
Streamlined Waiver FSR submissions

## Acceptance criteria

- [ ]  When a veteran qualifies for a streamlined waiver but requests a compromise, we should submit that FSR as a waiver.


