### PR TITLE
Remove statement to ignore CVE

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -18,7 +18,7 @@ jobs:
           bundler-cache: true
 
       - name: Run bundle-audit (checks gems for CVE issues)
-        run:  bundle exec bundle-audit check --update  --ignore CVE-2023-26141 CVE-2023-49090
+        run:  bundle exec bundle-audit check --update --ignore CVE-2023-26141
 
       - name: Run Rubocop
         run: bundle exec rubocop --parallel --format github


### PR DESCRIPTION
## Summary

- with #15070 merged, we no longer need to ignore this [CVE](https://nvd.nist.gov/vuln/detail/CVE-2023-49090), as it was fixed in carrierwave 3.0.5