### PR TITLE
API-32157-single-service-period-20D

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -544,8 +544,14 @@ module ClaimsApi
                      end: regex_date_conversion(sp[:activeDutyEndDate]) })
         end
         sorted = arr&.sort_by { |sp| sp[:activeDutyEndDate] }
-        sorted.pop if sorted.count > 1
-        @pdf_data[:data][:attributes][:serviceInformation][:additionalPeriodsOfService] = sorted
+
+        if sorted.count > 1
+          sorted.pop
+          @pdf_data[:data][:attributes][:serviceInformation][:additionalPeriodsOfService] = sorted
+        else
+          @pdf_data[:data][:attributes][:serviceInformation][:additionalPeriodsOfService] = {}
+        end
+
         @pdf_data[:data][:attributes][:serviceInformation].delete(:servicePeriods)
         @pdf_data
       end

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -367,8 +367,8 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         component = serv_info[:serviceComponent]
         recent_start = serv_info[:mostRecentActiveService][:start]
         recent_end = serv_info[:mostRecentActiveService][:end]
-        addtl_start = serv_info[:additionalPeriodsOfService][0][:start]
-        addtl_end = serv_info[:additionalPeriodsOfService][0][:end]
+        addtl_start = serv_info&.dig('additionalPeriodsOfService', '0', 'start')
+        addtl_end = serv_info&.dig('additionalPeriodsOfService', '0', 'end')
         last_sep = serv_info[:placeOfLastOrAnticipatedSeparation]
         pow = serv_info[:confinedAsPrisonerOfWar]
         pow_start = serv_info[:prisonerOfWarConfinement][:confinementDates][0][:start]
@@ -394,8 +394,8 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(component).to eq('ACTIVE')
         expect(recent_start).to eq({ month: '11', day: '14', year: '2008' })
         expect(recent_end).to eq({ month: '10', day: '30', year: '2023' })
-        expect(addtl_start).to eq({ month: '11', day: '14', year: '2008' })
-        expect(addtl_end).to eq({ month: '10', day: '30', year: '2023' })
+        expect(addtl_start).to eq(nil)
+        expect(addtl_end).to eq(nil)
         expect(last_sep).to eq('Aberdeen Proving Ground')
         expect(pow).to eq('YES')
         expect(pow_start).to eq({ month: '06', day: '04', year: '2018' })


### PR DESCRIPTION
## Summary

- Corrects mapper so when there is only one service period, that period is not mapped to 20D on the pdf.

## Related issue(s)
[API-32157](https://jira.devops.va.gov/browse/API-32157)


## Testing done

- rspec
- Postman
  1. Submit with one service period and check to see if 20D is empty (it should be)
  2. Submit with two service periods and check the pdf to see if 20D is populated (it should be)
  ```
                "servicePeriods": [
                    {
                        "serviceBranch": "Air Force",
                        "activeDutyBeginDate": "2008-11-14",
                        "activeDutyEndDate": "2023-10-30",
                        "serviceComponent": "Active",
                        "separationLocationCode": "98282"
                    },
                                        {
                        "serviceBranch": "Air Force",
                        "activeDutyBeginDate": "2023-10-30",
                        "activeDutyEndDate": "2024-01-01",
                        "serviceComponent": "Active",
                        "separationLocationCode": "98282"
                    }
                ]```

## Screenshots
![Screenshot 2024-01-02 at 9 40 00 AM](https://github.com/department-of-veterans-affairs/vets-api/assets/25069483/f1a6f27f-3e6c-429a-8eec-23fada6ca9de)



## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature
