### PR TITLE
VAOS Remove Missing ICN Logging

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -19,8 +19,6 @@ module VAOS
       AVS_FLIPPER = :va_online_scheduling_after_visit_summary
 
       def get_appointments(start_date, end_date, statuses = nil, pagination_params = {})
-        Rails.logger.info("VAOS: missing ICN, request_id: #{RequestStore.store['request_id']}") if user.icn.blank?
-
         params = date_params(start_date, end_date)
                  .merge(page_params(pagination_params))
                  .merge(status_params(statuses))
@@ -51,8 +49,6 @@ module VAOS
       end
 
       def get_appointment(appointment_id)
-        Rails.logger.info("VAOS: missing ICN, request_id: #{RequestStore.store['request_id']}") if user.icn.blank?
-
         params = {}
         with_monitoring do
           response = perform(:get, get_appointment_base_path(appointment_id), params, headers)


### PR DESCRIPTION
## Summary
Logging of missing ICNs is no longer needed. Removed missing ICN logging from AppointmentsService#get_appointments and AppointmentService#get_appointment methods.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/71272

