### PR TITLE
Simple Forms 21-0966 third parties go through Benefits Intake API

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -27,7 +27,7 @@ module SimpleFormsApi
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
 
-        if form_is210966 && icn
+        if form_is210966 && icn && first_party?
           handle_210966_authenticated
         else
           submit_form_to_central_mail
@@ -144,6 +144,10 @@ module SimpleFormsApi
 
       def icn
         @current_user&.icn
+      end
+
+      def first_party?
+        ['VETERAN', 'SURVIVING_DEPENDENT'].include?(params[:preparer_identification])
       end
 
       def get_form_id

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -147,7 +147,7 @@ module SimpleFormsApi
       end
 
       def first_party?
-        ['VETERAN', 'SURVIVING_DEPENDENT'].include?(params[:preparer_identification])
+        %w[VETERAN SURVIVING_DEPENDENT].include?(params[:preparer_identification])
       end
 
       def get_form_id

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -105,18 +105,50 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
         allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
       end
 
-      it 'makes the request with an intent to file' do
-        VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response') do
-          VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_pension') do
-            VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_survivor') do
-              VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_compensation_200_response') do
+      describe 'veteran or surviving dependent' do
+        ['VETERAN', 'SURVIVING_DEPENDENT'].each do |identification|
+          it 'makes the request with an intent to file' do
+            VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response') do
+              VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_pension') do
+                VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_survivor') do
+                  VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_compensation_200_response') do
+                    fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
+                                                   'vba_21_0966-min.json')
+                    data = JSON.parse(fixture_path.read)
+                    data["preparer_identification"] = identification
+    
+                    post '/simple_forms_api/v1/simple_forms', params: data
+    
+                    expect(response).to have_http_status(:ok)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      describe 'third party' do
+        let(:expiration_date) { Time.zone.now }
+
+        before do
+          allow_any_instance_of(ActiveSupport::TimeZone).to receive(:now).and_return(expiration_date)
+        end
+        
+        ['THIRD_PARTY_VETERAN', 'THIRD_PARTY_SURVIVING_DEPENDENT'].each do |identification|
+          it 'returns an expiration date' do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+              VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
                 fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
-                                               'vba_21_0966-min.json')
+                                               'vba_21_0966.json')
                 data = JSON.parse(fixture_path.read)
-
+                data["preparer_identification"] = identification
+    
                 post '/simple_forms_api/v1/simple_forms', params: data
-
-                expect(response).to have_http_status(:ok)
+    
+                parsed_response_body = JSON.parse(response.body)
+                parsed_expiration_date = Time.zone.parse(parsed_response_body['expiration_date'])
+                expect(parsed_expiration_date.to_s).to eq (expiration_date + 1.year).to_s
               end
             end
           end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
       end
 
       describe 'veteran or surviving dependent' do
-        ['VETERAN', 'SURVIVING_DEPENDENT'].each do |identification|
+        %w[VETERAN SURVIVING_DEPENDENT].each do |identification|
           it 'makes the request with an intent to file' do
             VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response') do
               VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_pension') do
@@ -115,10 +115,10 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
                     fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
                                                    'vba_21_0966-min.json')
                     data = JSON.parse(fixture_path.read)
-                    data["preparer_identification"] = identification
-    
+                    data['preparer_identification'] = identification
+
                     post '/simple_forms_api/v1/simple_forms', params: data
-    
+
                     expect(response).to have_http_status(:ok)
                   end
                 end
@@ -134,18 +134,18 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
         before do
           allow_any_instance_of(ActiveSupport::TimeZone).to receive(:now).and_return(expiration_date)
         end
-        
-        ['THIRD_PARTY_VETERAN', 'THIRD_PARTY_SURVIVING_DEPENDENT'].each do |identification|
+
+        %w[THIRD_PARTY_VETERAN THIRD_PARTY_SURVIVING_DEPENDENT].each do |identification|
           it 'returns an expiration date' do
             VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
               VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
                 fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
                                                'vba_21_0966.json')
                 data = JSON.parse(fixture_path.read)
-                data["preparer_identification"] = identification
-    
+                data['preparer_identification'] = identification
+
                 post '/simple_forms_api/v1/simple_forms', params: data
-    
+
                 parsed_response_body = JSON.parse(response.body)
                 parsed_expiration_date = Time.zone.parse(parsed_response_body['expiration_date'])
                 expect(parsed_expiration_date.to_s).to eq (expiration_date + 1.year).to_s


### PR DESCRIPTION
## Summary
This PR limits which kinds of preparers go through Benefits Intake API vs the intent API. If the preparer is a third party they go through Benefits Intake API, even if they are logged in. Only if the preparer is a first party ('VETERAN' or 'SURVIVING_DEPENDENT') and logged in would they go through the intent API.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/902


## Testing done
Tests are updated and passing.
