### PR TITLE
[73468] Update MAP provisioner logging to account for parsing errors

### DIFF
--- a/lib/map/sign_up/service.rb
+++ b/lib/map/sign_up/service.rb
@@ -74,8 +74,10 @@ module MAP
       end
 
       def successful_update_provisioning_response(response, icn)
+        parsed_response = parse_response(response.body, icn, 'update provisioning')
         Rails.logger.info("#{config.logging_prefix} update provisioning success, icn: #{icn}")
-        parse_response(response.body, icn, 'update provisioning')
+
+        parsed_response
       end
 
       def parse_and_raise_error(e, icn, action)
@@ -102,6 +104,7 @@ module MAP
           bypass_eligible: parsed_response_body['bypassEligible']
         }
       rescue => e
+        Rails.logger.error("#{config.logging_prefix} #{action} response parsing error", { response_body:, icn: })
         raise e, "#{config.logging_prefix} #{action} failed, response unknown, icn: #{icn}"
       end
     end

--- a/spec/lib/map/sign_up/service_spec.rb
+++ b/spec/lib/map/sign_up/service_spec.rb
@@ -254,5 +254,23 @@ describe MAP::SignUp::Service do
         expect(subject).to eq(expected_response_hash)
       end
     end
+
+    context 'when there is a parsing error' do
+      let(:expected_log_message) { "#{log_prefix} update provisioning response parsing error" }
+      let(:response_body) do
+        { agreementSigned: true, optOut: false, cernerProvisioned: false, bypassEligible: false }.to_json
+      end
+      let(:expected_log_payload) { { response_body:, icn: } }
+
+      before do
+        allow(JSON).to receive(:parse).and_raise(JSON::ParserError)
+      end
+
+      it 'logs the expected error message',
+         vcr: { cassette_name: 'map/sign_up_service_200_responses' } do
+        expect(Rails.logger).to receive(:error).with(expected_log_message, { response_body:, icn: })
+        expect { subject }.to raise_error(JSON::ParserError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Update provisioner logging to only log a success if the parsing is successful. Add a parsing error log.


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#73468


## Testing 
- This is hard to test without being on the VA network and our mocks only mock a successful response.
- Updated specs to cover parsing error case


## What areas of the site does it impact?
MAP, Terms of use

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
