### PR TITLE
[73207] removes UsersController #show logging

### DIFF
--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -4,14 +4,7 @@ require 'logging/third_party_transaction'
 
 module V0
   class UsersController < ApplicationController
-    extend Logging::ThirdPartyTransaction::MethodWrapper
     service_tag 'identity'
-
-    wrap_with_logging(
-      :show,
-      additional_class_logs: { action: 'Loading User' },
-      additional_instance_logs: { user_uuid: %i[current_user account_uuid] }
-    )
 
     def show
       pre_serialized_profile = Users::Profile.new(current_user, @session_object).pre_serialize


### PR DESCRIPTION
## Summary

- Updates the `UsersController#show` method to no longer invoke additional logging via the `wrap_with_logging` method.
- These logs can be found by querying `@payload.action:"Loading User"` [in Datadog](https://vagov.ddog-gov.com/logs?query=%40payload.action%3A%22Loading%20User%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1706049520100&to_ts=1706050420100&live=true)

## Related issue(s)

- [Issue ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73207)
- [Slack discussion](https://dsva.slack.com/archives/C053U7BUT27/p1706037175577139)

## Testing done

- [x] Logging was not covered in existing specs; nothing to remove
- Performed authentication and requested `/v0/user` route - confirmed "Loading User" log is not generated
