### PR TITLE
removes experiemnt lga feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -961,9 +961,6 @@ features:
     actor_type: cookie_id
     description: Enables the ability to use OAuth authentication via the Sign in Service (Identity)
     enable_in_development: true
-  sign_in_page_and_modal_experiment_lga:
-    actor_type: user
-    description: Enables users to see updated design of the sign in page to facilitate login.gov and id.me adoption.
   medical_copays_zero_debt:
     actor_type: user
     description: Enables zero debt balances feature on the medical copays application


### PR DESCRIPTION
In this [ticket](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/74147) we were asked to remove the ```sign_in_page_and_modal_experiment_lga``` feature flag from ```vets-api``` as we are no longer using it.