### PR TITLE
API-32635: `VAForms::FormBuilder` Job Fixes

### DIFF
--- a/lib/forms/schemas/forms.json
+++ b/lib/forms/schemas/forms.json
@@ -38,7 +38,7 @@
                 "type": "boolean"
               },
               "sha256": {
-                "type":"string"
+                "type": ["string", "null"]
               },
               "lastSha256Change": {
                 "type": ["string", "null"]

--- a/modules/va_forms/app/models/va_forms/form.rb
+++ b/modules/va_forms/app/models/va_forms/form.rb
@@ -18,6 +18,7 @@ module VAForms
     validates :title, presence: true
     validates :form_name, presence: true
     validates :row_id, uniqueness: true
+    validates :url, presence: true
     validates :valid_pdf, inclusion: { in: [true, false] }
 
     before_save :set_revision

--- a/modules/va_forms/spec/sidekiq/form_builder_spec.rb
+++ b/modules/va_forms/spec/sidekiq/form_builder_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe VAForms::FormBuilder, type: :job do
 
   let(:valid_pdf_cassette) { 'va_forms/valid_pdf' }
   let(:not_found_pdf_cassette) { 'va_forms/pdf_not_found' }
+
   let(:form_fetch_error_message) { described_class::FORM_FETCH_ERROR_MESSAGE }
 
   before do
@@ -27,7 +28,6 @@ RSpec.describe VAForms::FormBuilder, type: :job do
   end
 
   describe '#perform' do
-    let(:cassette) { nil }
     let(:form_name) { '21-0966' }
     let(:url) { 'https://www.vba.va.gov/pubs/forms/VBA-21-0966-ARE.pdf' }
     let(:valid_sha256) { 'b1ee32f44d7c17871e4aba19101ba6d55742674e6e1627498d618a356ea6bc78' }
@@ -40,7 +40,7 @@ RSpec.describe VAForms::FormBuilder, type: :job do
     let(:result) do
       form = VAForms::Form.create!(url:, form_name:, sha256:, title:, valid_pdf:, row_id:)
       with_settings(Settings.va_forms.slack, enabled: enable_notifications) do
-        VCR.use_cassette(cassette) do
+        VCR.use_cassette(valid_pdf_cassette) do
           form_builder.perform(form_data)
         end
       end
@@ -48,8 +48,6 @@ RSpec.describe VAForms::FormBuilder, type: :job do
     end
 
     context 'when the form url returns a valid body' do
-      let(:cassette) { valid_pdf_cassette }
-
       it 'correctly updates attributes based on the new form data' do
         expect(result).to have_attributes(
           form_name: '21-0966',


### PR DESCRIPTION
## Summary
Yesterday's deploy of #15045 brought to light the following issues with the `VAForms::FormBuilder` job. This PR resolves all of them.
1. The return of a `nil` `url` for a couple of new and invalid records broke the API contract between the VA Forms API and the `GET /v0/forms` endpoint, causing 500 errors on that endpoint. The change in this PR ensures that a `url` is always set, even if that url returns a 404.
2. The previous changes allowed a `sha256` to be `nil`. Our [VA Forms API documentation](https://developer.va.gov/explore/api/va-forms/docs?version=current) already states (and previously stated) that a `sha256` can be null. Therefore, this PR updates the schema validation yaml file that `GET /v0/forms` endpoint uses to validate the VA Forms API response, to allow for a string OR null value for this field.
3. A few of the specs in `modules/va_forms/spec/sidekiq/form_builder_spec.rb` were failing in a flaky manner. This was due to a nil VCR cassette reference, which emerged after reordering and regrouping of some of the specs in the spec file. The nil cassette reference has been resolved in this PR.

## Related issue(s)
- [API-32635](https://jira.devops.va.gov/browse/API-32635)

## Testing done
The job has been run locally with production form data to ensure that it is working as expected. Previously, it had been run with staging form data, which didn't catch the issues above.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `VAForms::FormBuilder` job.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.