### PR TITLE
Fix coverband initialization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -861,7 +861,7 @@ lib/gi/gids_response.rb @department-of-veterans-affairs/Benefits-Team-1 @departm
 lib/gi/search_client.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/gi/search_configuration.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/gibft @department-of-veterans-affairs/govcio-vfep-codereviewers
-lib/github_authentication @department-of-veterans-affairs/octo-identity
+lib/github_authentication @department-of-veterans-affairs/backend-review-group
 lib/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/form1010_ezr @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/va1010_forms @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem 'clam_scan'
 gem 'combine_pdf'
 gem 'config'
 gem 'connect_vbms', git: 'https://github.com/department-of-veterans-affairs/connect_vbms.git', branch: 'master', require: 'vbms'
-gem 'coverband', require: false
 gem 'date_validator'
 gem 'ddtrace'
 gem 'dogstatsd-ruby', '5.6.1'
@@ -154,6 +153,13 @@ gem 'virtus'
 gem 'warden-github'
 gem 'will_paginate'
 gem 'with_advisory_lock'
+
+group :development, :production do
+  # This needs to be required as early as possible in the initialization
+  # process because it starts collecting data on 'require'.
+  # Only require this in development and production to avoid slowing down tests.
+  gem 'coverband'
+end
 
 group :development do
   gem 'guard-rubocop'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -491,8 +491,7 @@ Rails.application.routes.draw do
   get '/flipper/features/logout', to: 'flipper#logout'
   mount Flipper::UI.app(Flipper.instance) => '/flipper', constraints: Flipper::AdminUserConstraint
 
-  if Rails.env.production?
-    require 'coverband'
+  unless Rails.env.test?
     mount Coverband::Reporters::Web.new, at: '/coverband', constraints: GithubAuthentication::CoverbandReportersWeb.new
   end
 

--- a/lib/github_authentication/coverband_reporters_web.rb
+++ b/lib/github_authentication/coverband_reporters_web.rb
@@ -3,7 +3,7 @@
 module GithubAuthentication
   class CoverbandReportersWeb
     def matches?(request)
-      return true if Settings.vsp_environment == 'development'
+      return true if Rails.env.development?
 
       warden = request.env['warden']
       request.session[:coverband_user] ||= warden.user


### PR DESCRIPTION
## Summary
- `coverband` starts on `require` and was being required in `routes.rb` so every file that got initialized before `routes.rb` would not have data.
- Move `coverband` to `production` and `development` gem group so it gets required when `config/boot` is run.
- remove `octo-identity` from `lib/github_authentication` `CODEOWNERS`

## Testing
- Start server
- Navigate to http://localhost:3000/coverband. You should see data being collected on files


## What areas of the site does it impact?
Coverband
