### PR TITLE
bump crack to 0.4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,8 @@ GEM
       colored2 (~> 3.1)
     coverband (6.0.2)
       redis (>= 3.0)
-    crack (0.4.5)
+    crack (0.4.6)
+      bigdecimal
       rexml
     crass (1.0.6)
     danger (9.4.2)


### PR DESCRIPTION
## Summary

- Bump [crack](https://rubygems.org/gems/crack) to 0.4.6
  - The newer version supports Ruby 3
  - This is a dependency of [webmock](https://rubygems.org/gems/webmock)

## Related issue(s)

- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/75286](https://github.com/department-of-veterans-affairs/va.gov-team/issues/75286)

## Testing done

- Local full-suite testing

## What areas of the site does it impact?

Webmock is only used in development and test Rails environment.

## Acceptance criteria

- [x]  Bump crack to 0.4.6
- [x]  Tests pass
