### PR TITLE
Remove Central Lighthouse Flipper for Benefits

### DIFF
--- a/app/sidekiq/central_mail/submit_central_form686c_job.rb
+++ b/app/sidekiq/central_mail/submit_central_form686c_job.rb
@@ -92,7 +92,6 @@ module CentralMail
       attachment_paths.each { |p| Common::FileHelpers.delete_file_if_exists(p) }
     end
 
-    # rubocop:disable Metrics/MethodLength #Temporary disable until flipper removed
     def check_success(response, saved_claim_id, user_struct)
       if response.success?
         Rails.logger.info('CentralMail::SubmitCentralForm686cJob succeeded!',
@@ -105,8 +104,6 @@ module CentralMail
         raise CentralMailResponseError
       end
     end
-
-    # rubocop:enable Metrics/MethodLength
 
     def create_request_body
       body = {

--- a/app/sidekiq/central_mail/submit_central_form686c_job.rb
+++ b/app/sidekiq/central_mail/submit_central_form686c_job.rb
@@ -35,8 +35,7 @@ module CentralMail
       claim.add_veteran_info(vet_info)
 
       get_files_from_claim
-      use_lighthouse = Flipper.enabled?(:dependents_central_submission_lighthouse)
-      result = use_lighthouse ? upload_to_lh : CentralMail::Service.new.upload(create_request_body)
+      result = upload_to_lh
       check_success(result, saved_claim_id, user_struct)
     rescue => e
       # if we fail, update the associated central mail record to failed and send the user the failure email
@@ -95,26 +94,14 @@ module CentralMail
 
     # rubocop:disable Metrics/MethodLength #Temporary disable until flipper removed
     def check_success(response, saved_claim_id, user_struct)
-      if Flipper.enabled?(:dependents_central_submission_lighthouse)
-        if response.success?
-          Rails.logger.info('CentralMail::SubmitCentralForm686cJob succeeded!',
-                            { user_uuid: user_struct['uuid'], saved_claim_id:, icn: user_struct['icn'] })
-          update_submission('success')
-          send_confirmation_email(OpenStruct.new(user_struct))
-        else
-          Rails.logger.info('CentralMail::SubmitCentralForm686cJob Unsuccessful',
-                            { response: response['message'].presence || response['errors'] })
-          raise CentralMailResponseError
-        end
-      elsif response.success?
+      if response.success?
         Rails.logger.info('CentralMail::SubmitCentralForm686cJob succeeded!',
-                          { user_uuid: user_struct['uuid'], saved_claim_id:, icn: user_struct['icn'],
-                            centralmail_uuid: extract_uuid_from_central_mail_message(response) })
+                          { user_uuid: user_struct['uuid'], saved_claim_id:, icn: user_struct['icn'] })
         update_submission('success')
         send_confirmation_email(OpenStruct.new(user_struct))
       else
         Rails.logger.info('CentralMail::SubmitCentralForm686cJob Unsuccessful',
-                          { response: response.body })
+                          { response: response['message'].presence || response['errors'] })
         raise CentralMailResponseError
       end
     end

--- a/config/features.yml
+++ b/config/features.yml
@@ -335,10 +335,6 @@ features:
     actor_type: user
     description: Manage dependent removal from view dependent page
     enable_in_development: true
-  dependents_central_submission_lighthouse:
-    actor_type: user
-    description: Manage whether central processing submission uses Lighthouse API
-    enable_in_development: true
   disability_526_classifier_new_claims:
     actor_type: user
     description: enables sending new 526-ez claims to VRO Contention Classification service for more accurate classification entry.

--- a/spec/sidekiq/central_mail/submit_central_form686c_job_spec.rb
+++ b/spec/sidekiq/central_mail/submit_central_form686c_job_spec.rb
@@ -51,176 +51,89 @@ RSpec.describe CentralMail::SubmitCentralForm686cJob, uploader_helpers: true do
     let(:success) { true }
     let(:path) { 'tmp/pdf_path' }
 
-    context 'with lighthouse flipper disabled' do
-      before do
-        Flipper.disable(:dependents_central_submission_lighthouse)
-        datestamp_double1 = double
-        datestamp_double2 = double
-        datestamp_double3 = double
-        timestamp = claim.created_at
-        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-        expect(claim).to receive(:to_pdf).and_return('path1')
-        expect(CentralMail::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)
-        expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5, timestamp:).and_return('path2')
-        expect(CentralMail::DatestampPdf).to receive(:new).with('path2').and_return(datestamp_double2)
-        expect(datestamp_double2).to receive(:run).with(
-          text: 'FDC Reviewed - va.gov Submission',
-          x: 400,
-          y: 770,
-          text_only: true
-        ).and_return('path3')
-        expect(CentralMail::DatestampPdf).to receive(:new).with('path3').and_return(datestamp_double3)
-        expect(datestamp_double3).to receive(:run).with(
-          text: 'Application Submitted on va.gov',
-          x: 400,
-          y: 675,
-          text_only: true,
-          timestamp:,
-          page_number: 6,
-          template: 'lib/pdf_fill/forms/pdfs/686C-674.pdf',
-          multistamp: true
-        ).and_return(path)
-        expect(Digest::SHA256).to receive(:file).with(path).and_return(
-          OpenStruct.new(hexdigest: 'hexdigest')
-        )
-        expect(PdfInfo::Metadata).to receive(:read).with(path).and_return(
-          OpenStruct.new(pages: 2)
-        )
-        expect(Faraday::UploadIO).to receive(:new).with(
-          path,
-          'application/pdf'
-        ).and_return('faraday1')
+    let(:lighthouse_mock) { double(:lighthouse_service) }
 
-        # subject.to_faraday_upload(file_path)
+    before do
+      expect(BenefitsIntakeService::Service).to receive(:new)
+        .with(with_upload_location: true)
+        .and_return(lighthouse_mock)
+      expect(lighthouse_mock).to receive(:uuid).and_return('uuid')
+      datestamp_double1 = double
+      datestamp_double2 = double
+      datestamp_double3 = double
+      timestamp = claim.created_at
 
-        body = 'Request was received successfully  [uuid: 0e95811d-55a9-4fb9-bc39-045e27b2c106]'
-        expect_any_instance_of(CentralMail::Service).to receive(:upload).with(
-          'metadata' => instance_of(String),
-          'document' => 'faraday1'
-        ).and_return(OpenStruct.new(success?: success, body:))
+      expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
+      expect(claim).to receive(:to_pdf).and_return('path1')
+      expect(CentralMail::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)
+      expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5, timestamp:).and_return('path2')
+      expect(CentralMail::DatestampPdf).to receive(:new).with('path2').and_return(datestamp_double2)
+      expect(datestamp_double2).to receive(:run).with(
+        text: 'FDC Reviewed - va.gov Submission',
+        x: 400,
+        y: 770,
+        text_only: true
+      ).and_return('path3')
+      expect(CentralMail::DatestampPdf).to receive(:new).with('path3').and_return(datestamp_double3)
+      expect(datestamp_double3).to receive(:run).with(
+        text: 'Application Submitted on va.gov',
+        x: 400,
+        y: 675,
+        text_only: true,
+        timestamp:,
+        page_number: 6,
+        template: 'lib/pdf_fill/forms/pdfs/686C-674.pdf',
+        multistamp: true
+      ).and_return(path)
 
-        expect(Common::FileHelpers).to receive(:delete_file_if_exists).with(path)
-      end
+      data = JSON.parse('{"id":"6d8433c1-cd55-4c24-affd-f592287a7572","type":"document_upload"}')
+      expect(lighthouse_mock).to receive(:upload_form).with(
+        main_document: { file: path, file_name: 'pdf_path' },
+        attachments: [],
+        form_metadata: hash_including(file_number: '796104437')
+      ).and_return(OpenStruct.new(success?: success, data:))
 
-      context 'with an response error' do
-        let(:success) { false }
+      expect(Common::FileHelpers).to receive(:delete_file_if_exists).with(path)
 
-        it 'raises CentralMailResponseError and updates submission to failed' do
-          mailer_double = double('Mail::Message')
-          allow(mailer_double).to receive(:deliver_now)
-          expect(claim).to receive(:submittable_686?).and_return(true)
-          expect(claim).to receive(:submittable_674?).and_return(false)
-          expect(DependentsApplicationFailureMailer).to receive(:build).with(an_instance_of(OpenStruct)) {
-                                                          mailer_double
-                                                        }
-          expect { subject.perform(claim.id, encrypted_vet_info, encrypted_user_struct) }.to raise_error(CentralMail::SubmitCentralForm686cJob::CentralMailResponseError) # rubocop:disable Layout/LineLength
+      expect(FormSubmission).to receive(:create).with(
+        form_type: '686C-674',
+        benefits_intake_uuid: 'uuid',
+        saved_claim: claim,
+        user_account: nil
+      ).and_return(FormSubmission.new)
+      expect(FormSubmissionAttempt).to receive(:create).with(form_submission: an_instance_of(FormSubmission))
+    end
 
-          expect(central_mail_submission.reload.state).to eq('failed')
-        end
-      end
+    context 'with an response error' do
+      let(:success) { false }
 
-      it 'submits the saved claim and updates submission to success' do
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user_struct.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'MARK'
-          }
-        )
-        expect(claim).to receive(:submittable_686?).and_return(true)
+      it 'raises CentralMailResponseError and updates submission to failed' do
+        mailer_double = double('Mail::Message')
+        allow(mailer_double).to receive(:deliver_now)
+        expect(claim).to receive(:submittable_686?).and_return(true).exactly(:twice)
         expect(claim).to receive(:submittable_674?).and_return(false)
-        subject.perform(claim.id, encrypted_vet_info, encrypted_user_struct)
-        expect(central_mail_submission.reload.state).to eq('success')
+        expect(DependentsApplicationFailureMailer).to receive(:build).with(an_instance_of(OpenStruct)) {
+                                                        mailer_double
+                                                      }
+        expect { subject.perform(claim.id, encrypted_vet_info, encrypted_user_struct) }.to raise_error(CentralMail::SubmitCentralForm686cJob::CentralMailResponseError) # rubocop:disable Layout/LineLength
+
+        expect(central_mail_submission.reload.state).to eq('failed')
       end
     end
 
-    context 'with lighthouse flipper enabled' do
-      let(:lighthouse_mock) { double(:lighthouse_service) }
-
-      before do
-        Flipper.enable(:dependents_central_submission_lighthouse)
-        expect(BenefitsIntakeService::Service).to receive(:new)
-          .with(with_upload_location: true)
-          .and_return(lighthouse_mock)
-        expect(lighthouse_mock).to receive(:uuid).and_return('uuid')
-        datestamp_double1 = double
-        datestamp_double2 = double
-        datestamp_double3 = double
-        timestamp = claim.created_at
-
-        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-        expect(claim).to receive(:to_pdf).and_return('path1')
-        expect(CentralMail::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)
-        expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5, timestamp:).and_return('path2')
-        expect(CentralMail::DatestampPdf).to receive(:new).with('path2').and_return(datestamp_double2)
-        expect(datestamp_double2).to receive(:run).with(
-          text: 'FDC Reviewed - va.gov Submission',
-          x: 400,
-          y: 770,
-          text_only: true
-        ).and_return('path3')
-        expect(CentralMail::DatestampPdf).to receive(:new).with('path3').and_return(datestamp_double3)
-        expect(datestamp_double3).to receive(:run).with(
-          text: 'Application Submitted on va.gov',
-          x: 400,
-          y: 675,
-          text_only: true,
-          timestamp:,
-          page_number: 6,
-          template: 'lib/pdf_fill/forms/pdfs/686C-674.pdf',
-          multistamp: true
-        ).and_return(path)
-
-        data = JSON.parse('{"id":"6d8433c1-cd55-4c24-affd-f592287a7572","type":"document_upload"}')
-        expect(lighthouse_mock).to receive(:upload_form).with(
-          main_document: { file: path, file_name: 'pdf_path' },
-          attachments: [],
-          form_metadata: hash_including(file_number: '796104437')
-        ).and_return(OpenStruct.new(success?: success, data:))
-
-        expect(Common::FileHelpers).to receive(:delete_file_if_exists).with(path)
-
-        expect(FormSubmission).to receive(:create).with(
-          form_type: '686C-674',
-          benefits_intake_uuid: 'uuid',
-          saved_claim: claim,
-          user_account: nil
-        ).and_return(FormSubmission.new)
-        expect(FormSubmissionAttempt).to receive(:create).with(form_submission: an_instance_of(FormSubmission))
-      end
-
-      context 'with an response error' do
-        let(:success) { false }
-
-        it 'raises CentralMailResponseError and updates submission to failed' do
-          mailer_double = double('Mail::Message')
-          allow(mailer_double).to receive(:deliver_now)
-          expect(claim).to receive(:submittable_686?).and_return(true).exactly(:twice)
-          expect(claim).to receive(:submittable_674?).and_return(false)
-          expect(DependentsApplicationFailureMailer).to receive(:build).with(an_instance_of(OpenStruct)) {
-                                                          mailer_double
-                                                        }
-          expect { subject.perform(claim.id, encrypted_vet_info, encrypted_user_struct) }.to raise_error(CentralMail::SubmitCentralForm686cJob::CentralMailResponseError) # rubocop:disable Layout/LineLength
-
-          expect(central_mail_submission.reload.state).to eq('failed')
-        end
-      end
-
-      it 'submits the saved claim and updates submission to success' do
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user_struct.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'MARK'
-          }
-        )
-        expect(claim).to receive(:submittable_686?).and_return(true).exactly(:twice)
-        expect(claim).to receive(:submittable_674?).and_return(false)
-        subject.perform(claim.id, encrypted_vet_info, encrypted_user_struct)
-        expect(central_mail_submission.reload.state).to eq('success')
-      end
+    it 'submits the saved claim and updates submission to success' do
+      expect(VANotify::EmailJob).to receive(:perform_async).with(
+        user_struct.va_profile_email,
+        'fake_template_id',
+        {
+          'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
+          'first_name' => 'MARK'
+        }
+      )
+      expect(claim).to receive(:submittable_686?).and_return(true).exactly(:twice)
+      expect(claim).to receive(:submittable_674?).and_return(false)
+      subject.perform(claim.id, encrypted_vet_info, encrypted_user_struct)
+      expect(central_mail_submission.reload.state).to eq('success')
     end
   end
 


### PR DESCRIPTION
## Summary
- Remove flipper `dependents_central_submission_lighthouse`  and keep logic from flipper
- Files changed best viewed with "hide whitespace" enabled

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/67518

## Testing done
- Unit tests ran
- This should be tested in staging environment due to lighthouse submission not possible locally

## What areas of the site does it impact?
Lighthouse submission is now permanent for benefits submissions

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  ~Documentation has been updated (link to documentation)~
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  ~Feature/bug has a monitor built into Datadog or Grafana (if applicable)~
- [x]  ~If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected~
- [x]  ~I added a screenshot of the developed feature~