### PR TITLE
Sanitize pdftk error output before sending to Sentry

### DIFF
--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -99,7 +99,6 @@ class EVSSClaimDocument < Common::Base
       file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}
       password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
-      puts sanitized_message
       log_message_to_sentry(sanitized_message, 'warn')
       errors.add(:base, I18n.t('errors.messages.uploads.pdf.incorrect_password'))
     end

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -96,9 +96,10 @@ class EVSSClaimDocument < Common::Base
                        'input_pw', password,
                        'output', tempfile_without_pass.path)
     rescue PdfForms::PdftkError => e
-      file_regex = /\/(?:\w+\/)*[\w-]+\.pdf\b/.freeze
-      password_regex = /(input_pw).*?(output)/.freeze
+      file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}
+      password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
+      puts sanitized_message
       log_message_to_sentry(sanitized_message, 'warn')
       errors.add(:base, I18n.t('errors.messages.uploads.pdf.incorrect_password'))
     end

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -96,7 +96,10 @@ class EVSSClaimDocument < Common::Base
                        'input_pw', password,
                        'output', tempfile_without_pass.path)
     rescue PdfForms::PdftkError => e
-      log_message_to_sentry(e.message, 'warn')
+      file_regex = /\/(?:\w+\/)*[\w-]+\.pdf\b/.freeze
+      password_regex = /(input_pw).*?(output)/.freeze
+      sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
+      log_message_to_sentry(sanitized_message, 'warn')
       errors.add(:base, I18n.t('errors.messages.uploads.pdf.incorrect_password'))
     end
 

--- a/app/models/form_attachment.rb
+++ b/app/models/form_attachment.rb
@@ -44,8 +44,8 @@ class FormAttachment < ApplicationRecord
     begin
       pdftk.call_pdftk(file.tempfile.path, 'input_pw', file_password, 'output', tmpf.path)
     rescue PdfForms::PdftkError => e
-      file_regex = /\/(?:\w+\/)*[\w-]+\.pdf\b/.freeze
-      password_regex = /(input_pw).*?(output)/.freeze
+      file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}
+      password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
       log_message_to_sentry(sanitized_message, 'warn')
       raise Common::Exceptions::UnprocessableEntity.new(

--- a/app/models/lighthouse_document.rb
+++ b/app/models/lighthouse_document.rb
@@ -98,7 +98,10 @@ class LighthouseDocument < Common::Base
                        'input_pw', password,
                        'output', tempfile_without_pass.path)
     rescue PdfForms::PdftkError => e
-      log_message_to_sentry(e.message, 'warn')
+      file_regex = /\/(?:\w+\/)*[\w-]+\.pdf\b/.freeze
+      password_regex = /(input_pw).*?(output)/.freeze
+      sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
+      log_message_to_sentry(sanitized_message, 'warn')
       errors.add(:base, I18n.t('errors.messages.uploads.pdf.incorrect_password'))
     end
 

--- a/app/models/lighthouse_document.rb
+++ b/app/models/lighthouse_document.rb
@@ -98,8 +98,8 @@ class LighthouseDocument < Common::Base
                        'input_pw', password,
                        'output', tempfile_without_pass.path)
     rescue PdfForms::PdftkError => e
-      file_regex = /\/(?:\w+\/)*[\w-]+\.pdf\b/.freeze
-      password_regex = /(input_pw).*?(output)/.freeze
+      file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b/}
+      password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
       log_message_to_sentry(sanitized_message, 'warn')
       errors.add(:base, I18n.t('errors.messages.uploads.pdf.incorrect_password'))


### PR DESCRIPTION
## Summary
_This is for `PdfForms#call_pdftk` only_ 

- replaced filenames and path with `[FILTERED FILENAME]`
- replaced pdf input password with `[FILTERED]`

## Related issue(s)
- [va.gov-team#73153](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73153)

## Testing done

- manual testing to proved info was removed. 

## What areas of the site does it impact?

- anywhere with pdf unlocking 

## Acceptance criteria

- [x] filename and path were removed
- [x] input password was removed
- [x] output is same as expected

### Comments

An alternative approach would be pull out only the necessary information instead of removing the "bad" information, but in case the necessary information contained "bad" information I decided against it. 