### PR TITLE
Skipping verify_authenticity_token in flag_a_representative

### DIFF
--- a/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
@@ -4,6 +4,7 @@ module Veteran
   module V0
     class FlagAccreditedRepresentativesController < ApplicationController
       service_tag 'lighthouse-veteran'
+      skip_before_action :verify_authenticity_token
       skip_before_action :authenticate
       before_action :feature_enabled
 


### PR DESCRIPTION
## Summary
Submitting a POST request to the flag_a_representative endpoint is returning a "Invalid Authenticity Token" 403 error in staging. Skipping verify_authenticity_token circumvents the issue locally. This change is temporary to confirm the controller is otherwise functional in staging.

- *This work is behind a feature toggle (flipper): YES*

To reproduce:
- Navigate to https://staging.va.gov/get-help-from-accredited-representative/find-rep/?address=43210&lat=40.001856&long=-83.014775&page=1&perPage=10&sort=distance_asc&type=veteran_service_officer&name
- Click the "Report outdated information" button on any of the search result card components
- This should trigger a modal with checkbox options. Select any option and click "Submit"
- Results in a 403

TEAM: Accredited Representative Management

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Find a Representative staging instance. This app is not live in prod. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
