### PR TITLE
71883 correction

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -58,7 +58,6 @@ module DebtsApi
       facility_form = remove_form_delimiters(facility_form)
       combined_adjustments(facility_form)
       streamline_adjustments(facility_form)
-      set_certification_date(facility_form)
       facility_form
     end
 


### PR DESCRIPTION
## Summary
Writing `veteranDateSigned` as a timestamp rather than a date string is causing problems down stream.

## Testing done

- Specs green

## What areas of the site does it impact?
VHA FSR submissions

## Acceptance criteria
- We are able to successfully submit VHA FSRs


