### PR TITLE
[74033] User Verifier ICN log

### DIFF
--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -119,7 +119,7 @@ module Login
     def post_transaction_message_logs
       Rails.logger.info(deprecated_log) if deprecated_log
       Rails.logger.info(user_account_mismatch_log) if user_account_mismatch_log
-      Rails.logger.info(new_user_log) if new_user_log
+      Rails.logger.info(new_user_log, { icn: }) if new_user_log
     end
 
     def set_deprecated_log(deprecated_user_account_id, user_verification_id, user_account_id)

--- a/spec/services/login/user_verifier_spec.rb
+++ b/spec/services/login/user_verifier_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Login::UserVerifier do
           let(:verified_at) { Time.zone.now - 1.day }
 
           it 'does not make new user log to rails logger' do
-            expect(Rails.logger).not_to receive(:info).with(expected_log)
+            expect(Rails.logger).not_to receive(:info).with(expected_log, { icn: })
             subject
           end
 
@@ -247,7 +247,7 @@ RSpec.describe Login::UserVerifier do
           let(:expected_log) { "[Login::UserVerifier] New VA.gov user, type=#{login_value}, broker=#{auth_broker}" }
 
           it 'makes a new user log to rails logger' do
-            expect(Rails.logger).to receive(:info).with(expected_log)
+            expect(Rails.logger).to receive(:info).with(expected_log, { icn: })
             subject
           end
 
@@ -311,7 +311,7 @@ RSpec.describe Login::UserVerifier do
           end
 
           it 'does not make new user log to rails logger' do
-            expect(Rails.logger).not_to receive(:info).with(expected_log)
+            expect(Rails.logger).not_to receive(:info).with(expected_log, { icn: })
             subject
           end
 
@@ -339,7 +339,7 @@ RSpec.describe Login::UserVerifier do
 
         context 'and user_verification for user credential does not already exist' do
           it 'makes a new user log to rails logger' do
-            expect(Rails.logger).to receive(:info).with(expected_log)
+            expect(Rails.logger).to receive(:info).with(expected_log, { icn: })
             subject
           end
 


### PR DESCRIPTION
## Summary

This PR updates the new user creation log - `[Login::UserVerifier] New VA.gov user, type=#{login_type}, broker=#{auth_broker}` to also include the user's ICN as part of the log's extra context.

## Related issue(s)

- [Add ICN to userverifier log](https://github.com/orgs/department-of-veterans-affairs/projects/1137/views/1?pane=issue&itemId=50548481)

## Testing done

- [x] updated `user_verifier_spec` to include ICN in new user logs for verified & unverified users
- To test, perform an authentication with an IAL2/LoA3 user that does not already have a record on your vets-api instance, you should see the following log line
  ```ruby
  Rails -- [Login::UserVerifier] New VA.gov user, type=logingov, broker=sis -- { :icn => "1008709396V637156" }
  ```
- If the new account isn't IAL2/LoA3 then it will not possess an ICN, resulting in a `nil` value
  ```ruby
  Rails -- [Login::UserVerifier] New VA.gov user, type=idme, broker=sis -- { :icn => nil }
  ```