### PR TITLE
API-33993-remove-icn-logging-from-v2 

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
@@ -95,8 +95,7 @@ module ClaimsApi
         elsif target_veteran&.mpi&.birls_id.present?
           @file_number = target_veteran&.birls_id || target_veteran&.mpi&.birls_id
         else
-          claims_v2_logging('missing_file_number', icn: nil,
-                                                   message: 'missing_file_number on request in application controller.')
+          claims_v2_logging('missing_file_number', message: 'missing_file_number on request in application controller.')
 
           raise ::Common::Exceptions::UnprocessableEntity.new(detail:
             "Unable to locate Veteran's 'File Number' in Master Person Index (MPI). " \
@@ -104,9 +103,8 @@ module ClaimsApi
         end
       end
 
-      def claims_v2_logging(tag = 'traceability', level: :info, message: nil, icn: target_veteran&.mpi&.icn)
+      def claims_v2_logging(tag = 'traceability', level: :info, message: nil)
         ClaimsApi::Logger.log(tag,
-                              icn:,
                               cid: token&.payload&.[]('cid'),
                               current_user: current_user&.uuid,
                               message:,


### PR DESCRIPTION
## Summary

- Removes ICN from the claims_v2_logging method.

## Related issue(s)

- [API-33993](https://jira.devops.va.gov/browse/API-33993)

## Testing done

- rspec
- Postman: ITF, POA, Claims, 526

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/application_controller.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature