### PR TITLE
API-34864 Remove inheritance relationships in appeals segemented API controllers

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v0/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v0/higher_level_reviews_controller.rb
@@ -3,26 +3,41 @@
 require 'appeals_api/form_schemas'
 
 module AppealsApi::HigherLevelReviews::V0
-  class HigherLevelReviewsController < AppealsApi::V2::DecisionReviews::HigherLevelReviewsController
+  class HigherLevelReviewsController < AppealsApi::ApplicationController
+    include AppealsApi::CharacterUtilities
+    include AppealsApi::IcnParameterValidation
+    include AppealsApi::JsonFormatValidation
+    include AppealsApi::MPIVeteran
     include AppealsApi::OpenidAuth
     include AppealsApi::PdfDownloads
+    include AppealsApi::Schemas
+    include AppealsApi::StatusSimulation
 
-    skip_before_action :validate_icn_header
-    skip_before_action :new_higher_level_review
-    skip_before_action :find_higher_level_review
-    skip_before_action :validate_json_format
+    skip_before_action :authenticate
+    before_action :validate_json_body, if: -> { request.post? }
+    before_action :validate_json_schema, only: %i[create validate]
+    before_action :validate_icn_parameter, only: %i[download index]
 
-    before_action :validate_icn_parameter, only: %i[download]
-    prepend_before_action :validate_json_body, if: -> { request.post? }
-
+    FORM_NUMBER = '200996'
     API_VERSION = 'V0'
+    MODEL_ERROR_STATUS = 422
     SCHEMA_OPTIONS = { schema_version: 'v0', api_name: 'higher_level_reviews' }.freeze
+    ALLOWED_COLUMNS = %i[id status code detail created_at updated_at].freeze
 
     OAUTH_SCOPES = {
       GET: %w[veteran/HigherLevelReviews.read representative/HigherLevelReviews.read system/HigherLevelReviews.read],
       PUT: %w[veteran/HigherLevelReviews.write representative/HigherLevelReviews.write system/HigherLevelReviews.write],
       POST: %w[veteran/HigherLevelReviews.write representative/HigherLevelReviews.write system/HigherLevelReviews.write]
     }.freeze
+
+    def schema
+      render json: AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(form_schema)
+    end
+
+    def index
+      veteran_hlrs = AppealsApi::HigherLevelReview.select(ALLOWED_COLUMNS).where(veteran_icn:).order(created_at: :desc)
+      render json: AppealsApi::HigherLevelReviewSerializer.new(veteran_hlrs).serializable_hash
+    end
 
     def show
       hlr = AppealsApi::HigherLevelReview.select(ALLOWED_COLUMNS).find(params[:id])
@@ -31,6 +46,17 @@ module AppealsApi::HigherLevelReviews::V0
       render_higher_level_review(hlr)
     rescue ActiveRecord::RecordNotFound
       render_higher_level_review_not_found(params[:id])
+    end
+
+    def validate
+      render json: {
+        data: {
+          type: 'higherLevelReviewValidation',
+          attributes: {
+            status: 'valid'
+          }
+        }
+      }
     end
 
     def create
@@ -64,23 +90,31 @@ module AppealsApi::HigherLevelReviews::V0
 
     def header_names = headers_schema['definitions']['hlrCreateParameters']['properties'].keys
 
+    def validate_json_schema
+      begin
+        validate_headers(request_headers)
+        validate_form_data(@json_body)
+      rescue JsonSchema::JsonApiMissingAttribute => e
+        render json: e.to_json_api, status: e.code
+      end
+
+      status, error = AppealsApi::HigherLevelReviews::PdfFormFieldV2Validator.new(@json_body, headers).validate!
+      return if error.blank?
+
+      render status:, json: error
+    end
+
+    def request_headers
+      header_names.index_with { |key| request.headers[key] }.compact
+    end
+
     def render_higher_level_review(hlr, **)
       render(json: HigherLevelReviewSerializer.new(hlr).serializable_hash, **)
     end
 
     def render_higher_level_review_not_found(id)
-      render(
-        status: :not_found,
-        json: {
-          errors: [
-            {
-              code: '404',
-              detail: I18n.t('appeals_api.errors.not_found', type: 'HigherLevelReview', id:),
-              status: '404',
-              title: 'Record not found'
-            }
-          ]
-        }
+      raise Common::Exceptions::ResourceNotFound.new(
+        detail: I18n.t('appeals_api.errors.not_found', type: 'Higher-Level Review', id:)
       )
     end
 

--- a/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements_controller.rb
@@ -3,19 +3,24 @@
 require 'appeals_api/form_schemas'
 
 module AppealsApi::NoticeOfDisagreements::V0
-  class NoticeOfDisagreementsController < AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController
+  class NoticeOfDisagreementsController < AppealsApi::ApplicationController
+    include AppealsApi::CharacterUtilities
+    include AppealsApi::IcnParameterValidation
+    include AppealsApi::JsonFormatValidation
     include AppealsApi::OpenidAuth
     include AppealsApi::PdfDownloads
+    include AppealsApi::Schemas
+    include AppealsApi::StatusSimulation
 
-    skip_before_action :new_notice_of_disagreement
-    skip_before_action :find_notice_of_disagreement
-    skip_before_action :validate_icn_header
-    skip_before_action :validate_json_format
-
-    prepend_before_action :validate_json_body, if: -> { request.post? }
+    skip_before_action :authenticate
+    before_action :validate_json_body, if: -> { request.post? }
+    before_action :validate_json_schema, only: %i[create validate]
     before_action :validate_icn_parameter, only: %i[download]
 
+    ALLOWED_COLUMNS = %i[id status code detail created_at updated_at].freeze
     API_VERSION = 'V0'
+    FORM_NUMBER = '10182'
+    MODEL_ERROR_STATUS = 422
     SCHEMA_OPTIONS = { schema_version: 'v0', api_name: 'notice_of_disagreements' }.freeze
 
     OAUTH_SCOPES = {
@@ -76,6 +81,17 @@ module AppealsApi::NoticeOfDisagreements::V0
       render_notice_of_disagreement_not_found(params[:id])
     end
 
+    def validate
+      render json: {
+        data: {
+          type: 'noticeOfDisagreementValidation',
+          attributes: {
+            status: 'valid'
+          }
+        }
+      }
+    end
+
     def schema
       render json: AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(form_schema)
     end
@@ -94,28 +110,31 @@ module AppealsApi::NoticeOfDisagreements::V0
       raise Common::Exceptions::UnprocessableEntity.new(detail:) if detail.present?
     end
 
+    def validate_json_schema
+      validate_headers(request_headers)
+      validate_form_data(@json_body)
+    rescue Common::Exceptions::DetailedSchemaErrors => e
+      render json: { errors: e.errors }, status: :unprocessable_entity
+    end
+
     def render_notice_of_disagreement(nod, **)
       render(json: NoticeOfDisagreementSerializer.new(nod).serializable_hash, **)
     end
 
     def render_notice_of_disagreement_not_found(id)
-      render(
-        status: :not_found,
-        json: {
-          errors: [
-            {
-              code: '404',
-              detail: I18n.t('appeals_api.errors.not_found', type: 'NoticeOfDisagreement', id:),
-              status: '404',
-              title: 'Record not found'
-            }
-          ]
-        }
+      raise Common::Exceptions::ResourceNotFound.new(
+        detail: I18n.t('appeals_api.errors.not_found', type: 'Notice of Disagreement', id:)
       )
     end
 
     def render_model_errors(nod)
       render json: model_errors_to_json_api(nod), status: MODEL_ERROR_STATUS
+    end
+
+    def header_names = headers_schema['definitions']['nodCreateParameters']['properties'].keys
+
+    def request_headers
+      header_names.index_with { |key| request.headers[key] }.compact
     end
 
     def token_validation_api_key

--- a/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
@@ -3,17 +3,25 @@
 require 'appeals_api/form_schemas'
 
 module AppealsApi::SupplementalClaims::V0
-  class SupplementalClaimsController < AppealsApi::V2::DecisionReviews::SupplementalClaimsController
+  class SupplementalClaimsController < AppealsApi::ApplicationController
+    include AppealsApi::CharacterUtilities
+    include AppealsApi::IcnParameterValidation
+    include AppealsApi::JsonFormatValidation
+    include AppealsApi::MPIVeteran
     include AppealsApi::OpenidAuth
     include AppealsApi::PdfDownloads
+    include AppealsApi::Schemas
+    include AppealsApi::StatusSimulation
 
-    skip_before_action :validate_icn_header
-    skip_before_action :validate_json_format
-
-    prepend_before_action :validate_json_body, if: -> { request.post? }
+    skip_before_action :authenticate
+    before_action :validate_json_body, if: -> { request.post? }
+    before_action :validate_json_schema, only: %i[create validate]
     before_action :validate_icn_parameter, only: %i[index download]
 
+    ALLOWED_COLUMNS = %i[id status code detail created_at updated_at].freeze
     API_VERSION = 'V0'
+    FORM_NUMBER = '200995'
+    MODEL_ERROR_STATUS = 422
     SCHEMA_OPTIONS = { schema_version: 'v0', api_name: 'supplemental_claims' }.freeze
 
     OAUTH_SCOPES = {
@@ -29,6 +37,18 @@ module AppealsApi::SupplementalClaims::V0
       render_supplemental_claim(veteran_scs)
     end
 
+    def schema
+      response = AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(form_schema)
+
+      unless Flipper.enabled?(:decision_review_sc_pact_act_boolean)
+        response.tap do |s|
+          s.dig(*%w[definitions scCreate properties data properties attributes properties])&.delete('potentialPactAct')
+        end
+      end
+
+      render json: response
+    end
+
     def show
       sc = AppealsApi::SupplementalClaim.select(ALLOWED_COLUMNS).find(params[:id])
       sc = with_status_simulation(sc) if status_requested_and_allowed?
@@ -36,6 +56,17 @@ module AppealsApi::SupplementalClaims::V0
       render_supplemental_claim(sc)
     rescue ActiveRecord::RecordNotFound
       render_supplemental_claim_not_found(params[:id])
+    end
+
+    def validate
+      render json: {
+        data: {
+          type: 'supplementalClaimValidation',
+          attributes: {
+            status: 'valid'
+          }
+        }
+      }
     end
 
     def create
@@ -66,6 +97,10 @@ module AppealsApi::SupplementalClaims::V0
 
     private
 
+    def evidence_submission_indicated?
+      @json_body.dig('data', 'attributes', 'evidenceSubmission', 'evidenceType').include?('upload')
+    end
+
     def validate_icn_parameter
       detail = nil
 
@@ -78,8 +113,31 @@ module AppealsApi::SupplementalClaims::V0
       raise Common::Exceptions::UnprocessableEntity.new(detail:) if detail.present?
     end
 
+    def validate_json_schema
+      validate_headers(request_headers)
+      validate_form_data(@json_body)
+    rescue Common::Exceptions::DetailedSchemaErrors => e
+      render json: { errors: e.errors }, status: :unprocessable_entity
+    end
+
     def render_supplemental_claim(sc, **)
       render(json: SupplementalClaimSerializer.new(sc).serializable_hash, **)
+    end
+
+    def render_supplemental_claim_not_found(id)
+      raise Common::Exceptions::ResourceNotFound.new(
+        detail: I18n.t('appeals_api.errors.not_found', type: 'Supplemental Claim', id:)
+      )
+    end
+
+    def header_names = headers_schema['definitions']['scCreateParameters']['properties'].keys
+
+    def request_headers
+      header_names.index_with { |key| request.headers[key] }.compact
+    end
+
+    def render_model_errors(model)
+      render json: model_errors_to_json_api(model), status: MODEL_ERROR_STATUS
     end
 
     def token_validation_api_key

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/openid_auth.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/openid_auth.rb
@@ -46,10 +46,6 @@ module AppealsApi
     end
 
     def validate_auth_token!
-      # Token validation can be skipped during local development by setting
-      # modules_appeals_api.enable_unsafe_mode = true in settings.local.yml
-      return if unsafe_mode?
-
       @token_validation_result = token_validation_client.validate_token!(
         audience: audience_url,
         scopes: DEFAULT_OAUTH_SCOPES[request.method.to_sym] + self.class::OAUTH_SCOPES[request.method.to_sym],

--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
@@ -691,10 +691,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Higher-Level Review with uuid invalid not found",
                       "code": "404",
-                      "detail": "HigherLevelReview with uuid invalid not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },
@@ -800,10 +800,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Higher-Level Review with uuid 44444444-5555-6666-7777-888888888888 not found",
                       "code": "404",
-                      "detail": "HigherLevelReview with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
@@ -691,10 +691,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Higher-Level Review with uuid invalid not found",
                       "code": "404",
-                      "detail": "HigherLevelReview with uuid invalid not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },
@@ -800,10 +800,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Higher-Level Review with uuid 44444444-5555-6666-7777-888888888888 not found",
                       "code": "404",
-                      "detail": "HigherLevelReview with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
@@ -537,10 +537,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Notice of Disagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
-                      "detail": "NoticeOfDisagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },
@@ -646,10 +646,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Notice of Disagreement with uuid 44444444-5555-6666-7777-888888888888 not found",
                       "code": "404",
-                      "detail": "NoticeOfDisagreement with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
@@ -537,10 +537,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Notice of Disagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
-                      "detail": "NoticeOfDisagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },
@@ -646,10 +646,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Notice of Disagreement with uuid 44444444-5555-6666-7777-888888888888 not found",
                       "code": "404",
-                      "detail": "NoticeOfDisagreement with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
@@ -787,10 +787,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Supplemental Claim with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
-                      "detail": "SupplementalClaim with uuid 00000000-0000-0000-0000-000000000000 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },
@@ -896,10 +896,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Supplemental Claim with uuid 44444444-5555-6666-7777-888888888888 not found",
                       "code": "404",
-                      "detail": "SupplementalClaim with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
@@ -789,10 +789,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Supplemental Claim with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
-                      "detail": "SupplementalClaim with uuid 00000000-0000-0000-0000-000000000000 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },
@@ -898,10 +898,10 @@
                 "example": {
                   "errors": [
                     {
+                      "title": "Resource not found",
+                      "detail": "Supplemental Claim with uuid 44444444-5555-6666-7777-888888888888 not found",
                       "code": "404",
-                      "detail": "SupplementalClaim with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "status": "404",
-                      "title": "Record not found"
+                      "status": "404"
                     }
                   ]
                 },


### PR DESCRIPTION
## Summary
In preparation for adding validations of token ICNs to these controllers, this PR removes the last of the inheritance relationships from Decision Reviews v2 in the NOD v0, HLR v0, and SC v0 APIs.

The goal here is to minimize the number of special cases required when validating submissions to these APIs based on the ICN in the OAuth token. Note that inheritance has already been removed from the other segmented APIs and from the evidence submission controllers for these APIs.

I made this PR separately from the actual changes for API-32864 because I figured this would make things easier to review. Behavior should not be changing at all with this PR.

## Related issue(s)
- This is to support [API-32864](https://jira.devops.va.gov/browse/API-32864)

## Testing done

- No changes to specs, examples still pass

## What areas of the site does it impact?
- Notice of Disagreements API v0
- Higher-Level Reviews API v0
- Supplemental Claims API v0
(none of these are in production yet)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
