### PR TITLE
Temporarily Silences Tests For CI Diagnostics

### DIFF
--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -5,7 +5,7 @@ require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::PdfFiller do
   def self.test_pdf_fill(form_number, test_payload = form_number)
-    it 'fills out a PDF from a templated JSON file - pending temporarily' do
+    it 'fills out a PDF from a templated JSON file' do
       skip 'pending temporarily'
       expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
 

--- a/modules/va_forms/spec/sidekiq/form_builder_spec.rb
+++ b/modules/va_forms/spec/sidekiq/form_builder_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe VAForms::FormBuilder, type: :job do
     end
 
     context 'when the PDF is unchanged' do
-      it 'keeps existing values without notifying slack - pending temporarily' do
-        skip 'pending temporarily'
+      it 'keeps existing values without notifying slack' do
+        skip 'skipping temporarily'
         expect(result.valid_pdf).to be(true)
         expect(result.sha256).to eq(valid_sha256)
         expect(slack_messenger).not_to have_received(:notify!)
@@ -98,8 +98,9 @@ RSpec.describe VAForms::FormBuilder, type: :job do
 
     context 'when the PDF has been marked as deleted (even though the URL is valid)' do
       let(:form_data) { deleted_form_data }
-      it 'includes a deleted_at date but still sets other values as usual and does not notify - pending temporarily' do
-        skip 'pending temporarily'
+
+      it 'includes a deleted_at date but still sets other values as usual and does not notify' do
+        skip 'skipping temporarily'
         expect(result.deleted_at.to_date.to_s).to eq('2020-07-16')
         expect(result.valid_pdf).to be(true)
         expect(result.sha256).to eq(valid_sha256)
@@ -109,8 +110,9 @@ RSpec.describe VAForms::FormBuilder, type: :job do
 
     context 'when the PDF was previously invalid' do
       let(:valid_pdf) { false }
-      it 'updates valid_pdf to true without notifying slack - pending temporarily' do
-        skip 'pending temporarily'
+
+      it 'updates valid_pdf to true without notifying slack' do
+        skip 'skipping temporarily'
         expect(result.valid_pdf).to be(true)
         expect(slack_messenger).not_to have_received(:notify!)
       end
@@ -120,8 +122,8 @@ RSpec.describe VAForms::FormBuilder, type: :job do
       let(:sha256) { 'arbitrary-old-sha256-value' }
 
       context 'and the url returns a PDF' do
-        it 'updates the saved sha256 and notifies slack - pending temporarily' do
-          skip 'pending temporarily'
+        it 'updates the saved sha256 and notifies slack' do
+          skip 'skipping temporarily'
           expect(result.sha256).to eq(valid_sha256)
           expect(VAForms::Slack::Messenger).to have_received(:new).with(
             {
@@ -138,8 +140,9 @@ RSpec.describe VAForms::FormBuilder, type: :job do
           allow_any_instance_of(Faraday::Utils::Headers).to receive(:[]).with(:user_agent).and_call_original
           allow_any_instance_of(Faraday::Utils::Headers).to receive(:[]).with('Content-Type').and_return('text/html')
         end
+
         it 'updates the saved sha256 but does not notify slack' do
-          skip 'pending temporarily'
+          skip 'skipping temporarily'
           expect(result.sha256).to eq(valid_sha256)
           expect(slack_messenger).not_to have_received(:notify!)
         end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *We've seen intermittent test failures on CI from the two files included here. This PR temporarily quiets the failures in those tests so we allow the codeowners the chance to take a look. 


## Testing done

-The changes made here were as a result of failing tests seen in CI, in #15038, #14991 and #14985


## What areas of the site does it impact?
*This temporarily silences failing tests across two spec files. 

## Acceptance criteria

- [ ] This temporarily silences failing tests across two spec files. 


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
