### PR TITLE
API-333721 remove id attribute from active POA V2 endpoint

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   module V2
     module Blueprints
       class PowerOfAttorneyBlueprint < Blueprinter::Base
-        identifier :id
+        field :id, if: ->(_field_name, obj, _options) { !obj[:id].nil? }
 
         field :type
 

--- a/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_blueprint.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   module V2
     module Blueprints
       class PowerOfAttorneyBlueprint < Blueprinter::Base
-        field :id, if: ->(_field_name, obj, _options) { !obj[:id].nil? }
+        field :id, if: ->(_field_name, obj, _options) { obj[:id].present? }
 
         field :type
 

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8473,7 +8473,6 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": null,
                     "type": "individual",
                     "attributes": {
                       "code": "A1Q",
@@ -8492,15 +8491,10 @@
                       "type": "object",
                       "additionalProperties": false,
                       "required": [
-                        "id",
                         "type",
                         "attributes"
                       ],
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "nullable": true
-                        },
                         "type": {
                           "type": "string",
                           "nullable": true,

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -7076,7 +7076,6 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": null,
                     "type": "individual",
                     "attributes": {
                       "code": "A1Q",
@@ -7095,15 +7094,10 @@
                       "type": "object",
                       "additionalProperties": false,
                       "required": [
-                        "id",
                         "type",
                         "attributes"
                       ],
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "nullable": true
-                        },
                         "type": {
                           "type": "string",
                           "nullable": true,

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
                       expected_response = {
                         'data' => {
-                          'id' => nil,
                           'type' => 'individual',
                           'attributes' => {
                             'code' => 'ABC',

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -359,7 +359,7 @@ describe 'PowerOfAttorney',
                                                       'claims_api',
                                                       'veterans',
                                                       'power-of-attorney',
-                                                      'get.json')))
+                                                      'post.json')))
 
           before do |example|
             expect_any_instance_of(local_bgs).to receive(:find_poa_by_participant_id).and_return(bgs_poa)

--- a/spec/support/schemas/claims_api/veterans/power-of-attorney/post.json
+++ b/spec/support/schemas/claims_api/veterans/power-of-attorney/post.json
@@ -5,8 +5,12 @@
     "data": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "attributes"],
+      "required": ["id", "type", "attributes"],
       "properties": {
+        "id": {
+          "type": "string",
+          "nullable": true
+        },
         "type": {
           "type": "string",
           "nullable": true,


### PR DESCRIPTION
## Summary

- This pr makes the `id` attribute conditional in the POA V2 blueprint

## Related issue(s)

- [API-33721](https://jira.devops.va.gov/browse/API-33721)

## Testing done

-Tested locally with postman

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/ec5ad6b2-b416-42c7-b0d1-73cde767123c)

![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/c5571e4e-a46d-492f-a80a-34b575cf2004)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature