### PR TITLE
DBEX: mark BIRLS ID as tried if non-retryable error raised

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -83,12 +83,13 @@ module EVSS
         Sentry.set_tags(source: '526EZ-all-claims')
         super(submission_id)
 
+        # This instantiates the service as defined by the inheriting object
+        # TODO: this meaningless variable assignment is required for the specs to pass, which
+        # indicates a problematic coupling of implementation and test logic.  This should eventually
+        # be addressed to make this service and test more robust and readable.
+        service = service(submission.auth_headers)
+
         with_tracking('Form526 Submission', submission.saved_claim_id, submission.id, submission.bdd?) do
-          # This instantiates the service as defined by the inheriting object
-          # TODO: this meaningless variable assignment is required for the specs to pass, which
-          # indicates a problematic coupling of implementation and test logic.  This should eventually
-          # be addressed to make this service and test more robust and readable.
-          service = service(submission.auth_headers)
           submission.mark_birls_id_as_tried!
 
           begin

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -175,6 +175,7 @@ module EVSS
       def non_retryable_error_handler(submission, error)
         # update JobStatus, log and metrics in JobStatus#non_retryable_error_handler
         super(error)
+        submission.mark_birls_id_as_tried!
         submission.submit_with_birls_id_that_hasnt_been_tried_yet!(
           silence_errors_and_log_to_sentry: true,
           extra_content_for_sentry: { job_class: self.class.to_s.demodulize, job_id: jid }


### PR DESCRIPTION
## Summary

- Marks a BIRLS ID as being tried when a non-retryable error is encountered, thus preventing an EVSS submission job from continuously running when the `prepare_for_evss!` call within the `perform` method on L94 raises a non-retryable error.

## Related issue(s)

- Remedies updates made in [PR #15195](https://github.com/department-of-veterans-affairs/vets-api/pull/15195)
- Addresses [a report](https://dsva.slack.com/archives/C04KW0B46N5/p1706491399988779) of '"submitform 526 Worker Results" spiking something labeled "non-retryable errors"' and [another report](https://dsva.slack.com/archives/C04KW0B46N5/p1706549548179909?thread_ts=1706491399.988779&cid=C04KW0B46N5) of 'duplicates of the same 3 claim ids happening over and over.'
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/50811220/986a424e-d57c-4363-99c7-0567b189314d)
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/50811220/ae638724-bf7c-4a3c-9825-28977415d418)

## Testing done

- Corresponding spec runs successfully after addition

## What areas of the site does it impact?

Form 526 Submission attempts

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

I believe this accounts for the related issues listed above, but welcome any and all feedback. 
