### PR TITLE
Add StatsD exhaustion metric to Pensions

### DIFF
--- a/spec/sidekiq/lighthouse/pension_benefit_intake_job_spec.rb
+++ b/spec/sidekiq/lighthouse/pension_benefit_intake_job_spec.rb
@@ -164,5 +164,14 @@ RSpec.describe Lighthouse::PensionBenefitIntakeJob, uploader_helpers: true do
     # form_submission_polling
   end
 
+  describe 'sidekiq_retries_exhausted block' do
+    it 'logs a distrinct error when retries are exhausted' do
+      Lighthouse::PensionBenefitIntakeJob.within_sidekiq_retries_exhausted_block do
+        expect(Rails.logger).to receive(:error).exactly(:once)
+        expect(StatsD).to receive(:increment).with('worker.lighthouse.pension_benefit_intake_job.exhausted')
+      end
+    end
+  end
+
   # Rspec.describe
 end


### PR DESCRIPTION
## Summary

- In order to track retry exhaustions for the Pensions Lighthouse submission, adds a StatsD metric to `Lighthouse::PensionBenefitIntakeJob`.

## Related issue(s)
- [Link to ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/70462)

## Testing done

- Temporarily set retries to 1, then added an error to `Lighthouse::PensionBenefitIntakeJob`.
- Confirmed that the exhaustion was triggered.

## Screenshots
<img width="786" alt="Screenshot 2024-01-10 at 12 09 33 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/21046714/6cdba251-d7df-49c9-9b99-b3cc07ddaf27">

## What areas of the site does it impact?
Pensions Benefits

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
