### PR TITLE
Stop using submit_form in 1010EZR datadog dashboard

### DIFF
--- a/lib/form1010_ezr/service.rb
+++ b/lib/form1010_ezr/service.rb
@@ -39,11 +39,6 @@ module Form1010Ezr
       submission = soap.build_request(:save_submit_form, message: content)
       response = with_monitoring do
         perform(:post, '', submission.body)
-      rescue => e
-        increment_failure('submit_form', e)
-        raise e
-      ensure
-        increment_total('submit_form')
       end
 
       root = response.body.locate('S:Envelope/S:Body/submitFormResponse').first

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -186,9 +186,9 @@ RSpec.describe Form1010Ezr::Service do
         it 'increments statsd' do
           allow(StatsD).to receive(:increment)
 
-          expect(StatsD).to receive(:increment).with('api.1010ezr.submit_form.fail',
+          expect(StatsD).to receive(:increment).with('api.1010ezr.submit_sync.fail',
                                                      tags: ['error:VCRErrorsUnhandledHTTPRequestError'])
-          expect(StatsD).to receive(:increment).with('api.1010ezr.submit_form.total')
+          expect(StatsD).to receive(:increment).with('api.1010ezr.submit_sync.total')
 
           expect do
             submit_form(form)


### PR DESCRIPTION

## Summary
Switch from using `submit_form` to `submit_sync` for 1010ezr datadog statistics

- *(Which team do you work for, does your team own the maintainence of this component?)*
I work for the 1010 team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/73493


## Testing done

will test in staging


## What areas of the site does it impact?
1010ezr form

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
