### PR TITLE
API-32302 delete remaining okta settings

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -699,26 +699,6 @@
     :path: "/api/v2/search/i14y"
     :file_path: "search/default"
 
-# Okta
-- :name: 'Okta'
-  :base_uri: <%= "#{URI(Settings.oidc.base_api_url).host}:#{URI(Settings.oidc.base_api_url).port}" %>
-  :endpoints:
-  # User
-  - :method: :get
-    :path: "/api/v1/users/*"
-    :file_path: "okta/users"
-    :cache_multiple_responses:
-      :uid_location: url
-      :uid_locator:  '\/api\/v1\/users\/(.*)'
-  # Keys
-  - :method: :get
-    :path: "/oauth2/default/v1/keys"
-    :file_path: "okta/keys"
-  # Metadata
-  - :method: :get
-    :path: "/oauth2/default/.well-known/oauth-authorization-server"
-    :file_path: "okta/metadata"
-
 #GIS
 - :name: 'GIS'
   :base_uri: <%= "#{URI(Settings.locators.gis_base_path).host}:#{URI(Settings.locators.gis_base_path).port}" %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -832,31 +832,6 @@ reports:
       - hocine.halli@accenturefederal.com
       - adam.freemer@accenturefederal.com
 
-oidc:
-  auth_server_metadata_url: ~
-  issuer: ~
-  issuer_prefix: ~
-  audience: ~
-  isolated_audience:
-    default: ~
-    veteran_verification: ~
-    claims: ~
-  charon:
-    endpoint: ~
-    audience: ~
-  base_api_url: https://example.com
-  base_api_token: ~
-  base_api_profile_key_icn: false
-  smart_launch_url: ~
-  issued_url: ~
-  issuers:
-    - prefix: "https://example.com/"
-      metadata: "/.well-known/openid-configuration"
-      proxy: "https://example.com/"
-  opaque_clients:
-    - route: ~
-      client_id: ~
-
 sentry:
   dsn: ~
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -832,6 +832,11 @@ reports:
       - hocine.halli@accenturefederal.com
       - adam.freemer@accenturefederal.com
 
+oidc:
+  isolated_audience:
+    default: ~
+    claims: ~
+
 sentry:
   dsn: ~
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -26,7 +26,6 @@ VCR.configure do |c|
   c.filter_sensitive_data('<MHV_SM_APP_TOKEN>') { Settings.mhv.sm.app_token }
   c.filter_sensitive_data('<MHV_SM_HOST>') { Settings.mhv.sm.host }
   c.filter_sensitive_data('<MPI_URL>') { Settings.mvi.url }
-  c.filter_sensitive_data('<OKTA_TOKEN>') { Settings.oidc.base_api_token }
   c.filter_sensitive_data('<PD_TOKEN>') { Settings.maintenance.pagerduty_api_token }
   c.filter_sensitive_data('<CENTRAL_MAIL_TOKEN>') { Settings.central_mail.upload.token }
   c.filter_sensitive_data('<PPMS_API_KEY>') { Settings.ppms.api_keys }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- This PR is to remove the oidc settings from the settings.yml so that the depending vsp-infra-application-manifests PR to remove okta settings can be merged.
- Lighthouse Team Pivot!
- 
## Related issue(s)

- https://jira.devops.va.gov/browse/API-21864
- https://jira.devops.va.gov/browse/API-32302

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
