### PR TITLE
Bug Fix: set kms_key_rotation_date with method instead of constant

### DIFF
--- a/app/models/concerns/kms_encrypted_model_patch.rb
+++ b/app/models/concerns/kms_encrypted_model_patch.rb
@@ -3,7 +3,7 @@
 module KmsEncryptedModelPatch
   extend self
 
-  KMS_KEY_ROTATION_DATE = Date.new(Time.zone.today.year, 10, 12)
+  # Update #kms_key_rotation_date method if rotation date changes from 10/12
 
   # rubocop:disable Naming/PredicateName
   def has_kms_key
@@ -14,10 +14,14 @@ module KmsEncryptedModelPatch
   # rubocop:enable Naming/PredicateName
 
   def kms_version
-    Time.zone.today < KMS_KEY_ROTATION_DATE ? Time.zone.today.year - 1 : Time.zone.today.year
+    Time.zone.today < kms_key_rotation_date ? Time.zone.today.year - 1 : Time.zone.today.year
   end
 
   private
+
+  def kms_key_rotation_date
+    Date.new(Time.zone.today.year, 10, 12)
+  end
 
   def kms_options
     # Enumerate key_ids so that all years/previous versions are accounted for. Every


### PR DESCRIPTION
## Summary

- setting the KMS_KEY_ROTATION_DATE as a constant had the effect of persisting a stale date during the new years code freeze as many pods weren't refreshed. By setting is as a method, the fresh date is always calculated
