### PR TITLE
enabled_in_development -> enable_in_development

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -746,7 +746,7 @@ features:
   post_911_gibill_statuses_new_error_handling:
     actor_type: user
     description: When enabled, create a StandardError to catch unknown errors VA-IIR-285
-    enabled_in_development: true
+    enable_in_development: true
   pre_entry_covid19_screener:
     actor_type: user
     description: >


### PR DESCRIPTION
This [PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15075) included a feature toggle.  `config/features.yml` has an error: [link](https://github.com/department-of-veterans-affairs/vets-api/blob/753e44753b4b5369f3cdf6ca0aee75b94a052bb9/config/features.yml#L745) the typo is `enabled_in_development`.  The key name is actually `enable_in_development`
