### PR TITLE
[72845] Log terms-of-use redirects

### DIFF
--- a/app/services/sign_in/redirect_url_generator.rb
+++ b/app/services/sign_in/redirect_url_generator.rb
@@ -20,7 +20,12 @@ module SignIn
     private
 
     def full_redirect_uri
-      terms_code ? terms_of_use_redirect_url : original_redirect_uri_with_params
+      if terms_code
+        Rails.logger.info('Redirecting to /terms-of-use', type: :sis)
+        return terms_of_use_redirect_url
+      end
+
+      original_redirect_uri_with_params
     end
 
     def original_redirect_uri_with_params

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -65,6 +65,7 @@ module SAML
     def terms_of_use_redirect_url
       application = @tracker&.payload_attr(:application) || 'vaweb'
       if TERMS_OF_USE_ENABLED_CLIENTS.include?(application)
+        Rails.logger.info('Redirecting to /terms-of-use', type: :ssoe)
         add_query(terms_of_use_url, { redirect_url: login_redirect_url })
       else
         login_redirect_url

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -610,6 +610,8 @@ RSpec.describe SAML::PostURLService do
             let(:expected_login_redirect_url) do
               "#{values[:base_redirect]}#{SAML::URLService::LOGIN_REDIRECT_PARTIAL}?type=idme"
             end
+            let(:expected_log_message) { 'Redirecting to /terms-of-use' }
+            let(:expected_log_payload) { { type: :ssoe } }
 
             context 'when tracker application is within TERMS_OF_USE_ENABLED_CLIENTS' do
               let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS.first }
@@ -624,12 +626,22 @@ RSpec.describe SAML::PostURLService do
                   expect(subject.terms_of_use_redirect_url)
                     .to eq("http://#{review_instance_url}/terms-of-use?#{expected_redirect_url_param}")
                 end
+
+                it 'logs expected message and payload' do
+                  expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                  subject.terms_of_use_redirect_url
+                end
               end
 
               context 'and authentication is not occurring on a review instance' do
                 it 'has a login redirect url as a parameter embedded in terms of use page with success' do
                   expect(subject.terms_of_use_redirect_url)
                     .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
+                end
+
+                it 'logs expected message and payload' do
+                  expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                  subject.terms_of_use_redirect_url
                 end
               end
             end
@@ -640,6 +652,11 @@ RSpec.describe SAML::PostURLService do
               it 'has a login redirect url as a parameter embedded in terms of use page with success' do
                 expect(subject.terms_of_use_redirect_url)
                   .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
+              end
+
+              it 'logs expected message and payload' do
+                expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                subject.terms_of_use_redirect_url
               end
             end
 

--- a/spec/services/sign_in/redirect_url_generator_spec.rb
+++ b/spec/services/sign_in/redirect_url_generator_spec.rb
@@ -24,9 +24,16 @@ RSpec.describe SignIn::RedirectUrlGenerator do
       let(:terms_of_use_url) { "#{terms_redirect_uri}?#{embedded_params}" }
       let(:embedded_params) { "#{{ redirect_url: redirect_uri_with_params }.to_query}&amp;terms_code=#{terms_code}" }
       let(:redirect_uri_with_params) { "#{redirect_uri}?#{params_hash.to_query}" }
+      let(:expected_log_message) { 'Redirecting to /terms-of-use' }
+      let(:expected_log_payload) { { type: :sis } }
 
       it 'renders a meta refresh with expected redirect uri embedded in terms of use redirect' do
         expect(subject).to include(terms_of_use_url)
+      end
+
+      it 'logs expected message' do
+        expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+        subject
       end
     end
 


### PR DESCRIPTION
## Summary
- Log redirects to terms-of-use page

## Related Issues
- department-of-veterans-affairs/va.gov-team#72845

## Testing
- login with a user that does not have terms accepted
- check logs for  `Redirecting to /terms-of-use,  {:type=>:sis}`
- Repeat for `ssoe` 
  - `Redirecting to /terms-of-use,  {:type=>:ssoe}`

## What areas of the site does it impact?
Terms of use, authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

