### PR TITLE
[BE] CST: 66043 Log claim types to data dog

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -17,6 +17,15 @@ module V0
     def show
       claim = service.get_claim(params[:id])
 
+      # We want to log some details about claim type patterns to track in DataDog
+      claim_info = claim['data']['attributes']
+      ::Rails.logger.info('Claim Type Details',
+        { message_type: 'lh.cst.claim_types',
+          claim_type: claim_info['claimType'],
+          claimTypeCode: claim_info['claimTypeCode'],
+          num_contentions: claim_info['contentions'].count,
+          ep_code: claim_info['endProductCode']})
+
       render json: claim
     end
 

--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -22,7 +22,7 @@ module V0
       ::Rails.logger.info('Claim Type Details',
                           { message_type: 'lh.cst.claim_types',
                             claim_type: claim_info['claimType'],
-                            claimTypeCode: claim_info['claimTypeCode'],
+                            claim_type_code: claim_info['claimTypeCode'],
                             num_contentions: claim_info['contentions'].count,
                             ep_code: claim_info['endProductCode'] })
 

--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -20,11 +20,11 @@ module V0
       # We want to log some details about claim type patterns to track in DataDog
       claim_info = claim['data']['attributes']
       ::Rails.logger.info('Claim Type Details',
-        { message_type: 'lh.cst.claim_types',
-          claim_type: claim_info['claimType'],
-          claimTypeCode: claim_info['claimTypeCode'],
-          num_contentions: claim_info['contentions'].count,
-          ep_code: claim_info['endProductCode']})
+                          { message_type: 'lh.cst.claim_types',
+                            claim_type: claim_info['claimType'],
+                            claimTypeCode: claim_info['claimTypeCode'],
+                            num_contentions: claim_info['contentions'].count,
+                            ep_code: claim_info['endProductCode'] })
 
       render json: claim
     end

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -74,6 +74,22 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it 'logs the claim type details' do
+        VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
+          get(:show, params: { id: '600383363' })
+        end
+
+        expect(response).to have_http_status(:ok)
+        expect(Rails.logger)
+            .to have_received(:info)
+            .with('Claim Type Details',
+                  { message_type: 'lh.cst.claim_types',
+                    claim_type: 'Compensation',
+                    claimTypeCode: '020NEW',
+                    num_contentions: 1,
+                    ep_code: '020' })
+      end
     end
 
     context 'when not authorized' do
@@ -112,23 +128,6 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
         get(:show, params: { id: '60038334' })
 
         expect(response).to have_http_status(:gateway_timeout)
-      end
-    end
-
-    context 'when there are contentions' do
-      it 'logs the claim type details' do
-        VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
-          get(:show, params: { id: '60038334' })
-        end
-
-        expect(Rails.logger)
-            .to have_received(:info)
-            .with('Claim Type Details',
-                  { message_type: 'lh.cst.claim_types',
-                    claim_type: 'Compensation',
-                    claimTypeCode: '020NEW',
-                    num_contentions: 1,
-                    ep_code: '020' })
       end
     end
   end

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
         expect(response).to have_http_status(:ok)
         expect(Rails.logger)
-            .to have_received(:info)
-            .with('Claim Type Details',
-                  { message_type: 'lh.cst.claim_types',
-                    claim_type: 'Compensation',
-                    claimTypeCode: '020NEW',
-                    num_contentions: 1,
-                    ep_code: '020' })
+          .to have_received(:info)
+          .with('Claim Type Details',
+                { message_type: 'lh.cst.claim_types',
+                  claim_type: 'Compensation',
+                  claimTypeCode: '020NEW',
+                  num_contentions: 1,
+                  ep_code: '020' })
       end
     end
 

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
           .with('Claim Type Details',
                 { message_type: 'lh.cst.claim_types',
                   claim_type: 'Compensation',
-                  claimTypeCode: '020NEW',
+                  claim_type_code: '020NEW',
                   num_contentions: 1,
                   ep_code: '020' })
       end


### PR DESCRIPTION
## Summary

- added claim type logging to `app/controllers/v0/benefits_claims_controller.rb`
- added rspec test to `spec/controllers/v0/benefits_claims_controller_spec.rb`

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#66043


## Testing done

- Manually verified that it logs claim type data
- added RSpec test and made sure that it passed

## What areas of the site does it impact?
Adds additional logging to the Claims Status Tool

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
