### PR TITLE
Remove calls to PCIU and PCIU_Address in 526ez pre-fill

### DIFF
--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -130,17 +130,17 @@ class FormProfiles::VA526ez < FormProfile
   def initialize_veteran_contact_information
     return {} unless user.authorize :evss, :access?
 
-    Rails.logger.info("disability_compensation_remove_pciu=#{:disability_compensation_remove_pciu}")
-    if Flipper.enabled?(:disability_compensation_remove_pciu)
-      contact_info = initialize_vets360_contact_info
-    else
-      # fill in blank values with PCIU data
-      contact_info = initialize_vets360_contact_info.merge(
-        mailing_address: get_common_address,
-        email_address: extract_pciu_data(:pciu_email),
-        primary_phone: pciu_us_phone
-      ) { |_, old_val, new_val| old_val.presence || new_val }
-    end
+    Rails.logger.info('disability_compensation_remove_pciu=disability_compensation_remove_pciu')
+    contact_info = if Flipper.enabled?(:disability_compensation_remove_pciu)
+                     initialize_vets360_contact_info
+                   else
+                     # fill in blank values with PCIU data
+                     initialize_vets360_contact_info.merge(
+                       mailing_address: get_common_address,
+                       email_address: extract_pciu_data(:pciu_email),
+                       primary_phone: pciu_us_phone
+                     ) { |_, old_val, new_val| old_val.presence || new_val }
+                   end
     Rails.logger.info("mailing_address=#{contact_info[:mailing_address].present?}")
     Rails.logger.info("email_address=#{contact_info[:email_address].present?}")
     Rails.logger.info("primary_phone=#{contact_info[:primary_phone].present?}")

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -130,17 +130,20 @@ class FormProfiles::VA526ez < FormProfile
   def initialize_veteran_contact_information
     return {} unless user.authorize :evss, :access?
 
-    Rails.logger.info('disability_compensation_remove_pciu=disability_compensation_remove_pciu')
     contact_info = if Flipper.enabled?(:disability_compensation_remove_pciu)
+                     Rails.logger.info('disability_compensation_remove_pciu=TRUE')
                      initialize_vets360_contact_info
                    else
                      # fill in blank values with PCIU data
+                     Rails.logger.info('disability_compensation_remove_pciu=FALSE')
                      initialize_vets360_contact_info.merge(
                        mailing_address: get_common_address,
                        email_address: extract_pciu_data(:pciu_email),
                        primary_phone: pciu_us_phone
                      ) { |_, old_val, new_val| old_val.presence || new_val }
                    end
+    # Logging was added above and below here to contrast/compare completeness of contact information returned
+    # from VA Profile alone versus VA Profile + PCIU. This logging will be removed when the Flipper flag is.
     Rails.logger.info("mailing_address=#{contact_info[:mailing_address].present?}")
     Rails.logger.info("email_address=#{contact_info[:email_address].present?}")
     Rails.logger.info("primary_phone=#{contact_info[:primary_phone].present?}")

--- a/config/features.yml
+++ b/config/features.yml
@@ -1233,6 +1233,9 @@ features:
   disability_compensation_prevent_submission_job:
     actor_type: user
     description: If enabled, the submission form526 record will be created, but there will be submission job
+  disability_compensation_remove_pciu:
+    actor_type: user
+    description: If enabled, the submission form526 record will be created, but there will be submission job
   virtual_agent_fetch_jwt_token:
     actor_type: user
     description: Enable the fetching of a JWT token to access MAP environment

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1661,6 +1661,7 @@ RSpec.describe FormProfile, type: :model do
 
             it 'returns prefilled 21-526EZ' do
               Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_RATED_DISABILITIES_FOREGROUND)
+              Flipper.disable(:disability_compensation_remove_pciu)
               VCR.use_cassette('evss/pciu_address/address_domestic') do
                 VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
                   VCR.use_cassette('evss/ppiu/payment_information') do
@@ -1693,6 +1694,7 @@ RSpec.describe FormProfile, type: :model do
 
             it 'returns prefilled 21-526EZ' do
               Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_RATED_DISABILITIES_FOREGROUND)
+              Flipper.disable(:disability_compensation_remove_pciu)
               expect(user).to receive(:authorize).with(:ppiu, :access?).and_return(true).at_least(:once)
               expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
               VCR.use_cassette('evss/pciu_address/address_domestic') do

--- a/spec/support/disability_compensation_form/submissions/with_everything.json
+++ b/spec/support/disability_compensation_form/submissions/with_everything.json
@@ -105,6 +105,16 @@
             "activeDutyEndDate": "1990-04-05"
           }
         ],
+        "confinements": [
+          {
+            "confinementBeginDate": "1987-02-01",
+            "confinementEndDate": "1989-01-01"
+          },
+          {
+            "confinementBeginDate": "1990-03-06",
+            "confinementEndDate": "1999-01-01"
+          }
+        ],
         "reservesNationalGuardService": {
           "title10Activation": {
             "anticipatedSeparationDate": "2024-01-01",


### PR DESCRIPTION
This PR adds the ability to remove calls to PCIU in the custom pre-fill functionality for 526ez (controlled by a flipper flag). Logging was also added in order to test for completeness of contact info from VA Profile + PCIU (status quo) vs. VA Profile-only (future quo). Both the flipper flag and logging will be removed once the flag is on in production and no issues are found (release and cleanup tickets to be created)

## Summary

- *This work is behind a feature toggle (flipper): YES/NO* 
   - Yes (except for some additional logging)
- *(Summarize the changes that have been made to the platform)*
   - Removal of PCIU calls from 526ez pre-fill
- *(Which team do you work for, does your team own the maintenance of this component?)*
   - Disability Benefits Experience Team 1 (DBEX-TREX 🦖)
- *(If introducing a flipper, what is the success criteria being targeted?)*
   - If VA Profile contact information is revealed to be sufficiently complete, the flag (`disability_compensation_remove_pciu`) will be removed

## Related issue(s)

- [Zenhub](https://app.zenhub.com/workspaces/disability-experience-63dbdb0a401c4400119d3a44/issues/gh/department-of-veterans-affairs/va.gov-team/73362) (73362)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
   - The same, minus the new logging. With flipper flag on, it will remove PCIU calls and allow VA Profile to be sole provider
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
   - Contact info pre-fill will work as usual when starting a new 526ez application
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
     - tests already exist for both on and off scenarios. When the flag is removed, so will the relevant unit tests
  - *What is the testing plan for rolling out the feature?*
     - This is TBD, but will likely mirror the process we have used for other EVSS migrations: Canary test, followed by a stepped rollout with monitoring in DataDog

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
