### PR TITLE
Update ICNs in appeals form data fixtures

### DIFF
--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
@@ -69,7 +69,7 @@
                                 "informalConference": false,
                                 "benefitType": "lifeInsurance",
                                 "veteran": {
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "ssn": "123456789",
                                   "firstName": "Jane",
                                   "lastName": "Doe",
@@ -113,7 +113,7 @@
                               "attributes": {
                                 "benefitType": "education",
                                 "veteran": {
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "ssn": "123456789",
                                   "firstName": "Jäñe",
                                   "middleInitial": "ø",
@@ -384,7 +384,7 @@
                         "informalConference": false,
                         "benefitType": "lifeInsurance",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jane",
                           "lastName": "Doe",
@@ -417,7 +417,7 @@
                       "attributes": {
                         "benefitType": "education",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
@@ -2339,7 +2339,7 @@
                         "informalConference": false,
                         "benefitType": "lifeInsurance",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jane",
                           "lastName": "Doe",
@@ -2372,7 +2372,7 @@
                       "attributes": {
                         "benefitType": "education",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",

--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
@@ -69,7 +69,7 @@
                                 "informalConference": false,
                                 "benefitType": "lifeInsurance",
                                 "veteran": {
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "ssn": "123456789",
                                   "firstName": "Jane",
                                   "lastName": "Doe",
@@ -113,7 +113,7 @@
                               "attributes": {
                                 "benefitType": "education",
                                 "veteran": {
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "ssn": "123456789",
                                   "firstName": "Jäñe",
                                   "middleInitial": "ø",
@@ -384,7 +384,7 @@
                         "informalConference": false,
                         "benefitType": "lifeInsurance",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jane",
                           "lastName": "Doe",
@@ -417,7 +417,7 @@
                       "attributes": {
                         "benefitType": "education",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
@@ -2339,7 +2339,7 @@
                         "informalConference": false,
                         "benefitType": "lifeInsurance",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jane",
                           "lastName": "Doe",
@@ -2372,7 +2372,7 @@
                       "attributes": {
                         "benefitType": "education",
                         "veteran": {
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "ssn": "123456789",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
@@ -67,7 +67,7 @@
                               "type": "noticeOfDisagreement",
                               "attributes": {
                                 "veteran": {
-                                  "icn": "1234567890V123456",
+                                  "icn": "1012667145V762142",
                                   "fileNumber": "987654321",
                                   "firstName": "Jäñe",
                                   "lastName": "Doe",
@@ -115,7 +115,7 @@
                               "type": "noticeOfDisagreement",
                               "attributes": {
                                 "veteran": {
-                                  "icn": "1234567890V123456",
+                                  "icn": "1012667145V762142",
                                   "fileNumber": "987654321",
                                   "firstName": "Jäñe",
                                   "middleInitial": "Z",
@@ -305,7 +305,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "lastName": "Doe",
@@ -342,7 +342,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "middleInitial": "Z",
@@ -2161,7 +2161,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "lastName": "Doe",
@@ -2198,7 +2198,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "middleInitial": "Z",

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
@@ -67,7 +67,7 @@
                               "type": "noticeOfDisagreement",
                               "attributes": {
                                 "veteran": {
-                                  "icn": "1234567890V123456",
+                                  "icn": "1012667145V762142",
                                   "fileNumber": "987654321",
                                   "firstName": "Jäñe",
                                   "lastName": "Doe",
@@ -115,7 +115,7 @@
                               "type": "noticeOfDisagreement",
                               "attributes": {
                                 "veteran": {
-                                  "icn": "1234567890V123456",
+                                  "icn": "1012667145V762142",
                                   "fileNumber": "987654321",
                                   "firstName": "Jäñe",
                                   "middleInitial": "Z",
@@ -305,7 +305,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "lastName": "Doe",
@@ -342,7 +342,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "middleInitial": "Z",
@@ -2161,7 +2161,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "lastName": "Doe",
@@ -2198,7 +2198,7 @@
                       "type": "noticeOfDisagreement",
                       "attributes": {
                         "veteran": {
-                          "icn": "1234567890V123456",
+                          "icn": "1012667145V762142",
                           "fileNumber": "987654321",
                           "firstName": "Jäñe",
                           "middleInitial": "Z",

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
@@ -70,7 +70,7 @@
                                 "claimantType": "veteran",
                                 "veteran": {
                                   "ssn": "123456789",
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "firstName": "Jäñe",
                                   "middleInitial": "ø",
                                   "lastName": "Doé",
@@ -129,7 +129,7 @@
                                 "claimantTypeOtherValue": "Veteran Attorney",
                                 "veteran": {
                                   "ssn": "123456789",
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "firstName": "Jäñe",
                                   "middleInitial": "ø",
                                   "lastName": "Doé",
@@ -445,7 +445,7 @@
                         "claimantType": "veteran",
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",
@@ -493,7 +493,7 @@
                         "claimantTypeOtherValue": "Veteran Attorney",
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",
@@ -2582,7 +2582,7 @@
                         "claimantType": "veteran",
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",
@@ -2630,7 +2630,7 @@
                         "claimantTypeOtherValue": "Veteran Attorney",
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
@@ -70,7 +70,7 @@
                                 "claimantType": "veteran",
                                 "veteran": {
                                   "ssn": "123456789",
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "firstName": "Jäñe",
                                   "middleInitial": "ø",
                                   "lastName": "Doé",
@@ -130,7 +130,7 @@
                                 "potentialPactAct": true,
                                 "veteran": {
                                   "ssn": "123456789",
-                                  "icn": "1013062086V794840",
+                                  "icn": "1012667145V762142",
                                   "firstName": "Jäñe",
                                   "middleInitial": "ø",
                                   "lastName": "Doé",
@@ -446,7 +446,7 @@
                         "claimantType": "veteran",
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",
@@ -495,7 +495,7 @@
                         "potentialPactAct": true,
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",
@@ -2587,7 +2587,7 @@
                         "claimantType": "veteran",
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",
@@ -2636,7 +2636,7 @@
                         "potentialPactAct": true,
                         "veteran": {
                           "ssn": "123456789",
-                          "icn": "1013062086V794840",
+                          "icn": "1012667145V762142",
                           "firstName": "Jäñe",
                           "middleInitial": "ø",
                           "lastName": "Doé",

--- a/modules/appeals_api/spec/factories/higher_level_reviews.rb
+++ b/modules/appeals_api/spec/factories/higher_level_reviews.rb
@@ -47,6 +47,10 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { FixtureHelpers.fixture_as_json 'higher_level_reviews/v0/valid_200996_headers.json' }
     form_data { FixtureHelpers.fixture_as_json 'higher_level_reviews/v0/valid_200996.json' }
+    after(:build) do |hlr, attrs|
+      hlr.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      hlr
+    end
   end
 
   factory :extra_higher_level_review_v0,
@@ -54,6 +58,10 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { FixtureHelpers.fixture_as_json 'higher_level_reviews/v0/valid_200996_headers.json' }
     form_data { FixtureHelpers.fixture_as_json 'higher_level_reviews/v0/valid_200996_extra.json' }
+    after(:build) do |hlr, attrs|
+      hlr.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      hlr
+    end
   end
 
   factory :minimal_higher_level_review_v0,
@@ -61,5 +69,9 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { {} }
     form_data { FixtureHelpers.fixture_as_json 'higher_level_reviews/v0/valid_200996_minimum.json' }
+    after(:build) do |hlr, attrs|
+      hlr.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      hlr
+    end
   end
 end

--- a/modules/appeals_api/spec/factories/notice_of_disagreements.rb
+++ b/modules/appeals_api/spec/factories/notice_of_disagreements.rb
@@ -81,6 +81,10 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { FixtureHelpers.fixture_as_json 'notice_of_disagreements/v0/valid_10182_headers.json' }
     form_data { FixtureHelpers.fixture_as_json 'notice_of_disagreements/v0/valid_10182.json' }
+    after(:build) do |nod, attrs|
+      nod.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      nod
+    end
   end
 
   factory :extra_notice_of_disagreement_v0,
@@ -88,6 +92,10 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { FixtureHelpers.fixture_as_json 'notice_of_disagreements/v0/valid_10182_headers.json' }
     form_data { FixtureHelpers.fixture_as_json 'notice_of_disagreements/v0/valid_10182_extra.json' }
+    after(:build) do |nod, attrs|
+      nod.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      nod
+    end
   end
 
   factory :minimal_notice_of_disagreement_v0,
@@ -95,5 +103,9 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { {} }
     form_data { FixtureHelpers.fixture_as_json 'notice_of_disagreements/v0/valid_10182_minimum.json' }
+    after(:build) do |nod, attrs|
+      nod.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      nod
+    end
   end
 end

--- a/modules/appeals_api/spec/factories/supplemental_claims.rb
+++ b/modules/appeals_api/spec/factories/supplemental_claims.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { FixtureHelpers.fixture_as_json 'supplemental_claims/v0/valid_200995_headers.json' }
     form_data { FixtureHelpers.fixture_as_json 'supplemental_claims/v0/valid_200995.json' }
+    after(:build) do |sc, attrs|
+      sc.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      sc
+    end
   end
 
   factory :extra_supplemental_claim_v0,
@@ -55,11 +59,19 @@ FactoryBot.define do
     api_version { 'V0' }
     auth_headers { FixtureHelpers.fixture_as_json 'supplemental_claims/v0/valid_200995_headers.json' }
     form_data { FixtureHelpers.fixture_as_json 'supplemental_claims/v0/valid_200995_extra.json' }
+    after(:build) do |sc, attrs|
+      sc.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      sc
+    end
   end
 
   factory :minimal_supplemental_claim_v0,
           class: 'AppealsApi::SupplementalClaim', parent: :minimal_supplemental_claim do
     api_version { 'V0' }
     form_data { FixtureHelpers.fixture_as_json 'supplemental_claims/v0/valid_200995.json' }
+    after(:build) do |sc, attrs|
+      sc.form_data['data']['attributes']['veteran']['icn'] = attrs.veteran_icn if attrs.veteran_icn.present?
+      sc
+    end
   end
 end

--- a/modules/appeals_api/spec/fixtures/higher_level_reviews/v0/valid_200996.json
+++ b/modules/appeals_api/spec/fixtures/higher_level_reviews/v0/valid_200996.json
@@ -5,7 +5,7 @@
       "informalConference": true,
       "benefitType": "fiduciary",
       "veteran": {
-        "icn": "1013062086V794840",
+        "icn": "1012667145V762142",
         "ssn": "123456789",
         "firstName": "Jäñe",
         "middleInitial": "ø",

--- a/modules/appeals_api/spec/fixtures/higher_level_reviews/v0/valid_200996_extra.json
+++ b/modules/appeals_api/spec/fixtures/higher_level_reviews/v0/valid_200996_extra.json
@@ -4,7 +4,7 @@
       "attributes": {
         "benefitType": "education",
         "veteran": {
-          "icn": "1013062086V794840",
+          "icn": "1012667145V762142",
           "ssn": "123456789",
           "firstName": "Jäñe",
           "middleInitial": "ø",

--- a/modules/appeals_api/spec/fixtures/higher_level_reviews/v0/valid_200996_minimum.json
+++ b/modules/appeals_api/spec/fixtures/higher_level_reviews/v0/valid_200996_minimum.json
@@ -5,7 +5,7 @@
       "informalConference": false,
       "benefitType": "lifeInsurance",
       "veteran": {
-        "icn": "1013062086V794840",
+        "icn": "1012667145V762142",
         "ssn": "123456789",
         "firstName": "Jane",
         "lastName": "Doe",

--- a/modules/appeals_api/spec/fixtures/notice_of_disagreements/v0/valid_10182.json
+++ b/modules/appeals_api/spec/fixtures/notice_of_disagreements/v0/valid_10182.json
@@ -3,7 +3,7 @@
     "type": "noticeOfDisagreement",
     "attributes": {
       "veteran": {
-        "icn": "1234567890V123456",
+        "icn": "1012667145V762142",
         "fileNumber": "987654321",
         "firstName": "Jäñe",
         "lastName": "Doe",

--- a/modules/appeals_api/spec/fixtures/notice_of_disagreements/v0/valid_10182_extra.json
+++ b/modules/appeals_api/spec/fixtures/notice_of_disagreements/v0/valid_10182_extra.json
@@ -3,7 +3,7 @@
     "type": "noticeOfDisagreement",
     "attributes": {
       "veteran": {
-        "icn": "1234567890V123456",
+        "icn": "1012667145V762142",
         "fileNumber": "987654321",
         "firstName": "Jäñe",
         "middleInitial": "Z",

--- a/modules/appeals_api/spec/fixtures/notice_of_disagreements/v0/valid_10182_minimum.json
+++ b/modules/appeals_api/spec/fixtures/notice_of_disagreements/v0/valid_10182_minimum.json
@@ -3,7 +3,7 @@
     "type": "noticeOfDisagreement",
     "attributes": {
       "veteran": {
-        "icn": "1234567890V123456",
+        "icn": "1012667145V762142",
         "fileNumber": "987654321",
         "firstName": "Jäñe",
         "lastName": "Doe",

--- a/modules/appeals_api/spec/fixtures/supplemental_claims/v0/valid_200995.json
+++ b/modules/appeals_api/spec/fixtures/supplemental_claims/v0/valid_200995.json
@@ -6,7 +6,7 @@
       "claimantType": "veteran",
       "veteran": {
         "ssn": "123456789",
-        "icn": "1013062086V794840",
+        "icn": "1012667145V762142",
         "firstName": "Jäñe",
         "middleInitial": "ø",
         "lastName": "Doé",

--- a/modules/appeals_api/spec/fixtures/supplemental_claims/v0/valid_200995_extra.json
+++ b/modules/appeals_api/spec/fixtures/supplemental_claims/v0/valid_200995_extra.json
@@ -8,7 +8,7 @@
       "potentialPactAct": true,
       "veteran": {
         "ssn": "123456789",
-        "icn": "1013062086V794840",
+        "icn": "1012667145V762142",
         "firstName": "Jäñe",
         "middleInitial": "ø",
         "lastName": "Doé",


### PR DESCRIPTION
## Summary

This is in support of API-32864, which involves validating the ICNs that we receive in OAuth tokens against the data we receive (to make sure people with veteran-scoped tokens can access only their own data, even if they can provide PII for someone else).

This makes two changes to support updates to ICN validation:

**First:**

The segmented appeals APIs use OAuth, so we use [this cassette with a successful token validation response](https://github.com/department-of-veterans-affairs/vets-api/blob/3e270c711dd14a2b2e49d98d5e012ff481261412/spec/support/vcr_cassettes/token_validation/v3/indicates_token_is_valid.yml#L89) with every successful request in our specs. This means that in every spec, the ICN `1012667145V762142` is returned as the veteran's ICN from the token. To confirm access is allowed, we'll soon be checking this ICN from the token against the ICN in the veteran's data. 

Until now, the ICNs in the veteran data fixtures did not match this ICN, so we would need to fix that in every spec if we were to start validating token ICNs against form data. To avoid that, this PR updates the form data in our fixtures for the HLR, NOD, and SC v0 APIs so that the ICN matches the one in the successful OAuth fixture. This will let us make far fewer adjustments to form data while writing specs for those APIs.

**Second:**

As I was making the changes above, I noticed that it's a little troublesome to create an appeal fixture with a particular ICN - for example, if you do this:
```ruby
# With the goal of overriding the created HLR's default ICN...
create(:higher_level_review_v0, veteran_icn: '1111111111V111111')
```
...the appeal that's created will have a correct `veteran_icn`, since it was specified explicitly, but the data nested inside the created appeal's `form_data` will _not_ match that value - it will still be the default because it hasn't been explicitly updated. To fix this, you'd have to _also_ override the deeply nested `veteran.icn` inside the appeal fixture's `form_data`, which is a lot to do every time. To automate this, I updated the factories for HLRs, NODs, and SCs (v0 only) so that providing a `veteran_icn` to `create` with any of those factories will also set the nested `veteran.icn` to match it.

## Related issue(s)
None, supports API-32864


## Testing done
- Tests still pass, docs have been regenerated


## What areas of the site does it impact?
- Notice of Disagreements API v0
- Higher-Level Reviews API v0
- Supplemental Claims API v0
(none of these are in production yet)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature