### PR TITLE
API-33396 Update nested phone to phone_number for POA V2

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
@@ -12,7 +12,7 @@ module ClaimsApi
           {
             code: poa[:code],
             name: poa[:name],
-            phone: { number: poa[:phone_number] }
+            phone_number: poa[:phone_number]
           }
         end
 

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8336,9 +8336,7 @@
                     "attributes": {
                       "code": "A1Q",
                       "name": "Firstname Lastname",
-                      "phone": {
-                        "number": "555-555-5555"
-                      }
+                      "phoneNumber": "555-555-5555"
                     }
                   }
                 },
@@ -8371,7 +8369,7 @@
                           "required": [
                             "code",
                             "name",
-                            "phone"
+                            "phoneNumber"
                           ],
                           "code": {
                             "type": "string",
@@ -8384,17 +8382,11 @@
                             "nullable": true,
                             "example": "Jane Smith"
                           },
-                          "phone": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                              "number": {
-                                "description": "Phone number of representative. Can be organization or individual phone number.",
-                                "type": "string",
-                                "nullable": true,
-                                "example": "555-555-5555"
-                              }
-                            }
+                          "phoneNumber": {
+                            "description": "Phone number of representative. Can be organization or individual phone number.",
+                            "type": "string",
+                            "nullable": true,
+                            "example": "555-555-5555"
                           }
                         }
                       }

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8366,27 +8366,31 @@
                           "example": "individual"
                         },
                         "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
                           "required": [
                             "code",
                             "name",
                             "phoneNumber"
                           ],
-                          "code": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Power of Attorney Code currently assigned to Veteran"
-                          },
-                          "name": {
-                            "description": "Name of individual representative or organization",
-                            "type": "string",
-                            "nullable": true,
-                            "example": "Jane Smith"
-                          },
-                          "phoneNumber": {
-                            "description": "Phone number of representative. Can be organization or individual phone number.",
-                            "type": "string",
-                            "nullable": true,
-                            "example": "555-555-5555"
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Power of Attorney Code currently assigned to Veteran"
+                            },
+                            "name": {
+                              "description": "Name of individual representative or organization",
+                              "type": "string",
+                              "nullable": true,
+                              "example": "Jane Smith"
+                            },
+                            "phoneNumber": {
+                              "description": "Phone number of representative. Can be organization or individual phone number.",
+                              "type": "string",
+                              "nullable": true,
+                              "example": "555-555-5555"
+                            }
                           }
                         }
                       }

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -6960,9 +6960,7 @@
                     "attributes": {
                       "code": "A1Q",
                       "name": "Firstname Lastname",
-                      "phone": {
-                        "number": "555-555-5555"
-                      }
+                      "phoneNumber": "555-555-5555"
                     }
                   }
                 },
@@ -6995,7 +6993,7 @@
                           "required": [
                             "code",
                             "name",
-                            "phone"
+                            "phoneNumber"
                           ],
                           "code": {
                             "type": "string",
@@ -7008,17 +7006,11 @@
                             "nullable": true,
                             "example": "Jane Smith"
                           },
-                          "phone": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                              "number": {
-                                "description": "Phone number of representative. Can be organization or individual phone number.",
-                                "type": "string",
-                                "nullable": true,
-                                "example": "555-555-5555"
-                              }
-                            }
+                          "phoneNumber": {
+                            "description": "Phone number of representative. Can be organization or individual phone number.",
+                            "type": "string",
+                            "nullable": true,
+                            "example": "555-555-5555"
                           }
                         }
                       }

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -6990,27 +6990,31 @@
                           "example": "individual"
                         },
                         "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
                           "required": [
                             "code",
                             "name",
                             "phoneNumber"
                           ],
-                          "code": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Power of Attorney Code currently assigned to Veteran"
-                          },
-                          "name": {
-                            "description": "Name of individual representative or organization",
-                            "type": "string",
-                            "nullable": true,
-                            "example": "Jane Smith"
-                          },
-                          "phoneNumber": {
-                            "description": "Phone number of representative. Can be organization or individual phone number.",
-                            "type": "string",
-                            "nullable": true,
-                            "example": "555-555-5555"
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Power of Attorney Code currently assigned to Veteran"
+                            },
+                            "name": {
+                              "description": "Name of individual representative or organization",
+                              "type": "string",
+                              "nullable": true,
+                              "example": "Jane Smith"
+                            },
+                            "phoneNumber": {
+                              "description": "Phone number of representative. Can be organization or individual phone number.",
+                              "type": "string",
+                              "nullable": true,
+                              "example": "555-555-5555"
+                            }
                           }
                         }
                       }

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -67,9 +67,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
                           'attributes' => {
                             'code' => 'ABC',
                             'name' => 'Robert Lawlaw',
-                            'phone' => {
-                              'number' => '321-654-0987'
-                            }
+                            'phoneNumber' => '321-654-0987'
                           }
                         }
                       }

--- a/spec/support/schemas/claims_api/veterans/power-of-attorney/get.json
+++ b/spec/support/schemas/claims_api/veterans/power-of-attorney/get.json
@@ -18,7 +18,7 @@
           "example": "individual"
         },
         "attributes": {
-          "required": ["code", "name", "phone"],
+          "required": ["code", "name", "phoneNumber"],
           "code": {
             "type": "string",
             "nullable": true,
@@ -30,17 +30,11 @@
             "nullable": true,
             "example": "Jane Smith"
           },
-          "phone": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "number": {
-                "description": "Phone number of representative. Can be organization or individual phone number.",
-                "type": "string",
-                "nullable": true,
-                "example": "555-555-5555"
-              }
-            }
+          "phoneNumber": {
+            "description": "Phone number of representative. Can be organization or individual phone number.",
+            "type": "string",
+            "nullable": true,
+            "example": "555-555-5555"
           }
         }
       }

--- a/spec/support/schemas/claims_api/veterans/power-of-attorney/get.json
+++ b/spec/support/schemas/claims_api/veterans/power-of-attorney/get.json
@@ -18,23 +18,27 @@
           "example": "individual"
         },
         "attributes": {
+          "type": "object",
+          "additionalProperties": false,
           "required": ["code", "name", "phoneNumber"],
-          "code": {
-            "type": "string",
-            "nullable": true,
-            "description": "Power of Attorney Code currently assigned to Veteran"
-          },
-          "name": {
-            "description": "Name of individual representative or organization",
-            "type": "string",
-            "nullable": true,
-            "example": "Jane Smith"
-          },
-          "phoneNumber": {
-            "description": "Phone number of representative. Can be organization or individual phone number.",
-            "type": "string",
-            "nullable": true,
-            "example": "555-555-5555"
+          "properties": {
+            "code": {
+              "type": "string",
+              "nullable": true,
+              "description": "Power of Attorney Code currently assigned to Veteran"
+            },
+            "name": {
+              "description": "Name of individual representative or organization",
+              "type": "string",
+              "nullable": true,
+              "example": "Jane Smith"
+            },
+            "phoneNumber": {
+              "description": "Phone number of representative. Can be organization or individual phone number.",
+              "type": "string",
+              "nullable": true,
+              "example": "555-555-5555"
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- This pr updates the nested `{phone: {number: ""}}`  to `phoneNumber: ""` in the active POA V2 endpoint

## Related issue(s)

- [API-33396](https://jira.devops.va.gov/browse/API-33396)

## Testing done

- [x] *New code is covered by unit tests*
- Tested locally with Postman and a BGS tunnel to staging

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/a0198b0b-45bd-417d-82ab-b4f4154e3a5e)

## What areas of the site does it impact?
Impact is to the POA V2 show endpoint

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature