### PR TITLE
Adding a separate list of apps to control TOU on/off for different en…

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -150,7 +150,7 @@ module V1
       set_cookies
       after_login_actions
 
-      if Settings.vsp_environment != 'production' && @current_user.needs_accepted_terms_of_use
+      if @current_user.needs_accepted_terms_of_use
         redirect_to url_service.terms_of_use_redirect_url
       else
         redirect_to url_service.login_redirect_url

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -72,14 +72,6 @@ module SAML
       end
     end
 
-    def what_clients_are_enabled
-      if Settings.vsp_environment == 'production'
-        TERMS_OF_USE_ENABLED_CLIENTS
-      else
-        TERMS_OF_USE_ENABLED_CLIENTS_STAGING
-      end
-    end
-
     # logout URL for SSOe
     def ssoe_slo_url
       Settings.saml_ssoe.logout_url
@@ -119,6 +111,14 @@ module SAML
       post_params = saml_auth_request.create_params(new_url_settings, 'RelayState' => relay_state_params)
       login_url = new_url_settings.idp_sso_service_url
       [login_url, post_params]
+    end
+
+    def enabled_tou_clients
+      if Settings.vsp_environment == 'production'
+        TERMS_OF_USE_ENABLED_CLIENTS
+      else
+        TERMS_OF_USE_ENABLED_CLIENTS_STAGING
+      end
     end
   end
 end

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -64,11 +64,19 @@ module SAML
 
     def terms_of_use_redirect_url
       application = @tracker&.payload_attr(:application) || 'vaweb'
-      if TERMS_OF_USE_ENABLED_CLIENTS.include?(application)
+      if what_clients_are_enabled.include?(application)
         Rails.logger.info('Redirecting to /terms-of-use', type: :ssoe)
         add_query(terms_of_use_url, { redirect_url: login_redirect_url })
       else
         login_redirect_url
+      end
+    end
+
+    def what_clients_are_enabled
+      if Settings.vsp_environment == 'production'
+        TERMS_OF_USE_ENABLED_CLIENTS
+      else
+        TERMS_OF_USE_ENABLED_CLIENTS_STAGING
       end
     end
 

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -64,7 +64,7 @@ module SAML
 
     def terms_of_use_redirect_url
       application = @tracker&.payload_attr(:application) || 'vaweb'
-      if what_clients_are_enabled.include?(application)
+      if enabled_tou_clients.include?(application)
         Rails.logger.info('Redirecting to /terms-of-use', type: :ssoe)
         add_query(terms_of_use_url, { redirect_url: login_redirect_url })
       else

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -117,7 +117,7 @@ module SAML
       if Settings.vsp_environment == 'production'
         TERMS_OF_USE_ENABLED_CLIENTS
       else
-        TERMS_OF_USE_ENABLED_CLIENTS_STAGING
+        TERMS_OF_USE_ENABLED_CLIENTS_LOWERS
       end
     end
   end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -26,7 +26,7 @@ module SAML
     MOBILE_CLIENT_ID = 'mobile'
     UNIFIED_SIGN_IN_CLIENTS = %w[vaweb mhv myvahealth ebenefits vamobile vaoccmobile].freeze
     TERMS_OF_USE_ENABLED_CLIENTS = %w[].freeze
-    TERMS_OF_USE_ENABLED_CLIENTS_STAGING = %w[vaweb mhv myvahealth].freeze
+    TERMS_OF_USE_ENABLED_CLIENTS_LOWERS = %w[vaweb mhv myvahealth].freeze
     TERMS_OF_USE_DECLINED_PATH = '/terms-of-use/declined'
 
     attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :tracker

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -25,7 +25,8 @@ module SAML
     WEB_CLIENT_ID = 'web'
     MOBILE_CLIENT_ID = 'mobile'
     UNIFIED_SIGN_IN_CLIENTS = %w[vaweb mhv myvahealth ebenefits vamobile vaoccmobile].freeze
-    TERMS_OF_USE_ENABLED_CLIENTS = %w[vaweb mhv].freeze
+    TERMS_OF_USE_ENABLED_CLIENTS = %w[].freeze
+    TERMS_OF_USE_ENABLED_CLIENTS_STAGING = %w[vaweb mhv myvahealth].freeze
     TERMS_OF_USE_DECLINED_PATH = '/terms-of-use/declined'
 
     attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :tracker

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -613,8 +613,26 @@ RSpec.describe SAML::PostURLService do
             let(:expected_log_message) { 'Redirecting to /terms-of-use' }
             let(:expected_log_payload) { { type: :ssoe } }
 
+            shared_examples 'client list' do |env, list|
+              before { allow(Settings).to receive(:vsp_environment).and_return(env) }
+
+              it 'returns the appropriate list of clients depending on the environment' do
+                expect(subject.what_clients_are_enabled)
+                  .to eq(list)
+              end
+            end
+
+            context 'when the environment is not production' do
+              include_examples 'client list', ['production', SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS]
+            end
+
+            context 'when the environment is production' do
+              include_examples 'client list',
+                               ['some-environment', SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS_STAGING]
+            end
+
             context 'when tracker application is within TERMS_OF_USE_ENABLED_CLIENTS' do
-              let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS.first }
+              let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS_STAGING.first }
 
               context 'and authentication is occuring on a review instance' do
                 let(:review_instance_slug) { 'some-review-instance-slug' }

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -613,27 +613,8 @@ RSpec.describe SAML::PostURLService do
             let(:expected_log_message) { 'Redirecting to /terms-of-use' }
             let(:expected_log_payload) { { type: :ssoe } }
 
-            shared_examples 'client list' do |env, list|
-              before { allow(Settings).to receive(:vsp_environment).and_return(env) }
-
-              it 'returns the appropriate list of clients depending on the environment' do
-                result = subject.send(:enabled_tou_clients)
-                expect(result)
-                  .to eq(list)
-              end
-            end
-
-            context 'when the environment is not production' do
-              include_examples 'client list', ['production', SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS]
-            end
-
-            context 'when the environment is production' do
-              include_examples 'client list',
-                               ['some-environment', SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS_STAGING]
-            end
-
             context 'when tracker application is within TERMS_OF_USE_ENABLED_CLIENTS' do
-              let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS_STAGING.first }
+              let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS_LOWERS.first }
 
               context 'and authentication is occuring on a review instance' do
                 let(:review_instance_slug) { 'some-review-instance-slug' }

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -617,7 +617,8 @@ RSpec.describe SAML::PostURLService do
               before { allow(Settings).to receive(:vsp_environment).and_return(env) }
 
               it 'returns the appropriate list of clients depending on the environment' do
-                expect(subject.what_clients_are_enabled)
+                result = subject.send(:enabled_tou_clients)
+                expect(result)
                   .to eq(list)
               end
             end


### PR DESCRIPTION
Adding a separate list of apps to control TOU on/off for different environments

## Summary

Added a new constant to control which apps use TOU in production and lower levels, added logic to check current env
## Related issue(s)
department-of-veterans-affairs/va.gov-team/issues/73017

## Testing done
Added specs that checks both sides of the logic to ensure that the appropriate list is being returned


## What areas of the site does it impact?
TOU

## Acceptance criteria

- [ x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x ]  No error nor warning in the console.
- [ x ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ x ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

To test this change pass different environments to the 'Settings.vsp_environment' and ensure that the appropriate constant is being returned in the 'what_clients_are_enabled' method in the SAML::PostURLService 