### PR TITLE
Revert "Update govdelivery-tms to 4.0.0 with action mailer delivery method fix"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,10 +77,10 @@ gem 'google-apis-core'
 gem 'google-apis-generator'
 gem 'googleauth'
 gem 'google-protobuf' # For Datadog Profiling
-gem 'govdelivery-tms', git: 'https://github.com/adhocteam/govdelivery-tms-ruby.git', tag: 'v4.0.0', require: 'govdelivery/tms/mail/delivery_method'
+gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
 gem 'gyoku'
 gem 'holidays'
-gem 'httpclient' # for lib/evss/base_service.rb
+gem 'httpclient'
 gem 'ice_nine'
 gem 'iso_country_codes'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/adhocteam/govdelivery-tms-ruby.git
-  revision: 9a2070f5b3982bfd9fa55cd3d2c7cfc977a9a96d
-  tag: v4.0.0
-  specs:
-    govdelivery-tms (4.0.0)
-      activesupport (>= 5.2.4.3, < 8.0.0)
-      faraday
-      mime-types
-
-GIT
   remote: https://github.com/department-of-veterans-affairs/apivore
   revision: 5f40ee08bd62bfdf8259201e5803050f2d326576
   branch: master
@@ -511,6 +501,11 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    govdelivery-tms (2.8.4)
+      activesupport
+      faraday
+      faraday_middleware
+      mime-types
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -575,8 +570,6 @@ GEM
     libdatadog (5.0.0.1.0)
     libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0)
-      ffi (~> 1.0)
-    libddwaf (1.14.0.0.0-arm64-darwin)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
@@ -1045,8 +1038,8 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-22
   java
+  ruby
   x64-mingw32
   x86-mingw32
   x86-mswin32
@@ -1117,7 +1110,7 @@ DEPENDENCIES
   google-apis-generator
   google-protobuf
   googleauth
-  govdelivery-tms!
+  govdelivery-tms (= 2.8.4)
   guard-rspec
   guard-rubocop
   gyoku
@@ -1247,4 +1240,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.9
+   2.4.10


### PR DESCRIPTION
## Summary

- change `govdelivery-tms` source to [adhocteam/govdelivery-tms](https://github.com/adhocteam/govdelivery-tms-ruby)
  - will fork to original gem in the hopes they will update it. If not this can be moved to department of veteran affairs org 
- remove `faraday_middleware` (use `Faraday::Response::Logger` instead)
- fixed previous PR [15099](https://github.com/department-of-veterans-affairs/vets-api/pull/15099) with missing require in Gemfile. 

## Related issue(s)

- [va.gov-team issue # 73519](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73519)

## Testing done

- local testing
- No additional test required

## What areas of the site does it impact?
Sending emails

## Acceptance criteria

- [x] confirmed gem is 4.0.0 in Gemfile.lock