### PR TITLE
MHV-52911 Prep notes domain for production

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -658,6 +658,10 @@ features:
     actor_type: user
     description: Show/hide in-progress Medical Records domains
     enable_in_development: true
+  mhv_medical_records_display_notes:
+    actor_type: user
+    description: Show/hide content related to Notes in Medical Records
+    enable_in_development: true
   mhv_medical_records_display_sidenav:
     actor_type: user
     description: Show/hide the Medical Records side navigation

--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -127,7 +127,10 @@ module MedicalRecords
     def list_clinical_notes
       loinc_codes = "#{PHYSICIAN_PROCEDURE_NOTE},#{DISCHARGE_SUMMARY}"
       bundle = fhir_search(FHIR::DocumentReference,
-                           search: { parameters: { patient: patient_fhir_id, type: loinc_codes } })
+                           {
+                             search: { parameters: { patient: patient_fhir_id, type: loinc_codes } },
+                             headers: { 'Cache-Control': 'no-cache' }
+                           })
 
       # Sort the bundle of notes based on the date field appropriate to each note type.
       sort_bundle_with_criteria(bundle, :desc) do |resource|

--- a/spec/lib/medical_records/client_spec.rb
+++ b/spec/lib/medical_records/client_spec.rb
@@ -151,6 +151,9 @@ describe MedicalRecords::Client do
   it 'gets a list of care summaries & notes', :vcr do
     VCR.use_cassette 'mr_client/get_a_list_of_clinical_notes' do
       note_list = client.list_clinical_notes
+      expect(
+        a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
+      ).to have_been_made.once
       expect(note_list).to be_a(FHIR::Bundle)
       # Verify that the list is sorted reverse chronologically (with nil values to the end).
       note_list.entry.each_cons(2) do |prev, curr|


### PR DESCRIPTION
## Summary

- Added the feature toggle for Care Summaries & Notes
- Added the "no-cache" header for Care Summaries & Notes

## Related issue(s)
### [MHV-52911](https://jira.devops.va.gov/browse/MHV-52911) - Create Feature Flag for Care Summary and Notes ###

> Create Feature Flag for Care Summary and Notes
> 
> User Story: As a Medical Record team, we want to Create Feature Flag for Care Summary and Notes
> 
> GIVEN:
> WHEN:
> THEN:
> 
> Feature Flag Y/N ? Y
> Manual Testing Y/N ? N
> Automated Testing Y/N ? N
> Accessibility Testing Y/N ? N
> 
> Acceptance Criteria:
> AC1 Feature Flag for Care Summary and Notes has been created
> AC2
> AC3
> AC4
> 
> Links to UCD:
> Sketch Link:
> Other Design Notes
> 
> Architectural Notes:

## Testing done

- Added a spec test for the "no-cache" header
- Feaure flag functionality will be tested on the frontend

## Screenshots


## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
