### PR TITLE
Fail silently if EnrollmentEligibility service is not working

### DIFF
--- a/app/models/form_profiles/va_1010ezr.rb
+++ b/app/models/form_profiles/va_1010ezr.rb
@@ -12,7 +12,13 @@ class FormProfiles::VA1010ezr < FormProfile
   end
 
   def ezr_data
-    @ezr_data ||= HCA::EnrollmentEligibility::Service.new.get_ezr_data(user.icn)
+    @ezr_data ||=
+      begin
+        HCA::EnrollmentEligibility::Service.new.get_ezr_data(user.icn)
+      rescue => e
+        log_exception_to_sentry(e)
+        OpenStruct.new
+      end
   end
 
   def clean!(hash)

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1235,6 +1235,39 @@ RSpec.describe FormProfile, type: :model do
         FormProfiles::VA1010ezr.new(user:, form_id: 'f')
       end
 
+      context 'when the ee service is down' do
+        let(:v10_10_ezr_expected) do
+          {
+            'veteranFullName' => {
+              'first' => user.first_name&.capitalize,
+              'middle' => user.middle_name&.capitalize,
+              'last' => user.last_name&.capitalize,
+              'suffix' => user.suffix
+            },
+            'veteranSocialSecurityNumber' => user.ssn,
+            'gender' => user.gender,
+            'veteranDateOfBirth' => user.birth_date,
+            'homePhone' => us_phone,
+            'veteranAddress' => {
+              'street' => street_check[:street],
+              'street2' => street_check[:street2],
+              'city' => user.address[:city],
+              'state' => user.address[:state],
+              'country' => user.address[:country],
+              'postal_code' => user.address[:postal_code][0..4]
+            },
+            'email' => user.pciu_email
+          }
+        end
+
+        it 'prefills the rest of the data and logs exception to sentry' do
+          expect_any_instance_of(FormProfiles::VA1010ezr).to receive(:log_exception_to_sentry).with(
+            instance_of(VCR::Errors::UnhandledHTTPRequestError)
+          )
+          expect_prefilled('10-10EZR')
+        end
+      end
+
       context 'with a user with dependents', run_at: 'Tue, 31 Oct 2023 12:04:33 GMT' do
         let(:v10_10_ezr_expected) do
           {


### PR DESCRIPTION

## Summary
Fail silently if EnrollmentEligibility service is not working so that the rest of the data can still be prefilled

- *This work is behind a feature toggle (flipper): No
- *(Which team do you work for, does your team own the maintenance of this component?)*
1010 team

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/73840

## Testing done
will check sentry logs in production

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
1010ezr form prefill


## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
