### PR TITLE
API-32555-fix-oauth-link-oas 

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -40,7 +40,7 @@
       },
       "productionOauth": {
         "type": "oauth2",
-        "description": "This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/authorization-code)",
+        "description": "This API uses OAuth 2 with the client credential grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/client-credentials)",
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://api.va.gov/oauth2/authorization",
@@ -54,7 +54,7 @@
       },
       "sandboxOauth": {
         "type": "oauth2",
-        "description": "This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/authorization-code)",
+        "description": "This API uses OAuth 2 with the client credential grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/client-credentials)",
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://sandbox-api.va.gov/oauth2/authorization",
@@ -1290,7 +1290,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "1be7e182-a0dc-4dc9-818a-7401a89fec32",
+                    "id": "ffdfb467-a70e-48f7-9e1c-c81bbf03d83a",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -1471,7 +1471,7 @@
                         },
                         "federalActivation": {
                           "activationDate": "2023-10-01",
-                          "anticipatedSeparationDate": "2024-01-20"
+                          "anticipatedSeparationDate": "2024-01-21"
                         },
                         "confinements": [
                           {
@@ -5676,7 +5676,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "1e5f5ce7-20b8-46f8-abef-a06d7c0e953c",
+                    "id": "64597fb2-b897-47d1-88c7-662103e42b1d",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -7744,8 +7744,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-01-18",
-                      "expirationDate": "2025-01-18",
+                      "creationDate": "2024-01-19",
+                      "expirationDate": "2025-01-19",
                       "type": "compensation",
                       "status": "active"
                     }

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -40,7 +40,7 @@
       },
       "productionOauth": {
         "type": "oauth2",
-        "description": "This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/authorization-code)",
+        "description": "This API uses OAuth 2 with the client credential grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/client-credentials)",
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://api.va.gov/oauth2/authorization",
@@ -54,7 +54,7 @@
       },
       "sandboxOauth": {
         "type": "oauth2",
-        "description": "This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/authorization-code)",
+        "description": "This API uses OAuth 2 with the client credential grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/client-credentials)",
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://sandbox-api.va.gov/oauth2/authorization",
@@ -1290,7 +1290,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "6c0ff93d-2b4f-40a5-af8c-4c5fbc85be21",
+                    "id": "1c24ba1a-935c-47d7-b3c9-989dea3c7b11",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -1471,7 +1471,7 @@
                         },
                         "federalActivation": {
                           "activationDate": "2023-10-01",
-                          "anticipatedSeparationDate": "2024-01-20"
+                          "anticipatedSeparationDate": "2024-01-21"
                         },
                         "confinements": [
                           {
@@ -5676,7 +5676,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "9d688094-2d46-472a-a60f-b779e6c16186",
+                    "id": "4eb408b0-932a-42c6-97a2-b05be0bf86fa",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -6368,8 +6368,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-01-18",
-                      "expirationDate": "2025-01-18",
+                      "creationDate": "2024-01-19",
+                      "expirationDate": "2025-01-19",
                       "type": "compensation",
                       "status": "active"
                     }

--- a/modules/claims_api/spec/support/rswag_config.rb
+++ b/modules/claims_api/spec/support/rswag_config.rb
@@ -140,7 +140,7 @@ class ClaimsApi::RswagConfig
             },
             productionOauth: {
               type: :oauth2,
-              description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/authorization-code)',
+              description: 'This API uses OAuth 2 with the client credential grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/client-credentials)',
               flows: {
                 authorizationCode: {
                   authorizationUrl: 'https://api.va.gov/oauth2/authorization',
@@ -154,7 +154,7 @@ class ClaimsApi::RswagConfig
             },
             sandboxOauth: {
               type: :oauth2,
-              description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/authorization-code)',
+              description: 'This API uses OAuth 2 with the client credential grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/client-credentials)',
               flows: {
                 authorizationCode: {
                   authorizationUrl: 'https://sandbox-api.va.gov/oauth2/authorization',


### PR DESCRIPTION
## Summary

- Update productionOauth and sandboxOauth descriptions to be:
"This API uses OAuth 2 with the client credential grant flow. [More info](https://developer.va.gov/explore/api/benefits-claims/client-credentials)",
 

## Related issue(s)

[API-32555](https://jira.devops.va.gov/browse/API-32555)

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] ran rspec
- [ ] ran check for logs
- [ ] flipper feature
- [ ] Postman
- [x] ran rake tasks
- [x] ran local docs check

## Screenshots
![Screenshot 2024-01-19 at 12 38 32 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/25069483/42223439-b988-4a1c-9c78-1c3b04a0ac4c)


## What areas of the site does it impact?
	modified:   modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
	modified:   modules/claims_api/spec/support/rswag_config.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature