### PR TITLE
[BE] CST: 66043 added claim_id to claim type data being logged

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -24,7 +24,8 @@ module V0
                             claim_type: claim_info['claimType'],
                             claim_type_code: claim_info['claimTypeCode'],
                             num_contentions: claim_info['contentions'].count,
-                            ep_code: claim_info['endProductCode'] })
+                            ep_code: claim_info['endProductCode'],
+                            claim_id: params[:id] })
 
       render json: claim
     end

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
                   claim_type: 'Compensation',
                   claim_type_code: '020NEW',
                   num_contentions: 1,
-                  ep_code: '020' })
+                  ep_code: '020',
+                  claim_id: '600383363' })
       end
     end
 


### PR DESCRIPTION
@RachalCassity @jerekshoe 

This amends the approved PR that was merged this morning (1/17/2024): https://github.com/department-of-veterans-affairs/vets-api/pull/15135

## Summary

- added claim_id to logging in `app/controllers/v0/benefits_claims_controller.rb`
- updated related rspec test in `spec/controllers/v0/benefits_claims_controller_spec.rb`

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#66043


## Testing done

- Manually verified that it logs claim_id to log data
- updated RSpec test and made sure that it passed

## What areas of the site does it impact?
Adds additional logging to the Claims Status Tool

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
