### PR TITLE
71883 Change vha FSRs veteranDateSigned to a timestamp

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -3,6 +3,7 @@
 require 'debts_api/v0/fsr_form'
 module DebtsApi
   class V0::VhaFsrForm < V0::FsrForm
+    DATE_TIMEZONE = 'Central Time (US & Canada)'
     VHA_TYPE_KEY = 'COPAY'
     VHA_AMOUNT_KEY = 'pHAmtDue'
     DEBTS_KEY = 'selectedDebtsAndCopays'
@@ -57,7 +58,15 @@ module DebtsApi
       facility_form = remove_form_delimiters(facility_form)
       combined_adjustments(facility_form)
       streamline_adjustments(facility_form)
+      set_certification_date(facility_form)
       facility_form
+    end
+
+    def set_certification_date(form)
+      date = Time.now.in_time_zone(self.class::DATE_TIMEZONE)
+      date_formatted = date.strftime('%I:%M%p UTC%z %m/%d/%Y')
+
+      form['applicantCertifications']['veteranDateSigned'] = date_formatted if form['applicantCertifications']
     end
 
     def remove_form_delimiters(form)

--- a/modules/debts_api/spec/fixtures/fsr_forms/vha_fsr_form.json
+++ b/modules/debts_api/spec/fixtures/fsr_forms/vha_fsr_form.json
@@ -174,8 +174,8 @@
                 "addressline_two": "",
                 "addressline_three": "",
                 "city": "Fakerville",
-                "state_orprovince": "CO",
-                "zip_orpostal_code": "11111",
+                "state_or_province": "CO",
+                "zip_or_postal_code": "11111",
                 "country_name": "USA"
             },
             "date_started": "06\/2020",


### PR DESCRIPTION
## Summary
VBS want box 37B of their FSR to contain a timestamp instead of a date.

## Related issue(s)
- None

## Testing done
- Specs green

## What areas of the site does it impact?
VHA financial status reports

## Acceptance criteria
Box 37B of the vha financial status report appears as a timestamp and not as a date.
