### PR TITLE
DBEX: adjust with_tracking of 526 Submission

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -76,7 +76,6 @@ module Form526ClaimFastTrackingConcern
   end
 
   def rrd_special_issue_set?
-    disabilities = form.dig('form526', 'form526', 'disabilities')
     disabilities.any? do |disability|
       disability['specialIssues']&.include?(RRD_CODE)
     end

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -82,6 +82,12 @@ module EVSS
 
         Sentry.set_tags(source: '526EZ-all-claims')
 
+        # This instantiates the service as defined by the inheriting object
+        # TODO: this meaningless variable assignment is required for the specs to pass, which
+        # indicates a problematic coupling of implementation and test logic.  This should eventually
+        # be addressed to make this service and test more robust and readable.
+        service = service(submission.auth_headers)
+
         with_tracking('Form526 Submission', submission.saved_claim_id, submission.id, submission.bdd?) do
           begin
             super(submission_id)
@@ -92,11 +98,6 @@ module EVSS
           end
 
           begin
-            # This instantiates the service as defined by the inheriting object
-            # TODO: this meaningless variable assignment is required for the specs to pass, which
-            # indicates a problematic coupling of implementation and test logic.  This should eventually
-            # be addressed to make this service and test more robust and readable.
-            service = service(submission.auth_headers)
             submission.mark_birls_id_as_tried!
 
             # send submission data to either EVSS or lighthouse

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -104,7 +104,7 @@ module EVSS
               # submit 526 through Lighthouse API
               # 1. get user's ICN
               user_account = UserAccount.find_by(id: submission.user_account_id) ||
-                              Account.find_by(idme_uuid: submission.user_uuid)
+                             Account.find_by(idme_uuid: submission.user_uuid)
               icn = user_account.icn
               # 2. transform submission data to Lighthouse format
               transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
@@ -112,13 +112,13 @@ module EVSS
               # 3. send transformed submission data to Lighthouse endpoint
               service = BenefitsClaims::Service.new(icn)
               raw_response = service.submit526(body)
-              # 4. convert raw response from Lighthouse to a FormSubmitResponse for further processing (claim_id, status)
+              # 4. convert response from Lighthouse to a FormSubmitResponse for further processing (claim_id, status)
               raw_response_struct = OpenStruct.new({
-                                                      body: { claim_id: raw_response.body },
-                                                      status: raw_response.status
-                                                    })
+                                                     body: { claim_id: raw_response.body },
+                                                     status: raw_response.status
+                                                   })
               response = EVSS::DisabilityCompensationForm::FormSubmitResponse
-                          .new(raw_response_struct.status, raw_response_struct)
+                         .new(raw_response_struct.status, raw_response_struct)
             else
               response = service.submit_form526(submission.form_to_json(Form526Submission::FORM_526))
             end
@@ -129,9 +129,7 @@ module EVSS
             handle_errors(submission, e)
           end
 
-          begin
-            send_post_evss_notifications(submission) if send_notifications
-          end
+          send_post_evss_notifications(submission) if send_notifications
         end
       end
       # rubocop:enable Metrics/MethodLength

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -100,29 +100,29 @@ module EVSS
           begin
             submission.mark_birls_id_as_tried!
 
-            # send submission data to either EVSS or lighthouse
-            if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration)
-              # submit 526 through Lighthouse API
-              # 1. get user's ICN
-              user_account = UserAccount.find_by(id: submission.user_account_id) ||
-                             Account.find_by(idme_uuid: submission.user_uuid)
-              icn = user_account.icn
-              # 2. transform submission data to Lighthouse format
-              transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
-              body = transform_service.transform(submission.form['form526'])
-              # 3. send transformed submission data to Lighthouse endpoint
-              service = BenefitsClaims::Service.new(icn)
-              raw_response = service.submit526(body)
-              # 4. convert response from Lighthouse to a FormSubmitResponse for further processing (claim_id, status)
-              raw_response_struct = OpenStruct.new({
-                                                     body: { claim_id: raw_response.body },
-                                                     status: raw_response.status
-                                                   })
-              response = EVSS::DisabilityCompensationForm::FormSubmitResponse
-                         .new(raw_response_struct.status, raw_response_struct)
-            else
-              response = service.submit_form526(submission.form_to_json(Form526Submission::FORM_526))
-            end
+            # send submission data to either EVSS or Lighthouse (LH)
+            response = if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration)
+                         # submit 526 through LH API
+                         # 1. get user's ICN
+                         user_account = UserAccount.find_by(id: submission.user_account_id) ||
+                                        Account.find_by(idme_uuid: submission.user_uuid)
+                         icn = user_account.icn
+                         # 2. transform submission data to LH format
+                         transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
+                         body = transform_service.transform(submission.form['form526'])
+                         # 3. send transformed submission data to LH endpoint
+                         service = BenefitsClaims::Service.new(icn)
+                         raw_response = service.submit526(body)
+                         # 4. convert LH raw response to a FormSubmitResponse for further processing (claim_id, status)
+                         raw_response_struct = OpenStruct.new({
+                                                                body: { claim_id: raw_response.body },
+                                                                status: raw_response.status
+                                                              })
+                         EVSS::DisabilityCompensationForm::FormSubmitResponse
+                           .new(raw_response_struct.status, raw_response_struct)
+                       else
+                         service.submit_form526(submission.form_to_json(Form526Submission::FORM_526))
+                       end
 
             response_handler(response)
           rescue => e

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -80,55 +80,55 @@ module EVSS
         @submission_id = submission_id
 
         Sentry.set_tags(source: '526EZ-all-claims')
-        super(submission_id)
 
-        submission.prepare_for_evss!
         with_tracking('Form526 Submission', submission.saved_claim_id, submission.id, submission.bdd?) do
-          # This instantiates the service as defined by the inheriting object
-          # TODO: this meaningless variable assignment is required for the specs to pass, which
-          # indicates a problematic coupling of implementation and test logic.  This should eventually
-          # be addressed to make this service and test more robust and readable.
-          service = service(submission.auth_headers)
-          submission.mark_birls_id_as_tried!
-
-          # send submission data to either EVSS or lighthouse
-          if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration)
-            # submit 526 through Lighthouse API
-            # 1. get user's ICN
-            user_account = UserAccount.find_by(id: submission.user_account_id) ||
-                           Account.find_by(idme_uuid: submission.user_uuid)
-            icn = user_account.icn
-            # 2. transform submission data to Lighthouse format
-            transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
-            body = transform_service.transform(submission.form['form526'])
-            # 3. send transformed submission data to Lighthouse endpoint
-            service = BenefitsClaims::Service.new(icn)
-            raw_response = service.submit526(body)
-            # 4. convert raw response from Lighthouse to a FormSubmitResponse for further processing (claim_id, status)
-            raw_response_struct = OpenStruct.new({
-                                                   body: { claim_id: raw_response.body },
-                                                   status: raw_response.status
-                                                 })
-            response = EVSS::DisabilityCompensationForm::FormSubmitResponse
-                       .new(raw_response_struct.status, raw_response_struct)
-          else
-
-            response = service.submit_form526(submission.form_to_json(Form526Submission::FORM_526))
+          begin
+            super(submission_id)
+            submission.prepare_for_evss!
+          rescue => e
+            handle_errors(submission, e)
+            return
           end
 
-          response_handler(response)
+          begin
+            # This instantiates the service as defined by the inheriting object
+            # TODO: this meaningless variable assignment is required for the specs to pass, which
+            # indicates a problematic coupling of implementation and test logic.  This should eventually
+            # be addressed to make this service and test more robust and readable.
+            service = service(submission.auth_headers)
+            submission.mark_birls_id_as_tried!
+
+            # send submission data to either EVSS or lighthouse
+            if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration)
+              # submit 526 through Lighthouse API
+              # 1. get user's ICN
+              user_account = UserAccount.find_by(id: submission.user_account_id) ||
+                              Account.find_by(idme_uuid: submission.user_uuid)
+              icn = user_account.icn
+              # 2. transform submission data to Lighthouse format
+              transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
+              body = transform_service.transform(submission.form['form526'])
+              # 3. send transformed submission data to Lighthouse endpoint
+              service = BenefitsClaims::Service.new(icn)
+              raw_response = service.submit526(body)
+              # 4. convert raw response from Lighthouse to a FormSubmitResponse for further processing (claim_id, status)
+              raw_response_struct = OpenStruct.new({
+                                                      body: { claim_id: raw_response.body },
+                                                      status: raw_response.status
+                                                    })
+              response = EVSS::DisabilityCompensationForm::FormSubmitResponse
+                          .new(raw_response_struct.status, raw_response_struct)
+            else
+              response = service.submit_form526(submission.form_to_json(Form526Submission::FORM_526))
+            end
+
+            response_handler(response)
+          rescue => e
+            handle_errors(submission, e)
+          ensure
+            send_post_evss_notifications(submission)
+          end
         end
-        submission.send_post_evss_notifications!
-      rescue Common::Exceptions::BackendServiceException,
-             Common::Exceptions::GatewayTimeout,
-             Breakers::OutageException,
-             EVSS::DisabilityCompensationForm::ServiceUnavailableException => e
-        retryable_error_handler(submission, e)
-      rescue EVSS::DisabilityCompensationForm::ServiceException => e
-        # retry submitting the form for specific upstream errors
-        retry_form526_error_handler!(submission, e)
-      rescue => e
-        non_retryable_error_handler(submission, e)
       end
       # rubocop:enable Metrics/MethodLength
 
@@ -141,6 +141,26 @@ module EVSS
       def response_handler(response)
         submission.submitted_claim_id = response.claim_id
         submission.save
+      end
+
+      def send_post_evss_notifications(submission)
+        submission.send_post_evss_notifications!
+      rescue => e
+        handle_errors(submission, e)
+      end
+
+      def handle_errors(submission, error)
+        raise error
+      rescue Common::Exceptions::BackendServiceException,
+             Common::Exceptions::GatewayTimeout,
+             Breakers::OutageException,
+             EVSS::DisabilityCompensationForm::ServiceUnavailableException => e
+        retryable_error_handler(submission, e)
+      rescue EVSS::DisabilityCompensationForm::ServiceException => e
+        # retry submitting the form for specific upstream errors
+        retry_form526_error_handler!(submission, e)
+      rescue => e
+        non_retryable_error_handler(submission, e)
       end
 
       def retryable_error_handler(_submission, error)

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -77,6 +77,7 @@ module EVSS
       #
       # rubocop:disable Metrics/MethodLength
       def perform(submission_id)
+        send_notifications = true
         @submission_id = submission_id
 
         Sentry.set_tags(source: '526EZ-all-claims')
@@ -124,9 +125,12 @@ module EVSS
 
             response_handler(response)
           rescue => e
+            send_notifications = false
             handle_errors(submission, e)
-          ensure
-            send_post_evss_notifications(submission)
+          end
+
+          begin
+            send_post_evss_notifications(submission) if send_notifications
           end
         end
       end

--- a/lib/sidekiq/form526_job_status_tracker/job_tracker.rb
+++ b/lib/sidekiq/form526_job_status_tracker/job_tracker.rb
@@ -91,7 +91,8 @@ module Sidekiq
           exception_raised = true
           raise
         ensure
-          job_success unless exception_raised
+          job_status = Form526JobStatus.find_by(job_id: jid)
+          job_success unless exception_raised || job_status&.error_class
         end
       end
 


### PR DESCRIPTION
## Summary

- A not null violation error is raised within the `Form526JobStatusTracker` when a job status update is attempted for a nil submission ID
- The submission ID in the job tracker's "on error" handlers is populated by the `with_tracking` block, outside of which occur both `prepare_for_evss!` and `send_post_evss_notifications!` service calls
- Analyzing stack traces of raised errors indicated failures directly attributed to outage exceptions when calling EVSS's `/ratedDisabilities` endpoint in the `prepare_for_evss!` step
- Relocating calls to both `prepare_for_evss!` and `send_post_evss_notifications!` within the `with_tracking` block should address the nil submission ID error

Error handling has been refactored and conditional logic introduced to:
1. return early if an exception is raised when calling `prepare_for_evss!`
2. only send notifications if form submission is successful
3. prevent duplicate submission attempts in the event `send_post_evss_notifications!` raises an exception

## Related issue(s)

- [Datadog spikes](https://vagov.ddog-gov.com/logs?query=%22ActiveRecord%3A%3ANotNullViolation%22%20form526_submission_id%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1704206104003&to_ts=1704810904003&live=true)
- [Sentry Error](https://vagov.ddog-gov.com/logs?query=%22ActiveRecord%3A%3ANotNullViolation%22%20form526_submission_id%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1704206104003&to_ts=1704810904003&live=true)
- Zenhub ticket [#73266](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/73266)

## Testing done

Corresponding spec runs successfully after refactoring code.

## What areas of the site does it impact?
Form 526 Submission notifications

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
