### PR TITLE
API-32629 Validate token ICN for `create` endpoints in appeals v0 APIs

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v0/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v0/higher_level_reviews_controller.rb
@@ -61,12 +61,15 @@ module AppealsApi::HigherLevelReviews::V0
     end
 
     def create
+      submitted_icn = @json_body.dig('data', 'attributes', 'veteran', 'icn')
+      validate_token_icn_access!(submitted_icn)
+
       hlr = AppealsApi::HigherLevelReview.new(
         auth_headers: request_headers,
         form_data: @json_body,
         source: request_headers['X-Consumer-Username'].presence&.strip,
         api_version: self.class::API_VERSION,
-        veteran_icn: @json_body.dig('data', 'attributes', 'veteran', 'icn')
+        veteran_icn: submitted_icn
       )
 
       return render_model_errors(hlr) unless hlr.validate

--- a/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements/evidence_submissions_controller.rb
@@ -3,6 +3,7 @@
 module AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreements
   class EvidenceSubmissionsController < AppealsApi::ApplicationController
     include AppealsApi::CharacterUtilities
+    include AppealsApi::IcnParameterValidation
     include AppealsApi::JsonFormatValidation
     include AppealsApi::OpenidAuth
     include AppealsApi::Schemas
@@ -19,7 +20,14 @@ module AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreements
 
     def show
       submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
-      raise Common::Exceptions::RecordNotFound, params[:id] unless submission
+
+      unless submission
+        raise Common::Exceptions::ResourceNotFound.new(
+          detail: I18n.t('appeals_api.errors.not_found', type: 'Evidence Submission', id: params[:id])
+        )
+      end
+
+      validate_token_nod_access!(submission.supportable_id)
 
       submission = with_status_simulation(submission) if status_requested_and_allowed?
 
@@ -29,6 +37,8 @@ module AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreements
     # rubocop:disable Metrics/MethodLength
     def create
       form_schemas.validate!('EVIDENCE_SUBMISSION', params.to_unsafe_h)
+
+      validate_token_nod_access!(params[:nodId])
 
       status, error = AppealsApi::EvidenceSubmissionRequestValidator.new(
         params[:nodId], params[:fileNumber], 'NoticeOfDisagreement'
@@ -57,6 +67,14 @@ module AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreements
     # rubocop:enable Metrics/MethodLength
 
     private
+
+    def validate_token_nod_access!(nod_id)
+      validate_token_icn_access!(AppealsApi::NoticeOfDisagreement.find(nod_id).veteran_icn)
+    rescue ActiveRecord::RecordNotFound
+      raise Common::Exceptions::ResourceNotFound.new(
+        detail: I18n.t('appeals_api.errors.not_found', type: 'Notice of Disagreement', id: nod_id)
+      )
+    end
 
     def token_validation_api_key
       Settings.dig(:modules_appeals_api, :token_validation, :notice_of_disagreements, :api_key)

--- a/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements_controller.rb
@@ -52,13 +52,16 @@ module AppealsApi::NoticeOfDisagreements::V0
     end
 
     def create
+      submitted_icn = @json_body.dig('data', 'attributes', 'veteran', 'icn')
+      validate_token_icn_access!(submitted_icn)
+
       nod = AppealsApi::NoticeOfDisagreement.new(
         auth_headers: request_headers,
         form_data: @json_body,
         source: request_headers['X-Consumer-Username'].presence&.strip,
         board_review_option: @json_body.dig('data', 'attributes', 'boardReviewOption'),
         api_version: self.class::API_VERSION,
-        veteran_icn: @json_body.dig('data', 'attributes', 'veteran', 'icn')
+        veteran_icn: submitted_icn
       )
 
       return render_model_errors(nod) unless nod.validate

--- a/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims/evidence_submissions_controller.rb
@@ -3,6 +3,7 @@
 module AppealsApi::SupplementalClaims::V0::SupplementalClaims
   class EvidenceSubmissionsController < AppealsApi::ApplicationController
     include AppealsApi::CharacterUtilities
+    include AppealsApi::IcnParameterValidation
     include AppealsApi::JsonFormatValidation
     include AppealsApi::OpenidAuth
     include AppealsApi::Schemas
@@ -19,7 +20,14 @@ module AppealsApi::SupplementalClaims::V0::SupplementalClaims
 
     def show
       submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
-      raise Common::Exceptions::RecordNotFound, params[:id] unless submission
+
+      unless submission
+        raise Common::Exceptions::ResourceNotFound.new(
+          detail: I18n.t('appeals_api.errors.not_found', type: 'Evidence Submission', id: params[:id])
+        )
+      end
+
+      validate_token_sc_access!(submission.supportable_id)
 
       submission = with_status_simulation(submission) if status_requested_and_allowed?
 
@@ -29,6 +37,8 @@ module AppealsApi::SupplementalClaims::V0::SupplementalClaims
     # rubocop:disable Metrics/MethodLength
     def create
       form_schemas.validate!('EVIDENCE_SUBMISSION', params.to_unsafe_h)
+
+      validate_token_sc_access!(params[:scId])
 
       status, error = AppealsApi::EvidenceSubmissionRequestValidator.new(
         params[:scId], params[:ssn], 'SupplementalClaim'
@@ -57,6 +67,14 @@ module AppealsApi::SupplementalClaims::V0::SupplementalClaims
     # rubocop:enable Metrics/MethodLength
 
     private
+
+    def validate_token_sc_access!(sc_id)
+      validate_token_icn_access!(AppealsApi::SupplementalClaim.find(sc_id).veteran_icn)
+    rescue ActiveRecord::RecordNotFound
+      raise Common::Exceptions::ResourceNotFound.new(
+        detail: I18n.t('appeals_api.errors.not_found', type: 'Supplemental Claim', id: sc_id)
+      )
+    end
 
     def token_validation_api_key
       Settings.dig(:modules_appeals_api, :token_validation, :supplemental_claims, :api_key)

--- a/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
@@ -70,13 +70,16 @@ module AppealsApi::SupplementalClaims::V0
     end
 
     def create
+      submitted_icn = @json_body.dig('data', 'attributes', 'veteran', 'icn')
+      validate_token_icn_access!(submitted_icn)
+
       sc = AppealsApi::SupplementalClaim.new(
         auth_headers: request_headers,
         form_data: @json_body,
         source: request_headers['X-Consumer-Username'].presence&.strip,
         evidence_submission_indicated: evidence_submission_indicated?,
         api_version: self.class::API_VERSION,
-        veteran_icn: @json_body.dig('data', 'attributes', 'veteran', 'icn')
+        veteran_icn: submitted_icn
       )
 
       return render_model_errors(sc) unless sc.validate

--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger.json
@@ -320,6 +320,50 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Body is not a JSON object": {
+                    "value": {
+                      "errors": [
+                        {
+                          "code": "109",
+                          "detail": "The request body isn't a JSON object",
+                          "status": "400",
+                          "title": "Bad Request"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create a Higher-Level Review for another veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Violates JSON schema",
             "content": {

--- a/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger_dev.json
@@ -320,6 +320,50 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Body is not a JSON object": {
+                    "value": {
+                      "errors": [
+                        {
+                          "code": "109",
+                          "detail": "The request body isn't a JSON object",
+                          "status": "400",
+                          "title": "Bad Request"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create a Higher-Level Review for another veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Violates JSON schema",
             "content": {

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
@@ -243,6 +243,50 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Body is not a JSON object": {
+                    "value": {
+                      "errors": [
+                        {
+                          "code": "109",
+                          "detail": "The request body isn't a JSON object",
+                          "status": "400",
+                          "title": "Bad Request"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create a Notice of Disagreement for another veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Violates JSON schema",
             "content": {

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger.json
@@ -2489,26 +2489,6 @@
               }
             }
           },
-          "404": {
-            "description": "Associated Notice of Disagreement not found",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "not_found",
-                      "detail": "NoticeOfDisagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
-                      "code": "404",
-                      "status": "404"
-                    }
-                  ]
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/errorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad request",
             "content": {
@@ -2526,6 +2506,46 @@
                       ]
                     }
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create an Evidence Submission for a Notice of Disagreement belonging to another Veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Associated Notice of Disagreement not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "detail": "Notice of Disagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
+                      "code": "404",
+                      "status": "404"
+                    }
+                  ]
                 },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
@@ -2800,6 +2820,26 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to view an Evidence Submission belonging to another Veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Forbidden",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Notice of Disagreement Evidence Submission not found",
             "content": {
@@ -2807,8 +2847,8 @@
                 "example": {
                   "errors": [
                     {
-                      "title": "Record not found",
-                      "detail": "The record identified by 00000000-0000-0000-0000-000000000000 could not be found",
+                      "title": "Resource not found",
+                      "detail": "Evidence Submission with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
                       "status": "404"
                     }

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
@@ -243,6 +243,50 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Body is not a JSON object": {
+                    "value": {
+                      "errors": [
+                        {
+                          "code": "109",
+                          "detail": "The request body isn't a JSON object",
+                          "status": "400",
+                          "title": "Bad Request"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create a Notice of Disagreement for another veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Violates JSON schema",
             "content": {

--- a/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger_dev.json
@@ -2489,26 +2489,6 @@
               }
             }
           },
-          "404": {
-            "description": "Associated Notice of Disagreement not found",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "not_found",
-                      "detail": "NoticeOfDisagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
-                      "code": "404",
-                      "status": "404"
-                    }
-                  ]
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/errorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad request",
             "content": {
@@ -2526,6 +2506,46 @@
                       ]
                     }
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create an Evidence Submission for a Notice of Disagreement belonging to another Veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Associated Notice of Disagreement not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "detail": "Notice of Disagreement with uuid 00000000-0000-0000-0000-000000000000 not found",
+                      "code": "404",
+                      "status": "404"
+                    }
+                  ]
                 },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"
@@ -2800,6 +2820,26 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to view an Evidence Submission belonging to another Veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Forbidden",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Notice of Disagreement Evidence Submission not found",
             "content": {
@@ -2807,8 +2847,8 @@
                 "example": {
                   "errors": [
                     {
-                      "title": "Record not found",
-                      "detail": "The record identified by 00000000-0000-0000-0000-000000000000 could not be found",
+                      "title": "Resource not found",
+                      "detail": "Evidence Submission with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
                       "status": "404"
                     }

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
@@ -361,7 +361,7 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "Not JSON object": {
+                  "Body is not a JSON object": {
                     "value": {
                       "errors": [
                         {
@@ -373,6 +373,26 @@
                       ]
                     }
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create a Supplemental Claim for another veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
                 },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger.json
@@ -865,7 +865,7 @@
     },
     "/forms/200995/{id}/download": {
       "get": {
-        "summary": "Download a watermarked copy of a submitted Supplemental CLaim",
+        "summary": "Download a watermarked copy of a submitted Supplemental Claim",
         "tags": [
           "Supplemental Claims"
         ],
@@ -3026,8 +3026,8 @@
                 "example": {
                   "errors": [
                     {
-                      "title": "not_found",
-                      "detail": "SupplementalClaim with uuid 00000000-0000-0000-0000-000000000000 not found",
+                      "title": "Resource not found",
+                      "detail": "Supplemental Claim with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
                       "status": "404"
                     }
@@ -3262,6 +3262,26 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to view an Evidence Submission belonging to another Veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Supplemental Claim Evidence Submission not found",
             "content": {
@@ -3269,8 +3289,8 @@
                 "example": {
                   "errors": [
                     {
-                      "title": "Record not found",
-                      "detail": "The record identified by 00000000-0000-0000-0000-000000000000 could not be found",
+                      "title": "Resource not found",
+                      "detail": "Evidence Submission with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
                       "status": "404"
                     }

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
@@ -867,7 +867,7 @@
     },
     "/forms/200995/{id}/download": {
       "get": {
-        "summary": "Download a watermarked copy of a submitted Supplemental CLaim",
+        "summary": "Download a watermarked copy of a submitted Supplemental Claim",
         "tags": [
           "Supplemental Claims"
         ],
@@ -3032,8 +3032,8 @@
                 "example": {
                   "errors": [
                     {
-                      "title": "not_found",
-                      "detail": "SupplementalClaim with uuid 00000000-0000-0000-0000-000000000000 not found",
+                      "title": "Resource not found",
+                      "detail": "Supplemental Claim with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
                       "status": "404"
                     }
@@ -3268,6 +3268,26 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to view an Evidence Submission belonging to another Veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Supplemental Claim Evidence Submission not found",
             "content": {
@@ -3275,8 +3295,8 @@
                 "example": {
                   "errors": [
                     {
-                      "title": "Record not found",
-                      "detail": "The record identified by 00000000-0000-0000-0000-000000000000 could not be found",
+                      "title": "Resource not found",
+                      "detail": "Evidence Submission with uuid 00000000-0000-0000-0000-000000000000 not found",
                       "code": "404",
                       "status": "404"
                     }

--- a/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/supplemental_claims/v0/swagger_dev.json
@@ -362,7 +362,7 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "Not JSON object": {
+                  "Body is not a JSON object": {
                     "value": {
                       "errors": [
                         {
@@ -374,6 +374,26 @@
                       ]
                     }
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden attempt using a veteran-scoped OAuth token to create a Supplemental Claim for another veteran",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Forbidden",
+                      "detail": "Veterans may access only their own records",
+                      "code": "403",
+                      "status": "403"
+                    }
+                  ]
                 },
                 "schema": {
                   "$ref": "#/components/schemas/errorModel"

--- a/modules/appeals_api/spec/docs/higher_level_reviews/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/higher_level_reviews/v0_spec.rb
@@ -19,14 +19,15 @@ RSpec.describe 'Higher-Level Reviews', openapi_spec:, type: :request do
 
   path '/forms/200996' do
     post 'Creates a new Higher-Level Review' do
-      scopes = AppealsApi::HigherLevelReviews::V0::HigherLevelReviewsController::OAUTH_SCOPES[:POST]
       description 'Submits an appeal of type Higher-Level Review. ' \
                   'This endpoint is the same as submitting [VA Form 20-0996](https://www.va.gov/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996)' \
                   ' via mail or fax directly to the Board of Veterans’ Appeals.'
 
       tags 'Higher-Level Reviews'
       operationId 'createHlr'
-      security DocHelpers.oauth_security_config(scopes)
+      security DocHelpers.oauth_security_config(
+        AppealsApi::HigherLevelReviews::V0::HigherLevelReviewsController::OAUTH_SCOPES[:POST]
+      )
       consumes 'application/json'
       produces 'application/json'
 
@@ -37,6 +38,8 @@ RSpec.describe 'Higher-Level Reviews', openapi_spec:, type: :request do
         'all fields used' => { value: FixtureHelpers.fixture_as_json('higher_level_reviews/v0/valid_200996_extra.json') }
       }
 
+      system_scopes = %w[system/HigherLevelReviews.write]
+
       response '201', 'Higher-Level Review created' do
         let(:hlr_body) { fixture_as_json('higher_level_reviews/v0/valid_200996_minimum.json') }
 
@@ -46,7 +49,7 @@ RSpec.describe 'Higher-Level Reviews', openapi_spec:, type: :request do
                         desc: 'minimum fields used',
                         response_wrapper: :normalize_appeal_response,
                         extract_desc: true,
-                        scopes:
+                        scopes: system_scopes
       end
 
       response '201', 'Higher-Level Review created' do
@@ -58,7 +61,30 @@ RSpec.describe 'Higher-Level Reviews', openapi_spec:, type: :request do
                         desc: 'all fields used',
                         response_wrapper: :normalize_appeal_response,
                         extract_desc: true,
-                        scopes:
+                        scopes: system_scopes
+      end
+
+      response '400', 'Bad request' do
+        schema '$ref' => '#/components/schemas/errorModel'
+
+        let(:hlr_body) { nil }
+
+        it_behaves_like 'rswag example',
+                        desc: 'Body is not a JSON object',
+                        extract_desc: true,
+                        scopes: system_scopes
+      end
+
+      response '403', 'Forbidden attempt using a veteran-scoped OAuth token to create a Higher-Level Review for another veteran' do
+        schema '$ref' => '#/components/schemas/errorModel'
+
+        let(:hlr_body) do
+          fixture_as_json('higher_level_reviews/v0/valid_200996.json').tap do |data|
+            data['data']['attributes']['veteran']['icn'] = '1234567890V987654'
+          end
+        end
+
+        it_behaves_like 'rswag example', scopes: %w[veteran/HigherLevelReviews.write]
       end
 
       response '422', 'Violates JSON schema' do
@@ -70,7 +96,7 @@ RSpec.describe 'Higher-Level Reviews', openapi_spec:, type: :request do
           request_body
         end
 
-        it_behaves_like 'rswag example', desc: 'Returns a 422 response', scopes:
+        it_behaves_like 'rswag example', desc: 'Returns a 422 response', scopes: system_scopes
       end
 
       it_behaves_like 'rswag 500 response'

--- a/modules/appeals_api/spec/docs/supplemental_claims/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/supplemental_claims/v0_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'Supplemental Claims', openapi_spec:, type: :request do
   end
 
   path '/forms/200995/{id}/download' do
-    get 'Download a watermarked copy of a submitted Supplemental CLaim' do
+    get 'Download a watermarked copy of a submitted Supplemental Claim' do
       scopes = AppealsApi::SupplementalClaims::V0::SupplementalClaimsController::OAUTH_SCOPES[:GET]
       tags 'Supplemental Claims'
       operationId 'downloadSc'
@@ -397,12 +397,14 @@ RSpec.describe 'Supplemental Claims', openapi_spec:, type: :request do
 
   path '/evidence-submissions/{id}' do
     get 'Returns all of the data associated with a specific Supplemental Claim Evidence Submission.' do
-      scopes = AppealsApi::SupplementalClaims::V0::SupplementalClaimsController::OAUTH_SCOPES[:GET]
       tags 'Supplemental Claims'
       operationId 'getSupplementalClaimEvidenceSubmission'
       description 'Returns all of the data associated with a specific Supplemental Claim Evidence Submission.'
 
-      security DocHelpers.oauth_security_config(scopes)
+      security DocHelpers.oauth_security_config(
+        AppealsApi::SupplementalClaims::V0::SupplementalClaimsController::OAUTH_SCOPES[:GET]
+      )
+
       produces 'application/json'
 
       parameter name: :id,
@@ -413,15 +415,26 @@ RSpec.describe 'Supplemental Claims', openapi_spec:, type: :request do
                   format: :uuid
                 }
 
+      scopes = %w[system/SupplementalClaims.read]
+
       response '200', 'Info about a single Supplemental Claim Evidence Submission.' do
         schema '$ref' => '#/components/schemas/scEvidenceSubmissionResponse'
 
-        let(:id) { FactoryBot.create(:sc_evidence_submission).guid }
+        let(:sc) { FactoryBot.create(:supplemental_claim_v0) }
+        let(:id) { FactoryBot.create(:evidence_submission_v0, supportable: sc).guid }
 
         it_behaves_like 'rswag example',
                         desc: 'returns a 200 response',
                         response_wrapper: :normalize_evidence_submission_response,
                         scopes:
+      end
+
+      response '403', 'Forbidden attempt using a veteran-scoped OAuth token to view an Evidence Submission belonging to another Veteran' do
+        schema '$ref' => '#/components/schemas/errorModel'
+        let(:sc) { FactoryBot.create(:supplemental_claim_v0, veteran_icn: '1111111111V111111') }
+        let(:id) { create(:evidence_submission_v0, supportable: sc).guid }
+
+        it_behaves_like 'rswag example', desc: 'returns a 404 response', scopes: %w[veteran/SupplementalClaims.read]
       end
 
       response '404', 'Supplemental Claim Evidence Submission not found' do

--- a/modules/appeals_api/spec/requests/higher_level_reviews/v0/higher_level_reviews_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/higher_level_reviews/v0/higher_level_reviews_controller_spec.rb
@@ -87,9 +87,10 @@ describe AppealsApi::HigherLevelReviews::V0::HigherLevelReviewsController, type:
 
     describe 'responses' do
       let(:created_hlr) { AppealsApi::HigherLevelReview.find(parsed_response['data']['id']) }
+      let(:scopes) { %w[system/HigherLevelReviews.write] }
 
       before do
-        with_openid_auth(described_class::OAUTH_SCOPES[:POST]) do |auth_header|
+        with_openid_auth(scopes) do |auth_header|
           post(path, params:, headers: headers.merge(auth_header))
         end
       end
@@ -151,6 +152,18 @@ describe AppealsApi::HigherLevelReviews::V0::HigherLevelReviewsController, type:
 
         it 'returns a 400 error' do
           expect(response).to have_http_status(:bad_request)
+        end
+      end
+
+      context "with a veteran token where the token's ICN doesn't match the submitted ICN" do
+        let(:scopes) { %w[veteran/HigherLevelReviews.write] }
+        let(:data) do
+          default_data['data']['attributes']['veteran']['icn'] = other_icn
+          default_data
+        end
+
+        it 'returns a 403 Forbidden error' do
+          expect(response).to have_http_status(:forbidden)
         end
       end
     end

--- a/modules/appeals_api/spec/requests/notice_of_disagreements/v0/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/notice_of_disagreements/v0/notice_of_disagreements_controller_spec.rb
@@ -12,7 +12,6 @@ describe AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController,
   let(:default_data) { fixture_as_json 'notice_of_disagreements/v0/valid_10182.json' }
   let(:min_data) { fixture_as_json 'notice_of_disagreements/v0/valid_10182_minimum.json' }
   let(:max_data) { fixture_as_json 'notice_of_disagreements/v0/valid_10182_extra.json' }
-  let(:other_icn) { '1111111111V111111' }
   let(:parsed_response) { JSON.parse(response.body) }
   let(:other_icn) { '1111111111V111111' }
 

--- a/modules/appeals_api/spec/requests/supplemental_claims/v0/supplemental_claims_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/supplemental_claims/v0/supplemental_claims_controller_spec.rb
@@ -87,10 +87,11 @@ describe AppealsApi::SupplementalClaims::V0::SupplementalClaimsController, type:
 
     describe 'responses' do
       let(:created_supplemental_claim) { AppealsApi::SupplementalClaim.find(json_body.dig('data', 'id')) }
+      let(:scopes) { %w[system/SupplementalClaims.write] }
       let(:json_body) { JSON.parse(response.body) }
 
       before do
-        with_openid_auth(described_class::OAUTH_SCOPES[:POST]) do |auth_header|
+        with_openid_auth(scopes) do |auth_header|
           post(path, params:, headers: headers.merge(auth_header))
         end
       end
@@ -152,6 +153,18 @@ describe AppealsApi::SupplementalClaims::V0::SupplementalClaimsController, type:
 
         it 'returns a 400 error' do
           expect(response).to have_http_status(:bad_request)
+        end
+      end
+
+      context "with a veteran token where the token's ICN doesn't match the submitted ICN" do
+        let(:scopes) { %w[veteran/SupplementalClaims.write] }
+        let(:data) do
+          default_data['data']['attributes']['veteran']['icn'] = other_icn
+          default_data
+        end
+
+        it 'returns a 403 Forbidden error' do
+          expect(response).to have_http_status(:forbidden)
         end
       end
     end


### PR DESCRIPTION
## Summary

- This validates the ICN in the request's OAuth token for the following endpoints:
  - `create` for Higher-Level Reviews v0
  - `create` for Notice of Disagreements v0
  - `create` for Supplemental Claims v0
  - `create` for Notice of Disagreements v0 Evidence Submissions
  - `create` for Supplemental Claims v0 Evidence Submissions
  - `get` for Notice of Disagreements v0 Evidence Submissions (forgot this in my last few PRs for GET endpoints)
  - `get` for Supplemental Claims v0 Evidence Submissions (forgot this in my last few PRs for GET endpoints)
- These requests will now return a 403 error when a user with a veteran-scoped OAuth token tries to access records belonging to another Veteran.

## Related issue(s)

- [API-32629](https://jira.devops.va.gov/browse/API-32629)

## Testing done

- [X] *New code is covered by unit tests*

## What areas of the site does it impact?
- v0 HLR, NOD, and SC APIs (not yet in prod)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
