### PR TITLE
BE | Ask VA API: GET `/topics` live data

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/static_data_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/static_data_controller.rb
@@ -8,7 +8,7 @@ module AskVAApi
 
       def index
         service = Crm::Service.new(icn: 'a')
-        data = service.call(endpoint: 'ping')
+        data = service.call(endpoint: 'topics')
         render json: data.to_json, status: :ok
       end
 

--- a/modules/ask_va_api/spec/requests/v0/static_data_spec.rb
+++ b/modules/ask_va_api/spec/requests/v0/static_data_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AskVAApi::V0::StaticDataController, type: :request do
 
     before do
       entity = OpenStruct.new(id: nil, info: 'pong')
-      allow_any_instance_of(Crm::Service).to receive(:call).with(endpoint: 'ping').and_return(entity)
+      allow_any_instance_of(Crm::Service).to receive(:call).with(endpoint: 'topics').and_return(entity)
       get index_path
     end
 


### PR DESCRIPTION
## Summary

- Updated `StaticData#Index` to get `/topics` instead of `ping`

## Related issue(s)
- department-of-veterans-affairs/ask-va#492

## Testing done

- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *Describe the tests completed and the results*

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
