### PR TITLE
Return nil if invalid date passed to parse_es_date

### DIFF
--- a/lib/hca/enrollment_eligibility/service.rb
+++ b/lib/hca/enrollment_eligibility/service.rb
@@ -261,6 +261,14 @@ module HCA
         return if date_str.blank?
 
         Date.parse(date_str).to_s
+      rescue Date::Error => e
+        log_exception_to_sentry(e)
+        PersonalInformationLog.create!(
+          data: date_str,
+          error_class: 'Form1010Ezr DateError'
+        )
+
+        nil
       end
 
       def part_a_effective_date(response)

--- a/spec/lib/hca/enrollment_eligibility/service_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/service_spec.rb
@@ -79,7 +79,7 @@ describe HCA::EnrollmentEligibility::Service do
         )
 
         expect(
-          PersonalInformationLog.where(error_class: "Form1010Ezr DateError").last.data
+          PersonalInformationLog.where(error_class: 'Form1010Ezr DateError').last.data
         ).to eq('f')
       end
     end

--- a/spec/lib/hca/enrollment_eligibility/service_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/service_spec.rb
@@ -66,6 +66,25 @@ describe HCA::EnrollmentEligibility::Service do
     end
   end
 
+  describe '#parse_es_date' do
+    context 'with an invalid date' do
+      it 'returns nil and logs the date' do
+        service = described_class.new
+        expect(service).to receive(:log_exception_to_sentry).with(instance_of(Date::Error))
+
+        expect(
+          service.send(:parse_es_date, 'f')
+        ).to eq(
+          nil
+        )
+
+        expect(
+          PersonalInformationLog.where(error_class: "Form1010Ezr DateError").last.data
+        ).to eq('f')
+      end
+    end
+  end
+
   describe '#lookup_user' do
     context 'with a user that has an ineligibility_reason' do
       it 'gets the ineligibility_reason', run_at: 'Wed, 13 Feb 2019 09:20:47 GMT' do


### PR DESCRIPTION
## Summary

Return nil if invalid date passed to parse_es_date, log the invalid date to PII logs table

- *This work is behind a feature toggle (flipper): no



- *(Which team do you work for, does your team own the maintenance of this component?)*
1010 team

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/73842

## Testing done
will check logs in production
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
1010ezr form

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
