### PR TITLE
API-32635: `VAForms::FormBuilder` Job Improvements

### DIFF
--- a/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
@@ -23,7 +23,7 @@ module VAForms
       row_id = form_data['fieldVaFormRowId']
 
       # Ensure that the form is marked "valid_pdf: false" if successive form fetches have failed
-      if error_class.to_s == VAForms::FormBuilder::FormFetchError.to_s
+      if error_class.to_s == FormFetchError.to_s
         form = VAForms::Form.find_by(row_id:)
         url = VAForms::Form.normalized_form_url(form_data.dig('fieldVaFormUrl', 'uri'))
         form_previously_valid = form.valid_pdf

--- a/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
@@ -7,26 +7,31 @@ module VAForms
   class FormBuilder
     include Sidekiq::Job
 
-    FORM_FETCH_ERROR_MESSAGE = 'The form could not be fetched from the url provided.'
+    class FormFetchError < StandardError; end
+
     STATSD_KEY_PREFIX = 'api.va_forms.form_builder'
 
     sidekiq_options retry: 7
 
-    sidekiq_retries_exhausted do |msg, error|
-      args = msg['args'] || {}
-      form_name = args['fieldVaFormNumber']
-      row_id = args['fieldVaFormRowId']
+    sidekiq_retries_exhausted do |msg, _ex|
+      job_id = msg['jid']
+      error_class = msg['error_class']
+      error_message = msg['error_message']
+
+      form_data = msg['args'].first
+      form_name = form_data['fieldVaFormNumber']
+      row_id = form_data['fieldVaFormRowId']
 
       # Ensure that the form is marked "valid_pdf: false" if successive form fetches have failed
-      if error.message == FORM_FETCH_ERROR_MESSAGE
+      if error_class.to_s == VAForms::FormBuilder::FormFetchError.to_s
         form = VAForms::Form.find_by(row_id:)
-        url = VAForms::Form.normalized_form_url(args.dig('fieldVaFormUrl', 'uri'))
+        url = VAForms::Form.normalized_form_url(form_data.dig('fieldVaFormUrl', 'uri'))
         form_previously_valid = form.valid_pdf
         form.update!(valid_pdf: false, sha256: nil, url:)
         if form_previously_valid
           VAForms::Slack::Messenger.new(
             {
-              class: self.class.name,
+              class: 'VAForms::FormBuilder',
               message: "URL for form_name: #{form_name}, row_id: #{row_id} no longer returns a valid PDF or web page.",
               form_url: url
             }
@@ -34,10 +39,27 @@ module VAForms
         end
       end
 
-      # Log error and increment StatsD metric
-      message = "#{self.class.name} failed to import form_name: #{form_name}, row_id: #{row_id} into forms database."
-      Rails.logger.error(message, error.message)
-      StatsD.increment("#{STATSD_KEY_PREFIX}.failure", tags: { form_name:, row_id: })
+      StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted", tags: { form_name:, row_id: })
+
+      Rails.logger.warn(
+        'VAForms::FormBuilder retries exhausted',
+        { job_id:, error_class:, error_message:, form_name:, row_id:, form_data: }
+      )
+    rescue => e
+      Rails.logger.error(
+        'Failure in VAForms::FormBuilder#sidekiq_retries_exhausted',
+        {
+          messaged_content: e.message,
+          job_id:,
+          form_name:,
+          row_id:,
+          pre_exhaustion_failure: {
+            error_class:,
+            error_message:
+          }
+        }
+      )
+      raise e
     end
 
     def perform(form_data)
@@ -71,7 +93,7 @@ module VAForms
 
         attrs
       else
-        raise FORM_FETCH_ERROR_MESSAGE
+        raise FormFetchError, 'The form could not be fetched from the url provided.'
       end
     end
 

--- a/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
@@ -76,8 +76,12 @@ module VAForms
       attrs[:url] = url if form.new_record?
       form.update!(attrs) # The job can fail later, so save current progress
 
-      attrs = check_form_validity(form, attrs, url)
-      form.update!(attrs)
+      if form.deleted_at.present?
+        form.update!(valid_pdf: false, sha256: nil)
+      else
+        attrs = check_form_validity(form, attrs, url)
+        form.update!(attrs)
+      end
     end
 
     # Given a +form+, +attrs+, and +url+, makes a request for the form; if response is successful, assigns attributes

--- a/modules/va_forms/spec/sidekiq/form_builder_spec.rb
+++ b/modules/va_forms/spec/sidekiq/form_builder_spec.rb
@@ -94,14 +94,21 @@ RSpec.describe VAForms::FormBuilder, type: :job do
       end
     end
 
-    context 'when the PDF has been marked as deleted (even though the URL is valid)' do
+    context 'when the PDF has been marked as deleted' do
       let(:form_data) { deleted_form_data }
 
-      it 'includes a deleted_at date but still sets other values as usual and does not notify' do
+      it 'updates the deleted_at date' do
         expect(result.deleted_at.to_date.to_s).to eq('2020-07-16')
-        expect(result.valid_pdf).to be(true)
-        expect(result.sha256).to eq(valid_sha256)
-        expect(slack_messenger).not_to have_received(:notify!)
+      end
+
+      it 'sets valid_pdf to true and the sha256 to nil' do
+        expect(result.valid_pdf).to be(false)
+        expect(result.sha256).to be_nil
+      end
+
+      it 'does not raise a form fetch error' do
+        expect { form_builder.perform(form_data) }
+          .not_to raise_error(described_class::FormFetchError, form_fetch_error_message)
       end
     end
 
@@ -210,7 +217,7 @@ RSpec.describe VAForms::FormBuilder, type: :job do
           end
 
           form.reload
-          expect(form.valid_pdf).to be_falsey
+          expect(form.valid_pdf).to be(false)
           expect(form.sha256).to be_nil
           expect(form.url).to eq(url)
         end


### PR DESCRIPTION
## Summary
This PR:
1. Updates the `sidekiq_retries_exhausted` block in the `VAForms::FormBuilder` job to log more specific information about the job failure, adds error handling for the block itself, and fixes references to the form data from the job `args`.
2. Updates the logic for deleted form records in the `VAForms::FormBuilder` job by not attempting to fetch the PDF if the form is marked deleted (and setting `valid_pdf: false` and `sha256: nil` on deleted records by default). This change is being made because 43 out of 55 of our recurring failing `VAForms::FormBuilder` jobs are deleted records, and they are all failing due to invalid URLs. Their URLs will never be valid again, but the job did not take this into account previously. I can't think of a reason why we would want to continually validate the form PDF (nightly) for a deleted form.

## Related issue(s)
- [API-32635](https://jira.devops.va.gov/browse/API-32635)

## Testing done
The job has been run locally with production form data to ensure that it is working as expected. Specs have also been updated.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `VAForms::FormBuilder` job only.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested.
