### PR TITLE
Upgrade active_model_serializer to v0.10.14 with monkey patch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -723,6 +723,7 @@ config/freshclam.conf @department-of-veterans-affairs/va-api-engineers @departme
 config/health_care_application @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/01_redis.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/aal.rb @department-of-veterans-affairs/vsp-identity
+config/initializers/active_model_serializers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/add_local_config.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/apivore_validator_monkeypatch.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/app_info.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 gem 'rails', github: 'rails/rails', branch: '6-1-stable'
 
 gem 'aasm'
-gem 'active_model_serializers', git: 'https://github.com/department-of-veterans-affairs/active_model_serializers', branch: 'master'
+gem 'active_model_serializers'
 gem 'activerecord-import'
 gem 'activerecord-postgis-adapter'
 gem 'addressable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,4 @@
 GIT
-  remote: https://github.com/department-of-veterans-affairs/active_model_serializers
-  revision: 19015caa80227e5ae5d62179129edcaa43fb3d9d
-  branch: master
-  specs:
-    active_model_serializers (0.10.4.vsp)
-      actionpack (>= 4.1)
-      activemodel (>= 4.1)
-      case_transform (>= 0.2)
-      jsonapi (= 0.1.1.beta6)
-
-GIT
   remote: https://github.com/department-of-veterans-affairs/apivore
   revision: b5b6c9803334f9ddc1c11e4f201fdc9f6353ef59
   branch: master
@@ -214,6 +203,11 @@ GEM
     Ascii85 (1.1.0)
     aasm (5.5.0)
       concurrent-ruby (~> 1.0)
+    active_model_serializers (0.10.14)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activerecord-import (1.5.0)
       activerecord (>= 4.2)
     activerecord-postgis-adapter (7.1.1)
@@ -574,9 +568,6 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
-    jsonapi (0.1.1.beta6)
-      jsonapi-parser (= 0.1.1.beta3)
-      jsonapi-renderer (= 0.1.1.beta1)
     jsonapi-parser (0.1.1.beta3)
     jsonapi-renderer (0.1.1.beta1)
     jsonapi-serializer (2.2.0)
@@ -1052,7 +1043,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  active_model_serializers!
+  active_model_serializers
   activerecord-import
   activerecord-postgis-adapter
   addressable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,8 @@ GEM
     blueprinter (0.30.0)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
-    brakeman (6.1.0)
+    brakeman (6.1.1)
+      racc
     breakers (0.7.1)
       faraday (>= 1.2.0, < 3.0)
       multi_json (~> 1.0)

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -47,6 +47,21 @@ module CustomPaginationLinks
   end
 end
 
+# In v0.10.14 as_json removes id if id is blank
+# This monkey patch is to override as_json and let nil be ""
+# https://github.com/rails-api/active_model_serializers/blob/v0.10.14/lib/active_model_serializers/adapter/json_api/resource_identifier.rb#L43
+module ActiveModelSerializers
+  module Adapter
+    class JsonApi
+      class ResourceIdentifier
+        def as_json
+          { id: id.to_s, type: }
+        end
+      end
+    end
+  end
+end
+
 # Prepend the custom module so that it overrides those in the gem.
 ActiveModelSerializers::Adapter::JsonApi::PaginationLinks.prepend CustomPaginationLinks
 ActiveModelSerializers.config.adapter = :json_api


### PR DESCRIPTION
## Summary

- upgrade `active_model_serializer` to v0.10.14
- remove `active_model_serializer` gem from `department-of-veterans-affairs` source
- add monkey patch to override `as_json` in `config/initializers/active_model_serializers.rb`
- v0.10.14 doesn't allow `id` to be `blank` which is why the monkey patch was required

## Related issue(s)
- [Issue #72560](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72560)
- [Issue #71543](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71543)

## Testing done
- local testing 
- comparing serialized data of spec/requests/va_profile/email_address_request_spec.rb

## What areas of the site does it impact?
- API endpoints that use AMS including under app/controller, modules (appeals_api, meb_api, mobile, my_health, test_user_dashboard, va_forms, vba_documents, veteran)  

## Acceptance criteria
- [x] `active_model_serializer` gem is v0.10.14
- [x] serialized data contains empty string for `id` where `id` is `nil` in serializer
