### PR TITLE
Update brakeman to 6.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,8 @@ GEM
     blueprinter (0.30.0)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
-    brakeman (6.1.0)
+    brakeman (6.1.1)
+      racc
     breakers (0.7.1)
       faraday (>= 1.2.0, < 3.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
## Summary

- Our code checks expect the latest version of brakeman: https://github.com/department-of-veterans-affairs/vets-api/blob/master/.github/workflows/code_checks.yml#L27, so I've updated to the latest using `bundle update brakeman`.

## Related issue(s)
- This failed here: https://github.com/department-of-veterans-affairs/vets-api/actions/runs/7330733936
- I was notified about it here: https://dsva.slack.com/archives/C039HRTHXDH/p1703605510200619


## Testing done

Before:
```
rebeccatolmach ~/git/vets-api bundle exec brakeman --ensure-latest --confidence-level=2
Could not find brakeman-6.1.1 in locally installed gems
```

After
```
rebeccatolmach ~/git/vets-api bundle update brakeman
...
Bundle updated!
rebeccatolmach ~/git/vets-api bundle exec brakeman --ensure-latest --confidence-level=2
Loading scanner...
Processing application in /Users/rebeccatolmach/git/vets-api
Processing gems...                      
[Notice] Detected Rails 6 application
...
```
🎉 

