### PR TITLE
Start tracking which type of user is filling out a form

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -96,10 +96,7 @@ module SimpleFormsApi
             status: #{status}, uuid #{confirmation_number}"
         )
 
-        json = { confirmation_number: }
-        json[:expiration_date] = 1.year.from_now if form_id == 'vba_21_0966'
-
-        render json:, status:
+        render json: get_json(confirmation_number, form_id), status:
       end
 
       def get_upload_location_and_uuid(lighthouse_service)
@@ -156,6 +153,13 @@ module SimpleFormsApi
         raise 'missing form_number in params' unless form_number
 
         FORM_NUMBER_MAP[form_number]
+      end
+
+      def get_json(confirmation_number, form_id)
+        json = { confirmation_number: }
+        json[:expiration_date] = 1.year.from_now if form_id == 'vba_21_0966'
+
+        json
       end
     end
   end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -75,6 +75,7 @@ module SimpleFormsApi
         parsed_form_data = JSON.parse(params.to_json)
         form_id = get_form_id
         form = "SimpleFormsApi::#{form_id.titleize.gsub(' ', '')}".constantize.new(parsed_form_data)
+        form.track_user_identity
         filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, form:)
 
         file_path = filler.generate

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -30,5 +30,8 @@ module SimpleFormsApi
         'businessLine' => 'CMP'
       }
     end
+
+    def track_user_identity
+    end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -31,6 +31,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -31,7 +31,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -30,8 +30,7 @@ module SimpleFormsApi
         person_address + organization_address
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -30,7 +30,7 @@ module SimpleFormsApi
         person_address + organization_address
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -30,6 +30,9 @@ module SimpleFormsApi
         person_address + organization_address
     end
 
+    def track_user_identity
+    end
+
     private
 
     def veteran_ssn

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -54,8 +54,7 @@ module SimpleFormsApi
       end
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -54,7 +54,7 @@ module SimpleFormsApi
       end
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -54,6 +54,9 @@ module SimpleFormsApi
       end
     end
 
+    def track_user_identity
+    end
+
     private
 
     def roles

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -22,7 +22,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -21,5 +21,8 @@ module SimpleFormsApi
         'businessLine' => 'CMP'
       }
     end
+
+    def track_user_identity
+    end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -22,6 +22,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -28,7 +28,7 @@ module SimpleFormsApi
         statement + witness_phone + witness_email
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -28,8 +28,7 @@ module SimpleFormsApi
         statement + witness_phone + witness_email
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -28,6 +28,9 @@ module SimpleFormsApi
         statement + witness_phone + witness_email
     end
 
+    def track_user_identity
+    end
+
     private
 
     def veteran_ssn

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -3,6 +3,7 @@
 module SimpleFormsApi
   class VBA214142
     include Virtus.model(nullify_blank: true)
+    STATS_KEY = 'api.simple_forms_api.21_4142'
 
     attribute :data
 
@@ -25,6 +26,10 @@ module SimpleFormsApi
         'docType' => @data['form_number'],
         'businessLine' => 'CMP'
       }
+    end
+
+    def track_user_identity
+      StatsD.increment("#{STATS_KEY}.#{data.dig('preparer_identification', 'relationship_to_veteran')}")
     end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -26,8 +26,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -26,6 +26,9 @@ module SimpleFormsApi
       }
     end
 
+    def track_user_identity
+    end
+
     private
 
     def veteran_ssn

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -26,7 +26,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -27,8 +27,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -27,6 +27,9 @@ module SimpleFormsApi
       }
     end
 
+    def track_user_identity
+    end
+
     private
 
     def veteran_ssn

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -27,7 +27,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -35,8 +35,7 @@ module SimpleFormsApi
       end
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -35,6 +35,9 @@ module SimpleFormsApi
       end
     end
 
+    def track_user_identity
+    end
+
     private
 
     def get_attachments

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -35,7 +35,7 @@ module SimpleFormsApi
       end
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -22,7 +22,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity
-    end
+    def track_user_identity;end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -21,5 +21,8 @@ module SimpleFormsApi
         'businessLine' => 'CMP'
       }
     end
+
+    def track_user_identity
+    end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -22,6 +22,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity;end
+    def track_user_identity; end
   end
 end


### PR DESCRIPTION
## Summary
This PR adds a StatsD metric for form 21-4142 to track which type of user (ie, Veteran or Spouse or Child, etc.) is filling out the form. We want to be able to track this on Datadog so we can see the breakdown of which paths are being traveled by users through a form.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/975

## Testing done
This is not a user-facing feature, so I don't think it's worth testing. Happy to talk about counter-arguments though :)