### PR TITLE
[CST] Workaround for EVSSClaimService with non-Veteran users

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -315,6 +315,17 @@ FactoryBot.define do
       ssn { '796043735' }
     end
 
+    factory :evss_non_veteran_user, traits: [:loa3] do
+      first_name { 'WESLEY' }
+      last_name { 'FORD' }
+      edipi { '1007697216' }
+      birls_id { nil }
+      participant_id { '600061742' }
+      last_signed_in { Time.zone.parse('2017-12-07T00:55:09Z') }
+      birth_date { '1986-05-06T00:00:00+00:00'.to_date.to_s }
+      ssn { '796043735' }
+    end
+
     factory :unauthorized_evss_user, traits: [:loa3] do
       first_name { 'WESLEY' }
       last_name { 'FORD' }


### PR DESCRIPTION
## Summary
EVSS has a requirement that the `va_eauth_birlsfilenumber` header must be present / not empty. This header is populated from the `birls_id` attribute of the `User` model. For non-Veteran users, we suspect that the `birls_id` attribute is always nil which presents us with an issue where we cannot satisfy the "not empty" part of their requirement for the `va_eauth_birlsfilenumber` header. EVSS suggested that we pass the SSN instead to see if that would work

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/75033

## Testing done
Added specs to verify that the correct code paths are reached and that logs are being generated as expected

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
