### PR TITLE
Expense Calculator

### DIFF
--- a/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_calculations_controller.rb
+++ b/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_calculations_controller.rb
@@ -6,7 +6,6 @@ require 'debts_api/v0/fsr_form_transform/expense_calculator'
 module DebtsApi
   module V0
     class FinancialStatusReportsCalculationsController < ApplicationController
-      
       def calculate_monthly_income(calculator, form_data)
         calculator.get_monthly_income(form_data)
       end
@@ -24,43 +23,42 @@ module DebtsApi
       # rubocop:disable Metrics/MethodLength
       def expense_form
         params.permit(
-          :"view:enhancedFinancialStatusReport",
+          :'view:enhancedFinancialStatusReport',
           expenses: [
             :food,
             :rentOrMortgage,
-            expenseRecords: [
-              :name,
-              :amount
-            ],
-            creditCardBills: [
-              :purpose,
-              :creditorName,
-              :originalAmount,
-              :unpaidBalance,
-              :amountDueMonthly,
-              :dateStarted,
-              :amountPastDue
-            ]
+            { expenseRecords: %i[
+                name
+                amount
+              ],
+              creditCardBills: %i[
+                purpose
+                creditorName
+                originalAmount
+                unpaidBalance
+                amountDueMonthly
+                dateStarted
+                amountPastDue
+              ] }
           ],
-          otherExpenses: [
-            :name,
-            :amount
+          otherExpenses: %i[
+            name
+            amount
           ],
-          installmentContracts: [
-            :creditorName,
-            :dateStarted,
-            :purpose,
-            :originalAmount,
-            :unpaid_balance,
-            :amountDueMonthly,
-            :amountPastDue
+          installmentContracts: %i[
+            creditorName
+            dateStarted
+            purpose
+            originalAmount
+            unpaid_balance
+            amountDueMonthly
+            amountPastDue
           ],
-          utilityRecords: [
-            :utilityType,
-            :amount,
-            :monthlyUtilityAmount
+          utilityRecords: %i[
+            utilityType
+            amount
+            monthlyUtilityAmount
           ]
-
         ).to_hash
       end
       # rubocop:enable Metrics/MethodLength

--- a/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_calculations_controller.rb
+++ b/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_calculations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'debts_api/v0/fsr_form_transform/income_calculator'
+require 'debts_api/v0/fsr_form_transform/expense_calculator'
 
 module DebtsApi
   module V0
@@ -8,6 +9,64 @@ module DebtsApi
       
       def calculate_monthly_income(calculator, form_data)
         calculator.get_monthly_income(form_data)
+      end
+
+      def monthly_expenses
+        render json: expense_calculator.get_monthly_expenses
+      end
+
+      def all_expenses
+        render json: expense_calculator.get_all_expenses
+      end
+
+      private
+
+      # rubocop:disable Metrics/MethodLength
+      def expense_form
+        params.permit(
+          :"view:enhancedFinancialStatusReport",
+          expenses: [
+            :food,
+            :rentOrMortgage,
+            expenseRecords: [
+              :name,
+              :amount
+            ],
+            creditCardBills: [
+              :purpose,
+              :creditorName,
+              :originalAmount,
+              :unpaidBalance,
+              :amountDueMonthly,
+              :dateStarted,
+              :amountPastDue
+            ]
+          ],
+          otherExpenses: [
+            :name,
+            :amount
+          ],
+          installmentContracts: [
+            :creditorName,
+            :dateStarted,
+            :purpose,
+            :originalAmount,
+            :unpaid_balance,
+            :amountDueMonthly,
+            :amountPastDue
+          ],
+          utilityRecords: [
+            :utilityType,
+            :amount,
+            :monthlyUtilityAmount
+          ]
+
+        ).to_hash
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def expense_calculator
+        DebtsApi::V0::FsrFormTransform::ExpenceCalculator.build(expense_form)
       end
     end
   end

--- a/modules/debts_api/config/routes.rb
+++ b/modules/debts_api/config/routes.rb
@@ -7,5 +7,7 @@ DebtsApi::Engine.routes.draw do
         get :download_pdf
       end
     end
+    post 'calculate_monthly_expenses', to: 'financial_status_reports_calculations#monthly_expenses'
+    post 'calculate_all_expenses', to: 'financial_status_reports_calculations#all_expenses'
   end
 end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'debts_api/v0/fsr_form_transform/expense_calculator'
+
+module DebtsApi
+  module V0
+    module FsrFormTransform
+      class EnhancedExpenceCalculator
+        RENT = 'Rent'
+        MORTGAGE_PAYMENT = 'Mortgage payment'
+        FOOD = 'Food'
+
+        def initialize(form)
+          @form = form
+          @enhanced = form['view:enhancedFinancialStatusReport'] || false
+          @expense_records = @form.dig('expenses', 'expenseRecords') || []
+          @old_rent_mortgage_attr = @form.dig('expenses', 'rentOrMortgage')
+          @old_food_attr = @form.dig('expenses', 'food')
+          @credit_card_bills = @form.dig('expenses', 'creditCardBills') || []
+          @other_expenses = @form['otherExpenses'].deep_dup
+          @installment_contracts = @form['installmentContracts']
+          @utility_records = @form['utilityRecords']
+
+          @filtered_expenses = [].concat(
+            exclude_by(@other_expenses, [FOOD]),
+            exclude_by(@expense_records, [RENT, MORTGAGE_PAYMENT])
+          )
+          @all_expenses ||= get_all_expenses
+        end
+
+        def get_monthly_expenses
+          utilities = get_utilities
+          installments = safe_sum(@installment_contracts.pluck('amountDueMonthly'))
+          other_exp = safe_sum(@other_expenses.pluck('amount'))
+          calculated_exp_records = safe_sum(@expense_records.pluck('amount'))
+          food = safe_number(@old_food_attr)
+          rent_or_mortgage_sum = safe_number(@old_rent_mortgage_attr)
+          credit_card_bills = safe_sum(@credit_card_bills.pluck('amountDueMonthly'))
+
+          sum = utilities +
+                installments +
+                other_exp +
+                calculated_exp_records +
+                food +
+                rent_or_mortgage_sum +
+                credit_card_bills
+
+          sum.round(2)
+        end
+
+        def get_all_expenses
+          {
+            rentOrMortgage: get_rent_mortgage_expenses,
+            food: get_food_expenses,
+            utilities: get_utilities,
+            otherLivingExpenses: get_other_living_expenses,
+            expensesInstallmentContractsAndOtherDebts: get_installments_and_other_debts,
+            otherExpenses: @other_expenses,
+            filteredExpenses: @filtered_expenses,
+            installmentContractsAndCreditCards: [@installment_contracts, @credit_card_bills].flatten
+          }
+        end
+
+        private
+
+        def get_rent_mortgage_expenses
+          safe_number(@old_rent_mortgage_attr)
+          rent_or_mortgage_expenses = @expense_records.filter do |record|
+            [RENT, MORTGAGE_PAYMENT].include?(record['name'])
+          end
+          safe_sum(rent_or_mortgage_expenses.pluck('amount'))
+        end
+
+        def get_food_expenses
+          food_expenses = @other_expenses.find { |expense| expense['name'] == 'Food' } || { amount: 0 }
+          safe_number(food_expenses['amount'])
+        end
+
+        def get_utilities
+          amounts = @utility_records.pluck('amount')
+          safe_sum(amounts)
+        end
+
+        def get_other_living_expenses
+          {
+            name: @filtered_expenses.pluck('name').join(', '),
+            amount: safe_sum(@filtered_expenses.pluck('amount'))
+          }
+        end
+
+        def get_installments_and_other_debts
+          installment_monthly_due = @installment_contracts.pluck('amountDueMonthly')
+          credit_card_monthly_due = @credit_card_bills.pluck('amountDueMonthly')
+          safe_sum([installment_monthly_due, credit_card_monthly_due].flatten)
+        end
+
+        def exclude_by(expenses, names)
+          expenses.filter { |expense| names.exclude?(expense['name']) }
+        end
+
+        def safe_number(str)
+          return 0.0 if str.nil?
+
+          str.gsub(/[^0-9.-]/, '').to_f
+        end
+
+        def safe_sum(ary)
+          ary.map { |el| safe_number(el) }.sum.round(2)
+        end
+      end
+    end
+  end
+end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
@@ -17,7 +17,7 @@ module DebtsApi
           @old_rent_mortgage_attr = @form.dig('expenses', 'rentOrMortgage')
           @old_food_attr = @form.dig('expenses', 'food')
           @credit_card_bills = @form.dig('expenses', 'creditCardBills') || []
-          @other_expenses = @form['otherExpenses'].deep_dup
+          @other_expenses = @form['otherExpenses'].deep_dup || []
           @installment_contracts = @form['installmentContracts']
           @utility_records = @form['utilityRecords']
 

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/expense_calculator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'debts_api/v0/fsr_form_transform/enhanced_expense_calculator'
+require 'debts_api/v0/fsr_form_transform/old_expense_calculator'
+
+module DebtsApi
+  module V0
+    module FsrFormTransform
+      class ExpenceCalculator
+        RENT = 'Rent'
+        MORTGAGE_PAYMENT = 'Mortgage payment'
+        FOOD = 'Food'
+
+        attr_reader :expenses, :all_expenses
+
+        def self.build(form)
+          enhanced = form['view:enhancedFinancialStatusReport'] || false
+          enhanced ? EnhancedExpenceCalculator.new(form) : OldExpenceCalculator.new(form)
+        end
+      end
+    end
+  end
+end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/expense_calculator.rb
@@ -7,11 +7,6 @@ module DebtsApi
   module V0
     module FsrFormTransform
       class ExpenceCalculator
-        RENT = 'Rent'
-        MORTGAGE_PAYMENT = 'Mortgage payment'
-        FOOD = 'Food'
-
-        attr_reader :expenses, :all_expenses
 
         def self.build(form)
           enhanced = form['view:enhancedFinancialStatusReport'] || false

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/expense_calculator.rb
@@ -7,7 +7,6 @@ module DebtsApi
   module V0
     module FsrFormTransform
       class ExpenceCalculator
-
         def self.build(form)
           enhanced = form['view:enhancedFinancialStatusReport'] || false
           enhanced ? EnhancedExpenceCalculator.new(form) : OldExpenceCalculator.new(form)

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/old_expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/old_expense_calculator.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'debts_api/v0/fsr_form_transform/expense_calculator'
+
+module DebtsApi
+  module V0
+    module FsrFormTransform
+      class OldExpenceCalculator
+        RENT = 'Rent'
+        MORTGAGE_PAYMENT = 'Mortgage payment'
+        FOOD = 'Food'
+
+        def initialize(form)
+          @form = form
+          @enhanced = form['view:enhancedFinancialStatusReport'] || false
+          @expense_records = @form.dig('expenses', 'expenseRecords') || []
+          @old_rent_mortgage_attr = @form.dig('expenses', 'rentOrMortgage')
+          @old_food_attr = @form.dig('expenses', 'food')
+          @credit_card_bills = @form.dig('expenses', 'creditCardBills') || []
+          @other_expenses = @form['otherExpenses'].deep_dup
+          @installment_contracts = @form['installmentContracts']
+          @utility_records = @form['utilityRecords']
+
+          @filtered_expenses = [].concat(
+            exclude_by(@other_expenses, [FOOD]),
+            exclude_by(@expense_records, [RENT, MORTGAGE_PAYMENT])
+          )
+          @all_expenses ||= get_all_expenses
+        end
+
+        def get_monthly_expenses
+          utilities = get_utilities
+          installments = safe_sum(@installment_contracts.pluck('amountDueMonthly'))
+          other_exp = safe_sum(@other_expenses.pluck('amount'))
+          calculated_exp_records = safe_sum(@expense_records.pluck('amount'))
+          food = safe_number(@old_food_attr)
+          rent_or_mortgage_sum = safe_number(@old_rent_mortgage_attr)
+          credit_card_bills = safe_sum(@credit_card_bills.pluck('amountDueMonthly'))
+
+          sum = utilities +
+                installments +
+                other_exp +
+                calculated_exp_records +
+                food +
+                rent_or_mortgage_sum +
+                credit_card_bills
+
+          sum.round(2)
+        end
+
+        def get_all_expenses
+          {
+            rentOrMortgage: get_rent_mortgage_expenses,
+            food: get_food_expenses,
+            utilities: get_utilities,
+            otherLivingExpenses: get_other_living_expenses,
+            expensesInstallmentContractsAndOtherDebts: get_installments_and_other_debts,
+            otherExpenses: @other_expenses,
+            filteredExpenses: @filtered_expenses,
+            installmentContractsAndCreditCards: [@installment_contracts, @credit_card_bills].flatten
+          }
+        end
+
+        private
+
+        def get_rent_mortgage_expenses
+          safe_number(@old_rent_mortgage_attr)
+        end
+
+        def get_food_expenses
+          safe_number(@old_food_attr)
+        end
+
+        def get_utilities
+          amounts = @utility_records.pluck('monthlyUtilityAmount')
+          safe_sum(amounts)
+        end
+
+        def get_other_living_expenses
+          {
+            name: @other_expenses.pluck('name').join(', '),
+            amount: safe_sum(@other_expenses.pluck('amount'))
+          }
+        end
+
+        def get_installments_and_other_debts
+          installment_monthly_due = @installment_contracts.pluck('amountDueMonthly')
+          credit_card_monthly_due = @credit_card_bills.pluck('amountDueMonthly')
+          safe_sum([installment_monthly_due, credit_card_monthly_due].flatten)
+        end
+
+        def exclude_by(expenses, names)
+          expenses.filter { |expense| names.exclude?(expense['name']) }
+        end
+
+        def safe_number(str)
+          return 0.0 if str.nil?
+
+          str.gsub(/[^0-9.-]/, '').to_f
+        end
+
+        def safe_sum(ary)
+          ary.map { |el| safe_number(el) }.sum.round(2)
+        end
+      end
+    end
+  end
+end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/old_expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/old_expense_calculator.rb
@@ -17,7 +17,7 @@ module DebtsApi
           @old_rent_mortgage_attr = @form.dig('expenses', 'rentOrMortgage')
           @old_food_attr = @form.dig('expenses', 'food')
           @credit_card_bills = @form.dig('expenses', 'creditCardBills') || []
-          @other_expenses = @form['otherExpenses'].deep_dup
+          @other_expenses = @form['otherExpenses'].deep_dup || []
           @installment_contracts = @form['installmentContracts']
           @utility_records = @form['utilityRecords']
 

--- a/modules/debts_api/spec/fixtures/pre_submission_fsr/enhanced_fsr_expenses.json
+++ b/modules/debts_api/spec/fixtures/pre_submission_fsr/enhanced_fsr_expenses.json
@@ -1,0 +1,79 @@
+{ 
+  "view:enhancedFinancialStatusReport": true,
+  "expenses": {
+    "food": "4000.38",
+    "expenseRecords": [
+      {
+        "name": "Rent",
+        "amount": "1200.53"
+      },
+      {
+        "name": "Mortgage payment",
+        "amount": "1000.00"
+      },
+      {
+        "name": "something else",
+        "amount": "100"
+      }
+    ],
+    "creditCardBills": [
+      {
+        "purpose": "Credit card payment",
+        "creditorName": "",
+        "originalAmount": "",
+        "unpaidBalance": "300000",
+        "amountDueMonthly": "10000",
+        "dateStarted": "",
+        "amountPastDue": "7000"
+      }
+    ]
+  },
+  "otherExpenses": [
+    {
+      "name": "Pool service",
+      "amount": "200"
+    },
+    {
+      "name": "Lawn service",
+      "amount": "100.54"
+    },
+    {
+      "name": "Food",
+      "amount": "300"
+    }
+  ],
+  "installmentContracts": [
+    {
+      "purpose": "Credit card payments",
+      "creditorName": "Creditor One",
+      "originalAmount": "50000.54",
+      "unpaidBalance": "15000.56",
+      "amountDueMonthly": "800.10",
+      "dateStarted": "2017-03-XX",
+      "amountPastDue": "125.43"
+    },
+    {
+      "purpose": "Car payment/lease",
+      "creditorName": "Creditor Two",
+      "originalAmount": "100000.43",
+      "unpaidBalance": "50000.26",
+      "amountDueMonthly": "1200.54",
+      "dateStarted": "2019-05-XX",
+      "amountPastDue": "0"
+    }
+  ],
+  "utilityRecords": [
+    {
+      "utilityType": "Electricity",
+      "amount": "350.45"
+    },
+    {
+      "utilityType": "Water",
+      "amount": "75.43"
+    },
+    {
+      "utilityType": "Cable",
+      "amount": "275.47"
+    }
+  ]
+}

--- a/modules/debts_api/spec/fixtures/pre_submission_fsr/non_enhanced_fsr_expenses.json
+++ b/modules/debts_api/spec/fixtures/pre_submission_fsr/non_enhanced_fsr_expenses.json
@@ -1,0 +1,66 @@
+{ 
+  "view:enhancedFinancialStatusReport": false,
+  "expenses": {
+    "rentOrMortgage": "1200.25",
+    "food": "4000.38",
+    "creditCardBills": [
+      {
+        "purpose": "Credit card payment",
+        "creditorName": "",
+        "originalAmount": "",
+        "unpaidBalance": "300000",
+        "amountDueMonthly": "10000",
+        "dateStarted": "",
+        "amountPastDue": "7000"
+      }
+    ]
+  },
+  "otherExpenses": [
+    {
+      "name": "Pool service",
+      "amount": "200"
+    },
+    {
+      "name": "Lawn service",
+      "amount": "100.54"
+    },
+    {
+      "name": "Food",
+      "amount": "300"
+    }
+  ],
+  "installmentContracts": [
+    {
+      "purpose": "Credit card payments",
+      "creditorName": "Creditor One",
+      "originalAmount": "50000.54",
+      "unpaidBalance": "15000.56",
+      "amountDueMonthly": "800.10",
+      "dateStarted": "2017-03-XX",
+      "amountPastDue": "125.43"
+    },
+    {
+      "purpose": "Car payment/lease",
+      "creditorName": "Creditor Two",
+      "originalAmount": "100000.43",
+      "unpaidBalance": "50000.26",
+      "amountDueMonthly": "1200.54",
+      "dateStarted": "2019-05-XX",
+      "amountPastDue": "0"
+    }
+  ],
+  "utilityRecords": [
+    {
+      "name": "Electricity",
+      "monthlyUtilityAmount": "402.35"
+    },
+    {
+      "name": "Gas",
+      "monthlyUtilityAmount": "85.16"
+    },
+    {
+      "name": "Cable",
+      "monthlyUtilityAmount": "175.47"
+    }
+  ]
+}

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'debts_api/v0/fsr_form_transform/expense_calculator'
+
+RSpec.describe DebtsApi::V0::FsrFormTransform::ExpenceCalculator, type: :service do
+  describe '#get_monthly_expenses' do
+    let(:enhanced_expenses) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/enhanced_fsr_expenses')
+    end
+    let(:old_expenses) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/non_enhanced_fsr_expenses')
+    end
+
+    context 'with enhanced FSR' do
+      it 'sums a bunch of stuff' do
+        calculator = described_class.build(enhanced_expenses)
+        expect(calculator.get_monthly_expenses).to eq(19_603.44)
+      end
+    end
+
+    context 'with old FSR' do
+      it 'sums a bunch of stuff' do
+        calculator = described_class.build(old_expenses)
+        expect(calculator.get_monthly_expenses).to eq(18_464.79)
+      end
+    end
+  end
+
+  describe '#getAllExpenses' do
+    let(:enhanced_expenses) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/enhanced_fsr_expenses')
+    end
+    let(:old_expenses) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/non_enhanced_fsr_expenses')
+    end
+
+    context 'with enhanced FSR' do
+      it 'gets rent/mortgage expenses from expenseRecords' do
+        calculator = described_class.build(enhanced_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:rentOrMortgage]).to eq(2200.53)
+      end
+
+      it 'gets food expenses from expenseRecords' do
+        calculator = described_class.build(enhanced_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:food]).to eq(300)
+      end
+
+      it 'gets utilities from utilityRecords' do
+        calculator = described_class.build(enhanced_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:utilities]).to eq(701.35)
+      end
+
+      it 'gets living expenses from filtered expenses' do
+        calculator = described_class.build(enhanced_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:otherLivingExpenses][:name]).to eq('Pool service, Lawn service, something else')
+        expect(calculated_expenses[:otherLivingExpenses][:amount]).to eq(400.54)
+      end
+
+      it 'gets expensesInstallmentContractsAndOtherDebts' do
+        calculator = described_class.build(enhanced_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:expensesInstallmentContractsAndOtherDebts]).to eq(12_000.64)
+      end
+    end
+
+    context 'with old FSR' do
+      it 'gets rent/mortgage expenses from rentOrMortgage field' do
+        calculator = described_class.build(old_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:rentOrMortgage]).to eq(1200.25)
+      end
+
+      it 'gets food expenses from expenseRecords' do
+        calculator = described_class.build(old_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:food]).to eq(4000.38)
+      end
+
+      it 'gets utilities from utilityRecords' do
+        calculator = described_class.build(old_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:utilities]).to eq(662.98)
+      end
+
+      it 'gets living expenses from other expenses' do
+        calculator = described_class.build(old_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:otherLivingExpenses][:name]).to eq('Pool service, Lawn service, Food')
+        expect(calculated_expenses[:otherLivingExpenses][:amount]).to eq(600.54)
+      end
+
+      it 'gets expensesInstallmentContractsAndOtherDebts' do
+        calculator = described_class.build(old_expenses)
+        calculated_expenses = calculator.get_all_expenses
+        expect(calculated_expenses[:expensesInstallmentContractsAndOtherDebts]).to eq(12_000.64)
+      end
+      # it '' do
+      # end
+    end
+  end
+end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
@@ -99,8 +99,6 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::ExpenceCalculator, type: :service
         calculated_expenses = calculator.get_all_expenses
         expect(calculated_expenses[:expensesInstallmentContractsAndOtherDebts]).to eq(12_000.64)
       end
-      # it '' do
-      # end
     end
   end
 end

--- a/modules/debts_api/spec/request/debts_api/v0/financial_status_reports_calculations_controller_spec.rb
+++ b/modules/debts_api/spec/request/debts_api/v0/financial_status_reports_calculations_controller_spec.rb
@@ -7,7 +7,6 @@ require 'rails_helper'
 # require 'support/financial_status_report_helpers'
 
 RSpec.describe 'DebtsApi::V0::FinancialStatusReportsCalculations requesting', type: :request do
-
   let(:user) { build(:user, :loa3) }
   let(:enhanced_expenses) do
     get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/enhanced_fsr_expenses')
@@ -17,35 +16,37 @@ RSpec.describe 'DebtsApi::V0::FinancialStatusReportsCalculations requesting', ty
   end
 
   before do
-    sign_in_as(user)    
+    sign_in_as(user)
   end
 
   describe '#all_expenses' do
-    context 'with enhanced form params' do 
+    context 'with enhanced form params' do
       it 'returns all expenses' do
         post('/debts_api/v0/calculate_all_expenses', params: enhanced_expenses.to_h, as: :json)
-        expect(response.code).to eq('200')
+        expect(response).to have_http_status(:ok)
       end
     end
-    context 'with old form params' do 
+
+    context 'with old form params' do
       it 'returns all expenses' do
         post('/debts_api/v0/calculate_all_expenses', params: old_expenses.to_h, as: :json)
-        expect(response.code).to eq('200')
+        expect(response).to have_http_status(:ok)
       end
     end
   end
 
   describe '#monthly_expenses' do
-    context 'with enhanced form params' do 
+    context 'with enhanced form params' do
       it 'returns all expenses' do
         post('/debts_api/v0/calculate_monthly_expenses', params: enhanced_expenses.to_h, as: :json)
-        expect(response.code).to eq('200')
+        expect(response).to have_http_status(:ok)
       end
     end
-    context 'with old form params' do 
+
+    context 'with old form params' do
       it 'returns all expenses' do
         post('/debts_api/v0/calculate_monthly_expenses', params: old_expenses.to_h, as: :json)
-        expect(response.code).to eq('200')
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/modules/debts_api/spec/request/debts_api/v0/financial_status_reports_calculations_controller_spec.rb
+++ b/modules/debts_api/spec/request/debts_api/v0/financial_status_reports_calculations_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# delete
+
+require 'rails_helper'
+# require_relative '../../../modules/debts_api/spec/support/stub_financial_status_report'
+# require 'support/financial_status_report_helpers'
+
+RSpec.describe 'DebtsApi::V0::FinancialStatusReportsCalculations requesting', type: :request do
+
+  let(:user) { build(:user, :loa3) }
+  let(:enhanced_expenses) do
+    get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/enhanced_fsr_expenses')
+  end
+  let(:old_expenses) do
+    get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/non_enhanced_fsr_expenses')
+  end
+
+  before do
+    sign_in_as(user)    
+  end
+
+  describe '#all_expenses' do
+    context 'with enhanced form params' do 
+      it 'returns all expenses' do
+        post('/debts_api/v0/calculate_all_expenses', params: enhanced_expenses.to_h, as: :json)
+        expect(response.code).to eq('200')
+      end
+    end
+    context 'with old form params' do 
+      it 'returns all expenses' do
+        post('/debts_api/v0/calculate_all_expenses', params: old_expenses.to_h, as: :json)
+        expect(response.code).to eq('200')
+      end
+    end
+  end
+
+  describe '#monthly_expenses' do
+    context 'with enhanced form params' do 
+      it 'returns all expenses' do
+        post('/debts_api/v0/calculate_monthly_expenses', params: enhanced_expenses.to_h, as: :json)
+        expect(response.code).to eq('200')
+      end
+    end
+    context 'with old form params' do 
+      it 'returns all expenses' do
+        post('/debts_api/v0/calculate_monthly_expenses', params: old_expenses.to_h, as: :json)
+        expect(response.code).to eq('200')
+      end
+    end
+  end
+end

--- a/modules/debts_api/spec/request/debts_api/v0/financial_status_reports_calculations_controller_spec.rb
+++ b/modules/debts_api/spec/request/debts_api/v0/financial_status_reports_calculations_controller_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-# delete
-
 require 'rails_helper'
-# require_relative '../../../modules/debts_api/spec/support/stub_financial_status_report'
-# require 'support/financial_status_report_helpers'
 
 RSpec.describe 'DebtsApi::V0::FinancialStatusReportsCalculations requesting', type: :request do
   let(:user) { build(:user, :loa3) }


### PR DESCRIPTION
## Summary

Porting the `getAllExpenses` and `getMonthlyExpenses` functions over from [vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/1b067a60ade8d458a24ac798e29984cbd57e0c91/src/applications/financial-status-report/utils/calculateExpenses.js#L90) to vets-api. 

## Related issue(s)

- [72791](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/72791)

## Testing done

- specs and features added.

## What areas of the site does it impact?
None currently. Will eventually impact the FSR submission process

## Acceptance criteria

- [ ]  My expense calculator methods behave identically to [these](https://github.com/department-of-veterans-affairs/vets-website/blob/1b067a60ade8d458a24ac798e29984cbd57e0c91/src/applications/financial-status-report/utils/calculateExpenses.js#L90)


