### PR TITLE
Adds VAProfile Service Metrics to Datadog Breakers Charts

### DIFF
--- a/lib/va_profile/veteran_status/service.rb
+++ b/lib/va_profile/veteran_status/service.rb
@@ -16,7 +16,7 @@ module VAProfile
 
       configuration VAProfile::VeteranStatus::Configuration
 
-      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.communication".freeze
+      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.veteran_status".freeze
       OID = '2.16.840.1.113883.3.42.10001.100001.12' # double check swagger
       AAID = '^NI^200DOD^USDOD' # double check swagger.
 


### PR DESCRIPTION
## Summary

It was noticed that not all VAProfile services are represented in our [Datadog breakers charts](https://vagov.ddog-gov.com/dashboard/ddc-w3t-mtf/breakers-external-services---failures%5B%E2%80%A6%5Dw%3Dspans%26from_ts%3D1698769110646%26to_ts%3D1706545110646%26live%3Dtrue?refresh_mode=sliding&view=spans&from_ts=1706556628989&to_ts=1706560228989&live=true).  

This PR adds StatsD logging to one of those VAProfile services. Once merged, if metrics for this service populates staging's breakers charts, a similar pattern will be added to remaining services. 

- Not behind a feature toggle
- The purpose is to eventually add all VAProfile services to Datadog's breakers charts using the pattern in this PR.
- This work is being done on behalf of the Product Platform team.

## Related issue(s)

- [Current ticket](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74428)
- [Previous ticket](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/72611) that led to discovery of missing services in breakers charts

## Testing done

- [x] Once merged, will monitor Breakers Charts in staging to determine if the service and its metrics are now visible.

## What areas of the site does it impact?
This should only impact Datadog's breakers charts dashboard.

## Acceptance criteria

- [X ]  Feature/bug has a monitor built into Datadog 

