### PR TITLE
Adjust Sidekiq Concurrency for Optimal Performance

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,2 @@
 ---
-:concurrency: 16
+:concurrency: 10


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
We recently encountered an issue where some of our scheduled Sidekiq jobs were not executing as planned. Upon investigating our logs, we identified `RTT warning can signal CPU saturation` [warnings](https://vagov.ddog-gov.com/logs?query=host%3Avets-api-sidekiq-%2A%20env%3Aeks-prod%20-status%3Ainfo%20%22Last%20RTT%20readings%20were%20%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=time%2Casc&viz=stream&from_ts=1703528705076&to_ts=1706120705076&live=true). These warnings suggest that our system is experiencing CPU overload, likely due to the high level of concurrency in our Sidekiq configuration due to resource intensive jobs.

Our current concurrency setting stands at 16, which is higher than Sidekiq's default of 10. In light of this, and in line with best practices for optimizing job processing efficiency, we propose reducing the concurrency level. This change is particularly crucial for queues handling CPU-intensive jobs.

This adjustment also aligns with our strategy to scale horizontally rather than vertically. Our HPA is configured based on max thread and pool capacity, ensuring that it remains effective even with the proposed changes to the concurrency settings. By reducing the concurrency, we aim to alleviate CPU pressure, enhance the stability of job processing, and ensure more reliable execution of scheduled tasks.

## Related issue(s)

https://dsva.slack.com/archives/C0460N83Y9G/p1706103881894809

https://dsva.slack.com/archives/CBU0KDSB1/p1706098329081429

https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74414