### PR TITLE
bump http to 5.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,7 +629,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.21.2)
+    minitest (5.22.0)
     msgpack (1.7.2)
     msgpack (1.7.2-java)
     multi_json (1.15.0)
@@ -1127,6 +1127,7 @@ DEPENDENCIES
   gyoku
   health_quest!
   holidays
+  http (= 5.1.1)
   httpclient
   ice_nine
   income_limits!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,11 +546,12 @@ GEM
     hashery (2.1.2)
     hashie (5.0.0)
     holidays (8.7.1)
-    http (5.1.1)
+    http (5.2.0)
       addressable (~> 2.8)
+      base64 (~> 0.1)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.4.0)
+      llhttp-ffi (~> 0.5.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
@@ -603,7 +604,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    llhttp-ffi (0.4.0)
+    llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     lockbox (1.3.0)
@@ -1127,7 +1128,6 @@ DEPENDENCIES
   gyoku
   health_quest!
   holidays
-  http (= 5.1.1)
   httpclient
   ice_nine
   income_limits!


### PR DESCRIPTION
## Summary

- Bump [http](https://rubygems.org/gems/http) to 5.2.0
  - This is a dependency of [fhir_client](https://github.com/adhocteam/fhir_client)
- This also bumps `llhttp-ffi` to 0.5.0 and `minitest` to 5.22.0

## Related issue(s)

- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/75370](https://github.com/department-of-veterans-affairs/va.gov-team/issues/75370)

## Testing done

- Local full-suite testing

## Acceptance criteria

- [x]  Bump `http` to 5.2.0
- [x]  Tests pass
