### PR TITLE
pass failed claim data to log_validation_error_to_metadata

### DIFF
--- a/app/controllers/v0/pension_claims_controller.rb
+++ b/app/controllers/v0/pension_claims_controller.rb
@@ -60,7 +60,7 @@ module V0
 
       unless claim.save
         StatsD.increment("#{stats_key}.failure")
-        log_validation_error_to_metadata(in_progress_form)
+        log_validation_error_to_metadata(in_progress_form, claim)
         raise Common::Exceptions::ValidationErrors, claim.errors
       end
 
@@ -77,7 +77,7 @@ module V0
 
     private
 
-    def log_validation_error_to_metadata(in_progress_form)
+    def log_validation_error_to_metadata(in_progress_form, claim)
       return if in_progress_form.blank?
 
       metadata = in_progress_form.metadata


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Added in previously missed param to pension_claims_controller#log_validation_error_to_metadata
- This is a bug introduced in a recent PR where we make a reference to a failed claim in a helper function, but forgot to pass in the claim data as a parameter.
- The fix is to pass the claim data to the helper function to fix the broken reference.
- Pension benefits team to own this code.

## Related issue(s)

- [*Link to previous change of the code/bug (if applicable)*](https://github.com/department-of-veterans-affairs/vets-api/pull/15110)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
Pension form submission.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
