### PR TITLE
Feature flag cleanup: post_911_gibill_statuses_new_error_handling

### DIFF
--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -47,16 +47,11 @@ module V0
         # 403
         raise Common::Exceptions::UnexpectedForbidden, detail: 'Missing correlation id'
       else
-        if Flipper.enabled?(:post_911_gibill_statuses_new_error_handling, @current_user)
-          error_message = 'An unknown error occurred. ' \
-                          "Response error type: #{response.error_type}, " \
-                          "status: #{response.status}, body: #{response.body}"
-          standard_error = StandardError.new(error_message)
-          raise Common::Exceptions::InternalServerError, standard_error
-        else
-          # 500
-          raise Common::Exceptions::InternalServerError
-        end
+        error_message = 'An unknown error occurred. ' \
+                        "Response error type: #{response.error_type}, " \
+                        "status: #{response.status}, body: #{response.body}"
+        standard_error = StandardError.new(error_message)
+        raise Common::Exceptions::InternalServerError, standard_error
       end
     end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -740,10 +740,6 @@ features:
     description: When enabled, will allow display of PDF cert warnings in find-a-form
     actor_type: user
     enable_in_development: true
-  post_911_gibill_statuses_new_error_handling:
-    actor_type: user
-    description: When enabled, create a StandardError to catch unknown errors VA-IIR-285
-    enable_in_development: true
   pre_entry_covid19_screener:
     actor_type: user
     description: >


### PR DESCRIPTION
This PR is to remove the feature flag added in this [PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15075) (fix a bug where an exception was raised without passing a required argument).

The parent ticket was part of the work to resolve [this issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/65182) to resolve unknown errors in the Post911GIBillStatus API.

This functionality is now working, and we now have helpful errors which can be used to spin up new issues or enhancements.


**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): YES/NO* - This ticket is to remove a feature flag
- *(Summarize the changes that have been made to the platform)* - default functionality will now be to not include `@response` instance variable when `inspect`ing the response object.  Previously this leaked PII
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)* N/A
- *(Which team do you work for, does your team own the maintenance of this component?)* VA-IIR, we do own this project currently
- *(If introducing a flipper, what is the success criteria being targeted?)* Deemed to be successful as now we no longer have unknown errors in logs, and can begin to address the underlying issues

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira* 
- *Link to previous change of the code/bug (if applicable)* 
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests* unit tests updated
- *Describe what the old behavior was prior to the change* depending on the state of the feature flag, the `inspect` method on the response object will display PII in the console/logs
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing* Verified that new entries in Sentry/Datadog no longer include PII
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
