### PR TITLE
VA-IIR-285: provide an exception when raising InternalServerError

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,16 +189,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (2.5.3)
-      einhorn (>= 0.7.4)
-      sidekiq (>= 6.5.0, < 7)
-      sidekiq-pro (>= 5.5.0, < 6)
-    sidekiq-pro (5.5.8)
-      sidekiq (~> 6.0, >= 6.5.6)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -385,7 +375,6 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -1200,8 +1189,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq (>= 6.4.0)
-  sidekiq-ent!
-  sidekiq-pro!
   sidekiq_alive
   simple_forms_api!
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,16 @@ PATH
     vye (0.1.0)
 
 GEM
+  remote: https://enterprise.contribsys.com/
+  specs:
+    sidekiq-ent (2.5.3)
+      einhorn (>= 0.7.4)
+      sidekiq (>= 6.5.0, < 7)
+      sidekiq-pro (>= 5.5.0, < 6)
+    sidekiq-pro (5.5.8)
+      sidekiq (~> 6.0, >= 6.5.6)
+
+GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -375,6 +385,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -1189,6 +1200,8 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq (>= 6.4.0)
+  sidekiq-ent!
+  sidekiq-pro!
   sidekiq_alive
   simple_forms_api!
   simplecov

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -47,8 +47,14 @@ module V0
         # 403
         raise Common::Exceptions::UnexpectedForbidden, detail: 'Missing correlation id'
       else
-        # 500
-        raise Common::Exceptions::InternalServerError
+        if Flipper.enabled?(:post_911_gibill_statuses_new_error_handling, @current_user)
+          error_message = "An unknown error occurred. Response error type: #{response.error_type}, status: #{response.status}, body: #{response.body}"
+          standard_error = StandardError.new(error_message)
+          raise Common::Exceptions::InternalServerError, standard_error
+        else
+          # 500
+          raise Common::Exceptions::InternalServerError
+        end
       end
     end
 

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -48,7 +48,9 @@ module V0
         raise Common::Exceptions::UnexpectedForbidden, detail: 'Missing correlation id'
       else
         if Flipper.enabled?(:post_911_gibill_statuses_new_error_handling, @current_user)
-          error_message = "An unknown error occurred. Response error type: #{response.error_type}, status: #{response.status}, body: #{response.body}"
+          error_message = 'An unknown error occurred. ' \
+                          "Response error type: #{response.error_type}, " \
+                          "status: #{response.status}, body: #{response.body}"
           standard_error = StandardError.new(error_message)
           raise Common::Exceptions::InternalServerError, standard_error
         else

--- a/config/features.yml
+++ b/config/features.yml
@@ -739,6 +739,10 @@ features:
     description: When enabled, will allow display of PDF cert warnings in find-a-form
     actor_type: user
     enable_in_development: true
+  post_911_gibill_statuses_new_error_handling:
+    actor_type: user
+    description: When enabled, create a StandardError to catch unknown errors VA-IIR-285
+    enabled_in_development: true
   pre_entry_covid19_screener:
     actor_type: user
     description: >

--- a/spec/controllers/v0/post911_gi_bill_statuses_controller_spec.rb
+++ b/spec/controllers/v0/post911_gi_bill_statuses_controller_spec.rb
@@ -121,3 +121,34 @@ RSpec.describe V0::Post911GIBillStatusesController, type: :controller do
     end
   end
 end
+
+RSpec.describe '#render_error_json' do
+  let(:controller) { V0::Post911GIBillStatusesController.new }
+  let(:response) { double(error_type: 'unknown', status: 500, body: 'Unknown error') }
+
+  before do
+    controller.instance_variable_set(:@current_user, User.new)
+  end
+
+  context 'when the feature toggle is enabled' do
+    before do
+      allow(Flipper).to receive(:enabled?).with(:post_911_gibill_statuses_new_error_handling, controller.instance_variable_get(:@current_user)).and_return(true)
+    end
+
+    it 'raises an InternalServerError including an exception with a detailed message to `raise Common::Exceptions::InternalServerError`' do
+      expect { controller.send(:render_error_json, response) }.to raise_error(Common::Exceptions::InternalServerError) do |error|
+        expect(error.exception.message).to eq('An unknown error occurred. Response error type: unknown, status: 500, body: Unknown error')
+      end
+    end
+  end
+
+  context 'when the feature toggle is disabled' do
+    before do
+      allow(Flipper).to receive(:enabled?).with(:post_911_gibill_statuses_new_error_handling, controller.instance_variable_get(:@current_user)).and_return(false)
+    end
+
+    it 'raises an ArgumentError because an exception is not passed to `raise Common::Exceptions::InternalServerError`' do
+      expect { controller.send(:render_error_json, response) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
I'm a developer on the VA-IIR team.  We do not specifically own this project, but have been tasked to address issues in orphaned or lightly maintained projects.

The controller action, ` V0::Post911GIBillStatusesController#show` will will call a `render_error_json` function if a request to a service fails.  Depending on the failure, we can raise different Exception types.  If none of those special cases are satisfied, the default failure is to raise `Common::Exceptions::InternalServerError`.  

In that fallback case, we are not supplying the required `exception` argument to `InternalServerError.initialize()`, so an unhandled exception happens, which pops up on Sentry:
![sentry](https://github.com/department-of-veterans-affairs/vets-api/assets/7659922/4bd3f5cb-d1ed-44ee-bb81-f8d35ea762a1)

This PR includes code to create the required `exception` argument pass it to `InternalServerError.initialize()`.  Out of an abundance of caution, this logic is gated off in a Feature Toggle, `:post_911_gibill_statuses_new_error_handling`.  We are seeing several hundred of these unhandled exceptions per hour, so the expected end date of the toggle should be less than one week.

![datadog](https://github.com/department-of-veterans-affairs/vets-api/assets/7659922/4bf0c15a-a1ea-452b-ada4-a4c161e307dc)

Related issue: [65182](https://github.com/department-of-veterans-affairs/va.gov-team/issues/65182)

## Testing done

I created unit tests to validate existing functionality, and the bugfix.


## What areas of the site does it impact?
Post 9-11 GI Bill tools

## Acceptance criteria

- [X]  I added **unit** tests and ~~integration~~ tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution **N/A**
- [ ]  Documentation has been updated (link to documentation) **N/A**
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected **N/A**
- [ ]  I added a screenshot of the developed feature **N/A**
