### PR TITLE
Mobile: Vet360 Linking log error rather than raise

### DIFF
--- a/modules/mobile/app/sidekiq/mobile/v0/vet360_linking_job.rb
+++ b/modules/mobile/app/sidekiq/mobile/v0/vet360_linking_job.rb
@@ -46,7 +46,6 @@ module Mobile
       rescue => e
         Rails.logger.error('Mobile Vet360 account linking request failed for user with uuid',
                            { user_uuid: uuid, message: e.message })
-        raise e
       end
     end
   end

--- a/modules/mobile/spec/sidekiq/vet360_linking_spec.rb
+++ b/modules/mobile/spec/sidekiq/vet360_linking_spec.rb
@@ -46,18 +46,16 @@ RSpec.describe Mobile::V0::Vet360LinkingJob, type: :job do
             message: 'BackendServiceException: {:source=>"VAProfile::Person::Service", :code=>"VET360_PERS101"}'
           }
         )
-        expect do
-          subject.perform(user.uuid)
-        end.to raise_error(Common::Exceptions::BackendServiceException)
+        subject.perform(user.uuid)
       end
     end
   end
 
   context 'when user is not found' do
     it 'caches the expected claims and appeals' do
-      expect do
-        subject.perform('iamtheuuidnow')
-      end.to raise_error(described_class::MissingUserError, 'iamtheuuidnow')
+      expect(Rails.logger).to receive(:error).with('Mobile Vet360 account linking request failed for user with uuid',
+                                                   { user_uuid: 'iamtheuuidnow', message: 'iamtheuuidnow' })
+      subject.perform('iamtheuuidnow')
     end
   end
 end


### PR DESCRIPTION
## Summary
This removes raising an error from the vet360 linking job in order to not clog up the dashboard and avoid making it look like the job failed when in fact it did not

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/7653

## Testing done
Existing tests cover the errors

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
