### PR TITLE
Add zip code flag to metadata validator

### DIFF
--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -37,7 +37,7 @@ module SimpleFormsApiSubmission
     end
 
     def self.validate_zip_code(metadata, zip_code_is_us_based)
-      zip_code = metadata['zipCode'].dup.gsub(/[0-9]/, '')
+      zip_code = metadata['zipCode'].dup.gsub(/[^0-9]/, '')
       validate_presence_and_stringiness(zip_code, 'zip code')
 
       zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -2,11 +2,11 @@
 
 module SimpleFormsApiSubmission
   class MetadataValidator
-    def self.validate(metadata)
+    def self.validate(metadata, zip_code_is_us_based = true)
       validate_first_name(metadata)
         .then { |m| validate_last_name(m) }
         .then { |m| validate_file_number(m) }
-        .then { |m| validate_zip_code(m) }
+        .then { |m| validate_zip_code(m, zip_code_is_us_based) }
         .then { |m| validate_source(m) }
         .then { |m| validate_doc_type(m) }
     end
@@ -14,7 +14,7 @@ module SimpleFormsApiSubmission
     def self.validate_first_name(metadata)
       validate_presence_and_stringiness(metadata['veteranFirstName'], 'veteran first name')
       metadata['veteranFirstName'] =
-        I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
+        I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\/\s]/, '').strip.first(50)
 
       metadata
     end
@@ -22,7 +22,7 @@ module SimpleFormsApiSubmission
     def self.validate_last_name(metadata)
       validate_presence_and_stringiness(metadata['veteranLastName'], 'veteran last name')
       metadata['veteranLastName'] =
-        I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
+        I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\/\s]/, '').strip.first(50)
 
       metadata
     end
@@ -36,9 +36,16 @@ module SimpleFormsApiSubmission
       metadata
     end
 
-    def self.validate_zip_code(metadata)
-      validate_presence_and_stringiness(metadata['zipCode'], 'zip code')
-      metadata['zipCode'] = '00000' unless metadata['zipCode'].match?(/\A\d{5}(-\d{4})?\z/)
+    def self.validate_zip_code(metadata, zip_code_is_us_based)
+      zip_code = metadata['zipCode'].dup
+      validate_presence_and_stringiness(zip_code, 'zip code')
+      if zip_code.match?(/\A[0-9]{9}\z/)
+        zip_code = zip_code.insert(5, '-')
+      end
+
+      zip_code = '00000' unless zip_code.match?(/\A[0-9]{5}(-[0-9]{4})?\z/)
+      zip_code = '00000' unless zip_code_is_us_based
+      metadata['zipCode'] = zip_code
 
       metadata
     end

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -2,7 +2,7 @@
 
 module SimpleFormsApiSubmission
   class MetadataValidator
-    def self.validate(metadata, zip_code_is_us_based = true)
+    def self.validate(metadata, zip_code_is_us_based: true)
       validate_first_name(metadata)
         .then { |m| validate_last_name(m) }
         .then { |m| validate_file_number(m) }
@@ -39,10 +39,8 @@ module SimpleFormsApiSubmission
     def self.validate_zip_code(metadata, zip_code_is_us_based)
       zip_code = metadata['zipCode'].dup
       validate_presence_and_stringiness(zip_code, 'zip code')
-      if zip_code.match?(/\A[0-9]{9}\z/)
-        zip_code = zip_code.insert(5, '-')
-      end
-
+      
+      zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)
       zip_code = '00000' unless zip_code.match?(/\A[0-9]{5}(-[0-9]{4})?\z/)
       zip_code = '00000' unless zip_code_is_us_based
       metadata['zipCode'] = zip_code

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -14,7 +14,7 @@ module SimpleFormsApiSubmission
     def self.validate_first_name(metadata)
       validate_presence_and_stringiness(metadata['veteranFirstName'], 'veteran first name')
       metadata['veteranFirstName'] =
-        I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\/\s]/, '').strip.first(50)
+        I18n.transliterate(metadata['veteranFirstName']).gsub(%r{[^a-zA-Z\-\/\s]}, '').strip.first(50)
 
       metadata
     end
@@ -22,7 +22,7 @@ module SimpleFormsApiSubmission
     def self.validate_last_name(metadata)
       validate_presence_and_stringiness(metadata['veteranLastName'], 'veteran last name')
       metadata['veteranLastName'] =
-        I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\/\s]/, '').strip.first(50)
+        I18n.transliterate(metadata['veteranLastName']).gsub(%r{[^a-zA-Z\-\/\s]}, '').strip.first(50)
 
       metadata
     end
@@ -39,7 +39,7 @@ module SimpleFormsApiSubmission
     def self.validate_zip_code(metadata, zip_code_is_us_based)
       zip_code = metadata['zipCode'].dup
       validate_presence_and_stringiness(zip_code, 'zip code')
-      
+
       zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)
       zip_code = '00000' unless zip_code.match?(/\A[0-9]{5}(-[0-9]{4})?\z/)
       zip_code = '00000' unless zip_code_is_us_based

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -37,7 +37,7 @@ module SimpleFormsApiSubmission
     end
 
     def self.validate_zip_code(metadata, zip_code_is_us_based)
-      zip_code = metadata['zipCode'].dup
+      zip_code = metadata['zipCode'].dup.gsub(/[0-9]/, '')
       validate_presence_and_stringiness(zip_code, 'zip code')
 
       zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)

--- a/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
+++ b/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
@@ -136,7 +136,7 @@ describe SimpleFormsApiSubmission::MetadataValidator do
       it 'returns metadata with disallowed characters of veteran last name stripped or corrected' do
         metadata = {
           'veteranFirstName' => 'John',
-          'veteranLastName' => '2Jöhn~! - Jo/hn?\\',
+          'veteranLastName' => '2Jöh’n~! - J\'o/hn?\\',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
           'source' => 'VA Platform Digital Forms',

--- a/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
+++ b/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
@@ -83,7 +83,7 @@ describe SimpleFormsApiSubmission::MetadataValidator do
           'businessLine' => 'CMP'
         }
         expected_metadata = {
-          'veteranFirstName' => 'John - John',
+          'veteranFirstName' => 'John - Jo/hn',
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
@@ -145,7 +145,7 @@ describe SimpleFormsApiSubmission::MetadataValidator do
         }
         expected_metadata = {
           'veteranFirstName' => 'John',
-          'veteranLastName' => 'John - John',
+          'veteranLastName' => 'John - Jo/hn',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
           'source' => 'VA Platform Digital Forms',
@@ -202,6 +202,61 @@ describe SimpleFormsApiSubmission::MetadataValidator do
       }
 
       validated_metadata = SimpleFormsApiSubmission::MetadataValidator.validate(metadata)
+
+      expect(validated_metadata).to eq expected_metadata
+    end
+  end
+
+  describe 'zip code is 9 digits long' do
+    it 'is transformed to a 5+4 format US zip code' do
+      metadata = {
+        'veteranFirstName' => 'John',
+        'veteranLastName' => 'Doe',
+        'fileNumber' => '444444444',
+        'zipCode' => '123456789',
+        'source' => 'VA Platform Digital Forms',
+        'docType' => '21-0845',
+        'businessLine' => 'CMP'
+      }
+      expected_metadata = {
+        'veteranFirstName' => 'John',
+        'veteranLastName' => 'Doe',
+        'fileNumber' => '444444444',
+        'zipCode' => '12345-6789',
+        'source' => 'VA Platform Digital Forms',
+        'docType' => '21-0845',
+        'businessLine' => 'CMP'
+      }
+
+      validated_metadata = SimpleFormsApiSubmission::MetadataValidator.validate(metadata)
+
+      expect(validated_metadata).to eq expected_metadata
+    end
+  end
+
+  describe 'zip code is not US based' do
+    it 'is set to 00000' do
+      metadata = {
+        'veteranFirstName' => 'John',
+        'veteranLastName' => 'Doe',
+        'fileNumber' => '444444444',
+        'zipCode' => '12345',
+        'source' => 'VA Platform Digital Forms',
+        'docType' => '21-0845',
+        'businessLine' => 'CMP'
+      }
+      expected_metadata = {
+        'veteranFirstName' => 'John',
+        'veteranLastName' => 'Doe',
+        'fileNumber' => '444444444',
+        'zipCode' => '00000',
+        'source' => 'VA Platform Digital Forms',
+        'docType' => '21-0845',
+        'businessLine' => 'CMP'
+      }
+      zip_code_is_us_based = false
+
+      validated_metadata = SimpleFormsApiSubmission::MetadataValidator.validate(metadata, zip_code_is_us_based)
 
       expect(validated_metadata).to eq expected_metadata
     end

--- a/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
+++ b/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
@@ -254,9 +254,8 @@ describe SimpleFormsApiSubmission::MetadataValidator do
         'docType' => '21-0845',
         'businessLine' => 'CMP'
       }
-      zip_code_is_us_based = false
 
-      validated_metadata = SimpleFormsApiSubmission::MetadataValidator.validate(metadata, zip_code_is_us_based)
+      validated_metadata = SimpleFormsApiSubmission::MetadataValidator.validate(metadata, zip_code_is_us_based: false)
 
       expect(validated_metadata).to eq expected_metadata
     end


### PR DESCRIPTION
## Summary

This PR does a few things to the metadata validator:
1. Adds a zip code nationality flag so that we can default to `00000` even if we get a valid-looking zip code which is actually non-US (looking at you, Germany!).
2. Slightly modified the regex for first name and last name to accept a forward slash (`/`).
3. Inserts a dash (`-`) in 9 digit zip codes to make them 5+4 format and pass the regex.


## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/72750


## Testing done

Tests updated and passing.
