### PR TITLE
Updating find_a_rep feature toggle name

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -454,11 +454,15 @@ features:
     actor_type: user
     description: Enables new review page navigation for users completing the Financial Status Report (FSR) form.
     enable_in_development: true
-  find_a_rep:
+  find_a_representative:
+    actor_type: user
+    description: Enables frontend of Find a Representative
+    enable_in_development: true
+  find_a_representative_enable_api:
     actor_type: user
     description: Enables the Find a Rep search endpoint
     enable_in_development: true
-  find_a_representative:
+  find_a_representative_enable_frontend:
     actor_type: user
     description: Enables frontend of Find a Representative
     enable_in_development: true
@@ -730,7 +734,7 @@ features:
     actor_type: user
     description: Toggle to control the amount of eligible users entering the send_email portion of the flow.
   pdf_warning_banner:
-    description: "When enabled, will allow display of PDF cert warnings in find-a-form"
+    description: 'When enabled, will allow display of PDF cert warnings in find-a-form'
     actor_type: user
     enable_in_development: true
   pre_entry_covid19_screener:

--- a/config/features.yml
+++ b/config/features.yml
@@ -734,7 +734,7 @@ features:
     actor_type: user
     description: Toggle to control the amount of eligible users entering the send_email portion of the flow.
   pdf_warning_banner:
-    description: 'When enabled, will allow display of PDF cert warnings in find-a-form'
+    description: When enabled, will allow display of PDF cert warnings in find-a-form
     actor_type: user
     enable_in_development: true
   pre_entry_covid19_screener:

--- a/modules/veteran/app/controllers/veteran/v0/accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/accredited_representatives_controller.rb
@@ -98,7 +98,7 @@ module Veteran
       end
 
       def feature_enabled
-        routing_error unless Flipper.enabled?(:find_a_rep)
+        routing_error unless Flipper.enabled?(:find_a_representative_enable_api)
       end
 
       def verify_type

--- a/modules/veteran/spec/requests/v0/accredited_representatives_spec.rb
+++ b/modules/veteran/spec/requests/v0/accredited_representatives_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Find a Rep - Accredited Representatives spec', type: :request do
   context 'when find a rep is disabled' do
     before do
-      Flipper.disable(:find_a_rep)
+      Flipper.disable(:find_a_representative_enable_api)
     end
 
     it 'returns a not found routing error' do
@@ -21,7 +21,7 @@ RSpec.describe 'Find a Rep - Accredited Representatives spec', type: :request do
 
   context 'when find a rep is enabled' do
     before do
-      Flipper.enable(:find_a_rep)
+      Flipper.enable(:find_a_representative_enable_api)
     end
 
     context 'when a required param is missing' do


### PR DESCRIPTION
## Summary
- Renamed `find_a_rep` feature toggle to `find_a_representative_enable_api`
- Added `find_a_representative_enable_frontend`
- Updated `find_a_rep` references

Delaying the removal of `find_a_representative` feature toggle (which gates the Find a Rep frontend) until references are updated in vets-website. This toggle will be removed once the frontend is referencing `find_a_representative_enable_frontend`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/70842
