### PR TITLE
DBEX: implement Metadata Validator for backup submissions

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1192,9 +1192,6 @@ features:
   form526_backup_submission_temp_killswitch:
     actor_type: user
     description: Provide a temporary killswitch to disable form526 backup submission if something were to go awry
-  form526_backup_submission_force_offramp:
-    actor_type: user
-    description: If enabled add the "forceOfframp" flag to backup 526 submission metadata
   virtual_agent_show_floating_chatbot:
     actor_type: user
     description: Enables a floating chatbot on the chatbot page - managed by virtual agent team

--- a/lib/sidekiq/form526_backup_submission_process/processor.rb
+++ b/lib/sidekiq/form526_backup_submission_process/processor.rb
@@ -200,7 +200,7 @@ module Sidekiq
           'claimDate' => submission.created_at.iso8601
         }
         metadata['forceOfframp'] = 'true' if Flipper.enabled?(:form526_backup_submission_force_offramp)
-        SimpleFormsApiSubmission::MetadataValidator.validate(metadata).to_json
+        SimpleFormsApiSubmission::MetadataValidator.validate(metadata)
       end
 
       def send_to_central_mail_through_lighthouse_claims_intake_api!

--- a/lib/sidekiq/form526_backup_submission_process/processor.rb
+++ b/lib/sidekiq/form526_backup_submission_process/processor.rb
@@ -197,9 +197,9 @@ module Sidekiq
           'source' => 'va.gov backup submission',
           'docType' => doc_type,
           'businessLine' => 'CMP',
-          'claimDate' => submission.created_at.iso8601
+          'claimDate' => submission.created_at.iso8601,
+          'forceOfframp' => 'true'
         }
-        metadata['forceOfframp'] = 'true' if Flipper.enabled?(:form526_backup_submission_force_offramp)
         SimpleFormsApiSubmission::MetadataValidator.validate(metadata)
       end
 


### PR DESCRIPTION
## Summary

Backup submission processing of form 526 has experienced failures triggered as a result of Benefits Intake API regex validations, including the presence of special characters (e.g., an apostrophe) in a Veteran's first and/or last names.

This PR adds a call to the [metadata validation library](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/simple_forms_api_submission/metadata_validator.rb). The validation cleans the passed metadata, aligning it with [Benefits Intake metadata requirements](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/75323#:~:text=https%3A//developer.va.gov/explore/api/benefits%2Dintake/docs%3Fversion%3Dcurrent).

According to the Benefits Intake `DocumentUploadMetadata` schema, "Only upper/lower case letters, hyphens(-), spaces and forward-slash(/)" are allowed characters for first and last names.

Also included in the PR is a hardcoding of the `forceOfframp` value as 'true', to avoid any future reversions. This Flipper was previously enabled and then later disabled, resulting in backup submissions not being appropriately routed. The corresponding Flipper, used only here, is removed from [config/features.yml](config/features.yml).

## Related issue(s)

- Zenhub ticket [#75323](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/75323) – Implement Metadata Validator for Backup Submissions
- Zenhub ticket [#75240](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/75240) – Default forceOfframp to true & delete corresponding Flipper

## Testing done

No adjustment required or impact to [spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb) as a result of the update. The `get_meta_data` method is private and the library it's leveraging has its own spec.

## What areas of the site does it impact?

Form 526 backup submission process

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
