### PR TITLE
Mobile: Add count for isRefillable to prescriptions

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/prescriptions_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/prescriptions_controller.rb
@@ -48,6 +48,8 @@ module Mobile
       def status_meta(resource)
         {
           prescription_status_count: resource.attributes.each_with_object(Hash.new(0)) do |obj, hash|
+            hash['isRefillable'] += 1 if obj.is_refillable
+
             if obj.is_trackable || %w[active submitted providerHold activeParked
                                       refillinprocess].include?(obj.refill_status)
               hash['active'] += 1

--- a/modules/mobile/spec/request/prescriptions_request_spec.rb
+++ b/modules/mobile/spec/request/prescriptions_request_spec.rb
@@ -397,6 +397,7 @@ RSpec.describe 'health/rx/prescriptions', type: :request do
                                                                                 'discontinued' => 6,
                                                                                 'transferred' => 1,
                                                                                 'expired' => 2,
+                                                                                'isRefillable' => 5,
                                                                                 'hold' => 1,
                                                                                 'unknown' => 1
                                                                               })


### PR DESCRIPTION
## Summary
Front end wants a count of how many prescriptions are refillable. This PR updates the count to include that information

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#7212](https://github.com/department-of-veterans-affairs/va-mobile-app/issues/7212)

## Testing done
Updated specs

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
I added the `isRefillable` count to the existing count even though front end currently only wants `isRefillable`. I figured the count is already there and could be useful if they ever want to use it again. I understand if people think it's worth removing since it's currently unused, but I personally thought it's innocuous enough that it's worth keeping. LMK your thoughts!
