### PR TITLE
Preferred name spaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -594,6 +594,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-darwin)
+      ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     liquid (5.4.0)
@@ -1050,6 +1052,7 @@ PLATFORMS
   x64-mingw32
   x86-mingw32
   x86-mswin32
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/va_profile/models/preferred_name.rb
+++ b/lib/va_profile/models/preferred_name.rb
@@ -7,17 +7,18 @@ require 'va_profile/concerns/defaultable'
 module VAProfile
   module Models
     class PreferredName < Base
-      include VAProfile::Concerns::Defaultable
+      include ActiveModel::Validations::Callbacks
+      include VAProfile::Concerns::Defaultable      
 
       attribute :text, String
       attribute :source_system_user, String
       attribute :source_date, Common::ISO8601Time
 
+      before_validation :strip_blanks
       validates :text, presence: true
       validates :text, length: { maximum: 25 }
-      validates :text, format: { without: /\s/, message: 'must not contain spaces' }
-      validates :text, format: { with: /\A[a-zA-ZÀ-ÖØ-öø-ÿ\-áéíóúäëïöüâêîôûãñõ]+\z/,
-                                 message: 'must only contain alpha, -, acute, grave, diaeresis, circumflex, tilde' }
+      validates :text, format: { with: /\A[a-zA-ZÀ-ÖØ-öø-ÿ\-áéíóúäëïöüâêîôûãñõ\s]+\z/,
+                                 message: 'must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde' }
 
       # Converts an instance of the PreferredName model to a JSON encoded string suitable for
       # use in the body of a request to VAProfile
@@ -44,6 +45,12 @@ module VAProfile
         VAProfile::Models::PreferredName.new(
           text: body['preferred_name']
         )
+      end
+
+      protected
+
+      def strip_blanks
+        self.text = self.text.strip if self.text
       end
     end
   end

--- a/lib/va_profile/models/preferred_name.rb
+++ b/lib/va_profile/models/preferred_name.rb
@@ -8,7 +8,7 @@ module VAProfile
   module Models
     class PreferredName < Base
       include ActiveModel::Validations::Callbacks
-      include VAProfile::Concerns::Defaultable      
+      include VAProfile::Concerns::Defaultable
 
       attribute :text, String
       attribute :source_system_user, String
@@ -17,8 +17,10 @@ module VAProfile
       before_validation :strip_blanks
       validates :text, presence: true
       validates :text, length: { maximum: 25 }
-      validates :text, format: { with: /\A[a-zA-ZÀ-ÖØ-öø-ÿ\-áéíóúäëïöüâêîôûãñõ\s]+\z/,
-                                 message: 'must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde' }
+      validates :text, format: {
+        with: /\A[a-zA-ZÀ-ÖØ-öø-ÿ\-áéíóúäëïöüâêîôûãñõ\s]+\z/,
+        message: 'must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde'
+      }
 
       # Converts an instance of the PreferredName model to a JSON encoded string suitable for
       # use in the body of a request to VAProfile
@@ -50,7 +52,7 @@ module VAProfile
       protected
 
       def strip_blanks
-        self.text = self.text.strip if self.text
+        self.text = text.strip if text
       end
     end
   end

--- a/spec/lib/va_profile/models/preferred_name_spec.rb
+++ b/spec/lib/va_profile/models/preferred_name_spec.rb
@@ -75,7 +75,9 @@ describe VAProfile::Models::PreferredName do
     it 'when text contains a digit' do
       model.text = 'mrrobot1'
       expect(model.valid?).to be(false)
-      expect(model.errors[:text]).to include('must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde')
+      expect(model.errors[:text]).to include(
+        'must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde'
+      )
     end
 
     it 'when text contains a special character' do
@@ -83,7 +85,9 @@ describe VAProfile::Models::PreferredName do
       special_chars.each do |special_char|
         model.text = special_char
         expect(model.valid?).to be(false)
-        expect(model.errors[:text]).to include('must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde')
+        expect(model.errors[:text]).to include(
+          'must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde'
+        )
       end
     end
   end

--- a/spec/lib/va_profile/models/preferred_name_spec.rb
+++ b/spec/lib/va_profile/models/preferred_name_spec.rb
@@ -49,19 +49,21 @@ describe VAProfile::Models::PreferredName do
       model.valid?
       expect(model).to be_valid
     end
+
+    it 'when text contains a space' do
+      model.text = 'mr robot'
+      model.valid?
+      expect(model).to be_valid
+    end
   end
 
   context 'is invalid' do
     it 'when blank' do
-      model.text = nil
-      expect(model.valid?).to be(false)
-      expect(model.errors[:text]).to include("can't be blank")
-    end
-
-    it 'when text contains a space' do
-      model.text = 'mr robot'
-      expect(model.valid?).to be(false)
-      expect(model.errors[:text]).to include('must not contain spaces')
+      ['', ' ', nil].each do |entry|
+        model.text = entry
+        expect(model.valid?).to be(false)
+        expect(model.errors[:text]).to include("can't be blank")
+      end
     end
 
     it 'when text length is over 25' do
@@ -73,7 +75,7 @@ describe VAProfile::Models::PreferredName do
     it 'when text contains a digit' do
       model.text = 'mrrobot1'
       expect(model.valid?).to be(false)
-      expect(model.errors[:text]).to include('must only contain alpha, -, acute, grave, diaeresis, circumflex, tilde')
+      expect(model.errors[:text]).to include('must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde')
     end
 
     it 'when text contains a special character' do
@@ -81,8 +83,26 @@ describe VAProfile::Models::PreferredName do
       special_chars.each do |special_char|
         model.text = special_char
         expect(model.valid?).to be(false)
-        expect(model.errors[:text]).to include('must only contain alpha, -, acute, grave, diaeresis, circumflex, tilde')
+        expect(model.errors[:text]).to include('must only contain alpha, -, space, acute, grave, diaeresis, circumflex, tilde')
       end
+    end
+  end
+
+  context 'removes spaces' do
+    it 'when leading' do
+      model.text = ' mr robot'
+      model.valid?
+
+      expect(model.text).to eq('mr robot')
+      expect(model).to be_valid
+    end
+
+    it 'when trailing' do
+      model.text = 'mr robot '
+      model.valid?
+
+      expect(model.text).to eq('mr robot')
+      expect(model).to be_valid
     end
   end
 end


### PR DESCRIPTION
## Summary
Updates validation rules for preferred name to allow empty spaces.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/71381