### PR TITLE
67399 - Update fsr reason to automatically approved, waiver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,16 @@ PATH
     vye (0.1.0)
 
 GEM
+  remote: https://enterprise.contribsys.com/
+  specs:
+    sidekiq-ent (2.5.3)
+      einhorn (>= 0.7.4)
+      sidekiq (>= 6.5.0, < 7)
+      sidekiq-pro (>= 5.5.0, < 6)
+    sidekiq-pro (5.5.8)
+      sidekiq (~> 6.0, >= 6.5.6)
+
+GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -380,6 +390,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -1196,6 +1207,8 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq (>= 6.4.0)
+  sidekiq-ent!
+  sidekiq-pro!
   sidekiq_alive
   simple_forms_api!
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,16 +199,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (2.5.3)
-      einhorn (>= 0.7.4)
-      sidekiq (>= 6.5.0, < 7)
-      sidekiq-pro (>= 5.5.0, < 6)
-    sidekiq-pro (5.5.8)
-      sidekiq (~> 6.0, >= 6.5.6)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -390,7 +380,6 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -1207,8 +1196,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq (>= 6.4.0)
-  sidekiq-ent!
-  sidekiq-pro!
   sidekiq_alive
   simple_forms_api!
   simplecov

--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -79,7 +79,7 @@ module DebtsApi
 
     def streamline_adjustments(form)
       if @streamlined_data
-        form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver' unless !@is_streamlined
+        form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver' if @is_streamlined
         form['streamlined'] = @is_streamlined
       end
     end

--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -80,10 +80,7 @@ module DebtsApi
     def streamline_adjustments(form)
       if @streamlined_data
         if @is_streamlined
-          reasons = form.dig('personalIdentification', 'fsrReason')
-          reasons_array = reasons.nil? ? [] : reasons.split(',').map(&:strip)
-          reasons = reasons_array.push('Automatically Approved').uniq.join(', ')
-          form['personalIdentification']['fsrReason'] = reasons
+          form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver'
         end
         form['streamlined'] = @is_streamlined
       end

--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -79,9 +79,7 @@ module DebtsApi
 
     def streamline_adjustments(form)
       if @streamlined_data
-        if @is_streamlined
-          form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver'
-        end
+        form['personalIdentification']['fsrReason'] = 'Automatically Approved, Waiver' unless !@is_streamlined
         form['streamlined'] = @is_streamlined
       end
     end

--- a/modules/debts_api/spec/fixtures/fsr_forms/streamlined_fsr_form.json
+++ b/modules/debts_api/spec/fixtures/fsr_forms/streamlined_fsr_form.json
@@ -2,7 +2,7 @@
     "personal_identification": {
         "ssn": "1234",
         "file_number": "5678",
-        "fsr_reason": ""
+        "fsr_reason": "waiver, monthly"
     },
     "personal_data": {
         "veteran_full_name": {
@@ -208,21 +208,24 @@
         {
             "debt_type": "COPAY",
             "p_h_amt_due": "100",
-            "station": {"facilit_y_num": "123"}
+            "station": {"facilit_y_num": "123"},
+            "resolution_option": "waiver"
         },
         {
             "debt_type": "COPAY",
             "p_h_amt_due": "200",
             "station": {
                 "facilit_y_num": "123"
-            }
+            },
+            "resolution_option": "waiver"
         },
         {
             "debt_type": "COPAY",
             "p_h_amt_due": "300",
             "station": {
                 "facilit_y_num": "999"
-            }
+            },
+            "resolution_option": "monthly"
         }
     ],
     "streamlined":{

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe DebtsApi::V0::FsrFormBuilder, type: :service do
       it 'updates fsrReason' do
         vha_form = form_builder.vha_forms.first.form_data
         reasons = vha_form['personalIdentification']['fsrReason']
-        expect(reasons.include?('Automatically Approved')).to eq(true)
+        expect(reasons).to eq('Automatically Approved, Waiver')
       end
 
       it 'does not change fsrReason for non-streamlined waivers' do


### PR DESCRIPTION
## Summary

- Updates FSR reason to always be "Automatically Approved, Waiver" when using streamlined waiver
-  Not a bug, just an update
- *Manually defines FSR reason to always be "Automatically Approved, Waiver", solution ensures all streamlined waivers have the proper reason regardless of user input*
- *debts-api team, yes*
- *N/A*

## Related issue(s)
- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/67399)


## Testing done

- *Rspec changes, tested and working, specs green*
-  ```bundle exec rspec modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb```
- ```ruby
  it 'updates fsrReason' do
        vha_form = form_builder.vha_forms.first.form_data
        reasons = vha_form['personalIdentification']['fsrReason']
        expect(reasons).to eq('Automatically Approved, Waiver')
      end


## What areas of the site does it impact?
*Streamlined FSR's*

## Acceptance criteria

- [X ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X ]  No error nor warning in the console.
- [X ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
