### PR TITLE
Ndbex/73954 ch31 report exhaustion

### DIFF
--- a/app/sidekiq/vre/create_ch31_submissions_report_job.rb
+++ b/app/sidekiq/vre/create_ch31_submissions_report_job.rb
@@ -4,6 +4,22 @@ module VRE
   class CreateCh31SubmissionsReportJob
     require 'csv'
     include Sidekiq::Job
+    include SentryLogging
+
+    STATSD_KEY_PREFIX = 'worker.vre.create_ch31_submissions_report_job'
+
+    # Sidekiq has built in exponential back-off functionality for retries
+    # A max retry attempt of 14 will result in a run time of ~25 hours
+    RETRY = 14
+
+    sidekiq_options retry: RETRY
+
+    sidekiq_retries_exhausted do |msg, _ex|
+      Rails.logger.error(
+        "Failed all retries on VRE::CreateCh31SubmissionsReportJob, last error: #{msg['error_message']}"
+      )
+      StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
+    end
 
     def perform(sidekiq_scheduler_args, run_date = nil)
       date = if run_date
@@ -15,6 +31,11 @@ module VRE
 
       submitted_claims = get_claims_created_between(build_range(date))
       Ch31SubmissionsReportMailer.build(submitted_claims).deliver_now unless FeatureFlipper.staging_email?
+    rescue => e
+      log_message_to_sentry(
+        'VRE::CreateCh31SubmissionsReportJob failed, retrying...', :warn, generate_sentry_details(e)
+      )
+      raise
     end
 
     private

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,13 +22,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "account_login_stats", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "idme_at", precision: nil
-    t.datetime "myhealthevet_at", precision: nil
-    t.datetime "dslogon_at", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "idme_at"
+    t.datetime "myhealthevet_at"
+    t.datetime "dslogon_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "current_verification"
-    t.datetime "logingov_at", precision: nil
+    t.datetime "logingov_at"
     t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
     t.index ["current_verification"], name: "index_account_login_stats_on_current_verification"
     t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
@@ -42,8 +42,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "idme_uuid"
     t.string "icn"
     t.string "edipi"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "sec_id"
     t.string "logingov_uuid"
     t.index ["icn"], name: "index_accounts_on_icn"
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -85,16 +85,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "decision_review_evidence_attachment_guid"
     t.string "appeal_submission_id"
     t.string "lighthouse_upload_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "appeal_submissions", force: :cascade do |t|
     t.string "user_uuid"
     t.string "submitted_appeal_uuid"
     t.string "type_of_appeal"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "board_review_option"
     t.text "upload_metadata_ciphertext"
     t.text "encrypted_kms_key"
@@ -105,8 +105,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "appeals_api_evidence_submissions", force: :cascade do |t|
     t.string "supportable_type"
     t.string "supportable_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "source"
     t.uuid "guid", null: false
     t.integer "upload_submission_id", null: false
@@ -119,8 +119,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "appeals_api_higher_level_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status", default: "pending", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "code"
     t.string "detail"
     t.string "source"
@@ -135,8 +135,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "appeals_api_notice_of_disagreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
@@ -157,9 +157,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "to"
     t.string "statusable_type"
     t.string "statusable_id"
-    t.datetime "status_update_time", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "status_update_time"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "code"
     t.string "detail"
     t.index ["statusable_type", "statusable_id"], name: "status_update_id_type_index"
@@ -172,8 +172,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "source"
     t.string "pdf_version"
     t.string "api_version"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "form_data_ciphertext"
     t.text "auth_headers_ciphertext"
     t.text "encrypted_kms_key"
@@ -191,8 +191,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "status"
     t.string "transaction_id"
     t.string "transaction_status"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -220,8 +220,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.jsonb "feedback"
     t.jsonb "access"
     t.string "fingerprint"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.boolean "mobile"
     t.string "active_status"
@@ -242,8 +242,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "claims_api_auto_established_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.integer "evss_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "md5"
     t.string "source"
     t.string "flashes", default: [], array: true
@@ -266,8 +266,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "claim_id", null: false
     t.string "claim_type", null: false
     t.string "consumer_label", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["claim_id"], name: "index_claims_api_claim_submissions_on_claim_id"
   end
 
@@ -275,8 +275,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "auth_headers_ciphertext"
     t.text "encrypted_kms_key"
     t.string "cid"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "status"
     t.string "vbms_error_message"
     t.string "bgs_error_message"
@@ -288,16 +288,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "claims_api_intent_to_files", force: :cascade do |t|
     t.string "status"
     t.string "cid"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "claims_api_power_of_attorneys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.string "current_poa"
     t.string "md5"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "vbms_new_document_version_ref_id"
     t.string "vbms_document_series_ref_id"
     t.string "vbms_error_message"
@@ -314,8 +314,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "auto_established_claim_id"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -329,8 +329,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.interval "access_token_duration", null: false
     t.string "access_token_audience", null: false
     t.interval "refresh_token_duration", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "logout_redirect_uri"
     t.boolean "pkce"
     t.string "certificates", array: true
@@ -349,8 +349,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "email_confirmation_id"
     t.string "enrollment_id"
     t.string "batch_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "raw_form_data_ciphertext"
     t.text "eligibility_info_ciphertext"
     t.text "form_data_ciphertext"
@@ -364,8 +364,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
     t.string "sid"
     t.uuid "account_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "expanded", default: false, null: false
     t.boolean "sequestered", default: false, null: false
     t.string "email_confirmation_id"
@@ -381,9 +381,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "icn", null: false
     t.string "email_address", null: false
     t.string "email_template_id", null: false
-    t.datetime "email_triggered_at", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "email_triggered_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["email_address"], name: "index_credential_adoption_email_records_on_email_address"
     t.index ["email_template_id"], name: "index_credential_adoption_email_records_on_email_template_id"
     t.index ["icn"], name: "index_credential_adoption_email_records_on_icn"
@@ -392,8 +392,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "deprecated_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id"
     t.bigint "user_verification_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_account_id"], name: "index_deprecated_user_accounts_on_user_account_id", unique: true
     t.index ["user_verification_id"], name: "index_deprecated_user_accounts_on_user_verification_id", unique: true
   end
@@ -401,8 +401,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "devices", force: :cascade do |t|
     t.string "key"
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["key"], name: "index_devices_on_key", unique: true
   end
 
@@ -416,8 +416,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "description"
     t.string "privacy_url"
     t.string "tos_url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_directory_applications_on_name", unique: true
   end
 
@@ -425,8 +425,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "code", null: false
     t.string "medical_term", null: false
     t.string "lay_term"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["code"], name: "index_disability_contentions_on_code", unique: true
     t.index ["lay_term"], name: "index_disability_contentions_on_lay_term", opclass: :gin_trgm_ops, using: :gin
     t.index ["medical_term"], name: "index_disability_contentions_on_medical_term", opclass: :gin_trgm_ops, using: :gin
@@ -437,19 +437,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "unit"
     t.geography "polygon", limit: {:srid=>4326, :type=>"st_polygon", :geographic=>true}, null: false
     t.string "vha_facility_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "min"
     t.integer "max"
-    t.datetime "vssc_extract_date", precision: nil, default: "2001-01-01 00:00:00"
+    t.datetime "vssc_extract_date", default: "2001-01-01 00:00:00"
     t.index ["polygon"], name: "index_drivetime_bands_on_polygon", using: :gist
   end
 
   create_table "education_benefits_claims", id: :serial, force: :cascade do |t|
-    t.datetime "submitted_at", precision: nil
-    t.datetime "processed_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "submitted_at"
+    t.datetime "processed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "regional_processing_office", null: false
     t.string "form_type", default: "1990"
     t.integer "saved_claim_id", null: false
@@ -462,8 +462,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "education_benefits_submissions", id: :serial, force: :cascade do |t|
     t.string "region", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "chapter33", default: false, null: false
     t.boolean "chapter30", default: false, null: false
     t.boolean "chapter1606", default: false, null: false
@@ -485,12 +485,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "education_benefits_claim_id"
     t.string "automated_decision_state", default: "init"
     t.string "user_uuid", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "poa"
     t.integer "remaining_entitlement"
-    t.datetime "denial_email_sent_at", precision: nil
-    t.datetime "confirmation_email_sent_at", precision: nil
+    t.datetime "denial_email_sent_at"
+    t.datetime "confirmation_email_sent_at"
     t.text "auth_headers_json_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -502,8 +502,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "evss_claims", id: :serial, force: :cascade do |t|
     t.integer "evss_id", null: false
     t.json "data", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "user_uuid", null: false
     t.json "list_data", default: {}, null: false
     t.boolean "requested_decision", default: false, null: false
@@ -520,8 +520,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "gate_name"
     t.string "value"
     t.string "user"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feature_name"], name: "index_feature_toggle_events_on_feature_name"
   end
 
@@ -538,25 +538,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "flipper_gates", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
     t.string "value"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
     t.string "carma_case_id", limit: 18, null: false
-    t.datetime "accepted_at", precision: nil, null: false
+    t.datetime "accepted_at", null: false
     t.json "metadata"
     t.json "attachments"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.uuid "claim_guid", null: false
     t.index ["carma_case_id"], name: "index_form1010cg_submissions_on_carma_case_id", unique: true
     t.index ["claim_guid"], name: "index_form1010cg_submissions_on_claim_guid", unique: true
@@ -567,8 +567,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "tax_year", null: false
     t.jsonb "form_data_ciphertext", null: false
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["veteran_icn", "tax_year"], name: "index_form1095_bs_on_veteran_icn_and_tax_year", unique: true
   end
 
@@ -579,7 +579,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "status", null: false
     t.string "error_class"
     t.string "error_message"
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "updated_at", null: false
     t.jsonb "bgjob_errors", default: {}
     t.index ["bgjob_errors"], name: "index_form526_job_statuses_on_bgjob_errors", using: :gin
     t.index ["form526_submission_id"], name: "index_form526_job_statuses_on_form526_submission_id"
@@ -591,8 +591,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "saved_claim_id", null: false
     t.integer "submitted_claim_id"
     t.boolean "workflow_complete", default: false, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "multiple_birls", comment: "*After* a SubmitForm526 Job fails, a lookup is done to see if the veteran has multiple BIRLS IDs. This field gets set to true if that is the case. If the initial submit job succeeds, this field will remain false whether or not the veteran has multiple BIRLS IDs --so this field cannot technically be used to sum all Form526 veterans that have multiple BIRLS. This field /can/ give us an idea of how often having multiple BIRLS IDs is a problem."
     t.text "auth_headers_json_ciphertext"
     t.text "form_json_ciphertext"
@@ -611,8 +611,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "form_json_ciphertext", null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.uuid "user_account_id"
     t.jsonb "public_metadata"
     t.integer "state", default: 0
@@ -622,8 +622,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "form_attachments", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "guid", null: false
     t.string "type", null: false
     t.text "file_data_ciphertext"
@@ -638,8 +638,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "aasm_state"
     t.string "error_message"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["form_submission_id"], name: "index_form_submission_attempts_on_form_submission_id"
   end
 
@@ -651,8 +651,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "saved_claim_id"
     t.bigint "in_progress_form_id"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.jsonb "form_data_ciphertext"
     t.index ["benefits_intake_uuid"], name: "index_form_submissions_on_benefits_intake_uuid"
     t.index ["in_progress_form_id"], name: "index_form_submissions_on_in_progress_form_id"
@@ -665,9 +665,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "edipi", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.datetime "dob", precision: nil, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "dob", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "ssn_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["edipi"], name: "index_gibs_not_found_users_on_edipi"
@@ -689,15 +689,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "msa", null: false
     t.string "msa_name"
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
 
   create_table "health_care_applications", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "state", default: "pending", null: false
     t.string "form_submission_id_string"
     t.string "timestamp"
@@ -707,8 +707,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "user_uuid"
     t.string "appointment_id"
     t.string "questionnaire_response_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "questionnaire_response_data_ciphertext"
     t.text "user_demographics_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -719,18 +719,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "id_card_announcement_subscriptions", id: :serial, force: :cascade do |t|
     t.string "email", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_id_card_announcement_subscriptions_on_email", unique: true
   end
 
   create_table "in_progress_forms", id: :serial, force: :cascade do |t|
     t.string "user_uuid", null: false
     t.string "form_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.json "metadata"
-    t.datetime "expires_at", precision: nil
+    t.datetime "expires_at"
     t.text "form_data_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -741,26 +741,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "inherited_proof_verified_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_account_id"], name: "index_inherited_proof_verified_user_accounts_on_user_account_id", unique: true
   end
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|
     t.string "edipi", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["edipi"], name: "index_invalid_letter_address_edipis_on_edipi"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
     t.string "pagerduty_id"
     t.string "external_service"
-    t.datetime "start_time", precision: nil
-    t.datetime "end_time", precision: nil
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.string "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["end_time"], name: "index_maintenance_windows_on_end_time"
     t.index ["pagerduty_id"], name: "index_maintenance_windows_on_pagerduty_id"
     t.index ["start_time"], name: "index_maintenance_windows_on_start_time"
@@ -769,16 +769,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "mhv_opt_in_flags", force: :cascade do |t|
     t.uuid "user_account_id"
     t.string "feature", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["feature"], name: "index_mhv_opt_in_flags_on_feature"
     t.index ["user_account_id"], name: "index_mhv_opt_in_flags_on_user_account_id"
   end
 
   create_table "mobile_users", force: :cascade do |t|
     t.string "icn", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "vet360_link_attempts"
     t.boolean "vet360_linked"
     t.index ["icn"], name: "index_mobile_users_on_icn", unique: true
@@ -788,10 +788,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "handle", null: false
     t.uuid "user_account_id", null: false
     t.string "hashed_refresh_token", null: false
-    t.datetime "refresh_expiration", precision: nil, null: false
-    t.datetime "refresh_creation", precision: nil, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "refresh_expiration", null: false
+    t.datetime "refresh_creation", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_verification_id", null: false
     t.string "credential_email"
     t.string "client_id", null: false
@@ -809,8 +809,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "template_id", null: false
     t.string "va_profile_id", null: false
     t.boolean "dismissed", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["va_profile_id", "dismissed"], name: "show_onsite_notifications_index"
   end
 
@@ -818,10 +818,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "guid"
     t.string "type"
     t.string "form_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "saved_claim_id"
-    t.datetime "completed_at", precision: nil
+    t.datetime "completed_at"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["guid"], name: "index_persistent_attachments_on_guid", unique: true
@@ -832,8 +832,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "personal_information_logs", id: :serial, force: :cascade do |t|
     t.jsonb "data", null: false
     t.string "error_class", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_personal_information_logs_on_created_at"
     t.index ["error_class"], name: "index_personal_information_logs_on_error_class"
   end
@@ -845,7 +845,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "query_hash"
     t.float "total_time"
     t.bigint "calls"
-    t.datetime "captured_at", precision: nil
+    t.datetime "captured_at"
     t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
   end
 
@@ -854,7 +854,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "schema"
     t.text "relation"
     t.bigint "size"
-    t.datetime "captured_at", precision: nil
+    t.datetime "captured_at"
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
@@ -863,22 +863,22 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "application_uuid"
     t.string "return_description", null: false
     t.integer "return_code"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["application_uuid"], name: "index_preneed_submissions_on_application_uuid", unique: true
     t.index ["tracking_number"], name: "index_preneed_submissions_on_tracking_number", unique: true
   end
 
   create_table "saved_claims", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "form_id"
     t.uuid "guid", null: false
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.string "uploaded_forms", array: true
-    t.datetime "itf_datetime", precision: nil
+    t.string "uploaded_forms", default: [], array: true
+    t.datetime "itf_datetime"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
@@ -891,8 +891,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "access_token_audience", null: false
     t.interval "access_token_duration", null: false
     t.string "certificates", array: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "access_token_user_attributes", default: [], array: true
     t.index ["service_account_id"], name: "index_service_account_configs_on_service_account_id", unique: true
   end
@@ -901,10 +901,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "rpo"
     t.integer "number_of_submissions"
     t.string "filename"
-    t.datetime "successful_at", precision: nil
+    t.datetime "successful_at"
     t.integer "retry_attempt", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["rpo", "filename"], name: "index_spool_file_events_uniqueness", unique: true
   end
 
@@ -914,8 +914,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "description", null: false
     t.integer "state_id", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -935,7 +935,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "add_ninety_day_hospital_copay"
     t.integer "outpatient_basic_care_copay"
     t.integer "outpatient_specialty_copay"
-    t.datetime "threshold_effective_date", precision: nil
+    t.datetime "threshold_effective_date"
     t.integer "aid_and_attendance_threshold"
     t.integer "outpatient_preventive_copay"
     t.integer "medication_copay"
@@ -946,8 +946,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "inpatient_per_diem"
     t.string "description"
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -958,8 +958,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "fips_code", null: false
     t.integer "country_id", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -971,8 +971,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "state_id", null: false
     t.integer "county_number", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -981,19 +981,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "user_account_id", null: false
     t.string "agreement_version", null: false
     t.integer "response", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_account_id"], name: "index_terms_of_use_agreements_on_user_account_id"
   end
 
   create_table "test_user_dashboard_tud_account_availability_logs", force: :cascade do |t|
     t.string "account_uuid"
-    t.datetime "checkout_time", precision: nil
-    t.datetime "checkin_time", precision: nil
+    t.datetime "checkout_time"
+    t.datetime "checkin_time"
     t.boolean "has_checkin_error"
     t.boolean "is_manual_checkin"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["account_uuid"], name: "tud_account_availability_logs"
   end
 
@@ -1003,14 +1003,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "middle_name"
     t.string "last_name"
     t.string "gender"
-    t.datetime "birth_date", precision: nil
+    t.datetime "birth_date"
     t.integer "ssn"
     t.string "phone"
     t.string "email"
     t.string "password"
-    t.datetime "checkout_time", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "checkout_time"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "services"
     t.string "loa"
     t.uuid "idme_uuid"
@@ -1021,11 +1021,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "user_acceptable_verified_credentials", force: :cascade do |t|
-    t.datetime "acceptable_verified_credential_at", precision: nil
-    t.datetime "idme_verified_credential_at", precision: nil
+    t.datetime "acceptable_verified_credential_at"
+    t.datetime "idme_verified_credential_at"
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["acceptable_verified_credential_at"], name: "index_user_avc_on_acceptable_verified_credential_at"
     t.index ["idme_verified_credential_at"], name: "index_user_avc_on_idme_verified_credential_at"
     t.index ["user_account_id"], name: "index_user_acceptable_verified_credentials_on_user_account_id", unique: true
@@ -1033,8 +1033,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "user_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "icn"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["icn"], name: "index_user_accounts_on_icn", unique: true
   end
 
@@ -1042,8 +1042,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "user_verification_id"
     t.text "credential_email_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_verification_id"], name: "index_user_credential_emails_on_user_verification_id", unique: true
   end
 
@@ -1053,9 +1053,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "logingov_uuid"
     t.string "mhv_uuid"
     t.string "dslogon_uuid"
-    t.datetime "verified_at", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "verified_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "backing_idme_uuid"
     t.boolean "locked", default: false, null: false
     t.index ["backing_idme_uuid"], name: "index_user_verifications_on_backing_idme_uuid"
@@ -1075,15 +1075,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.date "last_revision_on"
     t.integer "pages"
     t.string "sha256"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "valid_pdf", default: false
     t.text "form_usage"
     t.text "form_tool_intro"
     t.string "form_tool_url"
     t.string "form_type"
     t.string "language"
-    t.datetime "deleted_at", precision: nil
+    t.datetime "deleted_at"
     t.string "related_forms", array: true
     t.jsonb "benefit_categories"
     t.string "form_details_url"
@@ -1097,8 +1097,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "va_notify_in_progress_reminders_sent", force: :cascade do |t|
     t.string "form_id", null: false
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_account_id", "form_id"], name: "index_in_progress_reminders_sent_user_account_form_id", unique: true
     t.index ["user_account_id"], name: "index_va_notify_in_progress_reminders_sent_on_user_account_id"
   end
@@ -1108,8 +1108,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.jsonb "git_item"
     t.boolean "notified", default: false
     t.string "label"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["notified", "label"], name: "index_vba_documents_git_items_on_notified_and_label"
     t.index ["url"], name: "index_vba_documents_git_items_on_url", unique: true
   end
@@ -1118,8 +1118,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "month", null: false
     t.integer "year", null: false
     t.jsonb "stats", default: {}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["month", "year"], name: "index_vba_documents_monthly_stats_uniqueness", unique: true
   end
 
@@ -1128,8 +1128,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "s3_deleted"
     t.string "consumer_name"
     t.uuid "consumer_id"
@@ -1148,7 +1148,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at", precision: nil
+    t.datetime "created_at"
     t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
@@ -1157,8 +1157,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "device_id", null: false
     t.boolean "active", default: true, null: false
     t.string "icn", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["device_id"], name: "index_veteran_device_records_on_device_id"
     t.index ["icn", "device_id"], name: "index_veteran_device_records_on_icn_and_device_id", unique: true
   end
@@ -1168,8 +1168,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "name"
     t.string "phone"
     t.string "state", limit: 2
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "address_type"
     t.string "city"
     t.string "country_code_iso3"
@@ -1199,8 +1199,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "last_name"
     t.string "email"
     t.string "phone"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "poa_codes", default: [], array: true
     t.string "user_types", default: [], array: true
     t.text "ssn_ciphertext"
@@ -1233,8 +1233,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "vic_submissions", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "state", default: "pending", null: false
     t.uuid "guid", null: false
     t.json "response"
@@ -1254,26 +1254,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "state_ciphertext"
     t.text "zip_code_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_info_id"], name: "index_vye_address_changes_on_user_info_id"
   end
 
   create_table "vye_awards", force: :cascade do |t|
     t.integer "user_info_id"
     t.string "cur_award_ind"
-    t.datetime "award_begin_date", precision: nil
-    t.datetime "award_end_date", precision: nil
+    t.datetime "award_begin_date"
+    t.datetime "award_end_date"
     t.integer "training_time"
-    t.datetime "payment_date", precision: nil
+    t.datetime "payment_date"
     t.decimal "monthly_rate"
     t.string "begin_rsn"
     t.string "end_rsn"
     t.string "type_training"
     t.integer "number_hours"
     t.string "type_hours"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_info_id"], name: "index_vye_awards_on_user_info_id"
   end
 
@@ -1292,8 +1292,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "bank_name_ciphertext"
     t.text "bank_phone_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_info_id"], name: "index_vye_direct_deposit_changes_on_user_info_id"
   end
 
@@ -1302,11 +1302,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "ssn_ciphertext"
     t.string "claim_no_ciphertext"
     t.string "doc_type"
-    t.datetime "queue_date", precision: nil
+    t.datetime "queue_date"
     t.string "rpo"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["ssn_digest"], name: "index_vye_pending_documents_on_ssn_digest"
   end
 
@@ -1327,16 +1327,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "stub_nm_ciphertext"
     t.string "mr_status"
     t.string "rem_ent"
-    t.datetime "cert_issue_date", precision: nil
-    t.datetime "del_date", precision: nil
-    t.datetime "date_last_certified", precision: nil
+    t.datetime "cert_issue_date"
+    t.datetime "del_date"
+    t.datetime "date_last_certified"
     t.integer "rpo_code"
     t.string "fac_code"
     t.decimal "payment_amt"
     t.string "indicator"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["icn"], name: "index_vye_user_infos_on_icn"
     t.index ["ssn_digest"], name: "index_vye_user_infos_on_ssn_digest"
   end
@@ -1347,11 +1347,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "change_flag"
     t.integer "rpo_code"
     t.boolean "rpo_flag"
-    t.datetime "act_begin", precision: nil
-    t.datetime "act_end", precision: nil
+    t.datetime "act_begin"
+    t.datetime "act_end"
     t.string "source_ind"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_info_id"], name: "index_vye_verifications_on_user_info_id"
   end
 
@@ -1365,8 +1365,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "webhooks_notification_attempts", force: :cascade do |t|
     t.boolean "success", default: false
     t.jsonb "response", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "webhooks_notifications", force: :cascade do |t|
@@ -1379,8 +1379,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.jsonb "msg", null: false
     t.integer "final_attempt_id"
     t.integer "processing"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["api_name", "consumer_id", "api_guid", "event", "final_attempt_id"], name: "index_wh_notify"
     t.index ["final_attempt_id", "api_name", "event", "api_guid"], name: "index_wk_notify_processing"
   end
@@ -1391,8 +1391,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "consumer_id", null: false
     t.uuid "api_guid"
     t.jsonb "events", default: {"subscriptions"=>[]}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["api_name", "consumer_id", "api_guid"], name: "index_webhooks_subscription", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,13 +22,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "account_login_stats", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "idme_at"
-    t.datetime "myhealthevet_at"
-    t.datetime "dslogon_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "idme_at", precision: nil
+    t.datetime "myhealthevet_at", precision: nil
+    t.datetime "dslogon_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "current_verification"
-    t.datetime "logingov_at"
+    t.datetime "logingov_at", precision: nil
     t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
     t.index ["current_verification"], name: "index_account_login_stats_on_current_verification"
     t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
@@ -42,8 +42,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "idme_uuid"
     t.string "icn"
     t.string "edipi"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "sec_id"
     t.string "logingov_uuid"
     t.index ["icn"], name: "index_accounts_on_icn"
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -85,16 +85,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "decision_review_evidence_attachment_guid"
     t.string "appeal_submission_id"
     t.string "lighthouse_upload_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "appeal_submissions", force: :cascade do |t|
     t.string "user_uuid"
     t.string "submitted_appeal_uuid"
     t.string "type_of_appeal"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "board_review_option"
     t.text "upload_metadata_ciphertext"
     t.text "encrypted_kms_key"
@@ -105,8 +105,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "appeals_api_evidence_submissions", force: :cascade do |t|
     t.string "supportable_type"
     t.string "supportable_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "source"
     t.uuid "guid", null: false
     t.integer "upload_submission_id", null: false
@@ -119,8 +119,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "appeals_api_higher_level_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status", default: "pending", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "code"
     t.string "detail"
     t.string "source"
@@ -135,8 +135,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "appeals_api_notice_of_disagreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
@@ -157,9 +157,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "to"
     t.string "statusable_type"
     t.string "statusable_id"
-    t.datetime "status_update_time"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "status_update_time", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "code"
     t.string "detail"
     t.index ["statusable_type", "statusable_id"], name: "status_update_id_type_index"
@@ -172,8 +172,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "source"
     t.string "pdf_version"
     t.string "api_version"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "form_data_ciphertext"
     t.text "auth_headers_ciphertext"
     t.text "encrypted_kms_key"
@@ -191,8 +191,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "status"
     t.string "transaction_id"
     t.string "transaction_status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -220,8 +220,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.jsonb "feedback"
     t.jsonb "access"
     t.string "fingerprint"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.boolean "mobile"
     t.string "active_status"
@@ -242,8 +242,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "claims_api_auto_established_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.integer "evss_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "md5"
     t.string "source"
     t.string "flashes", default: [], array: true
@@ -266,8 +266,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "claim_id", null: false
     t.string "claim_type", null: false
     t.string "consumer_label", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["claim_id"], name: "index_claims_api_claim_submissions_on_claim_id"
   end
 
@@ -275,8 +275,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "auth_headers_ciphertext"
     t.text "encrypted_kms_key"
     t.string "cid"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "status"
     t.string "vbms_error_message"
     t.string "bgs_error_message"
@@ -288,16 +288,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "claims_api_intent_to_files", force: :cascade do |t|
     t.string "status"
     t.string "cid"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "claims_api_power_of_attorneys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.string "current_poa"
     t.string "md5"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "vbms_new_document_version_ref_id"
     t.string "vbms_document_series_ref_id"
     t.string "vbms_error_message"
@@ -314,8 +314,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "auto_established_claim_id"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -329,8 +329,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.interval "access_token_duration", null: false
     t.string "access_token_audience", null: false
     t.interval "refresh_token_duration", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "logout_redirect_uri"
     t.boolean "pkce"
     t.string "certificates", array: true
@@ -349,8 +349,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "email_confirmation_id"
     t.string "enrollment_id"
     t.string "batch_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "raw_form_data_ciphertext"
     t.text "eligibility_info_ciphertext"
     t.text "form_data_ciphertext"
@@ -364,8 +364,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
     t.string "sid"
     t.uuid "account_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "expanded", default: false, null: false
     t.boolean "sequestered", default: false, null: false
     t.string "email_confirmation_id"
@@ -381,9 +381,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "icn", null: false
     t.string "email_address", null: false
     t.string "email_template_id", null: false
-    t.datetime "email_triggered_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "email_triggered_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_credential_adoption_email_records_on_email_address"
     t.index ["email_template_id"], name: "index_credential_adoption_email_records_on_email_template_id"
     t.index ["icn"], name: "index_credential_adoption_email_records_on_icn"
@@ -392,8 +392,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "deprecated_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id"
     t.bigint "user_verification_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id"], name: "index_deprecated_user_accounts_on_user_account_id", unique: true
     t.index ["user_verification_id"], name: "index_deprecated_user_accounts_on_user_verification_id", unique: true
   end
@@ -401,8 +401,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "devices", force: :cascade do |t|
     t.string "key"
     t.string "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["key"], name: "index_devices_on_key", unique: true
   end
 
@@ -416,8 +416,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "description"
     t.string "privacy_url"
     t.string "tos_url"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["name"], name: "index_directory_applications_on_name", unique: true
   end
 
@@ -425,8 +425,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "code", null: false
     t.string "medical_term", null: false
     t.string "lay_term"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["code"], name: "index_disability_contentions_on_code", unique: true
     t.index ["lay_term"], name: "index_disability_contentions_on_lay_term", opclass: :gin_trgm_ops, using: :gin
     t.index ["medical_term"], name: "index_disability_contentions_on_medical_term", opclass: :gin_trgm_ops, using: :gin
@@ -437,19 +437,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "unit"
     t.geography "polygon", limit: {:srid=>4326, :type=>"st_polygon", :geographic=>true}, null: false
     t.string "vha_facility_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "min"
     t.integer "max"
-    t.datetime "vssc_extract_date", default: "2001-01-01 00:00:00"
+    t.datetime "vssc_extract_date", precision: nil, default: "2001-01-01 00:00:00"
     t.index ["polygon"], name: "index_drivetime_bands_on_polygon", using: :gist
   end
 
   create_table "education_benefits_claims", id: :serial, force: :cascade do |t|
-    t.datetime "submitted_at"
-    t.datetime "processed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "submitted_at", precision: nil
+    t.datetime "processed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "regional_processing_office", null: false
     t.string "form_type", default: "1990"
     t.integer "saved_claim_id", null: false
@@ -462,8 +462,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "education_benefits_submissions", id: :serial, force: :cascade do |t|
     t.string "region", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "chapter33", default: false, null: false
     t.boolean "chapter30", default: false, null: false
     t.boolean "chapter1606", default: false, null: false
@@ -485,12 +485,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "education_benefits_claim_id"
     t.string "automated_decision_state", default: "init"
     t.string "user_uuid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "poa"
     t.integer "remaining_entitlement"
-    t.datetime "denial_email_sent_at"
-    t.datetime "confirmation_email_sent_at"
+    t.datetime "denial_email_sent_at", precision: nil
+    t.datetime "confirmation_email_sent_at", precision: nil
     t.text "auth_headers_json_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -502,8 +502,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "evss_claims", id: :serial, force: :cascade do |t|
     t.integer "evss_id", null: false
     t.json "data", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "user_uuid", null: false
     t.json "list_data", default: {}, null: false
     t.boolean "requested_decision", default: false, null: false
@@ -520,8 +520,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "gate_name"
     t.string "value"
     t.string "user"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["feature_name"], name: "index_feature_toggle_events_on_feature_name"
   end
 
@@ -538,25 +538,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "flipper_gates", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
     t.string "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
     t.string "carma_case_id", limit: 18, null: false
-    t.datetime "accepted_at", null: false
+    t.datetime "accepted_at", precision: nil, null: false
     t.json "metadata"
     t.json "attachments"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "claim_guid", null: false
     t.index ["carma_case_id"], name: "index_form1010cg_submissions_on_carma_case_id", unique: true
     t.index ["claim_guid"], name: "index_form1010cg_submissions_on_claim_guid", unique: true
@@ -567,8 +567,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "tax_year", null: false
     t.jsonb "form_data_ciphertext", null: false
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["veteran_icn", "tax_year"], name: "index_form1095_bs_on_veteran_icn_and_tax_year", unique: true
   end
 
@@ -579,7 +579,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "status", null: false
     t.string "error_class"
     t.string "error_message"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.jsonb "bgjob_errors", default: {}
     t.index ["bgjob_errors"], name: "index_form526_job_statuses_on_bgjob_errors", using: :gin
     t.index ["form526_submission_id"], name: "index_form526_job_statuses_on_form526_submission_id"
@@ -591,8 +591,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "saved_claim_id", null: false
     t.integer "submitted_claim_id"
     t.boolean "workflow_complete", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "multiple_birls", comment: "*After* a SubmitForm526 Job fails, a lookup is done to see if the veteran has multiple BIRLS IDs. This field gets set to true if that is the case. If the initial submit job succeeds, this field will remain false whether or not the veteran has multiple BIRLS IDs --so this field cannot technically be used to sum all Form526 veterans that have multiple BIRLS. This field /can/ give us an idea of how often having multiple BIRLS IDs is a problem."
     t.text "auth_headers_json_ciphertext"
     t.text "form_json_ciphertext"
@@ -611,8 +611,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "form_json_ciphertext", null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "user_account_id"
     t.jsonb "public_metadata"
     t.integer "state", default: 0
@@ -622,8 +622,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "form_attachments", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "guid", null: false
     t.string "type", null: false
     t.text "file_data_ciphertext"
@@ -638,8 +638,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "aasm_state"
     t.string "error_message"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["form_submission_id"], name: "index_form_submission_attempts_on_form_submission_id"
   end
 
@@ -651,8 +651,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "saved_claim_id"
     t.bigint "in_progress_form_id"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.jsonb "form_data_ciphertext"
     t.index ["benefits_intake_uuid"], name: "index_form_submissions_on_benefits_intake_uuid"
     t.index ["in_progress_form_id"], name: "index_form_submissions_on_in_progress_form_id"
@@ -665,9 +665,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "edipi", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.datetime "dob", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "dob", precision: nil, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "ssn_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["edipi"], name: "index_gibs_not_found_users_on_edipi"
@@ -689,15 +689,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "msa", null: false
     t.string "msa_name"
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
 
   create_table "health_care_applications", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "pending", null: false
     t.string "form_submission_id_string"
     t.string "timestamp"
@@ -707,8 +707,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "user_uuid"
     t.string "appointment_id"
     t.string "questionnaire_response_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "questionnaire_response_data_ciphertext"
     t.text "user_demographics_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -719,18 +719,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "id_card_announcement_subscriptions", id: :serial, force: :cascade do |t|
     t.string "email", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_id_card_announcement_subscriptions_on_email", unique: true
   end
 
   create_table "in_progress_forms", id: :serial, force: :cascade do |t|
     t.string "user_uuid", null: false
     t.string "form_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.json "metadata"
-    t.datetime "expires_at"
+    t.datetime "expires_at", precision: nil
     t.text "form_data_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -741,26 +741,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "inherited_proof_verified_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id"], name: "index_inherited_proof_verified_user_accounts_on_user_account_id", unique: true
   end
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|
     t.string "edipi", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["edipi"], name: "index_invalid_letter_address_edipis_on_edipi"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
     t.string "pagerduty_id"
     t.string "external_service"
-    t.datetime "start_time"
-    t.datetime "end_time"
+    t.datetime "start_time", precision: nil
+    t.datetime "end_time", precision: nil
     t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["end_time"], name: "index_maintenance_windows_on_end_time"
     t.index ["pagerduty_id"], name: "index_maintenance_windows_on_pagerduty_id"
     t.index ["start_time"], name: "index_maintenance_windows_on_start_time"
@@ -769,16 +769,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "mhv_opt_in_flags", force: :cascade do |t|
     t.uuid "user_account_id"
     t.string "feature", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feature"], name: "index_mhv_opt_in_flags_on_feature"
     t.index ["user_account_id"], name: "index_mhv_opt_in_flags_on_user_account_id"
   end
 
   create_table "mobile_users", force: :cascade do |t|
     t.string "icn", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "vet360_link_attempts"
     t.boolean "vet360_linked"
     t.index ["icn"], name: "index_mobile_users_on_icn", unique: true
@@ -788,10 +788,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "handle", null: false
     t.uuid "user_account_id", null: false
     t.string "hashed_refresh_token", null: false
-    t.datetime "refresh_expiration", null: false
-    t.datetime "refresh_creation", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "refresh_expiration", precision: nil, null: false
+    t.datetime "refresh_creation", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_verification_id", null: false
     t.string "credential_email"
     t.string "client_id", null: false
@@ -809,8 +809,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "template_id", null: false
     t.string "va_profile_id", null: false
     t.boolean "dismissed", default: false, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["va_profile_id", "dismissed"], name: "show_onsite_notifications_index"
   end
 
@@ -818,10 +818,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "guid"
     t.string "type"
     t.string "form_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "saved_claim_id"
-    t.datetime "completed_at"
+    t.datetime "completed_at", precision: nil
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["guid"], name: "index_persistent_attachments_on_guid", unique: true
@@ -832,8 +832,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "personal_information_logs", id: :serial, force: :cascade do |t|
     t.jsonb "data", null: false
     t.string "error_class", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["created_at"], name: "index_personal_information_logs_on_created_at"
     t.index ["error_class"], name: "index_personal_information_logs_on_error_class"
   end
@@ -845,7 +845,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "query_hash"
     t.float "total_time"
     t.bigint "calls"
-    t.datetime "captured_at"
+    t.datetime "captured_at", precision: nil
     t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
   end
 
@@ -854,7 +854,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "schema"
     t.text "relation"
     t.bigint "size"
-    t.datetime "captured_at"
+    t.datetime "captured_at", precision: nil
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
@@ -863,22 +863,22 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "application_uuid"
     t.string "return_description", null: false
     t.integer "return_code"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["application_uuid"], name: "index_preneed_submissions_on_application_uuid", unique: true
     t.index ["tracking_number"], name: "index_preneed_submissions_on_tracking_number", unique: true
   end
 
   create_table "saved_claims", id: :serial, force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "form_id"
     t.uuid "guid", null: false
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.string "uploaded_forms", default: [], array: true
-    t.datetime "itf_datetime"
+    t.string "uploaded_forms", array: true
+    t.datetime "itf_datetime", precision: nil
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
@@ -891,8 +891,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "access_token_audience", null: false
     t.interval "access_token_duration", null: false
     t.string "certificates", array: true
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "access_token_user_attributes", default: [], array: true
     t.index ["service_account_id"], name: "index_service_account_configs_on_service_account_id", unique: true
   end
@@ -901,10 +901,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "rpo"
     t.integer "number_of_submissions"
     t.string "filename"
-    t.datetime "successful_at"
+    t.datetime "successful_at", precision: nil
     t.integer "retry_attempt", default: 0
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["rpo", "filename"], name: "index_spool_file_events_uniqueness", unique: true
   end
 
@@ -914,8 +914,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "description", null: false
     t.integer "state_id", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -935,7 +935,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "add_ninety_day_hospital_copay"
     t.integer "outpatient_basic_care_copay"
     t.integer "outpatient_specialty_copay"
-    t.datetime "threshold_effective_date"
+    t.datetime "threshold_effective_date", precision: nil
     t.integer "aid_and_attendance_threshold"
     t.integer "outpatient_preventive_copay"
     t.integer "medication_copay"
@@ -946,8 +946,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "inpatient_per_diem"
     t.string "description"
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -958,8 +958,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "fips_code", null: false
     t.integer "country_id", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -971,8 +971,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "state_id", null: false
     t.integer "county_number", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -981,19 +981,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "user_account_id", null: false
     t.string "agreement_version", null: false
     t.integer "response", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id"], name: "index_terms_of_use_agreements_on_user_account_id"
   end
 
   create_table "test_user_dashboard_tud_account_availability_logs", force: :cascade do |t|
     t.string "account_uuid"
-    t.datetime "checkout_time"
-    t.datetime "checkin_time"
+    t.datetime "checkout_time", precision: nil
+    t.datetime "checkin_time", precision: nil
     t.boolean "has_checkin_error"
     t.boolean "is_manual_checkin"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["account_uuid"], name: "tud_account_availability_logs"
   end
 
@@ -1003,14 +1003,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "middle_name"
     t.string "last_name"
     t.string "gender"
-    t.datetime "birth_date"
+    t.datetime "birth_date", precision: nil
     t.integer "ssn"
     t.string "phone"
     t.string "email"
     t.string "password"
-    t.datetime "checkout_time"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "checkout_time", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "services"
     t.string "loa"
     t.uuid "idme_uuid"
@@ -1021,11 +1021,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "user_acceptable_verified_credentials", force: :cascade do |t|
-    t.datetime "acceptable_verified_credential_at"
-    t.datetime "idme_verified_credential_at"
+    t.datetime "acceptable_verified_credential_at", precision: nil
+    t.datetime "idme_verified_credential_at", precision: nil
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["acceptable_verified_credential_at"], name: "index_user_avc_on_acceptable_verified_credential_at"
     t.index ["idme_verified_credential_at"], name: "index_user_avc_on_idme_verified_credential_at"
     t.index ["user_account_id"], name: "index_user_acceptable_verified_credentials_on_user_account_id", unique: true
@@ -1033,8 +1033,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
 
   create_table "user_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "icn"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["icn"], name: "index_user_accounts_on_icn", unique: true
   end
 
@@ -1042,8 +1042,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "user_verification_id"
     t.text "credential_email_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_verification_id"], name: "index_user_credential_emails_on_user_verification_id", unique: true
   end
 
@@ -1053,9 +1053,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "logingov_uuid"
     t.string "mhv_uuid"
     t.string "dslogon_uuid"
-    t.datetime "verified_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "verified_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "backing_idme_uuid"
     t.boolean "locked", default: false, null: false
     t.index ["backing_idme_uuid"], name: "index_user_verifications_on_backing_idme_uuid"
@@ -1075,15 +1075,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.date "last_revision_on"
     t.integer "pages"
     t.string "sha256"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "valid_pdf", default: false
     t.text "form_usage"
     t.text "form_tool_intro"
     t.string "form_tool_url"
     t.string "form_type"
     t.string "language"
-    t.datetime "deleted_at"
+    t.datetime "deleted_at", precision: nil
     t.string "related_forms", array: true
     t.jsonb "benefit_categories"
     t.string "form_details_url"
@@ -1097,8 +1097,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "va_notify_in_progress_reminders_sent", force: :cascade do |t|
     t.string "form_id", null: false
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id", "form_id"], name: "index_in_progress_reminders_sent_user_account_form_id", unique: true
     t.index ["user_account_id"], name: "index_va_notify_in_progress_reminders_sent_on_user_account_id"
   end
@@ -1108,8 +1108,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.jsonb "git_item"
     t.boolean "notified", default: false
     t.string "label"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["notified", "label"], name: "index_vba_documents_git_items_on_notified_and_label"
     t.index ["url"], name: "index_vba_documents_git_items_on_url", unique: true
   end
@@ -1118,8 +1118,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.integer "month", null: false
     t.integer "year", null: false
     t.jsonb "stats", default: {}
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["month", "year"], name: "index_vba_documents_monthly_stats_uniqueness", unique: true
   end
 
@@ -1128,8 +1128,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "s3_deleted"
     t.string "consumer_name"
     t.uuid "consumer_id"
@@ -1148,7 +1148,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
@@ -1157,8 +1157,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.bigint "device_id", null: false
     t.boolean "active", default: true, null: false
     t.string "icn", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["device_id"], name: "index_veteran_device_records_on_device_id"
     t.index ["icn", "device_id"], name: "index_veteran_device_records_on_icn_and_device_id", unique: true
   end
@@ -1168,8 +1168,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "name"
     t.string "phone"
     t.string "state", limit: 2
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "address_type"
     t.string "city"
     t.string "country_code_iso3"
@@ -1199,8 +1199,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "last_name"
     t.string "email"
     t.string "phone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "poa_codes", default: [], array: true
     t.string "user_types", default: [], array: true
     t.text "ssn_ciphertext"
@@ -1233,8 +1233,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   end
 
   create_table "vic_submissions", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "pending", null: false
     t.uuid "guid", null: false
     t.json "response"
@@ -1254,26 +1254,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "state_ciphertext"
     t.text "zip_code_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_address_changes_on_user_info_id"
   end
 
   create_table "vye_awards", force: :cascade do |t|
     t.integer "user_info_id"
     t.string "cur_award_ind"
-    t.datetime "award_begin_date"
-    t.datetime "award_end_date"
+    t.datetime "award_begin_date", precision: nil
+    t.datetime "award_end_date", precision: nil
     t.integer "training_time"
-    t.datetime "payment_date"
+    t.datetime "payment_date", precision: nil
     t.decimal "monthly_rate"
     t.string "begin_rsn"
     t.string "end_rsn"
     t.string "type_training"
     t.integer "number_hours"
     t.string "type_hours"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_awards_on_user_info_id"
   end
 
@@ -1292,8 +1292,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "bank_name_ciphertext"
     t.text "bank_phone_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_direct_deposit_changes_on_user_info_id"
   end
 
@@ -1302,11 +1302,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "ssn_ciphertext"
     t.string "claim_no_ciphertext"
     t.string "doc_type"
-    t.datetime "queue_date"
+    t.datetime "queue_date", precision: nil
     t.string "rpo"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["ssn_digest"], name: "index_vye_pending_documents_on_ssn_digest"
   end
 
@@ -1327,16 +1327,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.text "stub_nm_ciphertext"
     t.string "mr_status"
     t.string "rem_ent"
-    t.datetime "cert_issue_date"
-    t.datetime "del_date"
-    t.datetime "date_last_certified"
+    t.datetime "cert_issue_date", precision: nil
+    t.datetime "del_date", precision: nil
+    t.datetime "date_last_certified", precision: nil
     t.integer "rpo_code"
     t.string "fac_code"
     t.decimal "payment_amt"
     t.string "indicator"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["icn"], name: "index_vye_user_infos_on_icn"
     t.index ["ssn_digest"], name: "index_vye_user_infos_on_ssn_digest"
   end
@@ -1347,11 +1347,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.string "change_flag"
     t.integer "rpo_code"
     t.boolean "rpo_flag"
-    t.datetime "act_begin"
-    t.datetime "act_end"
+    t.datetime "act_begin", precision: nil
+    t.datetime "act_end", precision: nil
     t.string "source_ind"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_verifications_on_user_info_id"
   end
 
@@ -1365,8 +1365,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
   create_table "webhooks_notification_attempts", force: :cascade do |t|
     t.boolean "success", default: false
     t.jsonb "response", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "webhooks_notifications", force: :cascade do |t|
@@ -1379,8 +1379,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.jsonb "msg", null: false
     t.integer "final_attempt_id"
     t.integer "processing"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["api_name", "consumer_id", "api_guid", "event", "final_attempt_id"], name: "index_wh_notify"
     t.index ["final_attempt_id", "api_name", "event", "api_guid"], name: "index_wk_notify_processing"
   end
@@ -1391,8 +1391,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_212019) do
     t.uuid "consumer_id", null: false
     t.uuid "api_guid"
     t.jsonb "events", default: {"subscriptions"=>[]}
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["api_name", "consumer_id", "api_guid"], name: "index_webhooks_subscription", unique: true
   end
 

--- a/spec/sidekiq/vre/create_ch31_submissions_report_job_spec.rb
+++ b/spec/sidekiq/vre/create_ch31_submissions_report_job_spec.rb
@@ -31,7 +31,6 @@ describe VRE::CreateCh31SubmissionsReportJob do
   end
 
   describe 'raises an exception' do
-
     it 'when queue is exhausted' do
       VRE::CreateCh31SubmissionsReportJob.within_sidekiq_retries_exhausted_block do
         expect(Rails.logger).to receive(:error).exactly(:once).with(

--- a/spec/sidekiq/vre/create_ch31_submissions_report_job_spec.rb
+++ b/spec/sidekiq/vre/create_ch31_submissions_report_job_spec.rb
@@ -55,6 +55,16 @@ describe VRE::CreateCh31SubmissionsReportJob do
     #     subject
     #   end
     # end
+    describe 'raises an exception' do
+      it 'when queue is exhausted' do
+        VRE::CreateCh31SubmissionsReportJob.within_sidekiq_retries_exhausted_block do
+          expect(Rails.logger).to receive(:error).exactly(:once).with(
+            'Failed all retries on VRE::CreateCh31SubmissionsReportJob, last error: An error occured'
+          )
+          expect(StatsD).to receive(:increment).with('worker.vre.create_ch31_submissions_report_job.exhausted')
+        end
+      end
+    end
 
     context 'passed specific date in YYYY-MM-DD format' do
       let(:sidekiq_scheduler_args) { {} }


### PR DESCRIPTION

## Summary

- *This work is behind a feature toggle (flipper)* :NO
- Adds queue exhaustion exception logging to the CreateCh31SubmissionsReportJob
- Added in the retry and queue exhaustion block to account for an error and sentry log action
- Work done by the ndbex team

## Related issue(s)

- [Ticket 73954](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73954)

## Testing done

- [X] *New code is covered by unit tests*
- No queue exhaustion or exception monitoring was being done on the background job
- Manually retry jobs in sidekiq until the limit (14) has been surpassed

## What areas of the site does it impact?
This affects ch31 submission report generation

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)

