### PR TITLE
Pension - 72276 - Perform API meta data validation

### DIFF
--- a/spec/sidekiq/lighthouse/pension_benefit_intake_job_spec.rb
+++ b/spec/sidekiq/lighthouse/pension_benefit_intake_job_spec.rb
@@ -94,12 +94,14 @@ RSpec.describe Lighthouse::PensionBenefitIntakeJob, uploader_helpers: true do
 
     it 'returns expected hash' do
       expect(job.generate_form_metadata_lh).to include(
-        veteran_first_name: be_a(String),
-        veteran_last_name: be_a(String),
-        file_number: be_a(String),
-        zip: be_a(String),
-        doc_type: be_a(String),
-        claim_date: be_a(ActiveSupport::TimeWithZone)
+        'veteranFirstName' => be_a(String),
+        'veteranLastName' => be_a(String),
+        'fileNumber' => be_a(String),
+        'zipCode' => be_a(String),
+        'docType' => be_a(String),
+        'businessLine' => eq(described_class::PENSION_BUSINESSLINE),
+        'source' => eq(described_class::PENSION_SOURCE),
+        'claimDate' => be_a(ActiveSupport::TimeWithZone)
       )
     end
     # generate_form_metadata_lh


### PR DESCRIPTION
## Summary

- added metadata validation for benefit intake to pension job

- Pension

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/72276

## Testing done

- no validation present for metadata
- using saved_claim entry, run the job process via ruby console
- manual run of saved_claim and specs updated

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
