### PR TITLE
Update pensions regional office

### DIFF
--- a/app/models/saved_claim/pension.rb
+++ b/app/models/saved_claim/pension.rb
@@ -6,7 +6,10 @@ class SavedClaim::Pension < CentralMailClaim
   FORM = '21P-527EZ'
 
   def regional_office
-    PensionBurial::ProcessingOffice.address_for(open_struct_form.veteranAddress.postalCode)
+    ['Department of Veteran Affairs',
+     'Pension Intake Center',
+     'P.O. Box 5365',
+     'Janesville, Wisconsin 53547-5365']
   end
 
   def attachment_keys

--- a/spec/requests/pension_claims_controller_spec.rb
+++ b/spec/requests/pension_claims_controller_spec.rb
@@ -2,6 +2,8 @@
 
 require 'rails_helper'
 
+reg_office = 'Department of Veteran Affairs, Pension Intake Center, P.O. Box 5365, Janesville, Wisconsin 53547-5365'
+
 RSpec.describe 'Pension Claim Integration', type: %i[request serializer] do
   before do
     allow(Rails.logger).to receive(:info)
@@ -69,6 +71,12 @@ RSpec.describe 'Pension Claim Integration', type: %i[request serializer] do
         expect(Rails.logger).to receive(:info).with('Begin 21P-527EZ Submission', be_a(Hash))
         expect(Rails.logger).to receive(:info).with('Submit 21P-527EZ Success', be_a(Hash))
         subject
+      end
+
+      it 'returns the expected regional office' do
+        subject
+        expect(JSON.parse(response.body)['data']['attributes']['regionalOffice'].join(', '))
+          .to eq(reg_office)
       end
     end
   end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- All pensions mail now goes to a single address, so instead of returning regional_office addresses based on the veteran's zipcode, we return the same address every time. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75038

## Testing done

- [ ] New code is covered by unit tests
- [ ] Submit form 21P-527EZ. On the confirmation page and in the submission directions, confirm the new address is present.

## Screenshots
<img width="698" alt="Screenshot 2024-02-07 at 10 45 00 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/21046714/d9f76134-446b-46ac-b036-f8a0642ea868">
<img width="608" alt="Screenshot 2024-02-07 at 10 43 49 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/21046714/5a461630-54ca-492f-bca3-c74610c9261e">

## What areas of the site does it impact?
Pension Benefits

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
