### PR TITLE
API-32864 Validate token ICN for GET endpoints in Supplemental Claims API

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
@@ -16,7 +16,7 @@ module AppealsApi::SupplementalClaims::V0
     skip_before_action :authenticate
     before_action :validate_json_body, if: -> { request.post? }
     before_action :validate_json_schema, only: %i[create validate]
-    before_action :validate_icn_parameter, only: %i[index download]
+    before_action :validate_icn_parameter!, only: %i[index download]
 
     API_VERSION = 'V0'
     FORM_NUMBER = '200995'
@@ -31,7 +31,7 @@ module AppealsApi::SupplementalClaims::V0
 
     # NOTE: index route is disabled until questions around claimant vs. veteran privacy are resolved
     def index
-      veteran_scs = AppealsApi::SupplementalClaim.where(veteran_icn: params[:icn]).order(created_at: :desc)
+      veteran_scs = AppealsApi::SupplementalClaim.where(veteran_icn:).order(created_at: :desc)
       render_supplemental_claim(veteran_scs)
     end
 
@@ -49,6 +49,8 @@ module AppealsApi::SupplementalClaims::V0
 
     def show
       sc = AppealsApi::SupplementalClaim.find(params[:id])
+      validate_token_icn_access!(sc.veteran_icn)
+
       sc = with_status_simulation(sc) if status_requested_and_allowed?
 
       render_supplemental_claim(sc)
@@ -85,30 +87,19 @@ module AppealsApi::SupplementalClaims::V0
     end
 
     def download
-      id = params[:id]
-      supplemental_claim = AppealsApi::SupplementalClaim.find(id)
-
-      render_appeal_pdf_download(supplemental_claim, "#{FORM_NUMBER}-supplemental-claim-#{id}.pdf", params[:icn])
+      render_appeal_pdf_download(
+        AppealsApi::SupplementalClaim.find(params[:id]),
+        "#{FORM_NUMBER}-supplemental-claim-#{params[:id]}.pdf",
+        veteran_icn
+      )
     rescue ActiveRecord::RecordNotFound
-      render_supplemental_claim_not_found(id)
+      render_supplemental_claim_not_found(params[:id])
     end
 
     private
 
     def evidence_submission_indicated?
       @json_body.dig('data', 'attributes', 'evidenceSubmission', 'evidenceType').include?('upload')
-    end
-
-    def validate_icn_parameter
-      detail = nil
-
-      if params[:icn].blank?
-        detail = "'icn' parameter is required"
-      elsif !ICN_REGEX.match?(params[:icn])
-        detail = "'icn' parameter has an invalid format. Pattern: #{ICN_REGEX.inspect}"
-      end
-
-      raise Common::Exceptions::UnprocessableEntity.new(detail:) if detail.present?
     end
 
     def validate_json_schema

--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
@@ -684,26 +684,6 @@
               }
             }
           },
-          "404": {
-            "description": "Higher-Level Review not found",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "Resource not found",
-                      "detail": "Higher-Level Review with uuid 11111111-1111-1111-1111-111111111111 not found",
-                      "code": "404",
-                      "status": "404"
-                    }
-                  ]
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/errorModel"
-                }
-              }
-            }
-          },
           "403": {
             "description": "Forbidden access with a veteran-scoped OAuth token to an unowned Higher-Level Review",
             "content": {
@@ -715,6 +695,26 @@
                       "detail": "Veterans may access only their own records",
                       "code": "403",
                       "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Higher-Level Review not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "detail": "Higher-Level Review with uuid 11111111-1111-1111-1111-111111111111 not found",
+                      "code": "404",
+                      "status": "404"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
@@ -684,26 +684,6 @@
               }
             }
           },
-          "404": {
-            "description": "Higher-Level Review not found",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "Resource not found",
-                      "detail": "Higher-Level Review with uuid 11111111-1111-1111-1111-111111111111 not found",
-                      "code": "404",
-                      "status": "404"
-                    }
-                  ]
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/errorModel"
-                }
-              }
-            }
-          },
           "403": {
             "description": "Forbidden access with a veteran-scoped OAuth token to an unowned Higher-Level Review",
             "content": {
@@ -715,6 +695,26 @@
                       "detail": "Veterans may access only their own records",
                       "code": "403",
                       "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Higher-Level Review not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "detail": "Higher-Level Review with uuid 11111111-1111-1111-1111-111111111111 not found",
+                      "code": "404",
+                      "status": "404"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
@@ -718,12 +718,12 @@
     },
     "/forms/200995/{id}": {
       "get": {
-        "summary": "Shows a specific Supplemental Claim. (a.k.a. the Show endpoint)",
+        "summary": "Show a specific Supplemental Claim",
         "tags": [
           "Supplemental Claims"
         ],
         "operationId": "showSc",
-        "description": "Returns all of the data associated with a specific Supplemental Claim.",
+        "description": "Returns basic data associated with a specific Supplemental Claim.",
         "security": [
           {
             "productionOauth": [
@@ -760,7 +760,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Info about a single Supplemental Claim",
+            "description": "Success",
             "content": {
               "application/json": {
                 "example": {
@@ -776,6 +776,26 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/scCreateResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden access with a veteran-scoped OAuth token to an unowned Supplemental Claim",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
                 }
               }
             }
@@ -851,12 +871,12 @@
             ]
           }
         ],
-        "description": "Returns a watermarked copy of a Supplemental Claim PDF as submitted to the VA. PDFs are available\nwith the following caveats:\n\n1. The PDF download will become available only after after the Supplemental Claim has progressed to\n   the 'submitted' state.\n2. The PDF will stop being available one week after the Supplemental Claim has progressed to the\n   'completed' state. This is when the Veteran's personally identifying information is purged from our servers.\n",
+        "description": "Returns a watermarked copy of a Supplemental Claim PDF as submitted to the VA. PDFs are available\nwith the following caveats:\n\n1. The PDF download will become available only after after the Supplemental Claim has progressed to\n   the 'submitted' state.\n2. The PDF will stop being available one week after the Supplemental Claim has progressed to the\n   'completed' state. This is when the Veteran's personally identifying information is purged from our servers.\n\nThe 'icn' parameter is required when accessing this endpoint using an OAuth token with the 'representative/SupplementalClaims.read' or 'system/SupplementalClaims.read' scopes.\nRequests made with the 'veteran/SupplementalClaims.read' scope may omit the 'icn' parameter.\n",
         "parameters": [
           {
             "name": "icn",
-            "description": "ICN of the Veteran associated with the Supplemental Claim",
-            "example": "0123456789V012345",
+            "description": "ICN of the Veteran associated with the Supplemental Claim. Optional when using a veteran-scoped OAuth token. Required when using a representative- or system-scoped token.",
+            "example": "1012832025V743496",
             "schema": {
               "type": "string",
               "pattern": "^[0-9]{10}V[0-9]{6}$",
@@ -864,7 +884,7 @@
               "maxLength": 17
             },
             "in": "query",
-            "required": true
+            "required": false
           },
           {
             "name": "id",
@@ -889,19 +909,63 @@
               }
             }
           },
-          "404": {
-            "description": "Supplemental Claim record was not found, or the provided 'icn' query parameter does not match the record's ICN",
+          "400": {
+            "description": "Missing 'icn' query parameter (with a system- or representative-scoped OAuth token)",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
-                      "title": "Resource not found",
-                      "detail": "Supplemental Claim with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "code": "404",
-                      "status": "404"
+                      "title": "Missing parameter",
+                      "detail": "The 'icn' parameter is required with this request",
+                      "code": "108",
+                      "status": "400"
                     }
                   ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden access (with a veteran-scoped OAuth token to an unowned Supplemental Claim)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Invalid 'icn' parameter: Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Supplemental Claim not found, or 'icn' parameter does not match the Supplemental Claim's saved data": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Resource not found",
+                          "detail": "Supplemental Claim with uuid 44444444-5555-6666-7777-888888888888 not found",
+                          "code": "404",
+                          "status": "404"
+                        }
+                      ]
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
@@ -930,16 +994,16 @@
             }
           },
           "422": {
-            "description": "Missing 'icn' query parameter",
+            "description": "PDF not ready",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
-                      "title": "Unprocessable Entity",
-                      "detail": "'icn' parameter is required",
                       "code": "422",
-                      "status": "422"
+                      "detail": "PDF for SupplementalClaim with id 44444444-5555-6666-7777-888888888888 cannot be downloaded yet because the appeal is still being submitted",
+                      "status": "422",
+                      "title": "PDF download not ready"
                     }
                   ]
                 },

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
@@ -720,12 +720,12 @@
     },
     "/forms/200995/{id}": {
       "get": {
-        "summary": "Shows a specific Supplemental Claim. (a.k.a. the Show endpoint)",
+        "summary": "Show a specific Supplemental Claim",
         "tags": [
           "Supplemental Claims"
         ],
         "operationId": "showSc",
-        "description": "Returns all of the data associated with a specific Supplemental Claim.",
+        "description": "Returns basic data associated with a specific Supplemental Claim.",
         "security": [
           {
             "productionOauth": [
@@ -762,7 +762,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Info about a single Supplemental Claim",
+            "description": "Success",
             "content": {
               "application/json": {
                 "example": {
@@ -778,6 +778,26 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/scCreateResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden access with a veteran-scoped OAuth token to an unowned Supplemental Claim",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
                 }
               }
             }
@@ -853,12 +873,12 @@
             ]
           }
         ],
-        "description": "Returns a watermarked copy of a Supplemental Claim PDF as submitted to the VA. PDFs are available\nwith the following caveats:\n\n1. The PDF download will become available only after after the Supplemental Claim has progressed to\n   the 'submitted' state.\n2. The PDF will stop being available one week after the Supplemental Claim has progressed to the\n   'completed' state. This is when the Veteran's personally identifying information is purged from our servers.\n",
+        "description": "Returns a watermarked copy of a Supplemental Claim PDF as submitted to the VA. PDFs are available\nwith the following caveats:\n\n1. The PDF download will become available only after after the Supplemental Claim has progressed to\n   the 'submitted' state.\n2. The PDF will stop being available one week after the Supplemental Claim has progressed to the\n   'completed' state. This is when the Veteran's personally identifying information is purged from our servers.\n\nThe 'icn' parameter is required when accessing this endpoint using an OAuth token with the 'representative/SupplementalClaims.read' or 'system/SupplementalClaims.read' scopes.\nRequests made with the 'veteran/SupplementalClaims.read' scope may omit the 'icn' parameter.\n",
         "parameters": [
           {
             "name": "icn",
-            "description": "ICN of the Veteran associated with the Supplemental Claim",
-            "example": "0123456789V012345",
+            "description": "ICN of the Veteran associated with the Supplemental Claim. Optional when using a veteran-scoped OAuth token. Required when using a representative- or system-scoped token.",
+            "example": "1012832025V743496",
             "schema": {
               "type": "string",
               "pattern": "^[0-9]{10}V[0-9]{6}$",
@@ -866,7 +886,7 @@
               "maxLength": 17
             },
             "in": "query",
-            "required": true
+            "required": false
           },
           {
             "name": "id",
@@ -891,19 +911,63 @@
               }
             }
           },
-          "404": {
-            "description": "Supplemental Claim record was not found, or the provided 'icn' query parameter does not match the record's ICN",
+          "400": {
+            "description": "Missing 'icn' query parameter (with a system- or representative-scoped OAuth token)",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
-                      "title": "Resource not found",
-                      "detail": "Supplemental Claim with uuid 44444444-5555-6666-7777-888888888888 not found",
-                      "code": "404",
-                      "status": "404"
+                      "title": "Missing parameter",
+                      "detail": "The 'icn' parameter is required with this request",
+                      "code": "108",
+                      "status": "400"
                     }
                   ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden access (with a veteran-scoped OAuth token to an unowned Supplemental Claim)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Invalid 'icn' parameter: Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Supplemental Claim not found, or 'icn' parameter does not match the Supplemental Claim's saved data": {
+                    "value": {
+                      "errors": [
+                        {
+                          "title": "Resource not found",
+                          "detail": "Supplemental Claim with uuid 44444444-5555-6666-7777-888888888888 not found",
+                          "code": "404",
+                          "status": "404"
+                        }
+                      ]
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
@@ -932,16 +996,16 @@
             }
           },
           "422": {
-            "description": "Missing 'icn' query parameter",
+            "description": "PDF not ready",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
-                      "title": "Unprocessable Entity",
-                      "detail": "'icn' parameter is required",
                       "code": "422",
-                      "status": "422"
+                      "detail": "PDF for SupplementalClaim with id 44444444-5555-6666-7777-888888888888 cannot be downloaded yet because the appeal is still being submitted",
+                      "status": "422",
+                      "title": "PDF download not ready"
                     }
                   ]
                 },

--- a/modules/appeals_api/spec/docs/higher_level_reviews/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/higher_level_reviews/v0_spec.rb
@@ -103,16 +103,6 @@ RSpec.describe 'Higher-Level Reviews', openapi_spec:, type: :request do
                                          scopes: veteran_scopes
       end
 
-      response '404', 'Higher-Level Review not found' do
-        schema '$ref' => '#/components/schemas/errorModel'
-
-        let(:id) { '11111111-1111-1111-1111-111111111111' }
-
-        it_behaves_like 'rswag example',
-                        desc: 'returns a 404 response',
-                        scopes: veteran_scopes
-      end
-
       response '403', 'Forbidden access with a veteran-scoped OAuth token to an unowned Higher-Level Review' do
         schema '$ref' => '#/components/schemas/errorModel'
 
@@ -120,6 +110,16 @@ RSpec.describe 'Higher-Level Reviews', openapi_spec:, type: :request do
 
         it_behaves_like 'rswag example',
                         desc: 'with a veteran-scoped OAuth token for a Veteran who does not own the Higher-Level Review',
+                        scopes: veteran_scopes
+      end
+
+      response '404', 'Higher-Level Review not found' do
+        schema '$ref' => '#/components/schemas/errorModel'
+
+        let(:id) { '11111111-1111-1111-1111-111111111111' }
+
+        it_behaves_like 'rswag example',
+                        desc: 'returns a 404 response',
                         scopes: veteran_scopes
       end
 

--- a/modules/appeals_api/spec/docs/supplemental_claims/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/supplemental_claims/v0_spec.rb
@@ -106,13 +106,11 @@ RSpec.describe 'Supplemental Claims', openapi_spec:, type: :request do
   end
 
   path '/forms/200995/{id}' do
-    get 'Shows a specific Supplemental Claim. (a.k.a. the Show endpoint)' do
-      scopes = AppealsApi::SupplementalClaims::V0::SupplementalClaimsController::OAUTH_SCOPES[:GET]
+    get 'Show a specific Supplemental Claim' do
       tags 'Supplemental Claims'
       operationId 'showSc'
-      description 'Returns all of the data associated with a specific Supplemental Claim.'
-
-      security DocHelpers.oauth_security_config(scopes)
+      description 'Returns basic data associated with a specific Supplemental Claim.'
+      security DocHelpers.oauth_security_config(AppealsApi::SupplementalClaims::V0::SupplementalClaimsController::OAUTH_SCOPES[:GET])
       produces 'application/json'
 
       parameter name: :id,
@@ -121,14 +119,26 @@ RSpec.describe 'Supplemental Claims', openapi_spec:, type: :request do
                 example: '7efd87fc-fac1-4851-a4dd-b9aa2533f57f',
                 schema: { type: :string, format: :uuid }
 
-      response '200', 'Info about a single Supplemental Claim' do
+      veteran_scopes = %w[veteran/SupplementalClaims.read]
+
+      response '200', 'Success' do
         schema '$ref' => '#/components/schemas/scCreateResponse'
 
         let(:id) { FactoryBot.create(:supplemental_claim_v0).id }
 
         it_behaves_like 'rswag example', desc: 'returns a 200 response',
                                          response_wrapper: :normalize_appeal_response,
-                                         scopes:
+                                         scopes: veteran_scopes
+      end
+
+      response '403', 'Forbidden access with a veteran-scoped OAuth token to an unowned Supplemental Claim' do
+        schema '$ref' => '#/components/schemas/errorModel'
+
+        let(:id) { FactoryBot.create(:supplemental_claim_v0, veteran_icn: '1234567890V123456').id }
+
+        it_behaves_like 'rswag example',
+                        desc: 'with a veteran-scoped OAuth token for a Veteran who does not own the Supplemental Claim',
+                        scopes: veteran_scopes
       end
 
       response '404', 'Supplemental Claim not found' do
@@ -136,7 +146,7 @@ RSpec.describe 'Supplemental Claims', openapi_spec:, type: :request do
 
         let(:id) { '00000000-0000-0000-0000-000000000000' }
 
-        it_behaves_like 'rswag example', desc: 'returns a 404 response', scopes:
+        it_behaves_like 'rswag example', desc: 'returns a 404 response', scopes: veteran_scopes
       end
 
       it_behaves_like 'rswag 500 response'
@@ -150,13 +160,11 @@ RSpec.describe 'Supplemental Claims', openapi_spec:, type: :request do
       operationId 'downloadSc'
       security DocHelpers.oauth_security_config(scopes)
 
-      # FIXME: re-enable once download endpoint uses ICN from token
-      #
-      # include_examples 'PDF download docs', {
-      #   factory: :supplemental_claim_v0,
-      #   appeal_type_display_name: 'Supplemental Claim',
-      #   scopes:
-      # }
+      include_examples 'PDF download docs', {
+        factory: :supplemental_claim_v0,
+        appeal_type_display_name: 'Supplemental Claim',
+        scopes:
+      }
     end
   end
 

--- a/modules/appeals_api/spec/requests/supplemental_claims/v0/supplemental_claims_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/supplemental_claims/v0/supplemental_claims_controller_spec.rb
@@ -6,6 +6,7 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::SupplementalClaims::V0::SupplementalClaimsController, type: :request do
   let(:parsed_response) { JSON.parse(response.body) }
   let(:default_data) { fixture_as_json 'supplemental_claims/v0/valid_200995_extra.json' }
+  let(:other_icn) { '1234567890V987654' }
 
   def base_path(path)
     "/services/appeals/supplemental-claims/v0/#{path}"
@@ -33,8 +34,8 @@ describe AppealsApi::SupplementalClaims::V0::SupplementalClaimsController, type:
   end
 
   describe '#show' do
-    let(:uuid) { create(:supplemental_claim_v0).id }
-    let(:path) { base_path "forms/200995/#{uuid}" }
+    let(:id) { create(:supplemental_claim_v0).id }
+    let(:path) { base_path "forms/200995/#{id}" }
 
     describe 'auth behavior' do
       it_behaves_like('an endpoint with OpenID auth', scopes: described_class::OAUTH_SCOPES[:GET]) do
@@ -46,15 +47,24 @@ describe AppealsApi::SupplementalClaims::V0::SupplementalClaimsController, type:
 
     describe 'responses' do
       let(:body) { JSON.parse(response.body) }
+      let(:scopes) { %w[veteran/SupplementalClaims.read] }
 
       before do
-        with_openid_auth(described_class::OAUTH_SCOPES[:GET]) do |auth_header|
+        with_openid_auth(scopes) do |auth_header|
           get(path, headers: auth_header)
         end
       end
 
       it 'returns only minimal data with no PII' do
         expect(body.dig('data', 'attributes').keys).to eq(%w[status createDate updateDate])
+      end
+
+      context "with a veteran token where the token's ICN doesn't match the appeal's recorded ICN" do
+        let(:id) { create(:supplemental_claim_v0, veteran_icn: other_icn).id }
+
+        it 'returns a 403 Forbidden error' do
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
   end
@@ -176,6 +186,24 @@ describe AppealsApi::SupplementalClaims::V0::SupplementalClaimsController, type:
   end
 
   describe '#download' do
+    let(:sc) { create(:supplemental_claim_v0, status: 'submitted', api_version: 'V0', pdf_version: 'v3') }
+    let(:generated_path) { base_path "/forms/200995/#{sc.id}/download" }
+
     it_behaves_like 'watermarked pdf download endpoint', { factory: :supplemental_claim_v0 }
+
+    describe 'auth behavior' do
+      it_behaves_like('an endpoint with OpenID auth', scopes: %w[veteran/SupplementalClaims.read]) do
+        def make_request(auth_header)
+          get(generated_path, headers: auth_header)
+        end
+      end
+    end
+
+    describe 'icn parameter' do
+      it_behaves_like 'GET endpoint with optional Veteran ICN parameter', {
+        scope_base: 'SupplementalClaims',
+        skip_ssn_lookup_tests: true
+      }
+    end
   end
 end


### PR DESCRIPTION
## Summary
This makes the same changes to the Supplemental Claims API v0 that I made to the Higher-Level Reviews API v0 in #15259.

## Related issue(s)

- [API-32864](https://jira.devops.va.gov/browse/API-32864)

## Testing done

- [X] *New code is covered by unit tests*

## What areas of the site does it impact?
- Supplemental Claims API v0 (not yet publicly available)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature