### PR TITLE
Add special issue to EP400 merge-eligible claims

### DIFF
--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -154,6 +154,19 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             expect(submission.read_metadata(:ep_merge_pending_claim_id)).to eq('600114692') # from claims.yml
           end
 
+          context 'when EP400 merge API call is enabled' do
+            before { Flipper.enable(:disability_526_ep_merge_api) }
+            after { Flipper.disable(:disability_526_ep_merge_api) }
+
+            it 'adds the EP400 special issue to the submission' do
+              subject.perform_async(submission.id)
+              VCR.use_cassette('virtual_regional_office/contention_classification') do
+                described_class.drain
+              end
+              expect(submission.reload.disabilities.first).to include('specialIssues' => ['EP400 Merge Project'])
+            end
+          end
+
           context 'when pending claim has lifecycle status not considered open for EP400 merge' do
             let(:open_claims_cassette) { 'evss/claims/claims_pending_decision_approval' }
 


### PR DESCRIPTION
## Summary
- This PR updates the 526 submission process to include a new special issue on claims eligible for EP400 Merge.
- I am part of the Claims Fast-Tracking crew's Employee Experience team.
- The new logic is behind the feature toggle `disability_526_ep_merge_api` which will remain disabled in production for the near future, until after EE team completes end-to-end testing.

## Related issue(s)
- department-of-veterans-affairs/abd-vro#2148

## Testing done
- Added new rspec
- E2E testing in staging / VBMS UAT is planned once the VRO API server portion is complete.

## What areas of the site does it impact?
* No user-visible behavior change

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
