### PR TITLE
Add db:setup to vets-api instructions to reduce setup errors

### DIFF
--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -39,6 +39,11 @@ Steps 2-4 must be repeated if the repo's Ruby version is updated later.
 
    More information about installing _with_ Sidekiq Enterprise as well as our credentials are on the internal system [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md)
 
+1. Setup local databases and schema migrations:
+   ```bash
+   cd vets-api; rails db:setup; rails db:migrate
+   ```
+
 1. Make sure you have the [vets-api-mockdata](https://github.com/department-of-veterans-affairs/vets-api-mockdata) repo locally installed, preferably in a sibling directory to `vets-api`.
 
 1. Go to the file `config/settings/development.yml` and make sure the `cache-dir` points to the local installation of `vets-api-mockdata` from the previous step.
@@ -224,13 +229,13 @@ All of the OSX instructions assume `homebrew` is your [package manager](https://
    cp /etc/postgresql/##/main/pg_hba.conf .
    cp /etc/postgresql/##/main/postgresql.conf .
    ```
-   
+
 
    Remove any unwanted versions (replace hashes with the db vsn eg 11)
    ```bash
    dpkg -l | grep postgres
    sudo apt --purge remove postgresql-## postgresql-client-##
-   
+
       repeat the above command for each unwanted version
 
    sudo apt autoremove
@@ -245,7 +250,7 @@ All of the OSX instructions assume `homebrew` is your [package manager](https://
    Upgrade the database (replace hashes with the new db vsn eg 14)
    ```bash
    sudo apt install postgresql-## postgresql-server-dev-##
-   
+
 
    Very important! the upgrade will fail later if you don't install postgis in the updated postgresql
 
@@ -263,7 +268,7 @@ All of the OSX instructions assume `homebrew` is your [package manager](https://
      you should see the current version and the version you just installed
    ```
    Stop the postgresql service
-   ```bash   
+   ```bash
    sudo systemctl stop postgresql.service
 
      Check the status of the postgresql, it should be stopped
@@ -305,11 +310,11 @@ All of the OSX instructions assume `homebrew` is your [package manager](https://
      You should see the version you upgraded to
 
    exit
-   
+
      Remove the old cluster
 
      replace hashes with the CURRENT version eg 11
    sudo pg_dropcluster ## main
-     
+
    Done!!!
   ```

--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -39,7 +39,7 @@ Steps 2-4 must be repeated if the repo's Ruby version is updated later.
 
    More information about installing _with_ Sidekiq Enterprise as well as our credentials are on the internal system [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md)
 
-1. Setup local databases and schema migrations:
+1. Setup local databases and run schema migrations:
    ```bash
    cd vets-api; rails db:setup; rails db:migrate
    ```


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

When setting up Vets API, devs have came across similar schema issues. These issues include duplicate tables when running migrations.  Looking through the support channel, I noticed that most issues have been resolved by running` rails db:setup`. The setup command has been added to the docs after the `bundle install` instructions to help developers in the future. 

**Slack threads**
- https://dsva.slack.com/archives/CBU0KDSB1/p1700077909276959?thread_ts=1699987358.970369&cid=CBU0KDSB1
- https://dsva.slack.com/archives/CBU0KDSB1/p1611158721200300?thread_ts=1611155026.182400&cid=CBU0KDSB1
- https://dsva.slack.com/archives/CBU0KDSB1/p1569448272184100