### PR TITLE
Fix metadata validator nil zip code bug

### DIFF
--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -37,7 +37,7 @@ module SimpleFormsApiSubmission
     end
 
     def self.validate_zip_code(metadata, zip_code_is_us_based)
-      validate_presence_and_stringiness(zip_code, 'zip code')
+      validate_presence_and_stringiness(metadata['zipCode'], 'zip code')
       zip_code = metadata['zipCode'].dup.gsub(/[^0-9]/, '')
 
       zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -37,8 +37,8 @@ module SimpleFormsApiSubmission
     end
 
     def self.validate_zip_code(metadata, zip_code_is_us_based)
-      zip_code = metadata['zipCode'].dup.gsub(/[^0-9]/, '')
       validate_presence_and_stringiness(zip_code, 'zip code')
+      zip_code = metadata['zipCode'].dup.gsub(/[^0-9]/, '')
 
       zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)
       zip_code = '00000' unless zip_code.match?(/\A[0-9]{5}(-[0-9]{4})?\z/)

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -37,12 +37,16 @@ module SimpleFormsApiSubmission
     end
 
     def self.validate_zip_code(metadata, zip_code_is_us_based)
-      validate_presence_and_stringiness(metadata['zipCode'], 'zip code')
-      zip_code = metadata['zipCode'].dup.gsub(/[^0-9]/, '')
+      zip_code = metadata['zipCode']
+      if zip_code_is_us_based
+        validate_presence_and_stringiness(metadata['zipCode'], 'zip code')
+        zip_code = zip_code.dup.gsub(/[^0-9]/, '')
+      else
+        zip_code = '00000'
+      end
 
       zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)
       zip_code = '00000' unless zip_code.match?(/\A[0-9]{5}(-[0-9]{4})?\z/)
-      zip_code = '00000' unless zip_code_is_us_based
       metadata['zipCode'] = zip_code
 
       metadata

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -39,14 +39,14 @@ module SimpleFormsApiSubmission
     def self.validate_zip_code(metadata, zip_code_is_us_based)
       zip_code = metadata['zipCode']
       if zip_code_is_us_based
-        validate_presence_and_stringiness(metadata['zipCode'], 'zip code')
+        validate_presence_and_stringiness(zip_code, 'zip code')
         zip_code = zip_code.dup.gsub(/[^0-9]/, '')
+        zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)
+        zip_code = '00000' unless zip_code.match?(/\A[0-9]{5}(-[0-9]{4})?\z/)
       else
         zip_code = '00000'
       end
 
-      zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)
-      zip_code = '00000' unless zip_code.match?(/\A[0-9]{5}(-[0-9]{4})?\z/)
       metadata['zipCode'] = zip_code
 
       metadata

--- a/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
+++ b/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
@@ -259,5 +259,31 @@ describe SimpleFormsApiSubmission::MetadataValidator do
 
       expect(validated_metadata).to eq expected_metadata
     end
+
+    describe 'zip code is nil' do
+      it 'is set to 00000' do
+        metadata = {
+          'veteranFirstName' => 'John',
+          'veteranLastName' => 'Doe',
+          'fileNumber' => '444444444',
+          'source' => 'VA Platform Digital Forms',
+          'docType' => '21-0845',
+          'businessLine' => 'CMP'
+        }
+        expected_metadata = {
+          'veteranFirstName' => 'John',
+          'veteranLastName' => 'Doe',
+          'fileNumber' => '444444444',
+          'zipCode' => '00000',
+          'source' => 'VA Platform Digital Forms',
+          'docType' => '21-0845',
+          'businessLine' => 'CMP'
+        }
+
+        validated_metadata = SimpleFormsApiSubmission::MetadataValidator.validate(metadata, zip_code_is_us_based: false)
+
+        expect(validated_metadata).to eq expected_metadata
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
This PR fixes a subtle bug in the Metadata Validator where, if `nil` was given for a zip code, it would fail before the nil check. Just swapping the lines should resolve the issue. However, I failed to find a satisfactory way to test this change so I'd love any feedback on a reasonable way to test it. If we can't think of anything, I'm ok merging without a test exercising the precise bug, even though it is suboptimal.
