### PR TITLE
remove and replace emis PagerDuty references

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -870,7 +870,6 @@ maintenance:
     arcgis: P45YBFA
     coe: PXXXXXX
     dslogon: P9DJJAV
-    emis: P0HNT0I
     es: PH7OPR4
     evss: PZKWB6Y
     global: PLPSIB0

--- a/spec/factories/maintenance_windows.rb
+++ b/spec/factories/maintenance_windows.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     initialize_with do
       {
         pagerduty_id: 'ABCDEF',
-        external_service: 'emis',
+        external_service: 'vic',
         start_time: '2017-12-20 22:55:20',
         end_time: '2017-12-20 22:55:20',
         description: 'Outage'
@@ -25,7 +25,7 @@ FactoryBot.define do
     initialize_with do
       {
         pagerduty_id: 'ABCDEF',
-        external_service: 'emis',
+        external_service: 'vic',
         start_time: '2017-12-20 22:55:20',
         end_time: '2017-12-30 22:55:20',
         description: 'New Description'
@@ -49,7 +49,7 @@ FactoryBot.define do
     initialize_with do
       {
         pagerduty_id: 'ABC123',
-        external_service: 'emis',
+        external_service: 'vic',
         start_time: '2017-12-21 22:55:20',
         end_time: '2017-12-21 22:55:20',
         description: 'Outage'
@@ -61,10 +61,10 @@ FactoryBot.define do
     initialize_with do
       {
         pagerduty_id: 'ABCDEF',
-        external_service: 'emis',
+        external_service: 'vic',
         start_time: '2017-12-20 22:55:20',
         end_time: '2017-12-20 22:55:20',
-        description: 'Outage\nUSER_MESSAGE: Sorry, EMIS is unavailable RN\nTry again later  '
+        description: 'Outage\nUSER_MESSAGE: Sorry, VIC is unavailable RN\nTry again later  '
       }
     end
   end

--- a/spec/sidekiq/pager_duty/poll_maintenance_windows_spec.rb
+++ b/spec/sidekiq/pager_duty/poll_maintenance_windows_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe PagerDuty::PollMaintenanceWindows, type: :job do
       described_class.new.perform
       window = MaintenanceWindow.find_by(pagerduty_id: 'ABCDEF')
       expect(window).not_to be_nil
-      expect(window.description).to eq('Sorry, EMIS is unavailable RN\nTry again later')
+      expect(window.description).to eq('Sorry, VIC is unavailable RN\nTry again later')
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- eMIS is being decommissioned. We've stopped calling it from vets-api. This PR removes the PagerDuty eMIS references. There are more PRs to come with more eMIS deletion as part of the epic https://github.com/department-of-veterans-affairs/va.gov-team/issues/63326

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/72650

## Testing done

No new code. Passing specs is sufficient for testing.

## What areas of the site does it impact?
None. Only removes emis from PagerDuty configuration in vets-api.

