### PR TITLE
VAOS Add Feature Flag Toggle for Clinic Filtering

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1005,6 +1005,10 @@ features:
     actor_type: user
     description: Allows veterans to cancel VA appointments
     enable_in_development: true
+  va_online_scheduling_clinic_filtering:
+    actor_type: user
+    description: Allows clinic selection filtering by stop codes
+    enable_in_development: true
   va_online_scheduling_community_care:
     actor_type: user
     description: Allows veterans to submit requests for Community Care appointments


### PR DESCRIPTION
## Summary
This adds a feature flag toggle,  **va_online_scheduling_clinic_filtering**, for planned work on adding the ability to turn clinic filtering by stop codes on or off.

The feature toggle flag will be removed once the clinic filtering has been implemented and tested, estimated 2 to 3 weeks.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/74659


