### PR TITLE
API-33634 Add example ICN to active POA rswag

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8319,6 +8319,7 @@
             "name": "veteranId",
             "in": "path",
             "required": true,
+            "example": "1012667145V762142",
             "description": "ID of Veteran",
             "schema": {
               "type": "string"

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -6943,6 +6943,7 @@
             "name": "veteranId",
             "in": "path",
             "required": true,
+            "example": "1012667145V762142",
             "description": "ID of Veteran",
             "schema": {
               "type": "string"

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -25,11 +25,14 @@ describe 'PowerOfAttorney',
       description 'Retrieves current Power of Attorney for Veteran or empty data if no POA is assigned.'
 
       let(:Authorization) { 'Bearer token' }
+
       parameter name: 'veteranId',
                 in: :path,
                 required: true,
                 type: :string,
+                example: '1012667145V762142',
                 description: 'ID of Veteran'
+
       let(:veteranId) { '1013062086V794840' } # rubocop:disable RSpec/VariableName
       let(:scopes) { %w[system/claim.read system/system/claim.write] }
       let(:poa_code) { 'A1Q' }


### PR DESCRIPTION
## Summary

- This pr adds an example ICN to the V2 active POA swagger docs

## Related issue(s)

- [API-33634](https://jira.devops.va.gov/browse/API-33634)

## Testing done

- this is only an rswag change, so I looked at the local doc preview to verify

## Screenshots
| Before | After |
|----|----|
|![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/cf2c3e3d-f7b7-4833-81e2-88a7fb6ce8e3)|![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/3c4503bb-b997-4cdd-a92b-e060e23f948d)|


## What areas of the site does it impact?
This should only impact the developer docs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature