### PR TITLE
Uppercases needed fields.

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
@@ -22,11 +22,12 @@ module ClaimsApi
         poa_code: poa_form.form_data.dig('serviceOrganization', 'poaCode')
       )
 
+      # allow_poa_c_add reports 'No Data' if sent lowercase
       response = service.corporate_update.update_poa_access(
         participant_id: poa_form.auth_headers['va_eauth_pid'],
         poa_code: poa_form.form_data.dig('serviceOrganization', 'poaCode'),
         allow_poa_access: 'y',
-        allow_poa_c_add: allow_address_change?(poa_form, power_of_attorney_id) ? 'y' : 'n'
+        allow_poa_c_add: allow_address_change?(poa_form, power_of_attorney_id) ? 'Y' : 'N'
       )
 
       if response[:return_code] == 'GUIE50000'

--- a/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
   end
 
   context 'when address change is present and allowed' do
-    let(:allow_poa_c_add) { 'y' }
+    let(:allow_poa_c_add) { 'Y' }
     let(:consent_address_change) { true }
 
     it 'updates a the BIRLS record for a qualifying POA submittal' do
@@ -28,7 +28,7 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
   end
 
   context 'when address change is present and not allowed' do
-    let(:allow_poa_c_add) { 'n' }
+    let(:allow_poa_c_add) { 'N' }
     let(:consent_address_change) { false }
 
     it 'updates a the BIRLS record for a qualifying POA submittal' do
@@ -39,7 +39,7 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
   end
 
   context 'when address change is not present' do
-    let(:allow_poa_c_add) { 'n' }
+    let(:allow_poa_c_add) { 'N' }
     let(:consent_address_change) { nil }
 
     it 'updates a the BIRLS record for a qualifying POA submittal' do
@@ -50,7 +50,7 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
   end
 
   context 'when BGS fails the error is handled' do
-    let(:allow_poa_c_add) { 'y' }
+    let(:allow_poa_c_add) { 'Y' }
     let(:consent_address_change) { true }
 
     it 'marks the form as errored' do


### PR DESCRIPTION
## Summary
- VBMS Reports "No Data" if we send `allow_poa_c_add` lowercased.

## Related issue(s)
- https://jira.devops.va.gov/browse/API-33180

## Testing done

- Tested using staging VBMS to confirm that the uppercase *did* record the correct response.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
