### PR TITLE
POA v2: Get POA - Format response according to LH standards

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
@@ -4,12 +4,17 @@ module ClaimsApi
   module V2
     module Blueprints
       class PowerOfAttorneyBlueprint < Blueprinter::Base
-        identifier :code
-        field :name
-        field :phone do |entity, _options|
-          { number: entity[:phone_number] }
-        end
+        identifier :id
+
         field :type
+
+        field :attributes do |poa, _options|
+          {
+            code: poa[:code],
+            name: poa[:name],
+            phone: { number: poa[:phone_number] }
+          }
+        end
 
         transform ClaimsApi::V2::Blueprints::Transformers::LowerCamelTransformer
       end

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -14,11 +14,12 @@ module ClaimsApi
 
         def show
           poa_code = BGS::PowerOfAttorneyVerifier.new(target_veteran).current_poa_code
-          head(:no_content) && return if poa_code.blank?
-
-          render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyBlueprint.render(
-            representative(poa_code).merge({ code: poa_code })
-          )
+          data = poa_code.blank? ? {} : representative(poa_code).merge({ code: poa_code })
+          if poa_code.blank?
+            render json: { data: }
+          else
+            render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyBlueprint.render(data, root: :data)
+          end
         end
 
         def appoint_organization

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8281,7 +8281,7 @@
             ]
           }
         ],
-        "description": "Retrieves current Power of Attorney for Veteran.",
+        "description": "Retrieves current Power of Attorney for Veteran or empty data if no POA is assigned.",
         "parameters": [
           {
             "name": "veteranId",
@@ -8299,58 +8299,77 @@
             "content": {
               "application/json": {
                 "example": {
-                  "code": "A1Q",
-                  "name": "Firstname Lastname",
-                  "phone": {
-                    "number": "555-555-5555"
-                  },
-                  "type": "individual"
+                  "data": {
+                    "id": null,
+                    "type": "individual",
+                    "attributes": {
+                      "code": "A1Q",
+                      "name": "Firstname Lastname",
+                      "phone": {
+                        "number": "555-555-5555"
+                      }
+                    }
+                  }
                 },
                 "schema": {
                   "type": "object",
-                  "additionalProperties": false,
                   "required": [
-                    "code"
+                    "data"
                   ],
                   "properties": {
-                    "code": {
-                      "type": "string",
-                      "description": "Power of Attorney Code currently assigned to Veteran"
-                    },
-                    "name": {
-                      "description": "Name of individual representative or organization",
-                      "type": "string",
-                      "nullable": true,
-                      "example": "Jane Smith"
-                    },
-                    "type": {
-                      "description": "Type of representative, organization or individual",
-                      "type": "string",
-                      "nullable": true,
-                      "example": "individual"
-                    },
-                    "phone": {
+                    "data": {
                       "type": "object",
                       "additionalProperties": false,
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
                       "properties": {
-                        "number": {
-                          "description": "Phone number of representative. Can be organization or individual phone number.",
+                        "id": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "type": {
                           "type": "string",
                           "nullable": true,
-                          "example": "555-555-5555"
+                          "description": "Type of representative, organization or individual",
+                          "example": "individual"
+                        },
+                        "attributes": {
+                          "required": [
+                            "code",
+                            "name",
+                            "phone"
+                          ],
+                          "code": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Power of Attorney Code currently assigned to Veteran"
+                          },
+                          "name": {
+                            "description": "Name of individual representative or organization",
+                            "type": "string",
+                            "nullable": true,
+                            "example": "Jane Smith"
+                          },
+                          "phone": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "number": {
+                                "description": "Phone number of representative. Can be organization or individual phone number.",
+                                "type": "string",
+                                "nullable": true,
+                                "example": "555-555-5555"
+                              }
+                            }
+                          }
                         }
                       }
                     }
                   }
                 }
-              }
-            }
-          },
-          "204": {
-            "description": "Successful response with no current Power of Attorney",
-            "content": {
-              "application/json": {
-                "example": ""
               }
             }
           },

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe 'Power Of Attorney', type: :request do
         context 'when provided' do
           context 'when valid' do
             context 'when current poa code does not exist' do
-              it 'returns a 204' do
+              it 'returns a 200' do
                 mock_ccg(scopes) do |auth_header|
                   allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(OpenStruct.new(current_poa_code: nil))
 
                   get get_poa_path, headers: auth_header
 
-                  expect(response.status).to eq(204)
+                  expect(response.status).to eq(200)
                 end
               end
             end
@@ -61,12 +61,17 @@ RSpec.describe 'Power Of Attorney', type: :request do
                         .and_return(OpenStruct.new(current_poa_code: 'ABC'))
 
                       expected_response = {
-                        'code' => 'ABC',
-                        'name' => 'Robert Lawlaw',
-                        'phone' => {
-                          'number' => '321-654-0987'
-                        },
-                        'type' => 'individual'
+                        'data' => {
+                          'id' => nil,
+                          'type' => 'individual',
+                          'attributes' => {
+                            'code' => 'ABC',
+                            'name' => 'Robert Lawlaw',
+                            'phone' => {
+                              'number' => '321-654-0987'
+                            }
+                          }
+                        }
                       }
 
                       get get_poa_path, headers: auth_header

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -22,7 +22,7 @@ describe 'PowerOfAttorney',
         { bearer_token: [] }
       ]
       produces 'application/json'
-      description 'Retrieves current Power of Attorney for Veteran.'
+      description 'Retrieves current Power of Attorney for Veteran or empty data if no POA is assigned.'
 
       let(:Authorization) { 'Bearer token' }
       parameter name: 'veteranId',
@@ -64,34 +64,6 @@ describe 'PowerOfAttorney',
             example.metadata[:response][:content] = {
               'application/json' => {
                 example: JSON.parse(response.body, symbolize_names: true)
-              }
-            }
-          end
-
-          it 'returns a valid 200 response' do |example|
-            assert_response_matches_metadata(example.metadata)
-          end
-        end
-      end
-
-      describe 'No POA assigned to Veteran' do
-        let(:bgs_poa) { { person_org_name: nil } }
-
-        response '204', 'Successful response with no current Power of Attorney' do
-          before do |example|
-            expect_any_instance_of(local_bgs).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
-            allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
-              .and_return({ person_poa_history: nil })
-            mock_ccg(scopes) do |auth_header|
-              Authorization = auth_header # rubocop:disable Naming/ConstantName
-              submit_request(example.metadata)
-            end
-          end
-
-          after do |example|
-            example.metadata[:response][:content] = {
-              'application/json' => {
-                example: response.body
               }
             }
           end

--- a/spec/support/schemas/claims_api/veterans/power-of-attorney/get.json
+++ b/spec/support/schemas/claims_api/veterans/power-of-attorney/get.json
@@ -1,33 +1,47 @@
 {
   "type": "object",
-  "additionalProperties": false,
-  "required": ["code"],
+  "required": ["data"],
   "properties": {
-    "code": {
-      "type": "string",
-      "description": "Power of Attorney Code currently assigned to Veteran"
-    },
-    "name": {
-      "description": "Name of individual representative or organization",
-      "type": ["string", "null"],
-      "nullable": true,
-      "example": "Jane Smith"
-    },
-    "type": {
-      "description": "Type of representative, organization or individual",
-      "type": ["string", "null"],
-      "nullable": true,
-      "example": "individual"
-    },
-    "phone": {
+    "data": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["id", "type", "attributes"],
       "properties": {
-        "number": {
-          "description": "Phone number of representative. Can be organization or individual phone number.",
-          "type": ["string", "null"],
+        "id": {
+          "type": "string",
+          "nullable": true
+        },
+        "type": {
+          "type": "string",
           "nullable": true,
-          "example": "555-555-5555"
+          "description": "Type of representative, organization or individual",
+          "example": "individual"
+        },
+        "attributes": {
+          "required": ["code", "name", "phone"],
+          "code": {
+            "type": "string",
+            "nullable": true,
+            "description": "Power of Attorney Code currently assigned to Veteran"
+          },
+          "name": {
+            "description": "Name of individual representative or organization",
+            "type": "string",
+            "nullable": true,
+            "example": "Jane Smith"
+          },
+          "phone": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "number": {
+                "description": "Phone number of representative. Can be organization or individual phone number.",
+                "type": "string",
+                "nullable": true,
+                "example": "555-555-5555"
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Respond with a 200 when the POA for a veteran doesn't exist and update JSON response to match LH standards.

## Summary

- Show POA returns 200 when no POA is assigned
- Show POA response is formatted according to LH standards

## Related issue(s)

- [API-32087](https://jira.devops.va.gov/browse/API-32087)
- [API-32121](https://jira.devops.va.gov/browse/API-32121)

![image](https://github.com/department-of-veterans-affairs/vets-api/assets/534756/970a2ae2-eaf0-4f80-bda7-3ca2376ad8b2)

## Testing done

- RSpec request spec updated

## What areas of the site does it impact?
* Claims API

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature