### PR TITLE
Fix email length bug in HLR v3 PDF submission

### DIFF
--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v3/pages/additional_issues.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v3/pages/additional_issues.rb
@@ -51,15 +51,15 @@ module AppealsApi
           end
 
           def short_veteran_email?
-            form_data.veteran.email.length <= Structure::SHORT_EMAIL_THRESHOLD
+            form_data.veteran.email.blank? || form_data.veteran.email.length <= Structure::SHORT_EMAIL_THRESHOLD
           end
 
           def short_claimant_email?
-            form_data.claimant.email.length <= Structure::SHORT_EMAIL_THRESHOLD
+            form_data.claimant.email.blank? || form_data.claimant.email.length <= Structure::SHORT_EMAIL_THRESHOLD
           end
 
           def short_rep_email?
-            form_data.rep_email.length <= Structure::SHORT_EMAIL_THRESHOLD
+            form_data.rep_email.blank? || form_data.rep_email.length <= Structure::SHORT_EMAIL_THRESHOLD
           end
 
           def extra_issues_table_data


### PR DESCRIPTION


## Summary

An incorrect check for the length of a representative email was raising errors when we tried to switch to v3 instead of v2 of the HLR form. This should fix the problem.

## Related issue(s)

None

## Testing done

Manually tested. The automated PDF generation tests that we have for v3 of the HLR form cannot successfully run in the k8s branch of this repo for reasons we don't understand, so we haven't been able to add many automated tests for it.

## What areas of the site does it impact?
- This updates the processing code for version 3 of the Higher-Level Review form so that it doesn't error when processing an HLR with a representative but no email for that representative. We have determined that, so far, this impacts roughly 2% of users, but this percentage may change significantly based on new submissions in the future.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
