### PR TITLE
Update Sidekiq args to simple JSON types

### DIFF
--- a/app/controllers/v0/ppiu_controller.rb
+++ b/app/controllers/v0/ppiu_controller.rb
@@ -51,7 +51,7 @@ module V0
     end
 
     def send_confirmation_email
-      VANotifyDdEmailJob.send_to_emails(current_user.all_emails, :comp_pen)
+      VANotifyDdEmailJob.send_to_emails(current_user.all_emails, 'comp_and_pen')
     end
   end
 end

--- a/app/controllers/v0/profile/ch33_bank_accounts_controller.rb
+++ b/app/controllers/v0/profile/ch33_bank_accounts_controller.rb
@@ -23,7 +23,7 @@ module V0
           return render(json: res, status: :bad_request)
         end
 
-        VANotifyDdEmailJob.send_to_emails(current_user.all_emails, :ch33)
+        VANotifyDdEmailJob.send_to_emails(current_user.all_emails, 'ch33')
 
         Rails.logger.warn('Ch33BankAccountsController#update request completed', sso_logging_info)
 

--- a/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
+++ b/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe V0::Profile::Ch33BankAccountsController, type: :controller do
     context 'with a successful update' do
       it 'sends confirmation emails to the vanotify job' do
         expect(VANotifyDdEmailJob).to receive(:send_to_emails).with(
-          user.all_emails, :ch33
+          user.all_emails, 'ch33'
         )
 
         send_successful_update

--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -131,10 +131,10 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
 
   describe '#update successful' do
     let(:params) do
-      { 
-        account_number: '1234567890', 
-        account_type: 'CHECKING', 
-        routing_number: '031000503' 
+      {
+        account_number: '1234567890',
+        account_type: 'CHECKING',
+        routing_number: '031000503'
       }
     end
 
@@ -187,9 +187,8 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
           expect(response).to have_http_status(:ok)
         end
       end
-    end    
+    end
   end
-
 
   describe '#update unsuccessful' do
     context 'when missing account type' do

--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -129,32 +129,69 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
     end
   end
 
-  describe '#update' do
-    context 'when successful' do
-      it 'returns a status of 200' do
-        params = { account_number: '1234567890', account_type: 'CHECKING', routing_number: '031000503' }
+  describe '#update successful' do
+    let(:params) do
+      { 
+        account_number: '1234567890', 
+        account_type: 'CHECKING', 
+        routing_number: '031000503' 
+      }
+    end
 
-        VCR.use_cassette('lighthouse/direct_deposit/update/200_valid') do
-          put(:update, params:)
-        end
-
-        expect(response).to have_http_status(:ok)
+    it 'returns a status of 200' do
+      VCR.use_cassette('lighthouse/direct_deposit/update/200_valid') do
+        put(:update, params:)
       end
 
-      it 'capitalizes account type' do
-        params = { account_number: '1234567890', account_type: 'CHECKING', routing_number: '031000503' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'capitalizes account type' do
+      VCR.use_cassette('lighthouse/direct_deposit/update/200_valid') do
+        put(:update, params:)
+      end
+
+      body = JSON.parse(response.body)
+      payment_account = body['data']['attributes']['payment_account']
+
+      expect(payment_account['account_type']).to eq('Checking')
+    end
+
+    context 'when the user does have an associated email address' do
+      it 'sends an email through va notify' do
+        # params = { account_number: '1234567890', account_type: 'CHECKING', routing_number: '031000503' }
+
+        expect(VANotifyDdEmailJob).to receive(:send_to_emails).with(
+          user.all_emails, 'comp_and_pen'
+        )
 
         VCR.use_cassette('lighthouse/direct_deposit/update/200_valid') do
           put(:update, params:)
         end
-
-        body = JSON.parse(response.body)
-        payment_account = body['data']['attributes']['payment_account']
-
-        expect(payment_account['account_type']).to eq('Checking')
       end
     end
 
+    context 'when user does not have an associated email address' do
+      before do
+        allow(Settings.sentry).to receive(:dsn).and_return('asdf')
+      end
+
+      it 'logs a message to Sentry' do
+        # params = { account_number: '1234567890', account_type: 'CHECKING', routing_number: '031000503' }
+
+        VCR.use_cassette('lighthouse/direct_deposit/update/200_valid') do
+          expect_any_instance_of(User).to receive(:all_emails).and_return([])
+          expect(Sentry).to receive(:capture_message).once
+
+          put(:update, params:)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end    
+  end
+
+
+  describe '#update unsuccessful' do
     context 'when missing account type' do
       let(:params) do
         {

--- a/spec/requests/ppiu_request_spec.rb
+++ b/spec/requests/ppiu_request_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'PPIU' do
 
         it 'sends an email through va notify' do
           expect(VANotifyDdEmailJob).to receive(:send_to_emails).with(
-            user.all_emails, :comp_pen
+            user.all_emails, 'comp_and_pen'
           )
 
           subject


### PR DESCRIPTION
## Summary

The following warning was discovered in Datadog...
```
Job arguments to VANotifyDdEmailJob do not serialize to JSON safely. This will raise an error in
Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today
by calling `Sidekiq.strict_args!` during Sidekiq initialization.
```

Updates Sidekiq args to simple JSON types - replaced symbols with strings.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/73346