### PR TITLE
[CST] Add `canUpload` field to BenefitsClaimsController#show response

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -20,6 +20,9 @@ module V0
 
     def show
       claim = service.get_claim(params[:id])
+
+      # Document uploads to EVSS require a birls_id; This restriction should
+      # be removed when we move to Lighthouse Benefits Documents for document uploads
       claim['data']['attributes']['canUpload'] = !@current_user.birls_id.nil?
 
       # We want to log some details about claim type patterns to track in DataDog

--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -20,6 +20,7 @@ module V0
 
     def show
       claim = service.get_claim(params[:id])
+      claim['data']['attributes']['canUpload'] = !@current_user.birls_id.nil?
 
       # We want to log some details about claim type patterns to track in DataDog
       claim_info = claim['data']['attributes']

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -96,6 +96,16 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
         expect(EVSSClaim.all.count).to equal(1)
       end
 
+      it 'returns the correct value for canUpload' do
+        VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
+          get(:show, params: { id: '600383363' })
+        end
+
+        expect(response).to have_http_status(:ok)
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['data']['attributes']['canUpload']).to eq(true)
+      end
+
       it 'logs the claim type details' do
         VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
           get(:show, params: { id: '600383363' })


### PR DESCRIPTION
## Summary
Adding a field to the response of `V0::BenefitsClaimsController#show` to indicate whether the current_user an upload files to EVSS or not. We are aware of an issue where users without BIRLS IDs are unable to upload documents to EVSS. We are exploring options to modify the Claim Status Tool UI to indicate to these users that their uploads will not work while we work on a more permanent fix

- *This work is behind a feature toggle (flipper): NO*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/74409

## Testing done
Added a new spec to test that the `canUpload` fields value is correct and that the path to get the `canUpload`value is correct as well

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
