### PR TITLE
Enable VA Profile and Disable eMIS for RI's

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -693,11 +693,11 @@ features:
   military_information_vaprofile:
     actor_type: user
     description: Enables the post-EMIS military information of VAProfile
-    enable_in_development: false
+    enable_in_development: true
   military_information_vaprofile_vic:
     actor_type: user
     description: Enables the post-EMIS military information of VAProfile for the VIC form
-    enable_in_development: false
+    enable_in_development: true
   mobile_api:
     actor_type: user
     description: API endpoints consumed by the VA Mobile App (iOS/Android)
@@ -1266,7 +1266,7 @@ features:
   veteran_status_updated:
     actor_type: user
     description: Enable the veteran post-emis status
-    enable_in_development: false
+    enable_in_development: true
   virtual_agent_enable_param_error_detection:
     actor_type: user
     description: If enabled, Allows for the detection of errors in the chatbot params


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

It was observed that there were still calls to eMIS being utilized by the staging environment, as shown by [these datadog metrics](https://vagov.ddog-gov.com/metric/explorer?start=1704209855579&end=1704296255579&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyIwY8to4xFgAdIL1IghwIlBNXAjyTUZBGhZNCDgIGGjAdQ1YyHCqEBoubQg8AAQARljrwJ0AbhBt6u08TRjLmfjtABQAlCB8oJHRubFYAEyJyRNpGdnKfKFYogd7lSrVWr1RpNTYYTIAa063W2HQ0TXwCFG40m02hcwWSyccMRG22uwORykJzW50u1wQ90eAF0qK53HhMKFwuzVJyMDFSvFHhRQLz+YKdJ8WVRhlg0DlQPJJogOsooDgYE5MlyNBBMok0KI4E45IpyjgjVBDcanPQmMoRG4PGgRUklvJMFhTQociAjSIlDxmTw+CB7EaEABhKTCGAoESctA8IA). Upon examining the configuration of an active review instance, it was determined that [Review Instances were configured to communicate with eMIS](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/initializers/flipper.rb#L51) rather than VA Profile. By setting `enable_in_development` to true in the flipper config, the switch to direct calls to VA Profile is activated.


## Related issue(s)
https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/56871


## Testing done

- Tested config on a review instance and will continue to monitor the Datadog chart after merge

## Screenshots
<img width="1360" alt="Screenshot 2024-01-03 at 10 07 37 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/5834818/fbbfe18f-ce71-4647-a242-2354f40591df">
<img width="876" alt="Screenshot 2024-01-03 at 10 07 44 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/5834818/fa0c3c43-b06b-40b1-bed2-ea8d432c583a">





