### PR TITLE
62516 - remove HHV2 feature flags

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -39,10 +39,6 @@ features:
   hca_enrollment_status_override_enabled:
     actor_type: user
     description: Enables override of enrollment status for a user, to allow multiple submissions with same user.
-  hca_household_v2_enabled:
-    actor_type: user
-    description: Enables the optimized household section flow.
-    enable_in_development: true
   hca_performance_alert_enabled:
     actor_type: user
     description: Enables alert notifying users of a potential issue with application performance.


### PR DESCRIPTION
## Summary

Remove all traces of household v2 flipper

## Related issue(s)
[#62516](https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/62516)

## Testing done

- manual

## What areas of the site does it impact?
- None
