### PR TITLE
75189 change validation for vaMedicalFacility

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -267,4 +267,28 @@ class HealthCareApplication < ApplicationRecord
   def send_failure_mail
     HCASubmissionFailureMailer.build(parsed_form['email'], google_analytics_client_id).deliver_now
   end
+
+  # If the hca_use_facilities_API flag is on then vaMedicalFacility will only
+  # validate for a string, else it will validate through the enum.  This avoids
+  # changes to vets-website and vets-json-schema having to deploy simultaneously.
+  def form_matches_schema
+    if form.present?
+      JSON::Validator.fully_validate(current_schema, parsed_form).each do |v|
+        errors.add(:form, v.to_s)
+      end
+    end
+  end
+
+  def current_schema
+    @current_schema ||= begin
+      schema = VetsJsonSchema::SCHEMAS[self.class::FORM_ID]
+      if Flipper.enabled?(:hca_use_facilities_API)
+        schema
+      else
+        schema.deep_dup.tap do |c|
+          c['properties']['vaMedicalFacility'] = { type: 'string' }.as_json
+        end
+      end
+    end
+  end
 end

--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -283,11 +283,11 @@ class HealthCareApplication < ApplicationRecord
     @current_schema ||= begin
       schema = VetsJsonSchema::SCHEMAS[self.class::FORM_ID]
       if Flipper.enabled?(:hca_use_facilities_API)
-        schema
-      else
         schema.deep_dup.tap do |c|
           c['properties']['vaMedicalFacility'] = { type: 'string' }.as_json
         end
+      else
+        schema
       end
     end
   end

--- a/spec/requests/health_care_applications_request_spec.rb
+++ b/spec/requests/health_care_applications_request_spec.rb
@@ -408,6 +408,32 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
           end
         end
       end
+
+      context 'with hca_use_facilities_API enabled' do
+        before do
+          Flipper.enable(:hca_use_facilities_API)
+        end
+
+        let(:params) do
+          test_veteran['vaMedicalFacility'] = '000'
+          {
+            form: test_veteran.to_json
+          }
+        end
+
+        let(:body) do
+          {
+            'formSubmissionId' => nil,
+            'timestamp' => nil,
+            'state' => 'pending'
+          }
+        end
+
+        it 'does not error on vaMedicalFacility validation' do
+          subject
+          expect(JSON.parse(response.body)['data']['attributes']).to eq(body)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Currently, vets-json-schema has `vaMedicalFacility` as an enum type.  This causes issues on validations if the Frontend 
is using Lighthouse as there are more facilities in that list than in the enum.  The update here solves the issue while we 
remove the code from vets-website and vets-json-schema.  

## Related issue(s)

[https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/75189](https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/75189)

## Testing done

- manual and automated

## What areas of the site does it impact?

- 1010EZ submissions where `hca_use_facilities_API` is enabled.
