### PR TITLE
Updates ID in parameters for 5103 docs, compiles docs to reflect change

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -1290,7 +1290,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "5d4cb1e8-2403-4500-b180-6415f8b966ab",
+                    "id": "2c0b508e-7cc3-4d9b-9164-a5705a6b8f54",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -5676,7 +5676,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "845d5f30-ca9b-4fc4-be45-024aacfd001d",
+                    "id": "7f73e8cf-9d2e-4ab5-8a90-0b17d266ba03",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -7304,7 +7304,7 @@
           {
             "name": "id",
             "in": "path",
-            "example": "1234",
+            "example": "600400703",
             "description": "The ID of the claim being requested",
             "required": true,
             "schema": {

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -1290,7 +1290,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "ad62ec1c-e610-42eb-9498-26d4321d112b",
+                    "id": "4d9277ac-dab9-4105-85ee-519682056c9a",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -5676,7 +5676,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "a1e33c7e-04e1-48fe-8587-e2d47b2ba5a4",
+                    "id": "839d1a11-f412-4c83-8bb9-e93fccd5d3b8",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -5928,7 +5928,7 @@
           {
             "name": "id",
             "in": "path",
-            "example": "1234",
+            "example": "600400703",
             "description": "The ID of the claim being requested",
             "required": true,
             "schema": {

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_evidence_waiver_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_evidence_waiver_spec.rb
@@ -25,7 +25,7 @@ describe 'EvidenceWaiver5103',
       parameter name: :id,
                 in: :path,
                 type: :string,
-                example: '1234',
+                example: '600400703',
                 description: 'The ID of the claim being requested'
       parameter name: 'veteranId',
                 in: :path,


### PR DESCRIPTION
## Summary
* Updates ID shown in docs
* Compiles dev and production docs to show the change. 

## Related issue(s)
[API-31570](https://jira.devops.va.gov/browse/API-31570)

## Testing done


## Screenshots
<img width="759" alt="Screenshot 2024-01-18 at 2 07 54 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/129893414/bed09152-c64a-4f7f-a214-05a3cc9d8ec6">

## What areas of the site does it impact?
	modified:   modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
	modified:   modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
	modified:   modules/claims_api/spec/requests/v2/veterans/rswag_evidence_waiver_spec.rb

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_