### PR TITLE
[74157] Adding appointments to MAP security token service

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,6 +30,7 @@ map_services:
   chatbot_client_id: 2bb9803acfc3
   sign_up_service_client_id: c7d6e0fc9a39
   check_in_client_id: bc75b71c7e67
+  appointments_client_id: 74b3145e1354555e
   oauth_url: https://veteran.apps-staging.va.gov
   client_cert_path: spec/fixtures/map/oauth.crt
   client_key_path: spec/fixtures/map/oauth.key

--- a/lib/map/security_token/configuration.rb
+++ b/lib/map/security_token/configuration.rb
@@ -22,6 +22,10 @@ module MAP
         Settings.map_services.check_in_client_id
       end
 
+      def appointments_client_id
+        Settings.map_services.appointments_client_id
+      end
+
       def client_key_path
         Settings.map_services.client_key_path
       end

--- a/lib/map/security_token/service.rb
+++ b/lib/map/security_token/service.rb
@@ -48,6 +48,8 @@ module MAP
           config.sign_up_service_client_id
         when :check_in
           config.check_in_client_id
+        when :appointments
+          config.appointments_client_id
         else
           raise Errors::ApplicationMismatchError, "#{config.logging_prefix} application mismatch detected"
         end

--- a/spec/lib/map/security_token/service_spec.rb
+++ b/spec/lib/map/security_token/service_spec.rb
@@ -68,6 +68,12 @@ describe MAP::SecurityToken::Service do
       it_behaves_like 'STS token request'
     end
 
+    context 'when input application is appointments' do
+      let(:application) { :appointments }
+
+      it_behaves_like 'STS token request'
+    end
+
     context 'when input application is arbitrary' do
       let(:application) { :some_application }
       let(:expected_error) { MAP::SecurityToken::Errors::ApplicationMismatchError }


### PR DESCRIPTION
## Summary

- This PR adds a MAP Security token client for `appointments`, and maps it to an appropriate client_id
- 
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74157

## Testing done

- [ ] Confirmed `MAP::SecurityToken::Service.new.token(application: :appointments, ice: 'some-icn')` created a request to the MAP Security token service with the client_id set for `appointments`

## What areas of the site does it impact?
MAP Service

## Acceptance criteria

- [ ]  Confirm  `MAP::SecurityToken::Service.new.token(application: :appointments, ice: 'some-icn')` sends a request to MAP (a mocked token will be returned)
- [ ] Confirm MAP request is set with appropriate client_id for `appointments`