### PR TITLE
Remove defunct team vfs-benefits-delivery from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -228,9 +228,9 @@ app/models/emis_redis/military_information.rb @department-of-veterans-affairs/vf
 app/models/emis_redis/military_information_v2.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/models/emis_redis/model.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/models/emis_redis/veteran_status.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
-app/models/evss_claim_document.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-benefits-delivery
-app/models/evss_claim.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-benefits-delivery
-app/models/evss_claims_sync_status_tracker.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-benefits-delivery
+app/models/evss_claim_document.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/evss_claim.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/evss_claims_sync_status_tracker.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/expiry_scanner.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/external_services_redis/status.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/facilities @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -905,7 +905,7 @@ lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @d
 lib/lighthouse @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/benefit_claims @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/mail_automation @department-of-veterans-affairs/vfs-benefits-delivery @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/map/ @department-of-veterans-affairs/vsp-identity
 lib/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 lib/medical_records @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1355,7 +1355,7 @@ spec/lib/lighthouse/facilities/client_spec.rb @department-of-veterans-affairs/vf
 spec/lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/veterans_health @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/veteran_verification @department-of-veterans-affairs/backend-review-group
-spec/lib/mail_automation @department-of-veterans-affairs/vfs-benefits-delivery  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/map/ @department-of-veterans-affairs/vsp-identity
 spec/lib/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 spec/lib/medical_records @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1894,7 +1894,7 @@ spec/support/vcr_cassettes/lighthouse/benefits_intake/200_lighthouse_intake_bulk
 spec/support/vcr_cassettes/lighthouse/claims/200_response.yml @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/dbex-trex
 spec/support/vcr_cassettes/lighthouse/direct_deposit @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/dbex-trex  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/lighthouse/veteran_verification @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/mail_automation @department-of-veterans-affairs/vfs-benefits-delivery @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/support/vcr_cassettes/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/map @department-of-veterans-affairs/vsp-identity
 spec/support/vcr_cassettes/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/mhv_account_creation @department-of-veterans-affairs/vsp-identity


### PR DESCRIPTION
## Summary
- This PR removes the defunct team [vfs-benefits-delivery](https://github.com/orgs/department-of-veterans-affairs/teams/vfs-benefits-delivery) from CODEOWNERS, in preparation for removing that GitHub team itself.
- `vfs-benefits-delivery` is not an active VFS team. As far as we could ascertain in this [Slack thread](https://dsva.slack.com/archives/C04KW0B46N5/p1704219957189839), "Benefits Delivery" refers to a project circa 2022 through early 2023 called RRD (Rapid Ready for Decision) that split into multiple current-day teams. The members of `vfs-benefits-delivery` are now on the Employee Experience and Disability Experience teams.
- I am on the Employee Experience team, which is responsible for the small remainder of RRD code still in vets-api. We have [vfs-employee-experience-team](https://github.com/orgs/department-of-veterans-affairs/teams/vfs-employee-experience-team) (which needs to be properly populated) and [benefits-employee-exp-engineers](https://github.com/orgs/department-of-veterans-affairs/teams/benefits-employee-exp-engineers) but neither has write/reviewer access to vets-api and thus can't be a codeowner.

## Requested feedback
Of the lines in CODEOWNERS that are getting `vfs-benefits-delivery` removed,
- `app/models/evss_*.rb` (3 files) are not under the purview of any existing team; the `git blame` of all 3 show authorship that's predominantly 3-4+ years old. I let these fall back on `va-api-engineers` and `backend-review-group`.
- `**/mail_automation` (3 directories) are specific to RRD, currently under the purview of Employee Experience. `vfs-employee-experience-team` or preferably `benefits-employee-exp-engineers` could be code-owner of these directories, if granted the necessary permissions.

Does this seem like an appropriate course of action?

I've also opened a [#vfs-platform-support request](https://dsva.slack.com/archives/CBU0KDSB1/p1704923681578019) for assistance with GitHub/Atlas team management.