### PR TITLE
POA v2: retrieve the status of a POA

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -62,6 +62,17 @@ module ClaimsApi
           render json: validation_success('21-22a')
         end
 
+        def status
+          poa = ClaimsApi::PowerOfAttorney.find_by(id: params[:id])
+          unless poa
+            raise ::ClaimsApi::Common::Exceptions::Lighthouse::ResourceNotFound.new(
+              detail: "Could not find Power of Attorney with id: #{params[:id]}"
+            )
+          end
+
+          render json: poa, serializer: ClaimsApi::PowerOfAttorneySerializer
+        end
+
         private
 
         def shared_form_validation(form_number)

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
   let(:appoint_organization_path) { "/services/claims/v2/veterans/#{veteran_id}/2122" }
   let(:validate2122_path) { "/services/claims/v2/veterans/#{veteran_id}/2122/validate" }
   let(:validate2122a_path) { "/services/claims/v2/veterans/#{veteran_id}/2122a/validate" }
-
+  let(:status_path) { "/services/claims/v2/veterans/#{veteran_id}/power-of-attorney/" }
   let(:scopes) { %w[system/claim.write system/claim.read] }
   let(:individual_poa_code) { 'A1H' }
   let(:organization_poa_code) { '083' }
@@ -118,6 +118,28 @@ RSpec.describe 'Power Of Attorney', type: :request do
               expect(response.status).to eq(401)
             end
           end
+        end
+      end
+    end
+
+    describe 'status' do
+      it 'returns the status of a POA' do
+        mock_ccg(scopes) do |auth_header|
+          poa = create(:power_of_attorney, auth_headers: auth_header)
+
+          get "#{status_path}/#{poa.id}", params: nil, headers: auth_header
+          json = JSON.parse(response.body)
+
+          expect(json['data']['type']).to eq('claims_api_power_of_attorneys')
+          expect(json['data']['attributes']['status']).to eq('submitted')
+        end
+      end
+
+      it 'returns 404 when given an unknown id' do
+        mock_ccg(scopes) do |auth_header|
+          get "#{status_path}/123456", params: nil, headers: auth_header
+
+          expect(response).to have_http_status(:not_found)
         end
       end
     end


### PR DESCRIPTION
## Summary

Adds an endpoint to show the status of a POA submission.

`GET /veterans/:veteranId/power-of-attorney/:id`

## Related issue(s)
- [API-32120](https://jira.devops.va.gov/browse/API-32120)

## Testing done

Tested the following scenarios in postman locally:
- Unknown POA id responds with 404
- Known POA returns payload showing its status

**Unknown POA id responds with 404**
<img width="1032" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/534756/2c36eef5-f020-4f56-bb84-3c80e8665599">


**Known POA returns payload showing its status**
<img width="1008" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/534756/962865c7-2348-4a85-b0d2-9f37ac04e971">

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature