### PR TITLE
63663 Remove any references of va_online_scheduling_acheron_service feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1080,10 +1080,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for the new appointment List feature
-  va_online_scheduling_acheron_service:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for the Acheron service changes
   va_online_scheduling_breadcrumb_url_update:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary
This PR removes the 'va_online_scheduling_acheron_service' feature toggle.

## Related issue(s)
fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/63663

## Testing done
N/A

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
VAOS

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
