### PR TITLE
API-32464: Remove Slack Alerts for Missing Feature Flags (`AppealsApi`, `VAForms`, `VBADocuments` Modules)

### DIFF
--- a/lib/flipper/utilities/bulk_feature_checker.rb
+++ b/lib/flipper/utilities/bulk_feature_checker.rb
@@ -4,21 +4,14 @@ module Flipper
   module Utilities
     module BulkFeatureChecker
       # Accepts an array of feature keys (string or symbol format) and returns a result hash of which keys
-      # are enabled, disabled, or missing; feature keys are returned in string format
+      # are enabled or disabled; feature keys are returned in string format
       def self.enabled_status(features)
         result = {
           enabled: [],
-          disabled: [],
-          missing: []
+          disabled: []
         }
-        existing_features = Flipper.features.map(&:name)
 
         Array(features).map(&:to_s).each do |feature|
-          unless existing_features.include?(feature)
-            result[:missing] << feature
-            next
-          end
-
           if Flipper.enabled?(feature)
             result[:enabled] << feature
           else

--- a/modules/appeals_api/app/sidekiq/appeals_api/flipper_status_alert.rb
+++ b/modules/appeals_api/app/sidekiq/appeals_api/flipper_status_alert.rb
@@ -15,8 +15,8 @@ module AppealsApi
     def perform
       features_to_check = load_features_from_config
       if features_to_check.present?
-        @feature_statuses = Flipper::Utilities::BulkFeatureChecker.enabled_status(features_to_check)
-        notify_slack unless @feature_statuses[:disabled].empty?
+        feature_statuses = Flipper::Utilities::BulkFeatureChecker.enabled_status(features_to_check)
+        notify_slack(feature_statuses[:disabled]) unless feature_statuses[:disabled].empty?
       end
     end
 
@@ -56,11 +56,11 @@ module AppealsApi
       end
     end
 
-    def notify_slack
+    def notify_slack(disabled_features)
       slack_details = {
         class: self.class.name,
         warning: "#{WARNING_EMOJI} One or more features expected to be enabled were found to be disabled.",
-        disabled_flags: "#{TRAFFIC_LIGHT_EMOJI} #{@feature_statuses[:disabled].join(', ')} #{TRAFFIC_LIGHT_EMOJI}"
+        disabled_flags: "#{TRAFFIC_LIGHT_EMOJI} #{disabled_features.join(', ')} #{TRAFFIC_LIGHT_EMOJI}"
       }
       AppealsApi::Slack::Messager.new(slack_details).notify!
     end

--- a/modules/appeals_api/app/sidekiq/appeals_api/flipper_status_alert.rb
+++ b/modules/appeals_api/app/sidekiq/appeals_api/flipper_status_alert.rb
@@ -8,8 +8,7 @@ module AppealsApi
     include Sidekiq::Job
 
     WARNING_EMOJI = ':warning:'
-    DISABLED_FLAG_EMOJI = ':vertical_traffic_light:'
-    MISSING_FLAG_EMOJI = ':no_entry_sign:'
+    TRAFFIC_LIGHT_EMOJI = ':vertical_traffic_light:'
 
     sidekiq_options retry: 5, unique_for: 30.minutes
 
@@ -17,8 +16,7 @@ module AppealsApi
       features_to_check = load_features_from_config
       if features_to_check.present?
         @feature_statuses = Flipper::Utilities::BulkFeatureChecker.enabled_status(features_to_check)
-
-        slack_notify unless all_features_enabled?
+        notify_slack unless @feature_statuses[:disabled].empty?
       end
     end
 
@@ -35,7 +33,7 @@ module AppealsApi
       if features.empty?
         AppealsApi::Slack::Messager.new(
           {
-            warning: "#{WARNING_EMOJI} #{self.class.name} has no configured enabled features",
+            warning: "#{WARNING_EMOJI} #{self.class.name} has no configured enabled features.",
             file_path: file_path.to_s
           }
         ).notify!
@@ -50,7 +48,7 @@ module AppealsApi
       else
         AppealsApi::Slack::Messager.new(
           {
-            warning: "#{WARNING_EMOJI} #{self.class.name} features file does not exist",
+            warning: "#{WARNING_EMOJI} #{self.class.name} features file does not exist.",
             file_path: path.to_s
           }
         ).notify!
@@ -58,28 +56,13 @@ module AppealsApi
       end
     end
 
-    def all_features_enabled?
-      @feature_statuses[:missing].empty? && @feature_statuses[:disabled].empty?
-    end
-
-    def slack_notify
+    def notify_slack
       slack_details = {
         class: self.class.name,
-        warning: "#{WARNING_EMOJI} One or more features expected to be enabled were found disabled or missing",
-        disabled_flags: slack_message(:disabled),
-        missing_flags: slack_message(:missing)
+        warning: "#{WARNING_EMOJI} One or more features expected to be enabled were found to be disabled.",
+        disabled_flags: "#{TRAFFIC_LIGHT_EMOJI} #{@feature_statuses[:disabled].join(', ')} #{TRAFFIC_LIGHT_EMOJI}"
       }
-
       AppealsApi::Slack::Messager.new(slack_details).notify!
-    end
-
-    def slack_message(flag_category)
-      if @feature_statuses[flag_category].present?
-        emoji = self.class.const_get("#{flag_category.upcase}_FLAG_EMOJI")
-        "#{emoji} #{@feature_statuses[flag_category].join(', ')} #{emoji}"
-      else
-        'None'
-      end
     end
   end
 end

--- a/modules/appeals_api/spec/sidekiq/appeals_api/flipper_status_alert_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/flipper_status_alert_spec.rb
@@ -17,7 +17,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
 
     let(:missing_file_message) { "#{warning_emoji} #{described_class} features file does not exist." }
     let(:no_features_message) { "#{warning_emoji} #{described_class} has no configured enabled features." }
-    let(:flag_status_message) { "#{warning_emoji} One or more features expected to be enabled were found to be disabled." }
+    let(:flag_message) { "#{warning_emoji} One or more features expected to be enabled were found to be disabled." }
 
     before do
       allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
@@ -99,7 +99,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expected_notify = {
         class: described_class.name,
-        warning: flag_status_message,
+        warning: flag_message,
         disabled_flags: "#{traffic_light_emoji} feature2, feature3 #{traffic_light_emoji}"
       }
       expect(AppealsApi::Slack::Messager).to receive(:new).with(expected_notify).and_return(messager_instance)

--- a/modules/appeals_api/spec/sidekiq/appeals_api/flipper_status_alert_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/flipper_status_alert_spec.rb
@@ -13,13 +13,15 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
     let(:config_file_path) { AppealsApi::Engine.root.join('config', 'flipper', 'enabled_features.yml') }
 
     let(:warning_emoji) { described_class::WARNING_EMOJI }
-    let(:disabled_flag_emoji) { described_class::DISABLED_FLAG_EMOJI }
-    let(:missing_flag_emoji) { described_class::MISSING_FLAG_EMOJI }
+    let(:traffic_light_emoji) { described_class::TRAFFIC_LIGHT_EMOJI }
 
-    let(:missing_file_message) { "#{warning_emoji} #{described_class} features file does not exist" }
-    let(:no_features_message) { "#{warning_emoji} #{described_class} has no configured enabled features" }
-    let(:flag_status_message) do
-      "#{warning_emoji} One or more features expected to be enabled were found disabled or missing"
+    let(:missing_file_message) { "#{warning_emoji} #{described_class} features file does not exist." }
+    let(:no_features_message) { "#{warning_emoji} #{described_class} has no configured enabled features." }
+    let(:flag_status_message) { "#{warning_emoji} One or more features expected to be enabled were found to be disabled." }
+
+    before do
+      allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
+      allow(messager_instance).to receive(:notify!)
     end
 
     it 'notifies Slack of missing config file when no config file found' do
@@ -53,11 +55,9 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common and current env features when config file contains both' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'production' => %w[feature2] })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1 feature2] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1 feature2]).and_return(bulk_checker_result)
-      allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
-      allow(messager_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'production') do
         described_class.new.perform
@@ -66,11 +66,9 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common features only when config file contains no current env features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'development' => nil })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
-      allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
-      allow(messager_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'development') do
         described_class.new.perform
@@ -79,11 +77,9 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of current env features only when config file contains no common features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => nil, 'staging' => %w[feature1] })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
-      allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
-      allow(messager_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'staging') do
         described_class.new.perform
@@ -104,38 +100,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
       expected_notify = {
         class: described_class.name,
         warning: flag_status_message,
-        disabled_flags: "#{disabled_flag_emoji} feature2, feature3 #{disabled_flag_emoji}",
-        missing_flags: 'None'
-      }
-      expect(AppealsApi::Slack::Messager).to receive(:new).with(expected_notify).and_return(messager_instance)
-      expect(messager_instance).to receive(:notify!).once
-
-      described_class.new.perform
-    end
-
-    it 'notifies Slack when some features are missing' do
-      bulk_checker_result = { enabled: %w[feature1], disabled: [], missing: %w[feature2 feature3] }
-      allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
-      expected_notify = {
-        class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: 'None',
-        missing_flags: "#{missing_flag_emoji} feature2, feature3 #{missing_flag_emoji}"
-      }
-      expect(AppealsApi::Slack::Messager).to receive(:new).with(expected_notify).and_return(messager_instance)
-      expect(messager_instance).to receive(:notify!).once
-
-      described_class.new.perform
-    end
-
-    it 'notifies slack when there are disabled and missing features' do
-      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3], missing: %w[feature4 feature5] }
-      allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
-      expected_notify = {
-        class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: "#{disabled_flag_emoji} feature2, feature3 #{disabled_flag_emoji}",
-        missing_flags: "#{missing_flag_emoji} feature4, feature5 #{missing_flag_emoji}"
+        disabled_flags: "#{traffic_light_emoji} feature2, feature3 #{traffic_light_emoji}"
       }
       expect(AppealsApi::Slack::Messager).to receive(:new).with(expected_notify).and_return(messager_instance)
       expect(messager_instance).to receive(:notify!).once

--- a/modules/appeals_api/spec/sidekiq/appeals_api/flipper_status_alert_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/flipper_status_alert_spec.rb
@@ -55,7 +55,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common and current env features when config file contains both' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'production' => %w[feature2] })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1 feature2]).and_return(bulk_checker_result)
 
@@ -66,7 +66,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common features only when config file contains no current env features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'development' => nil })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
 
@@ -77,7 +77,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of current env features only when config file contains no common features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => nil, 'staging' => %w[feature1] })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
 
@@ -87,7 +87,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
     end
 
     it 'does not notify Slack when all features are enabled' do
-      bulk_checker_result = { enabled: %w[feature1 feature2], disabled: [], missing: [] }
+      bulk_checker_result = { enabled: %w[feature1 feature2], disabled: [] }
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expect(AppealsApi::Slack::Messager).not_to receive(:new)
 
@@ -95,7 +95,7 @@ describe AppealsApi::FlipperStatusAlert, type: :job do
     end
 
     it 'notifies Slack when some features are disabled' do
-      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3], missing: [] }
+      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3] }
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expected_notify = {
         class: described_class.name,

--- a/modules/va_forms/spec/sidekiq/flipper_status_alert_spec.rb
+++ b/modules/va_forms/spec/sidekiq/flipper_status_alert_spec.rb
@@ -13,12 +13,14 @@ describe VAForms::FlipperStatusAlert, type: :job do
     let(:config_file_path) { VAForms::Engine.root.join('config', 'flipper', 'enabled_features.yml') }
 
     let(:warning_emoji) { described_class::WARNING_EMOJI }
-    let(:disabled_flag_emoji) { described_class::DISABLED_FLAG_EMOJI }
-    let(:missing_flag_emoji) { described_class::MISSING_FLAG_EMOJI }
+    let(:traffic_light_emoji) { described_class::TRAFFIC_LIGHT_EMOJI }
 
-    let(:missing_file_message) { "#{warning_emoji} #{described_class} features file does not exist" }
-    let(:flag_status_message) do
-      "#{warning_emoji} One or more features expected to be enabled were found disabled or missing"
+    let(:missing_file_message) { "#{warning_emoji} #{described_class} features file does not exist." }
+    let(:flag_message) { "#{warning_emoji} One or more features expected to be enabled were found to be disabled." }
+
+    before do
+      allow(VAForms::Slack::Messenger).to receive(:new).and_return(messenger_instance)
+      allow(messenger_instance).to receive(:notify!)
     end
 
     it 'notifies Slack of missing config file when no config file found' do
@@ -32,11 +34,9 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common and current env features when config file contains both' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'production' => %w[feature2] })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1 feature2] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1 feature2]).and_return(bulk_checker_result)
-      allow(VAForms::Slack::Messenger).to receive(:new).and_return(messenger_instance)
-      allow(messenger_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'production') do
         described_class.new.perform
@@ -45,11 +45,9 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common features only when config file contains no current env features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'development' => nil })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
-      allow(VAForms::Slack::Messenger).to receive(:new).and_return(messenger_instance)
-      allow(messenger_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'development') do
         described_class.new.perform
@@ -58,11 +56,9 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of current env features only when config file contains no common features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => nil, 'staging' => %w[feature1] })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
-      allow(VAForms::Slack::Messenger).to receive(:new).and_return(messenger_instance)
-      allow(messenger_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'staging') do
         described_class.new.perform
@@ -84,41 +80,8 @@ describe VAForms::FlipperStatusAlert, type: :job do
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expected_notify = {
         class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: "#{disabled_flag_emoji} feature2, feature3 #{disabled_flag_emoji}",
-        missing_flags: 'None'
-      }
-      expect(VAForms::Slack::Messenger).to receive(:new).with(expected_notify).and_return(messenger_instance)
-      expect(messenger_instance).to receive(:notify!).once
-
-      described_class.new.perform
-    end
-
-    it 'notifies Slack when some features are missing' do
-      allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2 feature3] })
-      bulk_checker_result = { enabled: %w[feature1], disabled: [], missing: %w[feature2 feature3] }
-      allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
-      expected_notify = {
-        class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: 'None',
-        missing_flags: "#{missing_flag_emoji} feature2, feature3 #{missing_flag_emoji}"
-      }
-      expect(VAForms::Slack::Messenger).to receive(:new).with(expected_notify).and_return(messenger_instance)
-      expect(messenger_instance).to receive(:notify!).once
-
-      described_class.new.perform
-    end
-
-    it 'notifies slack when there are disabled and missing features' do
-      allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2 feature3 feature4 feature5] })
-      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3], missing: %w[feature4 feature5] }
-      allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
-      expected_notify = {
-        class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: "#{disabled_flag_emoji} feature2, feature3 #{disabled_flag_emoji}",
-        missing_flags: "#{missing_flag_emoji} feature4, feature5 #{missing_flag_emoji}"
+        warning: flag_message,
+        disabled_flags: "#{traffic_light_emoji} feature2, feature3 #{traffic_light_emoji}"
       }
       expect(VAForms::Slack::Messenger).to receive(:new).with(expected_notify).and_return(messenger_instance)
       expect(messenger_instance).to receive(:notify!).once

--- a/modules/va_forms/spec/sidekiq/flipper_status_alert_spec.rb
+++ b/modules/va_forms/spec/sidekiq/flipper_status_alert_spec.rb
@@ -34,7 +34,7 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common and current env features when config file contains both' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'production' => %w[feature2] })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1 feature2]).and_return(bulk_checker_result)
 
@@ -45,7 +45,7 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common features only when config file contains no current env features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'development' => nil })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
 
@@ -56,7 +56,7 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of current env features only when config file contains no common features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => nil, 'staging' => %w[feature1] })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
 
@@ -67,7 +67,7 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'does not notify Slack when all features are enabled' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2] })
-      bulk_checker_result = { enabled: %w[feature1 feature2], disabled: [], missing: [] }
+      bulk_checker_result = { enabled: %w[feature1 feature2], disabled: [] }
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expect(VAForms::Slack::Messenger).not_to receive(:new)
 
@@ -76,7 +76,7 @@ describe VAForms::FlipperStatusAlert, type: :job do
 
     it 'notifies Slack when some features are disabled' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2 feature3] })
-      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3], missing: [] }
+      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3] }
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expected_notify = {
         class: described_class.name,

--- a/modules/vba_documents/app/sidekiq/vba_documents/flipper_status_alert.rb
+++ b/modules/vba_documents/app/sidekiq/vba_documents/flipper_status_alert.rb
@@ -8,17 +8,15 @@ module VBADocuments
     include Sidekiq::Job
 
     WARNING_EMOJI = ':warning:'
-    DISABLED_FLAG_EMOJI = ':vertical_traffic_light:'
-    MISSING_FLAG_EMOJI = ':no_entry_sign:'
+    TRAFFIC_LIGHT_EMOJI = ':vertical_traffic_light:'
 
     sidekiq_options retry: 5, unique_for: 30.minutes
 
     def perform
       features_to_check = load_features_from_config
       if features_to_check.present?
-        @feature_statuses = Flipper::Utilities::BulkFeatureChecker.enabled_status(features_to_check)
-
-        slack_notify unless all_features_enabled?
+        feature_statuses = Flipper::Utilities::BulkFeatureChecker.enabled_status(features_to_check)
+        notify_slack(feature_statuses[:disabled]) unless feature_statuses[:disabled].empty?
       end
     end
 
@@ -40,7 +38,7 @@ module VBADocuments
       else
         VBADocuments::Slack::Messenger.new(
           {
-            warning: "#{WARNING_EMOJI} #{self.class.name} features file does not exist",
+            warning: "#{WARNING_EMOJI} #{self.class.name} features file does not exist.",
             file_path: path.to_s
           }
         ).notify!
@@ -48,28 +46,13 @@ module VBADocuments
       end
     end
 
-    def all_features_enabled?
-      @feature_statuses[:missing].empty? && @feature_statuses[:disabled].empty?
-    end
-
-    def slack_notify
+    def notify_slack(disabled_features)
       slack_details = {
         class: self.class.name,
-        warning: "#{WARNING_EMOJI} One or more features expected to be enabled were found disabled or missing",
-        disabled_flags: slack_message(:disabled),
-        missing_flags: slack_message(:missing)
+        warning: "#{WARNING_EMOJI} One or more features expected to be enabled were found to be disabled.",
+        disabled_flags: "#{TRAFFIC_LIGHT_EMOJI} #{disabled_features.join(', ')} #{TRAFFIC_LIGHT_EMOJI}"
       }
-
       VBADocuments::Slack::Messenger.new(slack_details).notify!
-    end
-
-    def slack_message(flag_category)
-      if @feature_statuses[flag_category].present?
-        emoji = self.class.const_get("#{flag_category.upcase}_FLAG_EMOJI")
-        "#{emoji} #{@feature_statuses[flag_category].join(', ')} #{emoji}"
-      else
-        'None'
-      end
     end
   end
 end

--- a/modules/vba_documents/spec/sidekiq/flipper_status_alert_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/flipper_status_alert_spec.rb
@@ -13,12 +13,14 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
     let(:config_file_path) { VBADocuments::Engine.root.join('config', 'flipper', 'enabled_features.yml') }
 
     let(:warning_emoji) { described_class::WARNING_EMOJI }
-    let(:disabled_flag_emoji) { described_class::DISABLED_FLAG_EMOJI }
-    let(:missing_flag_emoji) { described_class::MISSING_FLAG_EMOJI }
+    let(:traffic_light_emoji) { described_class::TRAFFIC_LIGHT_EMOJI }
 
-    let(:missing_file_message) { "#{warning_emoji} #{described_class} features file does not exist" }
-    let(:flag_status_message) do
-      "#{warning_emoji} One or more features expected to be enabled were found disabled or missing"
+    let(:missing_file_message) { "#{warning_emoji} #{described_class} features file does not exist." }
+    let(:flag_message) { "#{warning_emoji} One or more features expected to be enabled were found to be disabled." }
+
+    before do
+      allow(VBADocuments::Slack::Messenger).to receive(:new).and_return(messenger_instance)
+      allow(messenger_instance).to receive(:notify!)
     end
 
     it 'notifies Slack of missing config file when no config file found' do
@@ -32,11 +34,9 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common and current env features when config file contains both' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'production' => %w[feature2] })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1 feature2] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1 feature2]).and_return(bulk_checker_result)
-      allow(VBADocuments::Slack::Messenger).to receive(:new).and_return(messenger_instance)
-      allow(messenger_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'production') do
         described_class.new.perform
@@ -45,11 +45,9 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common features only when config file contains no current env features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'development' => nil })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
-      allow(VBADocuments::Slack::Messenger).to receive(:new).and_return(messenger_instance)
-      allow(messenger_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'development') do
         described_class.new.perform
@@ -58,11 +56,9 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of current env features only when config file contains no common features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => nil, 'staging' => %w[feature1] })
-      bulk_checker_result = { enabled: [], disabled: [], missing: %w[feature1] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
-      allow(VBADocuments::Slack::Messenger).to receive(:new).and_return(messenger_instance)
-      allow(messenger_instance).to receive(:notify!)
 
       with_settings(Settings, vsp_environment: 'staging') do
         described_class.new.perform
@@ -84,41 +80,8 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expected_notify = {
         class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: "#{disabled_flag_emoji} feature2, feature3 #{disabled_flag_emoji}",
-        missing_flags: 'None'
-      }
-      expect(VBADocuments::Slack::Messenger).to receive(:new).with(expected_notify).and_return(messenger_instance)
-      expect(messenger_instance).to receive(:notify!).once
-
-      described_class.new.perform
-    end
-
-    it 'notifies Slack when some features are missing' do
-      allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2 feature3] })
-      bulk_checker_result = { enabled: %w[feature1], disabled: [], missing: %w[feature2 feature3] }
-      allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
-      expected_notify = {
-        class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: 'None',
-        missing_flags: "#{missing_flag_emoji} feature2, feature3 #{missing_flag_emoji}"
-      }
-      expect(VBADocuments::Slack::Messenger).to receive(:new).with(expected_notify).and_return(messenger_instance)
-      expect(messenger_instance).to receive(:notify!).once
-
-      described_class.new.perform
-    end
-
-    it 'notifies slack when there are disabled and missing features' do
-      allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2 feature3 feature4 feature5] })
-      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3], missing: %w[feature4 feature5] }
-      allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
-      expected_notify = {
-        class: described_class.name,
-        warning: flag_status_message,
-        disabled_flags: "#{disabled_flag_emoji} feature2, feature3 #{disabled_flag_emoji}",
-        missing_flags: "#{missing_flag_emoji} feature4, feature5 #{missing_flag_emoji}"
+        warning: flag_message,
+        disabled_flags: "#{traffic_light_emoji} feature2, feature3 #{traffic_light_emoji}"
       }
       expect(VBADocuments::Slack::Messenger).to receive(:new).with(expected_notify).and_return(messenger_instance)
       expect(messenger_instance).to receive(:notify!).once

--- a/modules/vba_documents/spec/sidekiq/flipper_status_alert_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/flipper_status_alert_spec.rb
@@ -34,7 +34,7 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common and current env features when config file contains both' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'production' => %w[feature2] })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1 feature2] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1 feature2]).and_return(bulk_checker_result)
 
@@ -45,7 +45,7 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of common features only when config file contains no current env features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1], 'development' => nil })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
 
@@ -56,7 +56,7 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'fetches enabled status of current env features only when config file contains no common features' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => nil, 'staging' => %w[feature1] })
-      bulk_checker_result = { enabled: [], disabled: %w[feature1], missing: [] }
+      bulk_checker_result = { enabled: [], disabled: %w[feature1] }
       expect(Flipper::Utilities::BulkFeatureChecker)
         .to receive(:enabled_status).with(%w[feature1]).and_return(bulk_checker_result)
 
@@ -67,7 +67,7 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'does not notify Slack when all features are enabled' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2] })
-      bulk_checker_result = { enabled: %w[feature1 feature2], disabled: [], missing: [] }
+      bulk_checker_result = { enabled: %w[feature1 feature2], disabled: [] }
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expect(VBADocuments::Slack::Messenger).not_to receive(:new)
 
@@ -76,7 +76,7 @@ describe VBADocuments::FlipperStatusAlert, type: :job do
 
     it 'notifies Slack when some features are disabled' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => %w[feature1 feature2 feature3] })
-      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3], missing: [] }
+      bulk_checker_result = { enabled: %w[feature1], disabled: %w[feature2 feature3] }
       allow(Flipper::Utilities::BulkFeatureChecker).to receive(:enabled_status).and_return(bulk_checker_result)
       expected_notify = {
         class: described_class.name,

--- a/spec/lib/flipper/utilities/bulk_feature_checker_spec.rb
+++ b/spec/lib/flipper/utilities/bulk_feature_checker_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
     let(:empty_result) do
       {
         enabled: [],
-        disabled: [],
-        missing: []
+        disabled: []
       }
     end
 
@@ -30,28 +29,12 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
       end
     end
 
-    context 'when all provided features are missing' do
-      let(:features) { %w[missing_feature1 missing_feature2] }
-      let(:expected_result) do
-        {
-          enabled: [],
-          disabled: [],
-          missing: features
-        }
-      end
-
-      it 'returns all features in the missing key' do
-        expect(subject).to match_array(expected_result)
-      end
-    end
-
     context 'when all provided features are enabled' do
       let(:features) { %w[enabled_feature1 enabled_feature2] }
       let(:expected_result) do
         {
           enabled: features,
-          disabled: [],
-          missing: []
+          disabled: []
         }
       end
 
@@ -71,8 +54,7 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
       let(:expected_result) do
         {
           enabled: [],
-          disabled: features,
-          missing: []
+          disabled: features
         }
       end
 
@@ -90,13 +72,11 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
     context 'when features in various states are provided' do
       let(:enabled_features) { %w[enabled_feature3 enabled_feature4] }
       let(:disabled_features) { %w[disabled_feature3 disabled_feature4] }
-      let(:missing_features) { %w[missing_feature3 missing_feature4] }
-      let(:features) { enabled_features + disabled_features + missing_features }
+      let(:features) { enabled_features + disabled_features }
       let(:expected_result) do
         {
           enabled: enabled_features,
-          disabled: disabled_features,
-          missing: missing_features
+          disabled: disabled_features
         }
       end
 
@@ -118,13 +98,11 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
     context 'when provided feature keys are symbols' do
       let(:enabled_features) { %i[enabled_feature5 enabled_feature6] }
       let(:disabled_features) { %i[disabled_feature5 disabled_feature6] }
-      let(:missing_features) { %i[missing_feature5 missing_feature6] }
-      let(:features) { enabled_features + disabled_features + missing_features }
+      let(:features) { enabled_features + disabled_features }
       let(:expected_result) do
         {
           enabled: enabled_features.map(&:to_s),
-          disabled: disabled_features.map(&:to_s),
-          missing: missing_features.map(&:to_s)
+          disabled: disabled_features.map(&:to_s)
         }
       end
 


### PR DESCRIPTION
## Summary
This PR updates the Slack alerts generated by the `FlipperStatusAlert` jobs in the `AppealsApi`, `VAForms`, and `VBADocuments` modules (i.e. all modules owned by Lighthouse Team Banana Peels) in order to exclude "missing" feature flags from the alerts. (Disabled feature flags will continue to be included in the alert.)

Previously, it was believed that feature flags suddenly missing from the database were a problem in deployed environments, but this turned out not to be the case. (There was only a problem with disabled features.) In addition, the code in `Flipper::Utilities::BulkFeatureChecker` to check for missing flags was providing inconsistent false positive results, i.e. stating that features were "missing" when they were not.

Therefore, this PR also removes the `:missing` key from the `Flipper::Utilities::BulkFeatureChecker` result, since it is unreliable. This change should _not_ affect any other teams beyond Team Banana Peels since this utility class is only used by the three modules already updated in this ticket.

## Related issue(s)
[API-32464](https://jira.devops.va.gov/browse/API-32464)

## Testing done
Job changes were tested locally and the specs were updated for the new behavior.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `FlipperStatusAlert` jobs for the `AppealsApi`, `VAForms`, and `VBADocuments` modules. It also impacts the `Flipper::Utilities::BulkFeatureChecker` behavior, which is only currently used by the aforementioned modules.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested.
