### PR TITLE
API-32568 Use ICN from token in Legacy Appeals API

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/legacy_appeals/v0/legacy_appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/legacy_appeals/v0/legacy_appeals_controller.rb
@@ -6,9 +6,11 @@ module AppealsApi::LegacyAppeals::V0
   class LegacyAppealsController < AppealsApi::ApplicationController
     include AppealsApi::CaseflowRequest
     include AppealsApi::OpenidAuth
+    include AppealsApi::IcnParameterValidation
     include AppealsApi::Schemas
 
     skip_before_action :authenticate
+    before_action :validate_icn_parameter!, only: %i[index]
     before_action :validate_json_schema, only: %i[index]
 
     SCHEMA_OPTIONS = { schema_version: 'v0', api_name: 'legacy_appeals' }.freeze
@@ -32,7 +34,7 @@ module AppealsApi::LegacyAppeals::V0
     end
 
     def get_caseflow_response
-      caseflow_service.get_legacy_appeals headers: { 'X-VA-SSN' => icn_to_ssn!(params[:icn]) }
+      caseflow_service.get_legacy_appeals headers: { 'X-VA-SSN' => icn_to_ssn!(veteran_icn) }
     end
 
     def token_validation_api_key

--- a/modules/appeals_api/app/swagger/legacy_appeals/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/legacy_appeals/v0/swagger.json
@@ -47,43 +47,143 @@
         "parameters": [
           {
             "name": "icn",
-            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN)",
+            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN). Optional when using a veteran-scoped token. Required when using a representative- or system-scoped token.",
             "example": "1012832025V743496",
-            "required": true,
             "schema": {
               "type": "string",
               "pattern": "^[0-9]{10}V[0-9]{6}$",
               "minLength": 17,
               "maxLength": 17
             },
-            "in": "query"
+            "in": "query",
+            "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "Returns eligible legacy appeals for a Veteran",
+            "description": "Retrieve legacy appeals for the Veteran with the supplied ICN",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "with a veteran-scoped token (no 'icn' parameter necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2760964",
+                          "type": "legacyAppeal",
+                          "attributes": {
+                            "issues": [
+                              {
+                                "summary": "Service connection, pancreatitis"
+                              }
+                            ],
+                            "veteranFullName": "Elda Z Quigley",
+                            "decisionDate": "2021-05-04T00:00:00.000Z",
+                            "latestSocSsocDate": "2021-06-12"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "with a representative-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2760964",
+                          "type": "legacyAppeal",
+                          "attributes": {
+                            "issues": [
+                              {
+                                "summary": "Service connection, pancreatitis"
+                              }
+                            ],
+                            "veteranFullName": "Elda Z Quigley",
+                            "decisionDate": "2021-05-04T00:00:00.000Z",
+                            "latestSocSsocDate": "2021-06-12"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2760964",
+                          "type": "legacyAppeal",
+                          "attributes": {
+                            "issues": [
+                              {
+                                "summary": "Service connection, pancreatitis"
+                              }
+                            ],
+                            "veteranFullName": "Elda Z Quigley",
+                            "decisionDate": "2021-05-04T00:00:00.000Z",
+                            "latestSocSsocDate": "2021-06-12"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/legacyAppeals"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing ICN parameter",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "with a representative-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access forbidden",
             "content": {
               "application/json": {
                 "example": {
-                  "data": [
+                  "errors": [
                     {
-                      "id": "2760964",
-                      "type": "legacyAppeal",
-                      "attributes": {
-                        "issues": [
-                          {
-                            "summary": "Service connection, pancreatitis"
-                          }
-                        ],
-                        "veteranFullName": "Elda Z Quigley",
-                        "decisionDate": "2021-05-04T00:00:00.000Z",
-                        "latestSocSsocDate": "2021-06-12"
-                      }
+                      "title": "Forbidden",
+                      "detail": "Invalid 'icn' parameter: Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
                     }
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/legacyAppeals"
+                  "$ref": "#/components/schemas/errorModel"
                 }
               }
             }
@@ -109,37 +209,18 @@
             }
           },
           "422": {
-            "description": "Header Errors",
+            "description": "Invalid 'icn' parameter",
             "content": {
               "application/json": {
                 "examples": {
-                  "when ICN formatted incorrectly": {
+                  "when ICN is formatted incorrectly": {
                     "value": {
                       "errors": [
                         {
-                          "title": "Invalid length",
-                          "detail": "'12345' did not fit within the defined length limits",
-                          "code": "142",
-                          "source": {
-                            "pointer": "/icn"
-                          },
-                          "status": "422",
-                          "meta": {
-                            "max_length": 17,
-                            "min_length": 17
-                          }
-                        },
-                        {
-                          "title": "Invalid pattern",
-                          "detail": "'12345' did not match the defined pattern",
-                          "code": "143",
-                          "source": {
-                            "pointer": "/icn"
-                          },
-                          "status": "422",
-                          "meta": {
-                            "regex": "^[0-9]{10}V[0-9]{6}$"
-                          }
+                          "title": "Unprocessable Entity",
+                          "detail": "'icn' parameter has an invalid format. Pattern: /^[0-9]{10}V[0-9]{6}$/",
+                          "code": "422",
+                          "status": "422"
                         }
                       ]
                     }
@@ -172,36 +253,21 @@
             }
           },
           "502": {
-            "description": "Unknown Error",
+            "description": "Unknown upstream error",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "errors": {
-                      "type": "array",
-                      "items": {
-                        "properties": {
-                          "status": {
-                            "type": "string",
-                            "example": "502"
-                          },
-                          "detail": {
-                            "type": "string",
-                            "example": "Received a 500 response from the upstream server"
-                          },
-                          "code": {
-                            "type": "string",
-                            "example": "CASEFLOWSTATUS500"
-                          },
-                          "title": {
-                            "type": "string",
-                            "example": "Bad Gateway"
-                          }
-                        }
-                      }
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Bad Gateway",
+                      "detail": "Received an unusable response from Caseflow",
+                      "code": "502",
+                      "status": "502"
                     }
-                  }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
                 }
               }
             }

--- a/modules/appeals_api/app/swagger/legacy_appeals/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/legacy_appeals/v0/swagger_dev.json
@@ -47,43 +47,143 @@
         "parameters": [
           {
             "name": "icn",
-            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN)",
+            "description": "Veteran's Master Person Index (MPI) Integration Control Number (ICN). Optional when using a veteran-scoped token. Required when using a representative- or system-scoped token.",
             "example": "1012832025V743496",
-            "required": true,
             "schema": {
               "type": "string",
               "pattern": "^[0-9]{10}V[0-9]{6}$",
               "minLength": 17,
               "maxLength": 17
             },
-            "in": "query"
+            "in": "query",
+            "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "Returns eligible legacy appeals for a Veteran",
+            "description": "Retrieve legacy appeals for the Veteran with the supplied ICN",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "with a veteran-scoped token (no 'icn' parameter necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2760964",
+                          "type": "legacyAppeal",
+                          "attributes": {
+                            "issues": [
+                              {
+                                "summary": "Service connection, pancreatitis"
+                              }
+                            ],
+                            "veteranFullName": "Elda Z Quigley",
+                            "decisionDate": "2021-05-04T00:00:00.000Z",
+                            "latestSocSsocDate": "2021-06-12"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "with a representative-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2760964",
+                          "type": "legacyAppeal",
+                          "attributes": {
+                            "issues": [
+                              {
+                                "summary": "Service connection, pancreatitis"
+                              }
+                            ],
+                            "veteranFullName": "Elda Z Quigley",
+                            "decisionDate": "2021-05-04T00:00:00.000Z",
+                            "latestSocSsocDate": "2021-06-12"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token ('icn' parameter is necessary)": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2760964",
+                          "type": "legacyAppeal",
+                          "attributes": {
+                            "issues": [
+                              {
+                                "summary": "Service connection, pancreatitis"
+                              }
+                            ],
+                            "veteranFullName": "Elda Z Quigley",
+                            "decisionDate": "2021-05-04T00:00:00.000Z",
+                            "latestSocSsocDate": "2021-06-12"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/legacyAppeals"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing ICN parameter",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "with a representative-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  },
+                  "with a system-scoped token and no 'icn' parameter": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Missing parameter",
+                          "detail": "The required parameter \"icn\", is missing",
+                          "code": "108",
+                          "status": "400"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access forbidden",
             "content": {
               "application/json": {
                 "example": {
-                  "data": [
+                  "errors": [
                     {
-                      "id": "2760964",
-                      "type": "legacyAppeal",
-                      "attributes": {
-                        "issues": [
-                          {
-                            "summary": "Service connection, pancreatitis"
-                          }
-                        ],
-                        "veteranFullName": "Elda Z Quigley",
-                        "decisionDate": "2021-05-04T00:00:00.000Z",
-                        "latestSocSsocDate": "2021-06-12"
-                      }
+                      "title": "Forbidden",
+                      "detail": "Invalid 'icn' parameter: Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
                     }
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/legacyAppeals"
+                  "$ref": "#/components/schemas/errorModel"
                 }
               }
             }
@@ -109,37 +209,18 @@
             }
           },
           "422": {
-            "description": "Header Errors",
+            "description": "Invalid 'icn' parameter",
             "content": {
               "application/json": {
                 "examples": {
-                  "when ICN formatted incorrectly": {
+                  "when ICN is formatted incorrectly": {
                     "value": {
                       "errors": [
                         {
-                          "title": "Invalid length",
-                          "detail": "'12345' did not fit within the defined length limits",
-                          "code": "142",
-                          "source": {
-                            "pointer": "/icn"
-                          },
-                          "status": "422",
-                          "meta": {
-                            "max_length": 17,
-                            "min_length": 17
-                          }
-                        },
-                        {
-                          "title": "Invalid pattern",
-                          "detail": "'12345' did not match the defined pattern",
-                          "code": "143",
-                          "source": {
-                            "pointer": "/icn"
-                          },
-                          "status": "422",
-                          "meta": {
-                            "regex": "^[0-9]{10}V[0-9]{6}$"
-                          }
+                          "title": "Unprocessable Entity",
+                          "detail": "'icn' parameter has an invalid format. Pattern: /^[0-9]{10}V[0-9]{6}$/",
+                          "code": "422",
+                          "status": "422"
                         }
                       ]
                     }
@@ -172,36 +253,21 @@
             }
           },
           "502": {
-            "description": "Unknown Error",
+            "description": "Unknown upstream error",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "errors": {
-                      "type": "array",
-                      "items": {
-                        "properties": {
-                          "status": {
-                            "type": "string",
-                            "example": "502"
-                          },
-                          "detail": {
-                            "type": "string",
-                            "example": "Received a 500 response from the upstream server"
-                          },
-                          "code": {
-                            "type": "string",
-                            "example": "CASEFLOWSTATUS500"
-                          },
-                          "title": {
-                            "type": "string",
-                            "example": "Bad Gateway"
-                          }
-                        }
-                      }
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Bad Gateway",
+                      "detail": "Received an unusable response from Caseflow",
+                      "code": "502",
+                      "status": "502"
                     }
-                  }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
                 }
               }
             }

--- a/modules/appeals_api/config/schemas/legacy_appeals/v0/params.json
+++ b/modules/appeals_api/config/schemas/legacy_appeals/v0/params.json
@@ -6,6 +6,5 @@
     "icn": {
       "$ref": "icn.json"
     }
-  },
-  "required": ["icn"]
+  }
 }

--- a/modules/appeals_api/spec/docs/legacy_appeals/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/legacy_appeals/v0_spec.rb
@@ -11,25 +11,22 @@ def openapi_spec
   "modules/appeals_api/app/swagger/legacy_appeals/v0/swagger#{DocHelpers.doc_suffix}.json"
 end
 
-# rubocop:disable RSpec/VariableName, RSpec/ScatteredSetup
+# rubocop:disable RSpec/VariableName, Layout/LineLength
 RSpec.describe 'Legacy Appeals', openapi_spec:, type: :request do
   include DocHelpers
   let(:Authorization) { 'Bearer TEST_TOKEN' }
 
-  before do
-    mpi_response = create(:find_profile_response, profile: build(:mpi_profile))
-    allow_any_instance_of(MPI::Service)
-      .to receive(:find_profile_by_identifier)
-      .with(identifier: icn, identifier_type: MPI::Constants::ICN).and_return(mpi_response)
-  end
+  expected_icn = '1012832025V743496'
+  cassette = %w[caseflow/legacy_appeals_get_by_ssn mpi/find_candidate/valid]
+  veteran_scopes = %w[veteran/LegacyAppeals.read]
 
   path '/legacy-appeals' do
     get 'Returns eligible appeals in the legacy process for a Veteran.' do
-      scopes = AppealsApi::LegacyAppeals::V0::LegacyAppealsController::OAUTH_SCOPES[:GET]
-
       tags 'Legacy Appeals'
       operationId 'getLegacyAppeals'
-      security DocHelpers.oauth_security_config(scopes)
+      security DocHelpers.oauth_security_config(
+        AppealsApi::LegacyAppeals::V0::LegacyAppealsController::OAUTH_SCOPES[:GET]
+      )
       consumes 'application/json'
       produces 'application/json'
       description = 'Returns eligible legacy appeals for a Veteran. A legacy appeal is eligible if a statement of ' \
@@ -38,19 +35,72 @@ RSpec.describe 'Legacy Appeals', openapi_spec:, type: :request do
       description description
 
       parameter(
-        parameter_from_schema('legacy_appeals/v0/params.json', 'properties', 'icn')
-          .merge({ in: :query, required: true })
+        parameter_from_schema('shared/v0/icn.json', 'properties', 'icn').merge(
+          {
+            name: :icn,
+            in: :query,
+            description: "Veteran's Master Person Index (MPI) Integration Control Number (ICN). Optional when using a veteran-scoped token. Required when using a representative- or system-scoped token.",
+            required: false
+          }
+        )
       )
 
-      let(:icn) { '1012832025V743496' }
-
-      response '200', 'Returns eligible legacy appeals for a Veteran' do
+      response '200', 'Retrieve legacy appeals for the Veteran with the supplied ICN' do
         schema '$ref' => '#/components/schemas/legacyAppeals'
 
+        describe 'with veteran-scoped token' do
+          it_behaves_like 'rswag example',
+                          desc: "with a veteran-scoped token (no 'icn' parameter necessary)",
+                          extract_desc: true,
+                          cassette:,
+                          scopes: veteran_scopes
+        end
+
+        describe 'with representative-scoped token' do
+          let(:icn) { expected_icn }
+
+          it_behaves_like 'rswag example',
+                          desc: "with a representative-scoped token ('icn' parameter is necessary)",
+                          extract_desc: true,
+                          cassette:,
+                          scopes: %w[representative/LegacyAppeals.read]
+        end
+
+        describe 'with system-scoped token' do
+          let(:icn) { expected_icn }
+
+          it_behaves_like 'rswag example',
+                          desc: "with a system-scoped token ('icn' parameter is necessary)",
+                          extract_desc: true,
+                          cassette:,
+                          scopes: %w[system/LegacyAppeals.read]
+        end
+      end
+
+      response '400', 'Missing ICN parameter' do
+        schema '$ref' => '#/components/schemas/errorModel'
+
         it_behaves_like 'rswag example',
-                        desc: 'returns a 200 response',
-                        cassette: 'caseflow/legacy_appeals_get_by_ssn',
-                        scopes:
+                        desc: "with a representative-scoped token and no 'icn' parameter",
+                        extract_desc: true,
+                        cassette:,
+                        scopes: %w[representative/LegacyAppeals.read]
+
+        it_behaves_like 'rswag example',
+                        desc: "with a system-scoped token and no 'icn' parameter",
+                        extract_desc: true,
+                        cassette:,
+                        scopes: %w[system/LegacyAppeals.read]
+      end
+
+      response '403', 'Access forbidden' do
+        schema '$ref' => '#/components/schemas/errorModel'
+        let(:icn) { '1234567890V123456' }
+
+        it_behaves_like 'rswag example',
+                        desc: "with a veteran-scoped token and an optional 'icn' parameter that does not match the Veteran's ICN",
+                        cassette:,
+                        scopes: veteran_scopes
       end
 
       response '404', 'Veteran record not found' do
@@ -58,66 +108,33 @@ RSpec.describe 'Legacy Appeals', openapi_spec:, type: :request do
 
         it_behaves_like 'rswag example',
                         desc: 'returns a 404 response',
-                        cassette: 'caseflow/legacy_appeals_no_veteran_record',
-                        scopes:
+                        cassette: %w[caseflow/legacy_appeals_no_veteran_record mpi/find_candidate/valid],
+                        scopes: veteran_scopes
       end
 
-      response '422', 'Header Errors' do
+      response '422', "Invalid 'icn' parameter" do
         schema '$ref' => '#/components/schemas/errorModel'
 
-        context 'malformed ICN' do
-          let(:icn) { '12345' }
+        let(:icn) { '12345' }
 
-          it_behaves_like 'rswag example',
-                          desc: 'when ICN formatted incorrectly',
-                          extract_desc: true,
-                          scopes:
-        end
+        it_behaves_like 'rswag example',
+                        desc: 'when ICN is formatted incorrectly',
+                        extract_desc: true,
+                        cassette:,
+                        scopes: veteran_scopes
       end
 
       it_behaves_like 'rswag 500 response'
 
-      response '502', 'Unknown Error' do
-        schema type: :object,
-               properties: {
-                 errors: {
-                   type: :array,
-                   items: {
-                     properties: {
-                       status: {
-                         type: 'string',
-                         example: '502'
-                       },
-                       detail: {
-                         type: 'string',
-                         example: 'Received a 500 response from the upstream server'
-                       },
-                       code: {
-                         type: 'string',
-                         example: 'CASEFLOWSTATUS500'
-                       },
-                       title: {
-                         type: 'string',
-                         example: 'Bad Gateway'
-                       }
-                     }
-                   }
-                 }
-               }
+      response '502', 'Unknown upstream error' do
+        schema '$ref' => '#/components/schemas/errorModel'
 
-        before do |example|
-          with_rswag_auth(scopes) do
-            submit_request(example.metadata)
-          end
-        end
-
-        # rubocop:disable RSpec/NoExpectationExample
-        it 'returns a 502 response' do |_example|
-          # NOOP
-        end
-        # rubocop:enable RSpec/NoExpectationExample
+        it_behaves_like 'rswag example',
+                        desc: 'Upstream error from Caseflow service',
+                        cassette: %w[mpi/find_candidate/valid caseflow/legacy_appeals_server_error],
+                        scopes: veteran_scopes
       end
     end
   end
 end
-# rubocop:enable RSpec/VariableName, RSpec/ScatteredSetup
+# rubocop:enable RSpec/VariableName, Layout/LineLength

--- a/modules/appeals_api/spec/requests/v1/appeals_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/appeals_controller_spec.rb
@@ -4,165 +4,30 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::V1::AppealsController, type: :request do
-  describe '#index' do
-    include SchemaMatchers
+  include SchemaMatchers
 
+  describe '#index' do
+    let(:path) { '/services/appeals/v1/appeals' }
     let(:caseflow_cassette_name) { 'caseflow/appeals' }
     let(:mpi_cassette_name) { 'mpi/find_candidate/valid' }
+    let(:va_user) { 'test.user@example.com' }
+    let(:headers) { { 'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => va_user } }
     let(:icn) { '1012667145V762142' }
     let(:ssn) { '796122306' }
-    let(:consumer_username) { 'TestConsumer' }
-    let(:va_user) { 'test.user@example.com' }
-    let(:headers) { { 'X-Consumer-Username' => consumer_username, 'X-VA-User' => va_user } }
-    let(:scopes) { described_class::OAUTH_SCOPES[:GET] }
-    let(:params) { {} }
 
-    describe '#index' do
-      let(:path) { '/services/appeals/v1/appeals' }
+    describe 'ICN parameter handling' do
+      it_behaves_like(
+        'GET endpoint with optional Veteran ICN parameter',
+        {
+          cassette: 'caseflow/appeals',
+          path: '/services/appeals/v1/appeals',
+          scope_base: 'AppealsStatus',
+          headers: { 'X-VA-User' => 'test.user@example.com' }
+        }
+      )
+    end
 
-      before do
-        allow(Rails.logger).to receive(:info)
-        VCR.use_cassette(caseflow_cassette_name) do
-          VCR.use_cassette(mpi_cassette_name) do
-            with_openid_auth(scopes) do |auth_header|
-              get(path, params:, headers: auth_header.merge(headers))
-            end
-          end
-        end
-      end
-
-      describe 'successes' do
-        context 'with veteran scope' do
-          let(:scopes) { %w[veteran/AppealsStatus.read] }
-
-          context 'without ICN parameter' do
-            it 'returns appeals' do
-              expect(response).to have_http_status(:ok)
-              expect(response).to match_response_schema('appeals')
-            end
-
-            it 'logs the caseflow request and response' do
-              expect(Rails.logger).to have_received(:info).with(
-                'Caseflow Request',
-                { 'va_user' => va_user, 'lookup_identifier' => Digest::SHA2.hexdigest(ssn) }
-              )
-              expect(Rails.logger).to have_received(:info).with(
-                'Caseflow Response',
-                { 'va_user' => va_user, 'first_appeal_id' => '1196201', 'appeal_count' => 3 }
-              )
-            end
-          end
-
-          context 'with correct, optional ICN parameter' do
-            let(:params) { { icn: } }
-
-            it 'returns appeals' do
-              expect(response).to have_http_status(:ok)
-              expect(response).to match_response_schema('appeals')
-            end
-          end
-        end
-
-        context 'with system scope' do
-          let(:scopes) { %w[system/AppealsStatus.read] }
-          let(:params) { { icn: } }
-
-          it 'returns appeals' do
-            expect(response).to have_http_status(:ok)
-            expect(response).to match_response_schema('appeals')
-          end
-        end
-
-        context 'with representative scope' do
-          let(:scopes) { %w[representative/AppealsStatus.read] }
-          let(:params) { { icn: } }
-
-          it 'returns appeals' do
-            expect(response).to have_http_status(:ok)
-            expect(response).to match_response_schema('appeals')
-          end
-        end
-      end
-
-      describe 'errors' do
-        let(:error) { JSON.parse(response.body).dig('errors', 0) }
-
-        describe 'with veteran scope' do
-          describe 'with incorrect ICN parameter' do
-            let(:params) { { icn: '1234567890V123456' } }
-
-            it 'returns a 403 error' do
-              expect(response).to have_http_status(:forbidden)
-              expect(error['detail']).to include('Veterans may access only their own records')
-            end
-          end
-        end
-
-        describe 'with representative scope' do
-          let(:scopes) { %w[representative/AppealsStatus.read] }
-
-          describe 'with missing ICN parameter' do
-            it 'returns a 400 error' do
-              expect(response).to have_http_status(:bad_request)
-              expect(error['detail']).to include('required parameter "icn"')
-            end
-          end
-        end
-
-        describe 'with system scope' do
-          describe 'with missing ICN parameter' do
-            let(:scopes) { %w[system/AppealsStatus.read] }
-
-            it 'returns a 400 error' do
-              expect(response).to have_http_status(:bad_request)
-              expect(error['detail']).to include('required parameter "icn"')
-            end
-          end
-        end
-
-        describe 'with malformed ICN parameter' do
-          let(:params) { { icn: 'not-an-icn' } }
-
-          it 'returns a 422 error' do
-            expect(response).to have_http_status(:unprocessable_entity)
-          end
-        end
-
-        describe 'when veteran SSN is not found in MPI based on the provided ICN' do
-          let(:mpi_cassette_name) { 'mpi/find_candidate/icn_not_found' }
-
-          it 'returns a 404 error with a message that does not reference SSN' do
-            expect(response).to have_http_status(:not_found)
-            expect(error['detail']).not_to include('SSN')
-          end
-        end
-
-        describe 'when MPI throws an error' do
-          let(:mpi_cassette_name) { 'mpi/find_candidate/internal_server_error' }
-
-          it 'returns a 502 error instead' do
-            expect(response).to have_http_status(:bad_gateway)
-          end
-        end
-
-        describe 'when veteran is not found by SSN in caseflow' do
-          let(:caseflow_cassette_name) { 'caseflow/not_found' }
-
-          it 'returns a 404 error with a message that does not reference SSN' do
-            expect(response).to have_http_status(:not_found)
-            expect(error['detail']).not_to include('SSN')
-          end
-        end
-
-        describe 'when caseflow throws a 500 error' do
-          let(:caseflow_cassette_name) { 'caseflow/server_error' }
-
-          it 'returns a 502 error instead' do
-            expect(response).to have_http_status(:bad_gateway)
-          end
-        end
-      end
-
+    describe 'auth behavior' do
       it_behaves_like('an endpoint with OpenID auth', scopes: described_class::OAUTH_SCOPES[:GET]) do
         def make_request(auth_header)
           VCR.use_cassette(caseflow_cassette_name) do
@@ -170,6 +35,50 @@ describe AppealsApi::V1::AppealsController, type: :request do
               get(path, params: { icn: }, headers: auth_header.merge(headers))
             end
           end
+        end
+      end
+    end
+
+    describe 'caseflow interaction' do
+      let(:scopes) { %w[veteran/AppealsStatus.read] }
+      let(:params) { {} }
+      let(:error) { JSON.parse(response.body).dig('errors', 0) }
+
+      before do
+        allow(Rails.logger).to receive(:info)
+        VCR.use_cassette(caseflow_cassette_name) do
+          VCR.use_cassette(mpi_cassette_name) do
+            with_openid_auth(scopes) { |auth_header| get(path, params:, headers: auth_header.merge(headers)) }
+          end
+        end
+      end
+
+      it 'logs the caseflow request and response' do
+        expect(response).to match_response_schema('appeals')
+        expect(Rails.logger).to have_received(:info).with(
+          'Caseflow Request',
+          { 'va_user' => va_user, 'lookup_identifier' => Digest::SHA2.hexdigest(ssn) }
+        )
+        expect(Rails.logger).to have_received(:info).with(
+          'Caseflow Response',
+          { 'va_user' => va_user, 'first_appeal_id' => '1196201', 'appeal_count' => 3 }
+        )
+      end
+
+      describe 'when veteran is not found by SSN in caseflow' do
+        let(:caseflow_cassette_name) { 'caseflow/not_found' }
+
+        it 'returns a 404 error with a message that does not reference SSN' do
+          expect(response).to have_http_status(:not_found)
+          expect(error['detail']).not_to include('SSN')
+        end
+      end
+
+      describe 'when caseflow throws a 500 error' do
+        let(:caseflow_cassette_name) { 'caseflow/server_error' }
+
+        it 'returns a 502 error instead' do
+          expect(response).to have_http_status(:bad_gateway)
         end
       end
     end

--- a/modules/appeals_api/spec/support/shared_examples_for_icn_parameter_validation.rb
+++ b/modules/appeals_api/spec/support/shared_examples_for_icn_parameter_validation.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+shared_examples 'GET endpoint with optional Veteran ICN parameter' do |opts|
+  let(:path) { opts[:path] }
+  let(:scope_base) { opts[:scope_base] }
+  let(:headers) { opts[:headers].presence || {} }
+  let(:mpi_cassette) { 'mpi/find_candidate/valid' }
+  let(:cassettes) { (opts[:cassette] ? [opts[:cassette]] : []) + [mpi_cassette] }
+  let(:default_params) { opts[:params].presence || {} }
+  let(:params) { default_params }
+  let(:icn) { '1012667145V762142' }
+
+  before do
+    cassettes.each { |cassette_name| VCR.insert_cassette(cassette_name) }
+    with_openid_auth([scope]) { |auth_header| get(path, params:, headers: auth_header.merge(headers)) }
+  end
+
+  after { cassettes.each { |cassette_name| VCR.eject_cassette(cassette_name) } }
+
+  describe 'successes' do
+    context 'with veteran scope' do
+      let(:scope) { "veteran/#{scope_base}.read" }
+
+      context 'without ICN parameter' do
+        it 'succeeds' do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context 'with correct, optional ICN parameter' do
+        let(:params) { default_params.merge({ icn: }) }
+
+        it 'returns appeals' do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context 'with representative scope' do
+      let(:scope) { "representative/#{scope_base}.read" }
+      let(:params) { default_params.merge({ icn: }) }
+
+      it 'returns appeals' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with system scope' do
+      let(:scope) { "system/#{scope_base}.read" }
+      let(:params) { default_params.merge({ icn: }) }
+
+      it 'returns appeals' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'errors' do
+    let(:error) { JSON.parse(response.body).dig('errors', 0) }
+    let(:scope) { "veteran/#{scope_base}.read" }
+    let(:params) { default_params.merge({ icn: }) }
+
+    describe 'with veteran scope and incorrect optional ICN parameter' do
+      let(:params) { default_params.merge({ icn: '1234567890V123456' }) }
+
+      it 'returns a 403 error' do
+        expect(response).to have_http_status(:forbidden)
+        expect(error['detail']).to include('Veterans may access only their own records')
+      end
+    end
+
+    describe 'with representative scope and missing required ICN parameter' do
+      let(:scope) { "representative/#{scope_base}.read" }
+      let(:params) { default_params }
+
+      it 'returns a 400 error' do
+        expect(response).to have_http_status(:bad_request)
+        expect(error['detail']).to include('required parameter "icn"')
+      end
+    end
+
+    describe 'with system scope and missing required ICN parameter' do
+      let(:scope) { "system/#{scope_base}.read" }
+      let(:params) { default_params }
+
+      it 'returns a 400 error' do
+        expect(response).to have_http_status(:bad_request)
+        expect(error['detail']).to include('required parameter "icn"')
+      end
+    end
+
+    describe 'MPI SSN lookup errors' do
+      describe 'when veteran SSN is not found in MPI based on the provided ICN' do
+        let(:mpi_cassette) { 'mpi/find_candidate/icn_not_found' }
+
+        it 'returns a 404 error with a message that does not reference SSN' do
+          expect(response).to have_http_status(:not_found)
+          expect(error['detail']).not_to include('SSN')
+        end
+      end
+
+      describe 'when MPI throws an error' do
+        let(:mpi_cassette) { 'mpi/find_candidate/internal_server_error' }
+
+        it 'returns a 502 error instead' do
+          expect(response).to have_http_status(:bad_gateway)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/vcr_cassettes/caseflow/legacy_appeals_server_error.yml
+++ b/spec/support/vcr_cassettes/caseflow/legacy_appeals_server_error.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com/api/v3/decision_reviews/legacy_appeals
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Ssn:
+      - '111223333'
+      Authorization:
+      - Token token=PUBLICDEMO123
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 08 Jan 2018 14:44:00 GMT
+      Etag:
+      - W/"46b178ad8bb4e05c7320f42c3f5fa9fc"
+      Server:
+      - nginx/1.10.2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 39fcbafe-9e27-4070-862c-1e555d0db8f9
+      X-Runtime:
+      - '2.841798'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '187'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "errors": [{
+            "status": "500",
+            "title": "Internal Server Error",
+            "detail": "No method error"
+          }]
+        }
+    http_version:
+  recorded_at: Wed, 08 Jan 2018 14:44:00 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Summary

- This is similar to #14874, but it implements the same behavior for the Legacy Appeals API v0 - the ICN parameter is now optional for requests using a veteran-scoped token, and remains required for representative- and system-scoped tokens.

## Related issue(s)
- [API-32568](https://jira.devops.va.gov/browse/API-32568), which also includes Appealable Issues - I wasn't able to fit that part into this PR, so I'll make a follow-up PR for Appealable Issues.

## Testing done
- Added new specs

## What areas of the site does it impact?
- Legacy Appeals API v0 (not yet in production)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature