### PR TITLE
VFEP-1064: increase timeout for institution searches to fix DataDog errors

### DIFF
--- a/lib/gi/search_configuration.rb
+++ b/lib/gi/search_configuration.rb
@@ -2,7 +2,7 @@
 
 module GI
   class SearchConfiguration < GI::Configuration
-    self.read_timeout = Settings.gids.search&.read_timeout || 2
-    self.open_timeout = Settings.gids.search&.open_timeout || 2
+    self.read_timeout = Settings.gids.search&.read_timeout || 4
+    self.open_timeout = Settings.gids.search&.open_timeout || 4
   end
 end

--- a/spec/lib/gi/search_configuration_spec.rb
+++ b/spec/lib/gi/search_configuration_spec.rb
@@ -7,7 +7,7 @@ describe GI::SearchConfiguration do
   describe '.open_timeout' do
     context 'when Settings.gi.search.open_timeout is not set' do
       it 'uses the setting' do
-        expect(GI::SearchConfiguration.instance.open_timeout).to eq(2)
+        expect(GI::SearchConfiguration.instance.open_timeout).to eq(4)
       end
     end
   end
@@ -15,7 +15,7 @@ describe GI::SearchConfiguration do
   describe '.read_timeout' do
     context 'when Settings.gi.search.read_timeout is not set' do
       it 'uses the setting' do
-        expect(GI::SearchConfiguration.instance.read_timeout).to eq(2)
+        expect(GI::SearchConfiguration.instance.read_timeout).to eq(4)
       end
     end
   end


### PR DESCRIPTION
## Summary

- VFEP-1064: increase timeout for institution searches to fix DataDog errors
- increase search timeout from 2 seconds to 4 seconds
- VFEP Sustainment

## Related issue(s)
- [vfep-1064](https://jira.devops.va.gov/browse/VFEP-1064)
- [github 15034](https://github.com/department-of-veterans-affairs/vets-api/issues/15034)

## Testing done

- DataDog errors related to timeout of institution searches
- Developer testing on local passed confirming searches work.  After deploy, on production check that DataDog errors go away.

## What areas of the site does it impact?
timeouts on institution searches

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
