### PR TITLE
[dbx-num] add state machine to 526

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -6,9 +6,79 @@ require 'logging/third_party_transaction'
 
 class Form526Submission < ApplicationRecord
   extend Logging::ThirdPartyTransaction::MethodWrapper
-
+  include AASM
   include SentryLogging
   include Form526ClaimFastTrackingConcern
+
+  # Documentation:
+  # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/implementation/form_526_state_machine.md
+  aasm do
+    after_all_transitions :log_status_change
+
+    state :unprocessed, initial: true
+    state :delivered_to_primary, :failed_primary_delivery, :rejected_by_primary,
+          :delivered_to_backup, :failed_backup_delivery, :rejected_by_backup,
+          :in_remediation, :finalized_as_successful, :unprocessable
+
+    # - a submission has been delivered to our happy path
+    # - requires polling to finalize
+    event :deliver_to_primary do
+      transitions to: :delivered_to_primary
+    end
+
+    # - submission failed delivery to primary path for any reason
+    # - requires backup submission or remediation
+    event :fail_primary_delivery do
+      transitions to: :failed_primary_delivery
+    end
+
+    # - a successfully delivered submission has failed 3rd party validations on primary path
+    # - requires backup submission or remediation
+    event :reject_from_primary do
+      transitions to: :rejected_by_primary
+    end
+
+    # - a submission has been delivered to our backup path
+    # - requires polling to finalize
+    event :deliver_to_backup do
+      transitions to: :delivered_to_backup
+    end
+
+    # - a submission has failed to be delivered to our backup path
+    # - requires remediation
+    event :fail_backup_delivery do
+      transitions to: :failed_backup_delivery
+    end
+
+    # - a successfully delivered submission has failed 3rd party validations on backup path
+    # - requires remediation
+    event :reject_from_backup do
+      transitions to: :failed_backup_delivery
+    end
+
+    # - Submission has entered a manual remediation flow, e.g. failsafe, paper submission
+    # - requires confirmation of success, e.g. polling or manual confirmation via audit
+    event :begin_remediation do
+      transitions to: :in_remediation
+    end
+
+    # TODO: add this transition when we add 526 completion polling
+    # - The only state that means we no longer own completion of this submission
+    # - There is nothing more to do.  E.G.
+    #   - VBMS has accepted and returned the applicable status to us via
+    #     lighthouse benefits intack API
+    #   - Manual remediation has been confirmed successful
+    #   - EVSS has received this submission and now owns it
+    event :finalize_success do
+      transitions to: :finalized_as_successful
+    end
+
+    # - a submission should be ignored
+    # - we probably want to avoid using this state
+    event :mark_as_unprocessable do
+      transitions to: :unprocessable
+    end
+  end
 
   wrap_with_logging(:start_evss_submission_job,
                     :enqueue_backup_submission,
@@ -47,7 +117,6 @@ class Form526Submission < ApplicationRecord
   #   @return [Timestamp] created at date.
   # @!attribute updated_at
   #   @return [Timestamp] updated at date.
-  #
   has_kms_key
   has_encrypted :auth_headers_json, :birls_ids_tried, :form_json, key: :kms_key, **lockbox_options
 
@@ -59,6 +128,16 @@ class Form526Submission < ApplicationRecord
   belongs_to :user_account, dependent: nil, optional: true
 
   validates(:auth_headers_json, presence: true)
+
+  def log_status_change
+    log_hash = {
+      form_submission_id: id,
+      from_state: aasm.from_state,
+      to_state: aasm.to_state,
+      event: aasm.current_event
+    }
+    Rails.logger.info(log_hash)
+  end
 
   FORM_526 = 'form526'
   FORM_526_UPLOADS = 'form526_uploads'

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -5,6 +5,7 @@ require 'evss/disability_compensation_form/gateway_timeout'
 require 'evss/disability_compensation_form/form526_to_lighthouse_transform'
 require 'sentry_logging'
 require 'logging/third_party_transaction'
+require 'sidekiq/form526_job_status_tracker/job_tracker'
 
 module EVSS
   module DisabilityCompensationForm
@@ -58,6 +59,7 @@ module EVSS
 
         # if no more unused birls to attempt submit with, give up, let vet know
         begin
+          submission.fail_primary_delivery!
           notify_enabled = Flipper.enabled?(:disability_compensation_pif_fail_notification)
           if submission && next_birls_jid.nil? && msg['error_message'] == 'PIF in use' && notify_enabled
             first_name = submission.get_first_name&.capitalize || 'Sir or Madam'
@@ -143,6 +145,7 @@ module EVSS
 
       def response_handler(response)
         submission.submitted_claim_id = response.claim_id
+        submission.deliver_to_primary!
         submission.save
       end
 
@@ -163,6 +166,7 @@ module EVSS
         # retry submitting the form for specific upstream errors
         retry_form526_error_handler!(submission, e)
       rescue => e
+        submission.fail_primary_delivery!
         non_retryable_error_handler(submission, e)
       end
 

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -29,6 +29,7 @@ module Sidekiq
         error_message = msg['error_message']
         timestamp = Time.now.utc
         form526_submission_id = msg['args'].first
+        Form526Submission.find(form526_submission_id).fail_backup_delivery!
 
         form_job_status = Form526JobStatus.find_by(job_id:)
         bgjob_errors = form_job_status.bgjob_errors || {}
@@ -79,6 +80,7 @@ module Sidekiq
 
         Processor.new(form526_submission_id).process!
         job_status.update(status: Form526JobStatus::STATUS[:success])
+        Form526Submission.find(form526_submission_id).deliver_to_backup!
       rescue => e
         ::Rails.logger.error(
           message: "FORM526 BACKUP SUBMISSION FAILURE. Investigate immediately: #{e.message}.",

--- a/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
+++ b/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
@@ -16,11 +16,10 @@ module Sidekiq
         # Does not have a backup submission ID (protect against dup submissions)
         # Does not have a submission ID (protect against dup submissions)
         # Does not have additional birls it is going to try and submit with
+        submission_obj = Form526Submission.find(form526_submission_id)
         send_backup_submission = Settings.form526_backup.enabled && Flipper.enabled?(flipper_sym) &&
                                  job_class == 'SubmitForm526AllClaim' &&
-                                 (submission_obj ||=
-                                    Form526Submission.find(form526_submission_id)
-                                 ).submitted_claim_id.nil? &&
+                                 submission_obj.submitted_claim_id.nil? &&
                                  (additional_birls = submission_obj.birls_ids_that_havent_been_tried_yet).empty? &&
                                  submission_obj.backup_submitted_claim_id.nil? &&
                                  submission_obj.submitted_claim_id.nil?

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -34,15 +34,16 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
     end
   end
 
-  context 'catastrophic failure state' do
+  context 'on failure' do
     describe 'when all retries are exhausted' do
-      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_submission) { create(:form526_submission, aasm_state: 'failed_primary_delivery') }
       let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
-        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+        args = { 'jid' => form526_job_status.job_id, 'args' => [form526_submission.id] }
+        subject.within_sidekiq_retries_exhausted_block(args) do
           expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
-          expect(Rails).to receive(:logger).and_call_original
+          expect(Rails).to receive(:logger).twice.and_call_original
         end
         form526_job_status.reload
         expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
@@ -57,7 +58,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
         allow(Settings.form526_backup).to receive(:enabled).and_return(true)
       end
 
-      let!(:submission) { create :form526_submission, :with_everything }
+      let!(:submission) { create :form526_submission, :with_everything, aasm_state: 'failed_primary_delivery' }
       let!(:upload_data) { submission.form[Form526Submission::FORM_526_UPLOADS] }
 
       context 'successfully' do
@@ -111,6 +112,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
                 expect(job_status.status).to eq('success')
                 submission = Form526Submission.last
                 expect(submission.backup_submitted_claim_id).not_to be(nil)
+                expect(submission.aasm_state).to eq('delivered_to_backup')
               end
             end
           end
@@ -195,6 +197,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
               expect(job_status.status).to eq('success')
               submission = Form526Submission.last
               expect(submission.backup_submitted_claim_id).not_to be(nil)
+              expect(submission.aasm_state).to eq('delivered_to_backup')
             end
           end
         end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -33,6 +33,39 @@ RSpec.describe Form526Submission do
     end
   end
 
+  describe 'state' do
+    let(:submission) { create(:form526_submission) }
+
+    it 'transitions states' do
+      expect(submission).to transition_from(:unprocessed)
+        .to(:delivered_to_primary).on_event(:deliver_to_primary)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:failed_primary_delivery).on_event(:fail_primary_delivery)
+      expect(submission).to transition_from(:failed_primary_delivery)
+        .to(:delivered_to_backup).on_event(:deliver_to_backup)
+      expect(submission).to transition_from(:rejected_by_primary)
+        .to(:delivered_to_backup).on_event(:deliver_to_backup)
+      expect(submission).to transition_from(:failed_primary_delivery)
+        .to(:failed_backup_delivery).on_event(:fail_backup_delivery)
+      expect(submission).to transition_from(:rejected_by_primary)
+        .to(:failed_backup_delivery).on_event(:reject_from_backup)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:rejected_by_primary).on_event(:reject_from_primary)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:delivered_to_backup).on_event(:deliver_to_backup)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:failed_backup_delivery).on_event(:fail_backup_delivery)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:failed_backup_delivery).on_event(:reject_from_backup)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:finalized_as_successful).on_event(:finalize_success)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:unprocessable).on_event(:mark_as_unprocessable)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:in_remediation).on_event(:begin_remediation)
+    end
+  end
+
   describe '#start' do
     context 'the submission is for hypertension' do
       let(:form_json) do


### PR DESCRIPTION
## Summary
*NOTE: this is PR 3 of 3 to add this logic*
- [PR 1](https://github.com/department-of-veterans-affairs/vets-api/pull/15736)
- [PR 2](https://github.com/department-of-veterans-affairs/vets-api/pull/15801)

### The Problem
We are about to do an audit in cooperation with VBMS to determine the success of our past year of remediation efforts.  Though VBMS is the source of truth, we need a way to easily mark submissions as conceptually 'done' or 'off our plate'.  

To date, we have been using the presence of `submitted_claim_id` and `backup_submitted_claim_id` to represent success via the primary or backup submission path, respectively.  

**This did not account for our 'failsafe' remediations**

Additionally, with a simple state machine in place we have a way to record the results of Lighthouse's status updates. Even after we send a submission to lighthouse, it isn't "off our plate" until LH has marked it as successful (status of `vbms`).

### The solution

- Add a basic state machine to the form 526 Submission flow with pass fail states for VBMS and remediation
- Add other transitory states for completeness

### Other stuff
- add state changes everywhere it's applicable in our current code.  This covers only a few of the available states, as it will take a while to backfill states (as part of our audit) and to implement our status polling (will inform state transitions).

## Omissions
This work *does not* add any transition validation to the state machine.  That would be out of scope for MVP, and dangerous to roll out as it could cause errors in the submission flow.  MVP is to simply add the datapoint, unblocking our audit of VBMS.

## Related issue(s)

- [Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/75526)
- [Feature / Implementation Documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/implementation/form_526_state_machine.md)

## Testing done

- [x] *New code is covered by unit tests*
- Instantiation of affected objects and testing for continuity

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- Form 526, but not in a veteran facing way.  this will be used primarily for remediation of failed submissions, at least for MVP

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
