### PR TITLE
Added PendingDocument model

### DIFF
--- a/modules/vye/app/models/vye/pending_document.rb
+++ b/modules/vye/app/models/vye/pending_document.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Vye
+  class Vye::PendingDocument < ApplicationRecord
+    include Vye::GenDigest
+
+    belongs_to :user_info, foreign_key: :ssn_digest, primary_key: :ssn_digest, inverse_of: :pending_documents
+
+    ENCRYPTED_ATTRIBUTES = %i[claim_no ssn].freeze
+
+    has_kms_key
+    has_encrypted(*ENCRYPTED_ATTRIBUTES, key: :kms_key, **lockbox_options)
+
+    REQUIRED_ATTRIBUTES = [
+      *ENCRYPTED_ATTRIBUTES,
+      *%i[doc_type queue_date rpo ssn_digest].freeze
+    ].freeze
+
+    validates(*REQUIRED_ATTRIBUTES, presence: true)
+
+    before_validation :digest_ssn
+
+    private
+
+    def digest_ssn
+      self.ssn_digest = gen_digest(ssn) if ssn_changed?
+    end
+  end
+end

--- a/modules/vye/spec/factories/vye/pending_documents.rb
+++ b/modules/vye/spec/factories/vye/pending_documents.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :vye_pending_document, class: 'Vye::PendingDocument' do
+    claim_no { Faker::Lorem.word }
+    doc_type { Faker::Lorem.word }
+    queue_date { Faker::Time.backward(days: 14) }
+    rpo { Faker::Lorem.word }
+  end
+end

--- a/modules/vye/spec/models/vye/pending_document_spec.rb
+++ b/modules/vye/spec/models/vye/pending_document_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Vye::PendingDocument, type: :model do
+  describe 'create' do
+    let(:user_info) { FactoryBot.create(:vye_user_info) }
+
+    before do
+      s =
+        Struct.new(:settings, :scrypt_config) do
+          include Vye::GenDigest
+          settings =
+            Config.load_files(
+              Rails.root / 'config/settings.yml',
+              Vye::Engine.root / 'config/settings/test.yml'
+            )
+          scrypt_config = extract_scrypt_config settings
+          new(settings, scrypt_config)
+        end
+
+      allow_any_instance_of(Vye::GenDigest::Common)
+        .to receive(:scrypt_config)
+        .and_return(s.scrypt_config)
+    end
+
+    it 'creates a record' do
+      expect do
+        attributes = { ssn: user_info.ssn, **FactoryBot.attributes_for(:vye_pending_document) }
+        Vye::PendingDocument.create!(attributes)
+      end.to change(Vye::PendingDocument, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
Starting development for **VYE (Verify Your Enrollment)** API.

## Summary

- This API is part of the migration of WAVE (https://www.gibill.va.gov/wave/vba/) from a standalone Java app to the main va.gov Ruby or Rails site.
- It's being done to bring the app to a code base when development is more active.
- This pull request does the following:
	- adds the pending documents model
	- 
## Related issue(s)

https://jira.devops.va.gov/browse/VYE-111

As:

VYE Developer

I need:

To create an API GET request

So that: 

Enrollment Verification status and Pending Documents are retrieved from the VYE database for the specified user when the API is called on

Considerations:

Needs to handle the edge case where the user is not enrolled in Chap 30/1606/1607 and there is no information to retrieve.

Acceptance Criteria: 

Enter the acceptance criteria that will be used to test the user story. 

API successfully retrieves User specific Enrollment Verification Status and Pending Documents.

Testing Considerations:

Unit test will be written for API to ensure it behaves as intended

Other Considerations: 

## Testing done

- This is a new feature so there is no old behavior prior to the change
- Basic specs were added to exercise the model; more will be added in future sprints. 

## What areas of the site does it impact?

- No areas of the site are impacted

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution 
	- *will be added as API gets fleshed out further in future commits*
- [ ]  Documentation has been updated (link to documentation)
	- *will be added as API gets fleshed out further in future commits*
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
	- *will be added as API gets fleshed out further in future commits*
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback