### PR TITLE
bump rgeo to 3.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -814,7 +814,7 @@ GEM
       jwt (>= 1.5.6)
     retriable (3.1.2)
     rexml (3.2.6)
-    rgeo (3.0.0)
+    rgeo (3.0.1)
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)
       rgeo (>= 1.0.0)


### PR DESCRIPTION
## Summary

- Bump [rgeo](https://rubygems.org/gems/rgeo) to 3.0.1
  - This is a dependency of [activerecord-postgis-adapter](https://rubygems.org/gems/activerecord-postgis-adapter)

## Related issue(s)

- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/75341](https://github.com/department-of-veterans-affairs/va.gov-team/issues/75341)

## Testing done

- Local full-suite testing

## Acceptance criteria

- [x]  Bump `rgeo` to 3.0.1
- [x]  Tests pass