### PR TITLE
API-30616-hub-updates-v1

### DIFF
--- a/modules/claims_api/catalog-info.yaml
+++ b/modules/claims_api/catalog-info.yaml
@@ -6,9 +6,8 @@ metadata:
   annotations:
     github.com/project-slug: https://github.com/department-of-veterans-affairs/vets-api
     datadog/production-monitor-id: '98a-nx5-icf'
-    datadog/sandbox-monitor-id: '2ne-mbd-mve' # // status tab
-    hub.lighthouse.va.gov/api-id: '' # // release notes tab
-    # Lighthouse hub > catalog > benefits claims api > release notes > "If your API has published it's release notes on https://developer.va.gov/, then use the altId of your API as defined by the https://github.com/department-of-veterans-affairs/lighthouse-platform-backend"
+    datadog/sandbox-monitor-id: '2ne-mbd-mve' # status tab
+    hub.lighthouse.va.gov/api-id: 'claims' # release notes tab
   title: Benefits Claims API v1
   tags:
     - lighthouse

--- a/modules/claims_api/catalog-info.yaml
+++ b/modules/claims_api/catalog-info.yaml
@@ -3,6 +3,12 @@ kind: API
 metadata:
   name: benefits-claims-v1
   description: The Benefits Claims API is a suite of services that enables VA and third-party consumers to build applications that let Veterans and their authorized representatives view and submit certain claims and claim-related information to the VA. We provide the ability to auto-establish claims by submitting structured data that can return realtime validations, allowing for better data quality. 
+  annotations:
+    github.com/project-slug: https://github.com/department-of-veterans-affairs/vets-api
+    datadog/production-monitor-id: '98a-nx5-icf'
+    datadog/sandbox-monitor-id: '2ne-mbd-mve' # // status tab
+    hub.lighthouse.va.gov/api-id: '' # // release notes tab
+    # Lighthouse hub > catalog > benefits claims api > release notes > "If your API has published it's release notes on https://developer.va.gov/, then use the altId of your API as defined by the https://github.com/department-of-veterans-affairs/lighthouse-platform-backend"
   title: Benefits Claims API v1
   tags:
     - lighthouse
@@ -54,4 +60,4 @@ spec:
   owner: lighthouse-dash
   system: vets-api
   definition:
-    $text: https://github.com/department-of-veterans-affairs/vets-api/blob/48ae39ee3a329dfc9dc09376f6fbea004229a692/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+    $text: https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/claims_api/app/swagger/claims_api/v1/swagger.json


### PR DESCRIPTION
## Summary

- Changes link to swagger doc for v1; 
- adds annotations for status. Right now it is pointed to the Vets API Dashboard on DataDog.
- release notes. Our altId is 'claims'
- more work is needed. We need to set up a synthetic test on dataDag and add our ID

## Related issue(s)
- [API-30616](https://jira.devops.va.gov/browse/API-30616)


## Testing done

- not sure how I can test this yet


## What areas of the site does it impact?
	modified:   modules/claims_api/catalog-info.yaml

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature