### PR TITLE
API-33544: Ensure All Slack Messages Sent by Forms API Check the `slack.enabled` Setting

### DIFF
--- a/modules/va_forms/app/services/va_forms/slack/messenger.rb
+++ b/modules/va_forms/app/services/va_forms/slack/messenger.rb
@@ -14,6 +14,8 @@ module VAForms
       end
 
       def notify!
+        return unless Settings.va_forms.slack.enabled
+
         Faraday.post(API_PATH, request_body, request_headers)
       end
 

--- a/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
@@ -195,13 +195,9 @@ module VAForms
     end
 
     def notify_slack(message, **)
-      return unless Settings.va_forms.slack.enabled
-
-      begin
-        VAForms::Slack::Messenger.new({ class: self.class.name, message:, ** }).notify!
-      rescue => e
-        Rails.logger.error("#{self.class.name} failed to notify Slack, message: #{message}", e)
-      end
+      VAForms::Slack::Messenger.new({ class: self.class.name, message:, ** }).notify!
+    rescue => e
+      Rails.logger.error("#{self.class.name} failed to notify Slack, message: #{message}", e)
     end
   end
 end

--- a/modules/va_forms/spec/services/va_forms/slack/messenger_spec.rb
+++ b/modules/va_forms/spec/services/va_forms/slack/messenger_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe VAForms::Slack::Messenger do
   describe '.notify!' do
-    let(:params) do
+    let(:args) do
       {
         'class' => 'SomeClass',
         'args' => %w[1234 5678],
@@ -12,25 +12,35 @@ describe VAForms::Slack::Messenger do
         'error_message' => 'Here there be dragons'
       }
     end
+    let(:api_key) { 'slack api key' }
+    let(:channel_id) { 'slack channel id' }
 
-    it 'sends a network request' do
-      with_settings(Settings, vsp_environment: 'production') do
-        with_settings(Settings.va_forms.slack, api_key: 'api token', channel_id: 'slack channel id') do
-          body = {
-            text: VAForms::Slack::HashNotification.new(params).message_text,
-            channel: 'slack channel id'
-          }.to_json
+    before { allow(Faraday).to receive(:post) }
 
-          headers = {
-            'Content-type' => 'application/json; charset=utf-8',
-            'Authorization' => 'Bearer api token'
-          }
+    it 'makes a POST request to Slack with the message as the body' do
+      with_settings(Settings.va_forms.slack, enabled: true, api_key:, channel_id:) do
+        body = {
+          text: VAForms::Slack::HashNotification.new(args).message_text,
+          channel: channel_id
+        }.to_json
 
-          allow(Faraday).to receive(:post).with(VAForms::Slack::Messenger::API_PATH, body, headers)
+        headers = {
+          'Content-type' => 'application/json; charset=utf-8',
+          'Authorization' => "Bearer #{api_key}"
+        }
 
-          VAForms::Slack::Messenger.new(params).notify!
+        expect(Faraday).to receive(:post).with(VAForms::Slack::Messenger::API_PATH, body, headers)
 
-          expect(Faraday).to have_received(:post).with(VAForms::Slack::Messenger::API_PATH, body, headers)
+        VAForms::Slack::Messenger.new(args).notify!
+      end
+    end
+
+    context 'when the Slack enabled setting is set to false' do
+      it 'does not make a POST request to Slack' do
+        with_settings(Settings.va_forms.slack, enabled: false) do
+          expect(Faraday).not_to receive(:post)
+
+          VAForms::Slack::Messenger.new(args).notify!
         end
       end
     end


### PR DESCRIPTION
## Summary
This PR updates the `VAForms::Slack::Messenger` to check the contents of the `Settings.va_forms.slack.enabled` setting before triggering any Slack notification (or not triggering a notification, if the value is `false`). Previously the `va_forms` module relied on engineers checking the Slack setting before every call to `VAForms::Slack::Messenger`, and so we had places where Slack notifications were being sent without checking the setting.

## Related issue(s)
[API-33544](https://jira.devops.va.gov/browse/API-33544)

## Testing done
Ran the affected jobs locally to ensure they were successful, and added a new unit test for `VAForms::Slack::Messenger` for when the Slack enabled setting is set to `false`.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `va_forms` module only, which is owned by my team.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested.
