### PR TITLE
[70134] Update ClientConfig `client_id`s

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -3,8 +3,9 @@
 require 'sign_in/constants/auth'
 
 # Create Config for va.gov Sign in Service client
-vaweb = SignIn::ClientConfig.find_or_initialize_by(client_id: 'vaweb')
+vaweb = SignIn::ClientConfig.find_or_initialize_by(client_id: '6f317064-d9c8-41d9-9158-4d77d20bb0b3')
 vaweb.update!(authentication: SignIn::Constants::Auth::COOKIE,
+              description: 'VA.gov Web Client',
               anti_csrf: true,
               redirect_uri: 'http://localhost:3001/auth/login/callback',
               access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
@@ -16,8 +17,9 @@ vaweb.update!(authentication: SignIn::Constants::Auth::COOKIE,
               refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Config for VA flagship mobile Sign in Service client
-vamobile = SignIn::ClientConfig.find_or_initialize_by(client_id: 'vamobile')
+vamobile = SignIn::ClientConfig.find_or_initialize_by(client_id: '7e2d73b0-d2fd-4f9f-969b-605698dd7a95')
 vamobile.update!(authentication: SignIn::Constants::Auth::API,
+                 description: 'VA.gov Mobile Client',
                  anti_csrf: false,
                  redirect_uri: 'vamobile://login-success',
                  pkce: true,
@@ -27,9 +29,10 @@ vamobile.update!(authentication: SignIn::Constants::Auth::API,
                  terms_of_use_url: 'http://localhost:3001/terms-of-use',
                  refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_LONG_DAYS)
 
-# Create Config for localhost mocked authentication client
-vamobile_mock = SignIn::ClientConfig.find_or_initialize_by(client_id: 'vamobile_test')
+# Create Config for VA mobile test Sign in Service client
+vamobile_mock = SignIn::ClientConfig.find_or_initialize_by(client_id: '4a7d3355-a3d3-4546-82c5-1d8835760f15')
 vamobile_mock.update!(authentication: SignIn::Constants::Auth::API,
+                      description: 'VA.gov Mobile Test Client',
                       anti_csrf: false,
                       redirect_uri: 'http://localhost:4001/auth/sis/login-success',
                       pkce: true,
@@ -38,8 +41,9 @@ vamobile_mock.update!(authentication: SignIn::Constants::Auth::API,
                       refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_LONG_DAYS)
 
 # Create Config for localhost mocked authentication client
-vamock = SignIn::ClientConfig.find_or_initialize_by(client_id: 'vamock')
+vamock = SignIn::ClientConfig.find_or_initialize_by(client_id: 'cf239149-83db-4cda-9269-8fe796c8dc19')
 vamock.update!(authentication: SignIn::Constants::Auth::MOCK,
+               description: 'VA.gov Mock Client',
                anti_csrf: true,
                pkce: true,
                redirect_uri: 'http://localhost:3001/auth/login/callback',
@@ -49,8 +53,9 @@ vamock.update!(authentication: SignIn::Constants::Auth::MOCK,
                refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Config for example external client using cookie auth
-sample_client_web = SignIn::ClientConfig.find_or_initialize_by(client_id: 'sample_client_web')
+sample_client_web = SignIn::ClientConfig.find_or_initialize_by(client_id: '52af9141-853f-411e-9c00-bee3adbf57a2')
 sample_client_web.update!(authentication: SignIn::Constants::Auth::COOKIE,
+                          description: 'Sample Cookie Auth Client',
                           anti_csrf: true,
                           pkce: true,
                           redirect_uri: 'http://localhost:4567/auth/result',
@@ -60,8 +65,9 @@ sample_client_web.update!(authentication: SignIn::Constants::Auth::COOKIE,
                           refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Config for example external client using api auth
-sample_client_api = SignIn::ClientConfig.find_or_initialize_by(client_id: 'sample_client_api')
+sample_client_api = SignIn::ClientConfig.find_or_initialize_by(client_id: 'd248310c-d398-4068-a8dd-fb3f0a535b41')
 sample_client_api.update!(authentication: SignIn::Constants::Auth::API,
+                          description: 'Sample API Auth Client',
                           anti_csrf: false,
                           pkce: true,
                           redirect_uri: 'http://localhost:4567/auth/result',
@@ -71,8 +77,9 @@ sample_client_api.update!(authentication: SignIn::Constants::Auth::API,
                           refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Config for VA Identity Dashboard using cookie auth
-vaid_dash = SignIn::ClientConfig.find_or_initialize_by(client_id: 'identity_dashboard')
+vaid_dash = SignIn::ClientConfig.find_or_initialize_by(client_id: '521d8378-8283-4756-919f-2dee61175b90')
 vaid_dash.update!(authentication: SignIn::Constants::Auth::COOKIE,
+                  description: 'VA Identity Dashboard Client',
                   anti_csrf: true,
                   pkce: true,
                   redirect_uri: 'http://localhost:3001/auth/login/callback',
@@ -91,11 +98,13 @@ identity_dashboard_service_account_config =
 identity_dashboard_service_account_config.update!(service_account_id: vaid_service_account_id,
                                                   description: 'VA Identity Dashboard API',
                                                   scopes: ['http://localhost:3000/sign_in/client_configs',
-                                                           'http://localhost:3000/v0/account-controls/csp-lock',
-                                                           'http://localhost:3000/v0/account-controls/csp-unlock'],
+                                                           'http://localhost:3000/v0/account_controls/credential_index',
+                                                           'http://localhost:3000/v0/account_controls/credential_lock',
+                                                           'http://localhost:3000/v0/account_controls/credential_unlock'],
                                                   access_token_audience: 'http://localhost:4000',
                                                   access_token_duration: vaid_access_token_duration,
-                                                  certificates: [vaid_certificate])
+                                                  certificates: [vaid_certificate],
+                                                  access_token_user_attributes: %w[icn])
 
 # Create Service Account Config for Chatbot
 chatbot = SignIn::ServiceAccountConfig.find_or_initialize_by(service_account_id: '88a6d94a3182fd63279ea5565f26bcb4')


### PR DESCRIPTION
## Summary

- The Identity Team has decided to change the `client_id` unique string identifying a SiS ClientConfig from a human-readable string (`vaweb`) to a proper uuid (`ef7294f0-72dd-4b98-9665-f7f05ae033f9`). This PR updates the default ClientConfigs populated from the `db/seeds/development.rb` file, updating the `client_id`s for the following clients:
  - [ ] VA.gov web
  - [ ] VA flagship mobile
  - [ ] VA.gov mobile test
  - [ ] VA.gov mock
  - [ ] Sample Cookie Client
  - [ ] Sample API Client
  - [ ] VA Identity Dashboard
 
Clients will be checked off after review & actions to ensure this change will not result in outages.

- PR also contains a small update to VA Identity Dashboard scopes and access_token_user_attributes unrelated to the uuid change.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#15017

## Testing done
