### PR TITLE
Remove skip_before_action in Find a Rep flag_accredited_reps controller

### DIFF
--- a/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
@@ -4,7 +4,6 @@ module Veteran
   module V0
     class FlagAccreditedRepresentativesController < ApplicationController
       service_tag 'lighthouse-veteran'
-      skip_before_action :verify_authenticity_token
       skip_before_action :authenticate
       before_action :feature_enabled
 


### PR DESCRIPTION

## Summary

This PR reverts a temporary workaround submitted [in a previous PR ](https://github.com/department-of-veterans-affairs/vets-api/pull/15414) - namely, removing `verify_authenticity_token` from the `flag_accredited_representatives` controller for the purposes of testing the endpoint in staging. 

We've confirmed the endpoint can receive requests, so we will continue investigating the 403 issue outlined in the previous PR. 

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311

## Testing done
- [x] *New code is covered by unit tests*
