### PR TITLE
Include more flipper questions in template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,28 +3,30 @@
 
 ## Summary
 
+- *This work is behind a feature toggle (flipper): YES/NO*
 - *(Summarize the changes that have been made to the platform)*
 - *(If bug, how to reproduce)*
-- *(What is the solution, why is this the solution)*
-- *(Which team do you work for, does your team own the maintainence of this component?)*
-- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
+- *(What is the solution, why is this the solution?)*
+- *(Which team do you work for, does your team own the maintenance of this component?)*
+- *(If introducing a flipper, what is the success criteria being targeted?)*
 
 ## Related issue(s)
-- department-of-veterans-affairs/va.gov-team#0000
-- *Link to ticket created in va.gov-team repo*
+
+- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
 - *Link to previous change of the code/bug (if applicable)*
 - *Link to epic if not included in ticket*
 
-
 ## Testing done
 
+- [ ] *New code is covered by unit tests*
 - *Describe what the old behavior was prior to the change*
 - *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
-- *Describe the tests completed and the results*
+- *If this work is behind a flipper:*
+  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
+  - *What is the testing plan for rolling out the feature?*
 
 ## Screenshots
 _Note: Optional_
-
 
 ## What areas of the site does it impact?
 *(Describe what parts of the site are impacted and*if*code touched other areas)*


### PR DESCRIPTION
## Summary

When reviewing PRs, it's sometimes hard to know whether modified code is behind a feature flag or not. This piece of info impacts the code review. The Platform CoP was discussing how to have a better understanding of whether code is behind a flipper or not and we thought modifying the template was a good first step. 

## Related issue(s)
- Slack conversation: https://dsva.slack.com/archives/C0460N83Y9G/p1704215947797249
- CoP meeting notes: https://vfs.atlassian.net/wiki/spaces/BCP/pages/2890563598/1+8+24#2%EF%B8%8F%E2%83%A3--Discussion


## Testing done

- This is what it will look like formatted: https://github.com/department-of-veterans-affairs/vets-api/blob/dfecc31f0283e1305cbf87928e8d8d22fd34cfd5/.github/PULL_REQUEST_TEMPLATE.md


## What areas of the site does it impact?
The PR template for vets-api.

