### PR TITLE
MHV 53459 Secure Messaging Handle "No messages in the requested folder" error

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/threads_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/threads_controller.rb
@@ -4,13 +4,25 @@ module MyHealth
   module V1
     class ThreadsController < SMController
       def index
-        resource = client.get_folder_threads(
-          params[:folder_id].to_s,
-          params[:page_size],
-          params[:page_number],
-          params[:sort_field],
-          params[:sort_order]
-        )
+        begin 
+          resource = client.get_folder_threads(
+            params[:folder_id].to_s,
+            params[:page_size],
+            params[:page_number],
+            params[:sort_field],
+            params[:sort_order]
+          )
+        rescue => e
+          error = e.errors.first
+          # If there are no messages in the folder, MHV API returns a 400 error
+          # We want to return an empty array in this case
+          if error.status.to_i == 400 && error.detail == "No messages in the requested folder"
+            resource = Common::Collection.new(MessageThread, data: [])
+          else
+            raise e
+          end
+        end
+        
 
         raise Common::Exceptions::RecordNotFound, params[:folder_id] if resource.blank?
 

--- a/modules/my_health/app/controllers/my_health/v1/threads_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/threads_controller.rb
@@ -4,7 +4,7 @@ module MyHealth
   module V1
     class ThreadsController < SMController
       def index
-        begin 
+        begin
           resource = client.get_folder_threads(
             params[:folder_id].to_s,
             params[:page_size],
@@ -16,13 +16,12 @@ module MyHealth
           error = e.errors.first
           # If there are no messages in the folder, MHV API returns a 400 error
           # We want to return an empty array in this case
-          if error.status.to_i == 400 && error.detail == "No messages in the requested folder"
+          if error.status.to_i == 400 && error.detail == 'No messages in the requested folder'
             resource = Common::Collection.new(MessageThread, data: [])
           else
             raise e
           end
         end
-        
 
         raise Common::Exceptions::RecordNotFound, params[:folder_id] if resource.blank?
 

--- a/modules/my_health/spec/request/v1/threads_request_spec.rb
+++ b/modules/my_health/spec/request/v1/threads_request_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Threads Integration', type: :request do
           expect(response).to be_successful
 
           json_response = JSON.parse(response.body)
-          expect(json_response).to eq({ "data" => [] })
+          expect(json_response).to eq({ 'data' => [] })
           expect(response).to match_response_schema('message_threads_no_messages')
         end
       end

--- a/modules/my_health/spec/request/v1/threads_request_spec.rb
+++ b/modules/my_health/spec/request/v1/threads_request_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe 'Threads Integration', type: :request do
           expect(response.body).to be_a(String)
           expect(response).to match_camelized_response_schema('message_threads')
         end
+
+        it 'returns an empty array when there are no messages in the folder' do
+          VCR.use_cassette('sm_client/threads/gets_threads_in_a_folder_no_messages') do
+            get "/my_health/v1/messaging/folders/#{inbox_id}/threads",
+                params: { page_size: '5', page_number: '1', sort_field: 'SENDER_NAME', sort_order: 'ASC' }
+          end
+
+          expect(response).to be_successful
+
+          json_response = JSON.parse(response.body)
+          expect(json_response).to eq({ "data" => [] })
+          expect(response).to match_response_schema('message_threads_no_messages')
+        end
       end
     end
 

--- a/spec/support/schemas/message_threads_no_messages.json
+++ b/spec/support/schemas/message_threads_no_messages.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": ["data"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_no_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_no_messages.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/threadlistview/0?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Token: "<SESSION_TOKEN>"
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 400
+        message: Bad Request
+      headers:
+        Date:
+          - Fri, 12 Jan 2024 20:31:43 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "87"
+        X-Amzn-Requestid:
+          - 13cc1fdc-4275-4e20-b83e-104b25d81eeb
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Frame-Options:
+          - DENY
+        X-Amzn-Remapped-Connection:
+          - keep-alive
+        X-Amz-Apigw-Id:
+          - RcYzcG0cPHMFXTg=
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Expires:
+          - "0"
+        X-Content-Type-Options:
+          - nosniff
+        Pragma:
+          - no-cache
+        X-Amzn-Remapped-Date:
+          - Fri, 12 Jan 2024 20:31:43 GMT
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+      body:
+        encoding: ASCII-8BIT
+        string:
+          '{"errorCode":915,"developerMessage":"","message":"No messages in the
+          requested folder"}'
+    recorded_at: Fri, 12 Jan 2024 20:31:43 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

**GIVEN** sending a request to MHV SM Patient API to retrieve a list of threads for a folder
**WHEN** a folder contains no threads/messages
**THEN** MHV SM API returns "400 Bad Request" error
**AND** vets-api just passes it to vets-website front end.

 

The error described above is not an accurate representation of an error, since the request is well structured and complies with documentation. A more standard pattern across API best practices is to return status 200 and a body of an empty array, since no values where found contained in that folder. "404 Not Found" is also not appropriate as we are passing `:folderId` in the request and the folder does exist. 

Main benefits:

clearing front end console of irrelevant error logging
reducing unnecessary error logging noise In DataDog for better monitoring of other significant errors
 

Acceptance Criteria: 

**GIVEN** sending a request to MHV SM Patient API to retrieve a list of threads for a folder
**WHEN** a folder contains no threads/messages
**THEN** MHV SM API returns "400 Bad Request" error
**AND** vets-api catches this specific error based on response status and error message and returns an empty array with status 200 

## Related issue(s)
- https://jira.devops.va.gov/browse/MHV-53459


## Testing done

- including a spec with VCR cassette
- SQA validation

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
MyHealth::V1::ThreadsController

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
