### PR TITLE
Track form submissions by id in DataDog with statsd metrics

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -9,8 +9,8 @@ class BenefitsIntakeStatusJob
   def perform
     Rails.logger.info('BenefitsIntakeStatusJob started')
     pending_form_submissions = FormSubmission
-                                  .joins(:form_submission_attempts)
-                                  .where(form_submission_attempts: { aasm_state: 'pending' })
+                               .joins(:form_submission_attempts)
+                               .where(form_submission_attempts: { aasm_state: 'pending' })
     pending_form_submission_ids = pending_form_submissions.map(&:benefits_intake_uuid)
     response = BenefitsIntakeService::Service.new.get_bulk_status_of_uploads(pending_form_submission_ids)
     handle_response(response, pending_form_submissions)
@@ -24,7 +24,7 @@ class BenefitsIntakeStatusJob
       form_id = pending_form_submissions.find do |submission_from_db|
         submission_from_db.benefits_intake_uuid == submission['id']
       end.form_type
-      
+
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
         StatsD.increment("#{STATS_KEY}.#{form_id}.failure")
         handle_failure(submission)


### PR DESCRIPTION
## Summary
This PR makes our StatsD a bit more sophisticated such that we can now track metrics on individual form types, rather than all forms that pass through the Benefits Intake Status Job. This will allow us to re-work the dashboard to rely on metrics instead of other data sources and display Pending forms in addition to the success and failed ones.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/976
