### PR TITLE
Update running_natively.md

### DIFF
--- a/docs/setup/running_natively.md
+++ b/docs/setup/running_natively.md
@@ -22,7 +22,7 @@ they would be when running rails directly.
 ### Running tests in parallel
 - NOTE: Running specs in parallel requires that your development database exists, and is up to date. If necessary, you may need to run `bundle exec rake db:create` and `bundle exec rake db:migrate` before the following steps.
 - `RAILS_ENV=test bundle exec rake parallel:setup` - This prepares all of the test databases. It will create a test database for each processor on your computer.
-- `RAILS_ENV=test NOCOVERAGE=true bundle exec rake parallel:spec` - This runs the entire test suite. Optionally, a folder path can be given as a parameter. Each file is assigned a processor, so it probably doesn't make sense to pass an individual file to run it in parallel. It is currently suggested to forgo the coverage testing by adding `NOCOVERAGE=true` flag (currently the coverage check will fail, even if the test suite passes). If you would like to check coverage for the test run, remove that flag.
+- `RAILS_ENV=test NOCOVERAGE=true bundle exec parallel_rspec spec modules` - This runs the entire test suite. Optionally, a folder path can be given as a parameter. Each file is assigned a processor, so it probably doesn't make sense to pass an individual file to run it in parallel. It is currently suggested to forgo the coverage testing by adding `NOCOVERAGE=true` flag (currently the coverage check will fail, even if the test suite passes). If you would like to check coverage for the test run, remove that flag.
 
 ### Running linters
 


### PR DESCRIPTION
## Summary

- This command was missing `modules`, 
- I updated confluence and that will update the Platform Website. [Diff is here](https://vfs.atlassian.net/wiki/pages/diffpagesbyversion.action?pageId=1893793863&selectedPageVersions=16&selectedPageVersions=17)

## Related issue(s)
- brought up in this comment: https://github.com/department-of-veterans-affairs/vets-api/pull/14606/files/08fd727d1da826cca6529bdf0d2b0e5fb0fa173a#r1428598978


## Testing done

```
rebeccatolmach ~/git/vets-api RAILS_ENV=test NOCOVERAGE=true bundle exec parallel_rspec spec modules
10 processes for 1563 specs, ~ 156 specs per process
...
```
Compared to:
```
rebeccatolmach ~/git/vets-api RAILS_ENV=test NOCOVERAGE=true bundle exec rake parallel:spec
...
10 processes for 922 specs, ~ 92 specs per process
```
