### PR TITLE
[CST] Adding logging when user doesn't have veteran identifiers

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -52,12 +52,12 @@ module V0
     end
 
     def check_for_birls_id
-      ::Rails.logger.info('No birls id') if current_user.birls_id.nil?
+      ::Rails.logger.info('[BenefitsClaims#index No birls id') if current_user.birls_id.nil?
     end
 
     def check_for_file_number
       bgs_file_number = BGS::People::Request.new.find_person_by_participant_id(user: current_user).file_number
-      ::Rails.logger.info('No file number') if bgs_file_number.blank?
+      ::Rails.logger.info('BenefitsClaims#index No file number') if bgs_file_number.blank?
     end
 
     def tap_claims(claims)

--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -52,12 +52,12 @@ module V0
     end
 
     def check_for_birls_id
-      ::Rails.logger.info('[BenefitsClaims#index No birls id') if current_user.birls_id.nil?
+      ::Rails.logger.info('[BenefitsClaims#index] No birls id') if current_user.birls_id.nil?
     end
 
     def check_for_file_number
       bgs_file_number = BGS::People::Request.new.find_person_by_participant_id(user: current_user).file_number
-      ::Rails.logger.info('BenefitsClaims#index No file number') if bgs_file_number.blank?
+      ::Rails.logger.info('[BenefitsClaims#index] No file number') if bgs_file_number.blank?
     end
 
     def tap_claims(claims)

--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -9,6 +9,10 @@ module V0
 
     def index
       claims = service.get_claims
+
+      check_for_birls_id
+      check_for_file_number
+
       tap_claims(claims['data'])
 
       render json: claims
@@ -45,6 +49,15 @@ module V0
 
     def service
       @service ||= BenefitsClaims::Service.new(@current_user.icn)
+    end
+
+    def check_for_birls_id
+      ::Rails.logger.info('No birls id') if current_user.birls_id.nil?
+    end
+
+    def check_for_file_number
+      bgs_file_number = BGS::People::Request.new.find_person_by_participant_id(user: current_user).file_number
+      ::Rails.logger.info('No file number') if bgs_file_number.blank?
     end
 
     def tap_claims(claims)


### PR DESCRIPTION
## Summary
We want to add logging to DataDog to identify what percentage of users don't have a birls_id or a file_number. We have identified issues related to these users trying to perform common actions with our APIs, but we need to collect more information to determine how many users fall into this category. We would also like to see if there is a correlation between a user lacking a birls_id and a file number. This logging should not capture any PII

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/74138

## Testing done
We may not be supporting users without birls_ids or file numbers in the future via modifications to our Pundit policy, so this code may be short lived

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
