### PR TITLE
Remove feature flags for v3 appeals forms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -304,12 +304,6 @@ features:
   decision_review_monthly_stats_report_enabled:
     actor_type: user
     description: Enables the monthly decision review stats report email
-  decision_review_higher_level_review_pdf_v3:
-    actor_type: user
-    description: Defaults to v3 of the Higher-Level Review PDF form instead of v2
-  decision_review_supplemental_claim_pdf_v3:
-    actor_type: user
-    description: Defaults to v3 of the Supplemental Claim PDF form instead of v2
   decision_review_sc_pact_act_boolean:
     actor_type: user
     description: Adds a 'potentialPactAct' field to the Supplemental Claims V2 API schema

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -35,8 +35,7 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def create
     @higher_level_review.save
-    pdf_version = Flipper.enabled?(:decision_review_higher_level_review_pdf_v3) ? 'v3' : 'v2'
-    AppealsApi::PdfSubmitJob.perform_async(@higher_level_review.id, 'AppealsApi::HigherLevelReview', pdf_version)
+    AppealsApi::PdfSubmitJob.perform_async(@higher_level_review.id, 'AppealsApi::HigherLevelReview', 'v3')
     if @higher_level_review.veteran_icn.blank?
       AppealsApi::AddIcnUpdater.perform_async(@higher_level_review.id, 'AppealsApi::HigherLevelReview')
     end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
@@ -44,8 +44,7 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
 
     sc.save
 
-    pdf_version = Flipper.enabled?(:decision_review_supplemental_claim_pdf_v3) ? 'v3' : 'v2'
-    AppealsApi::PdfSubmitJob.perform_async(sc.id, 'AppealsApi::SupplementalClaim', pdf_version)
+    AppealsApi::PdfSubmitJob.perform_async(sc.id, 'AppealsApi::SupplementalClaim', 'v3')
     AppealsApi::AddIcnUpdater.perform_async(sc.id, 'AppealsApi::SupplementalClaim') if sc.veteran_icn.blank?
 
     render json: AppealsApi::SupplementalClaimSerializer.new(sc).serializable_hash


### PR DESCRIPTION
## Summary

- Ensures v3 of the form PDF is always used for Supplemental Claims and Higher-Level Reviews. These flags are already set to use v3 in production.
- Note that the NOD form never had a feature flag, but was updated months ago (there were no breaking changes to the form fields)

## Related issue(s)

## Testing done

## What areas of the site does it impact?
- Decision Reviews v2 and the Supplemental Claims v0 and Higher-Level Reviews v0 APIs.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
