### PR TITLE
Track all form submissions again

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -27,15 +27,15 @@ class BenefitsIntakeStatusJob
 
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
         StatsD.increment("#{STATS_KEY}.#{form_id}.failure")
-        StatsD.increment("#{STATS_KEY}.failure")
+        StatsD.increment("#{STATS_KEY}.all_forms.failure")
         handle_failure(submission)
       elsif submission.dig('attributes', 'status') == 'vbms'
         StatsD.increment("#{STATS_KEY}.#{form_id}.success")
-        StatsD.increment("#{STATS_KEY}.success")
+        StatsD.increment("#{STATS_KEY}.all_forms.success")
         handle_success(submission)
       else
         StatsD.increment("#{STATS_KEY}.#{form_id}.pending")
-        StatsD.increment("#{STATS_KEY}.pending")
+        StatsD.increment("#{STATS_KEY}.all_forms.pending")
       end
     end
   end

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -27,12 +27,15 @@ class BenefitsIntakeStatusJob
 
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
         StatsD.increment("#{STATS_KEY}.#{form_id}.failure")
+        StatsD.increment("#{STATS_KEY}.failure")
         handle_failure(submission)
       elsif submission.dig('attributes', 'status') == 'vbms'
         StatsD.increment("#{STATS_KEY}.#{form_id}.success")
+        StatsD.increment("#{STATS_KEY}.success")
         handle_success(submission)
       else
         StatsD.increment("#{STATS_KEY}.#{form_id}.pending")
+        StatsD.increment("#{STATS_KEY}.pending")
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR restores some code that was [previously deleted](https://github.com/department-of-veterans-affairs/vets-api/pull/15318). We want to track both submissions by form but also by all forms with `statsd`. This restores the incrementing lines for tracking by all forms. This will make the Datadog dashboard easier and faster to generate.