### PR TITLE
Change kms key rotation date to be a method instead of a constant

### DIFF
--- a/app/models/concerns/kms_encrypted_model_patch.rb
+++ b/app/models/concerns/kms_encrypted_model_patch.rb
@@ -3,8 +3,6 @@
 module KmsEncryptedModelPatch
   extend self
 
-  KMS_KEY_ROTATION_DATE = Date.new(Time.zone.today.year, 10, 12)
-
   # rubocop:disable Naming/PredicateName
   def has_kms_key
     # implicitly calls #has_kms_key with specified options, so that we don't need to require it
@@ -13,8 +11,12 @@ module KmsEncryptedModelPatch
   end
   # rubocop:enable Naming/PredicateName
 
+  def kms_key_rotation_date
+    Date.new(Time.zone.today.year, 10, 12)
+  end
+
   def kms_version
-    Time.zone.today < KMS_KEY_ROTATION_DATE ? Time.zone.today.year - 1 : Time.zone.today.year
+    Time.zone.today < kms_key_rotation_date ? Time.zone.today.year - 1 : Time.zone.today.year
   end
 
   private


### PR DESCRIPTION
This is an attempt to resolves an issue with pods being booted the previous year but has the wrong key rotation date.
