### PR TITLE
POA v2: Add docs for 2122 submit endpoint

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -26,12 +26,8 @@ module ClaimsApi
 
         def submit2122
           shared_form_validation('2122')
-          poa_code = parse_and_validate_poa_code('2122')
-          unless poa_code_in_organization?(poa_code)
-            raise ::ClaimsApi::Common::Exceptions::Lighthouse::UnprocessableEntity.new(
-              detail: 'POA Code must belong to an organization.'
-            )
-          end
+          poa_code = get_poa_code('2122')
+          validate_org_poa_code!(poa_code)
 
           submit_power_of_attorney(poa_code, '2122')
         end
@@ -45,10 +41,8 @@ module ClaimsApi
         end
 
         def validate2122
-          target_veteran
-          validate_json_schema
-
-          poa_code = form_attributes.dig('serviceOrganization', 'poaCode')
+          shared_form_validation('2122')
+          poa_code = get_poa_code('2122')
           validate_org_poa_code!(poa_code)
 
           render json: validation_success('21-22')

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -8526,7 +8526,7 @@
                       "status": "422",
                       "detail": "Could not retrieve Power of Attorney due to multiple representatives with code: A1Q",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:114:in `representative'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:108:in `representative'"
                       }
                     }
                   ]
@@ -8625,7 +8625,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "3878dbc3-0b55-4475-abee-72acb84c6f2d",
+                    "id": "62e7a49e-c3dd-407d-aba1-edefef6fbeed",
                     "type": "individual",
                     "attributes": {
                       "code": "083",
@@ -8811,7 +8811,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:141:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:135:in `validate_individual_poa_code!'"
                       }
                     }
                   ]
@@ -9305,6 +9305,715 @@
         }
       }
     },
+    "/veterans/{veteranId}/2122": {
+      "post": {
+        "summary": "Appoint an organization Power of Attorney for a Veteran.",
+        "description": "Updates current Power of Attorney for Veteran.",
+        "tags": [
+          "Power of Attorney"
+        ],
+        "operationId": "post2122",
+        "security": [
+          {
+            "productionOauth": [
+              "system/claim.read",
+              "system/claim.write"
+            ]
+          },
+          {
+            "sandboxOauth": [
+              "system/claim.read",
+              "system/claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "veteranId",
+            "in": "path",
+            "required": true,
+            "example": "1012667145V762142",
+            "description": "ID of Veteran",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Valid request response",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "id": "aca869e7-ede2-4cab-bc1b-57d3d4fd1c1f",
+                    "type": "organization",
+                    "attributes": {
+                      "code": "083",
+                      "name": "083 - DISABLED AMERICAN VETERANS",
+                      "phoneNumber": "555-555-5555"
+                    }
+                  }
+                },
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "type",
+                        "attributes"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "code"
+                          ],
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "description": "code for Power of attorney"
+                            },
+                            "phoneNumber": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Not authorized",
+                      "status": "401",
+                      "detail": "Not authorized"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Unprocessable entity",
+                      "detail": "The property /serviceOrganization did not contain the required key poaCode",
+                      "status": "422",
+                      "source": {
+                        "pointer": "data/attributes/serviceOrganization"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Organization with code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:143:in `validate_org_poa_code!'"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "attributes",
+                      null
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "description": "Form 2122 Schema",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "serviceOrganization"
+                        ],
+                        "properties": {
+                          "veteran": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "address",
+                              "phone",
+                              "email"
+                            ],
+                            "properties": {
+                              "address": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "numberAndStreet",
+                                  "city",
+                                  "country",
+                                  "zipFirstFive"
+                                ],
+                                "properties": {
+                                  "numberAndStreet": {
+                                    "description": "Street address with number and name.",
+                                    "type": "string",
+                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 30
+                                  },
+                                  "aptUnitNumber": {
+                                    "type": "integer"
+                                  },
+                                  "city": {
+                                    "description": "City for the address.",
+                                    "type": "string",
+                                    "example": "Portland"
+                                  },
+                                  "state": {
+                                    "description": "State for the address.",
+                                    "type": "string",
+                                    "example": "OR"
+                                  },
+                                  "country": {
+                                    "description": "Country of the address.",
+                                    "type": "string",
+                                    "example": "USA"
+                                  },
+                                  "zipFirstFive": {
+                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{5}?$",
+                                    "example": "12345"
+                                  },
+                                  "zipLastFour": {
+                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{4}?$",
+                                    "example": "6789"
+                                  }
+                                }
+                              },
+                              "phone": {
+                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "areaCode",
+                                  "phoneNumber"
+                                ],
+                                "properties": {
+                                  "countryCode": {
+                                    "type": "string",
+                                    "pattern": "^[0-9]+$"
+                                  },
+                                  "areaCode": {
+                                    "description": "Area code of the phone number.",
+                                    "type": "string",
+                                    "pattern": "^[2-9][0-9]{2}$",
+                                    "example": "555"
+                                  },
+                                  "phoneNumber": {
+                                    "description": "Phone number.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{1,14}$",
+                                    "example": "555-5555"
+                                  },
+                                  "phoneNumberExt": {
+                                    "type": "string",
+                                    "pattern": "^[a-zA-Z0-9]{1,10}$"
+                                  }
+                                }
+                              },
+                              "email": {
+                                "description": "Email address of the veteran.",
+                                "type": "string",
+                                "pattern": ".@.",
+                                "maxLength": 61,
+                                "example": "veteran@example.com"
+                              },
+                              "serviceBranch": {
+                                "description": "Service Branch for the veteran.",
+                                "type": "string",
+                                "enum": [
+                                  "AIR FORCE",
+                                  "ARMY",
+                                  "COAST GUARD",
+                                  "MARINE CORPS",
+                                  "NAVY",
+                                  "SPACE FORCE",
+                                  "OTHER"
+                                ],
+                                "example": "ARMY"
+                              },
+                              "serviceBranchOther": {
+                                "description": "For a 'service branch' of value 'other', please provide the service branch name.",
+                                "type": "string",
+                                "maxLength": 50,
+                                "example": "Air National Guard"
+                              }
+                            }
+                          },
+                          "claimant": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "firstName",
+                              "lastName",
+                              "address",
+                              "phone",
+                              "email",
+                              "relationship"
+                            ],
+                            "properties": {
+                              "firstName": {
+                                "description": "First name of Claimant.",
+                                "type": "string",
+                                "example": "John"
+                              },
+                              "middleInitial": {
+                                "description": "Middle initial of Claimant.",
+                                "type": "string",
+                                "example": "M"
+                              },
+                              "lastName": {
+                                "description": "Last name of Claimant.",
+                                "type": "string",
+                                "example": "Dow"
+                              },
+                              "address": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "numberAndStreet",
+                                  "city",
+                                  "country",
+                                  "zipFirstFive"
+                                ],
+                                "properties": {
+                                  "numberAndStreet": {
+                                    "description": "Street address with number and name.",
+                                    "type": "string",
+                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 30
+                                  },
+                                  "aptUnitNumber": {
+                                    "type": "integer"
+                                  },
+                                  "city": {
+                                    "description": "City for the address.",
+                                    "type": "string",
+                                    "example": "Portland"
+                                  },
+                                  "state": {
+                                    "description": "State for the address.",
+                                    "type": "string",
+                                    "example": "OR"
+                                  },
+                                  "country": {
+                                    "description": "Country of the address.",
+                                    "type": "string",
+                                    "example": "USA"
+                                  },
+                                  "zipFirstFive": {
+                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{5}?$",
+                                    "example": "12345"
+                                  },
+                                  "zipLastFour": {
+                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{4}?$",
+                                    "example": "6789"
+                                  },
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              },
+                              "phone": {
+                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "areaCode",
+                                  "phoneNumber"
+                                ],
+                                "properties": {
+                                  "countryCode": {
+                                    "type": "string",
+                                    "pattern": "^[0-9]+$"
+                                  },
+                                  "areaCode": {
+                                    "description": "Area code of the phone number.",
+                                    "type": "string",
+                                    "pattern": "^[2-9][0-9]{2}$",
+                                    "example": "555"
+                                  },
+                                  "phoneNumber": {
+                                    "description": "Phone number.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{1,14}$",
+                                    "example": "555-5555"
+                                  },
+                                  "phoneNumberExt": {
+                                    "type": "string",
+                                    "pattern": "^[a-zA-Z0-9]{1,10}$"
+                                  }
+                                }
+                              },
+                              "email": {
+                                "description": "Email address of the claimant.",
+                                "type": "string",
+                                "pattern": ".@.",
+                                "maxLength": 61,
+                                "example": "claimant@example.com"
+                              },
+                              "relationship": {
+                                "description": "Relationship of claimant to the veteran.",
+                                "type": "string",
+                                "example": "Spouse"
+                              }
+                            }
+                          },
+                          "serviceOrganization": {
+                            "description": "Details of the Service Organization representing the veteran.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "poaCode"
+                            ],
+                            "properties": {
+                              "poaCode": {
+                                "description": "The POA code of the organization.",
+                                "type": "string",
+                                "example": "A1Q"
+                              },
+                              "organizationName": {
+                                "description": "Name of the service organization.",
+                                "type": "string",
+                                "example": "I help vets LLC."
+                              },
+                              "firstName": {
+                                "description": "First Name of the representative.",
+                                "type": "string",
+                                "example": "John"
+                              },
+                              "lastName": {
+                                "description": "Last Name of the representative",
+                                "type": "string",
+                                "example": "Doe"
+                              },
+                              "jobTitle": {
+                                "description": "Job title of the representative.",
+                                "type": "string",
+                                "example": "Veteran Service representative"
+                              },
+                              "address": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "numberAndStreet",
+                                  "city",
+                                  "country",
+                                  "zipFirstFive"
+                                ],
+                                "properties": {
+                                  "numberAndStreet": {
+                                    "description": "Street address with number and name.",
+                                    "type": "string",
+                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 30
+                                  },
+                                  "aptUnitNumber": {
+                                    "type": "integer"
+                                  },
+                                  "city": {
+                                    "description": "City for the address.",
+                                    "type": "string",
+                                    "example": "Portland"
+                                  },
+                                  "state": {
+                                    "description": "State for the address.",
+                                    "type": "string",
+                                    "example": "OR"
+                                  },
+                                  "country": {
+                                    "description": "Country of the address.",
+                                    "type": "string",
+                                    "example": "USA"
+                                  },
+                                  "zipFirstFive": {
+                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{5}?$",
+                                    "example": "12345"
+                                  },
+                                  "zipLastFour": {
+                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{4}?$",
+                                    "example": "6789"
+                                  },
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              },
+                              "email": {
+                                "description": "Email address of the service organization or representative.",
+                                "type": "string",
+                                "pattern": ".@.",
+                                "maxLength": 61,
+                                "example": "veteran_representative@example.com"
+                              },
+                              "appointmentDate": {
+                                "description": "Date of appointment with Veteran.",
+                                "type": "string",
+                                "pattern": "^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$"
+                              }
+                            }
+                          },
+                          "recordConsent": {
+                            "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
+                            "type": "boolean"
+                          },
+                          "consentLimits": {
+                            "description": "Consent in Item 19 for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows.",
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "DRUG ABUSE",
+                                "ALCOHOLISM",
+                                "HIV",
+                                "SICKLE CELL"
+                              ]
+                            },
+                            "example": "DRUG ABUSE"
+                          },
+                          "consentAddressChange": {
+                            "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
+                            "type": "boolean"
+                          },
+                          "signatures": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "veteran",
+                              "representative"
+                            ],
+                            "properties": {
+                              "veteran": {
+                                "description": "Base64 encoded png image of the veteran or claimant signature.",
+                                "title": "Signature of the Veteran",
+                                "type": "string"
+                              },
+                              "representative": {
+                                "description": "Base64 encoded png image of the representative signature.",
+                                "title": "Signature of the Veteran Representative",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "attributes": {
+                      "serviceOrganization": {
+                        "poaCode": "083"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/veterans/{veteranId}/2122a/validate": {
       "post": {
         "summary": "Validates a 2122a form submission.",
@@ -9528,7 +10237,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:141:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:135:in `validate_individual_poa_code!'"
                       }
                     }
                   ]
@@ -10245,7 +10954,7 @@
                       "status": "404",
                       "detail": "Could not find an Organization with code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:149:in `validate_org_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:143:in `validate_org_poa_code!'"
                       }
                     }
                   ]

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -314,64 +314,47 @@ describe 'PowerOfAttorney',
 
   path '/veterans/{veteranId}/2122', production: false do
     post 'Appoint an organization Power of Attorney for a Veteran.' do
+      description 'Updates current Power of Attorney for Veteran.'
       tags 'Power of Attorney'
-      operationId 'appointOrganizationPowerOfAttorney'
+      operationId 'post2122'
       security [
-        { productionOauth: ['system/claim.write'] },
-        { sandboxOauth: ['system/claim.write'] },
+        { productionOauth: ['system/claim.read', 'system/claim.write'] },
+        { sandboxOauth: ['system/claim.read', 'system/claim.write'] },
         { bearer_token: [] }
       ]
       consumes 'application/json'
       produces 'application/json'
-      description 'Updates current Power of Attorney for Veteran.'
-
-      let(:Authorization) { 'Bearer token' }
       parameter name: 'veteranId',
                 in: :path,
                 required: true,
                 type: :string,
+                example: '1012667145V762142',
                 description: 'ID of Veteran'
+      parameter SwaggerSharedComponents::V2.body_examples[:power_of_attorney2122]
 
-      parameter SwaggerSharedComponents::V2.body_examples[:power_of_attorney]
-
+      let(:Authorization) { 'Bearer token' }
       let(:veteranId) { '1013062086V794840' } # rubocop:disable RSpec/VariableName
       let(:scopes) { %w[system/claim.write] }
-      let(:individual_poa_code) { 'A1H' }
       let(:organization_poa_code) { '083' }
-      let(:bgs_poa) { { person_org_name: "#{individual_poa_code} name-here" } }
+      let(:bgs_poa) { { person_org_name: "#{organization_poa_code} name-here" } }
       let(:data) do
-        {
-          data: {
-            attributes: {
-              serviceOrganization: {
-                poaCode: organization_poa_code.to_s
-              }
-            }
-          }
-        }
+        temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                               'power_of_attorney', '2122', 'valid.json').read
+        JSON.parse(temp)
       end
 
-      describe 'Getting a successful response', document: false do
-        response '202', 'Successful response with the submitted Power of Attorney' do
-          schema JSON.parse(File.read(Rails.root.join('spec',
-                                                      'support',
-                                                      'schemas',
-                                                      'claims_api',
-                                                      'veterans',
-                                                      'power-of-attorney',
-                                                      'post.json')))
+      describe 'Getting a successful response' do
+        response '202', 'Valid request response' do
+          schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'veterans',
+                                                      'power_of_attorney', '2122', 'submit.json')))
 
           before do |example|
             expect_any_instance_of(local_bgs).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
             allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
               .and_return({ person_poa_history: nil })
-            Veteran::Service::Representative.new(representative_id: '67890',
-                                                 poa_codes: [organization_poa_code],
-                                                 first_name: 'Firstname',
-                                                 last_name: 'Lastname',
-                                                 phone: '555-555-5555').save!
-            Veteran::Service::Organization.create(poa: organization_poa_code,
-                                                  name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
+            Veteran::Service::Organization.create!(poa: organization_poa_code,
+                                                   name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS",
+                                                   phone: '555-555-5555')
 
             mock_ccg(scopes) do |auth_header|
               Authorization = auth_header # rubocop:disable Naming/ConstantName
@@ -393,7 +376,7 @@ describe 'PowerOfAttorney',
         end
       end
 
-      describe 'Getting a 401 response', document: false do
+      describe 'Getting a 401 response' do
         response '401', 'Unauthorized' do
           schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
                                                       'power_of_attorney', 'default.json')))
@@ -418,21 +401,22 @@ describe 'PowerOfAttorney',
         end
       end
 
-      describe 'Getting a 422 response', document: false do
+      describe 'Getting a 422 response' do
         response '422', 'Unprocessable Entity' do
           schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
                                                       'power_of_attorney', 'default.json')))
+
+          let(:data) do
+            temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                   'power_of_attorney', '2122', 'invalid_schema.json').read
+            JSON.parse(temp)
+          end
 
           before do |example|
             mock_ccg(scopes) do |auth_header|
               allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
                 .and_return({ person_poa_history: nil })
               Authorization = auth_header # rubocop:disable Naming/ConstantName
-              data[:data][:attributes][:serviceOrganization][:poaCode] = individual_poa_code.to_s
-              Veteran::Service::Representative.new(representative_id: '00000', poa_codes: [individual_poa_code],
-                                                   first_name: 'George', last_name: 'Washington').save!
-              Veteran::Service::Organization.create(poa: organization_poa_code,
-                                                    name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
               submit_request(example.metadata)
             end
           end
@@ -446,6 +430,37 @@ describe 'PowerOfAttorney',
           end
 
           it 'returns a 422 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+          end
+        end
+      end
+
+      describe 'Getting a 404 response' do
+        response '404', 'Resource not found' do
+          schema JSON.parse(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
+                                            'power_of_attorney', 'default.json').read)
+
+          let(:data) do
+            temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                   'power_of_attorney', '2122', 'valid.json').read
+            JSON.parse(temp)
+          end
+
+          before do |example|
+            mock_ccg(scopes) do
+              submit_request(example.metadata)
+            end
+          end
+
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end
+
+          it 'returns a 404 response' do |example|
             assert_response_matches_metadata(example.metadata)
           end
         end


### PR DESCRIPTION
Adds Swagger docs for `POST /veterans/:veteranId/2122`

## Summary

- Updates RSwag specs for endpoint
- Cleaned up the submit2122 endpoint a bit

## Related issue(s)

- [API-32122](https://jira.devops.va.gov/browse/API-32122)

## Testing done

- RSwag specs updated

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/534756/c1fe6a53-da23-4870-b2f4-74c7f78468b6)

![image](https://github.com/department-of-veterans-affairs/vets-api/assets/534756/3ee5be69-dad0-46c7-a229-c30755d8bab9)

## What areas of the site does it impact?
Lighthouse Claims API

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
