### PR TITLE
71784 - Add response when ezr_async is enabled

### DIFF
--- a/lib/form1010_ezr/service.rb
+++ b/lib/form1010_ezr/service.rb
@@ -20,8 +20,6 @@ module Form1010Ezr
 
     FORM_ID = '10-10EZR'
 
-    attr_accessor :success_response
-
     # @param [Object] user
     def initialize(user)
       super()
@@ -34,7 +32,7 @@ module Form1010Ezr
         HealthCareApplication.get_user_identifier(@user)
       )
 
-      { success: true, formSubmissionId: '', timestamp: Time.now.getlocal.to_s }
+      { success: true, formSubmissionId: nil, timestamp: nil }
     end
 
     def submit_sync(parsed_form)

--- a/lib/form1010_ezr/service.rb
+++ b/lib/form1010_ezr/service.rb
@@ -20,6 +20,8 @@ module Form1010Ezr
 
     FORM_ID = '10-10EZR'
 
+    attr_accessor :success_response
+
     # @param [Object] user
     def initialize(user)
       super()
@@ -31,6 +33,8 @@ module Form1010Ezr
         HealthCareApplication::LOCKBOX.encrypt(parsed_form.to_json),
         HealthCareApplication.get_user_identifier(@user)
       )
+
+      { success: true, formSubmissionId: '', timestamp: Time.now.getlocal.to_s }
     end
 
     def submit_sync(parsed_form)
@@ -57,6 +61,7 @@ module Form1010Ezr
     # @param [HashWithIndifferentAccess] parsed_form JSON form data
     def submit_form(parsed_form)
       parsed_form = configure_and_validate_form(parsed_form)
+
       if Flipper.enabled?(:ezr_async, @user)
         submit_async(parsed_form)
       else

--- a/spec/requests/form1010_ezrs_request_spec.rb
+++ b/spec/requests/form1010_ezrs_request_spec.rb
@@ -140,24 +140,20 @@ RSpec.describe 'Form1010 Ezrs', type: :request do
           end
           let(:body) do
             {
-              'formSubmissionId' => '',
-              'timestamp' => Time.now.getlocal.to_s,
+              'formSubmissionId' => nil,
+              'timestamp' => nil,
               'success' => true
             }
           end
 
-          it 'renders a successful response and deletes the saved form', run_at: 'Tue, 21 Nov 2023 20:42:44 GMT' do
+          it 'renders a successful response and deletes the saved form' do
             VCR.use_cassette(
               'form1010_ezr/authorized_submit_async',
               { match_requests_on: %i[method uri body], erb: true }
             ) do
-              # # The required fields for the Enrollment System should be absent from the form data initially
-              # # and then added via the 'post_fill_required_fields' method
-              # expect(params[:form].to_json['isEssentialAcaCoverage']).to eq(nil)
-              # expect(params[:form].to_json['vaMedicalFacility']).to eq(nil)
-              # expect_any_instance_of(ApplicationController).to receive(:clear_saved_form).with('10-10EZR').once
-              # subject
-              # expect(JSON.parse(response.body)).to eq(body)
+              expect_any_instance_of(ApplicationController).to receive(:clear_saved_form).with('10-10EZR').once
+              subject
+              expect(JSON.parse(response.body)).to eq(body)
             end
           end
         end

--- a/spec/requests/form1010_ezrs_request_spec.rb
+++ b/spec/requests/form1010_ezrs_request_spec.rb
@@ -129,6 +129,38 @@ RSpec.describe 'Form1010 Ezrs', type: :request do
             end
           end
         end
+
+        context 'when ezr_async is on' do
+          before do
+            Flipper.enable(:ezr_async)
+          end
+
+          let(:params) do
+            { form: }
+          end
+          let(:body) do
+            {
+              'formSubmissionId' => '',
+              'timestamp' => Time.now.getlocal.to_s,
+              'success' => true
+            }
+          end
+
+          it 'renders a successful response and deletes the saved form', run_at: 'Tue, 21 Nov 2023 20:42:44 GMT' do
+            VCR.use_cassette(
+              'form1010_ezr/authorized_submit_async',
+              { match_requests_on: %i[method uri body], erb: true }
+            ) do
+              # # The required fields for the Enrollment System should be absent from the form data initially
+              # # and then added via the 'post_fill_required_fields' method
+              # expect(params[:form].to_json['isEssentialAcaCoverage']).to eq(nil)
+              # expect(params[:form].to_json['vaMedicalFacility']).to eq(nil)
+              # expect_any_instance_of(ApplicationController).to receive(:clear_saved_form).with('10-10EZR').once
+              # subject
+              # expect(JSON.parse(response.body)).to eq(body)
+            end
+          end
+        end
       end
 
       context 'when an error occurs' do

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_async.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_async.yml
@@ -1,0 +1,133 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: <%= Settings.hca.ee.endpoint %>
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sch="http://jaxws.webservices.esr.med.va.gov/schemas">
+          <SOAP-ENV:Header>
+            <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustUnderstand="1">
+              <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="XWSSGID-1281117217796-43574433">
+                <wsse:Username>HCASvcUsr</wsse:Username>
+                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"><EE_PASS></wsse:Password>
+              </wsse:UsernameToken>
+            </wsse:Security>
+          </SOAP-ENV:Header>
+          <SOAP-ENV:Body>
+            <sch:getEESummaryRequest>
+              <sch:key>1013032368V065534</sch:key>
+              <sch:requestName>HCAData</sch:requestName>
+            </sch:getEESummaryRequest>
+          </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Date:
+      - Thu, 01 Feb 2024 20:53:43 GMT
+      Content-Length:
+      - '975'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Feb 2024 20:53:43 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
+      Content-Length:
+      - '12607'
+      Accept:
+      - text/xml
+      X-Oracle-Dms-Rid:
+      - '0'
+      X-Oracle-Dms-Ecid:
+      - 1a6a995c-aa91-4eca-b07c-bf0e9271cc9c-0007a256
+      Soapaction:
+      - '""'
+      X-Oneagent-Js-Injection:
+      - 'true'
+      Ssl-Env:
+      - 'On'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - max-age=0, no-store
+      Server-Timing:
+      - dtSInfo;desc="0", dtRpid;desc="-522265326"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
+        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
+        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>Part
+        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
+        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
+        Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
+        IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
+        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Pre-Certification
+        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
+        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
+        CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
+        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
+        for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
+        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
+        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
+        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
+        Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
+        condition</disability><percentage>60</percentage><diagnosticExtremity>Both
+        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2023-12-22T11:23:42.000-06:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
+        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
+        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>742
+        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>988
+        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
+        M ST</line1><city>CO SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
+        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
+        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>123
+        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-27T12:59:14.000-06:00</addressChangeDateTime><addressChangeSource>Health
+        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
+        CENTER</addressChangeSite></address><address><line1>7321 SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2023-12-22T11:23:42.000-06:00</addressChangeDateTime><addressChangeSource>Health
+        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
+        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2023-12-22T11:23:42.000-06:00</contactMethodReportDate></address></addresses><phones><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2023-12-22T11:23:42.000-06:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
+        - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
+        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate><preferredLanguage>eng
+        - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:32:19.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-02-01T14:53:43</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
+  recorded_at: Thu, 01 Feb 2024 20:53:43 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

The `#submit_async` method was simply returning the unique job id from sidekiq, but the frontend was expecting a json response.  We instead now return a json object that the platform forms system will have no issue with.  

## Related issue(s)

[https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/71784](https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/71784)

## Testing done

- manual and automated
- will test on staging after enabling the `ezr_async` flag.

## What areas of the site does it impact?

This impacts EZR submissions when the `ezr_async` flag is enabled
