### PR TITLE
Converting tracked_item_ids param to an array

### DIFF
--- a/app/controllers/v0/benefits_documents_controller.rb
+++ b/app/controllers/v0/benefits_documents_controller.rb
@@ -14,6 +14,13 @@ module V0
       # Service expects a different claim ID param
       params[:claim_id] = params[:benefits_claim_id]
 
+      # The frontend may pass a stringified Array of tracked item ids
+      # because of the way array values are handled by formData
+      if params[:tracked_item_ids].instance_of?(String)
+        # Value should look "[123,456]" before it's parsed
+        params[:tracked_item_ids] = JSON.parse(params[:tracked_item_ids])
+      end
+
       jid = service.queue_document_upload(params)
       render_job_id(jid)
     end


### PR DESCRIPTION
## Summary
The `BenefitsDocuments::Service.queue_document_upload` method expects a set of params, including a param called `tracked_item_ids` that should be an array of numbers. Vets-website is going to be sending this param as stringified JSON so that vets-api can parse the param value into an array of numbers. Adding a check to make sure that the value of `params[:tracked_item_ids]` is an instance of the String class, just in case we want to be able to send something else in the future

`params[:tracked_item_id]` should look like this before the conversion:
```ruby
puts params[:tracked_item_id] # => "[123,456]"
```

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#72886

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
