### PR TITLE
Track PensionBenefitIntakeJob failure

### DIFF
--- a/app/controllers/v0/pension_claims_controller.rb
+++ b/app/controllers/v0/pension_claims_controller.rb
@@ -67,8 +67,8 @@ module V0
       use_lighthouse = Flipper.enabled?(:pension_claim_submission_to_lighthouse)
       use_lighthouse ? claim.upload_to_lighthouse : claim.process_attachments!
 
-      StatsD.increment("#{stats_key}.success")
-      Rails.logger.info("Submit #{claim.class::FORM} Success",
+      StatsD.increment("#{stats_key}.sidekiq_submission")
+      Rails.logger.info("Began #{claim.class::FORM} sidekiq job",
                         { confirmation_number: claim.confirmation_number, user_uuid: })
 
       clear_saved_form(claim.form_id)

--- a/app/sidekiq/lighthouse/pension_benefit_intake_job.rb
+++ b/app/sidekiq/lighthouse/pension_benefit_intake_job.rb
@@ -58,6 +58,7 @@ module Lighthouse
       Rails.logger.warn('Lighthouse::PensionBenefitIntakeJob failed!',
                         { error: e.message })
       @form_submission_attempt&.fail!
+      StatsD.increment("#{STATSD_KEY_PREFIX}.failure")
       raise
     ensure
       cleanup_file_paths
@@ -125,6 +126,7 @@ module Lighthouse
     def check_success(response)
       if response.success?
         Rails.logger.info('Lighthouse::PensionBenefitIntakeJob Succeeded!', { saved_claim_id: @claim.id })
+        StatsD.increment("#{STATSD_KEY_PREFIX}.success")
         @claim.send_confirmation_email if @claim.respond_to?(:send_confirmation_email)
       else
         raise PensionBenefitIntakeError, response.to_s


### PR DESCRIPTION
## Summary

Errors in `Lighthouse::PensionBenefitIntakeJob` aren't visible to the calling controller, `V0::PensionClaimsController`. Therefore, instead of recording/logging a success at the end of `V0::PensionClaimsController#create`, we need to call it within `Lighthouse::PensionBenefitIntakeJob` when it completes successfully.

## Related issue(s)
- [Ticket on Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73850)

## Testing done

- Artificially inserted an error into `Lighthouse::PensionBenefitIntakeJob` and confirmed that `Lighthouse::PensionBenefitIntakeJob Succeeded!` wasn't logged, but that `Lighthouse::PensionBenefitIntakeJob failed!` was.

## What areas of the site does it impact?
Pension Benefits

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
