### PR TITLE
Mobile - Rspec stubbing File bug fix

### DIFF
--- a/modules/mobile/spec/models/lighthouse_assertion_spec.rb
+++ b/modules/mobile/spec/models/lighthouse_assertion_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Mobile::V0::LighthouseAssertion, type: :model do
     before do
       Timecop.freeze(Time.utc(2021, 10, 11, 0, 0, 0))
       allow(SecureRandom).to receive(:uuid).and_return(uuid)
-      allow(File).to receive(:read).and_return(rsa_key.to_s)
+      allow_any_instance_of(Mobile::V0::LighthouseAssertion).to receive(:rsa_key).and_return(
+        OpenSSL::PKey::RSA.new(rsa_key.to_s)
+      )
     end
 
     after { Timecop.return }

--- a/modules/mobile/spec/request/immunizations_request_spec.rb
+++ b/modules/mobile/spec/request/immunizations_request_spec.rb
@@ -11,8 +11,10 @@ RSpec.describe 'immunizations', type: :request do
   let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
 
   before do
-    allow(File).to receive(:read).and_return(rsa_key.to_s)
     Timecop.freeze(Time.zone.parse('2021-10-20T15:59:16Z'))
+    allow_any_instance_of(Mobile::V0::LighthouseAssertion).to receive(:rsa_key).and_return(
+      OpenSSL::PKey::RSA.new(rsa_key.to_s)
+    )
   end
 
   after { Timecop.return }
@@ -30,8 +32,6 @@ RSpec.describe 'immunizations', type: :request do
       end
 
       it 'matches the expected schema' do
-        # TODO: this should use the matcher helper instead (was throwing an Oj::ParseError)
-        # expect().to match_json_schema('immunizations')
         expect(response.parsed_body).to eq(
           {
             'data' => [{

--- a/modules/mobile/spec/request/locations_request_spec.rb
+++ b/modules/mobile/spec/request/locations_request_spec.rb
@@ -11,8 +11,10 @@ RSpec.describe 'locations', type: :request do
   let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
 
   before do
-    allow(File).to receive(:read).and_return(rsa_key.to_s)
     Timecop.freeze(Time.zone.parse('2021-10-20T15:59:16Z'))
+    allow_any_instance_of(Mobile::V0::LighthouseAssertion).to receive(:rsa_key).and_return(
+      OpenSSL::PKey::RSA.new(rsa_key.to_s)
+    )
   end
 
   after { Timecop.return }

--- a/modules/mobile/spec/request/v1/immunizations_request_spec.rb
+++ b/modules/mobile/spec/request/v1/immunizations_request_spec.rb
@@ -8,10 +8,13 @@ RSpec.describe 'immunizations', type: :request do
   include JsonSchemaMatchers
 
   let!(:user) { sis_user(icn: '9000682') }
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
 
   before do
-    allow_any_instance_of(Mobile::V0::LighthouseAssertion).to receive(:token).and_return('abc123')
     Timecop.freeze(Time.zone.parse('2021-10-20T15:59:16Z'))
+    allow_any_instance_of(Mobile::V0::LighthouseAssertion).to receive(:rsa_key).and_return(
+      OpenSSL::PKey::RSA.new(rsa_key.to_s)
+    )
   end
 
   after { Timecop.return }

--- a/modules/mobile/spec/services/lighthouse_health_service_spec.rb
+++ b/modules/mobile/spec/services/lighthouse_health_service_spec.rb
@@ -90,8 +90,10 @@ describe Mobile::V0::LighthouseHealth::Service do
   end
 
   before do
-    allow(File).to receive(:read).and_return(rsa_key.to_s)
     Timecop.freeze(Time.zone.parse('2021-10-20T15:59:16Z'))
+    allow_any_instance_of(Mobile::V0::LighthouseAssertion).to receive(:rsa_key).and_return(
+      OpenSSL::PKey::RSA.new(rsa_key.to_s)
+    )
   end
 
   after { Timecop.return }


### PR DESCRIPTION
## Summary
Some mobile specs that use Lighthouse CCG authentication uses this line to spoof authentication.
allow(File).to receive(:read).and_return(rsa_key.to_s)

This is too generic and causes issues when trying to use files that are not rsa keys

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/7614

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
