### PR TITLE
Add datebox timestamp and auth info to bottom of PDF

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -24,6 +24,8 @@ module SimpleFormsApi
         '20-10206' => 'vba_20_10206'
       }.freeze
 
+      UNAUTHENTICATED_FORMS = ['40-0247', '21-10210', '21P-0847']
+
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
 
@@ -78,7 +80,11 @@ module SimpleFormsApi
         form.track_user_identity
         filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, form:)
 
-        file_path = filler.generate
+        file_path = if @current_user
+                      filler.generate(@current_user.loa[:current])
+                    else
+                      filler.generate
+                    end
         metadata = SimpleFormsApiSubmission::MetadataValidator.validate(form.metadata)
 
         form.handle_attachments(file_path) if form_id == 'vba_40_0247'
@@ -137,7 +143,7 @@ module SimpleFormsApi
       end
 
       def should_authenticate
-        params[:form_number] == '21-0966' || params[:form_number] == '21-0845'
+        true unless UNAUTHENTICATED_FORMS.include? params[:form_number]
       end
 
       def icn

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -75,7 +75,8 @@ module SimpleFormsApi
 
       def submit_form_to_central_mail
         form_id = get_form_id
-        file_path, metadata = get_file_path_and_metadata
+        parsed_form_data = JSON.parse(params.to_json)
+        file_path, metadata = get_file_path_and_metadata(parsed_form_data)
         status, confirmation_number = upload_pdf_to_benefits_intake(file_path, metadata)
 
         if status == 200 && Flipper.enabled?(:simple_forms_email_confirmations)
@@ -92,8 +93,7 @@ module SimpleFormsApi
         render json: get_json(confirmation_number, form_id), status:
       end
 
-      def get_file_path_and_metadata
-        parsed_form_data = JSON.parse(params.to_json)
+      def get_file_path_and_metadata(parsed_form_data)
         form_id = get_form_id
         form = "SimpleFormsApi::#{form_id.titleize.gsub(' ', '')}".constantize.new(parsed_form_data)
         form.track_user_identity

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -31,6 +31,15 @@ module SimpleFormsApi
       }
     end
 
+    def submission_date_config
+      {
+        should_stamp_date?: true,
+        page_number: 1,
+        title_coords: [460, 710],
+        text_coords: [460, 690]
+      }
+    end
+
     def track_user_identity; end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -30,6 +30,15 @@ module SimpleFormsApi
         person_address + organization_address
     end
 
+    def submission_date_config
+      {
+        should_stamp_date?: true,
+        page_number: 1,
+        title_coords: [460, 710],
+        text_coords: [460, 690]
+      }
+    end
+
     def track_user_identity; end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -54,6 +54,15 @@ module SimpleFormsApi
       end
     end
 
+    def submission_date_config
+      {
+        should_stamp_date?: true,
+        page_number: 0,
+        title_coords: [460, 710],
+        text_coords: [460, 690]
+      }
+    end
+
     def track_user_identity; end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -22,6 +22,15 @@ module SimpleFormsApi
       }
     end
 
+    def submission_date_config
+      {
+        should_stamp_date?: true,
+        page_number: 1,
+        title_coords: [440, 690],
+        text_coords: [440, 670]
+      }
+    end
+
     def track_user_identity; end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -28,6 +28,15 @@ module SimpleFormsApi
         statement + witness_phone + witness_email
     end
 
+    def submission_date_config
+      {
+        should_stamp_date?: true,
+        page_number: 0,
+        title_coords: [460, 710],
+        text_coords: [460, 690]
+      }
+    end
+
     def track_user_identity; end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -28,6 +28,15 @@ module SimpleFormsApi
       }
     end
 
+    def submission_date_config
+      {
+        should_stamp_date?: true,
+        page_number: 0,
+        title_coords: [440, 710],
+        text_coords: [440, 690]
+      }
+    end
+
     def track_user_identity
       StatsD.increment("#{STATS_KEY}.#{data.dig('preparer_identification', 'relationship_to_veteran')}")
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -26,6 +26,15 @@ module SimpleFormsApi
       }
     end
 
+    def submission_date_config
+      {
+        should_stamp_date?: true,
+        page_number: 1,
+        title_coords: [460, 710],
+        text_coords: [460, 690]
+      }
+    end
+
     def track_user_identity; end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -27,6 +27,10 @@ module SimpleFormsApi
       }
     end
 
+    def submission_date_config
+      { should_stamp_date?: false }
+    end
+
     def track_user_identity; end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -35,6 +35,10 @@ module SimpleFormsApi
       end
     end
 
+    def submission_date_config
+      { should_stamp_date?: false }
+    end
+
     def track_user_identity; end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -22,6 +22,10 @@ module SimpleFormsApi
       }
     end
 
+    def submission_date_config
+      { should_stamp_date?: false }
+    end
+
     def track_user_identity; end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -14,13 +14,13 @@ module SimpleFormsApi
       @name = name || form_number
     end
 
-    def generate
+    def generate(current_loa = nil)
       template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
       generated_form_path = "tmp/#{name}-tmp.pdf"
       stamped_template_path = "tmp/#{name}-stamped.pdf"
       pdftk = PdfForms.new(Settings.binaries.pdftk)
       FileUtils.copy(template_form_path, stamped_template_path)
-      PdfStamper.stamp_pdf(stamped_template_path, form)
+      PdfStamper.stamp_pdf(stamped_template_path, form, current_loa)
       pdftk.fill_form(stamped_template_path, generated_form_path, mapped_data, flatten: true)
       generated_form_path
     ensure

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -6,18 +6,29 @@ module SimpleFormsApi
   class PdfStamper
     FORM_REQUIRES_STAMP = %w[26-4555 21-4142 21-10210 21-0845 21P-0847 21-0966 21-0972].freeze
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
+    SUBMISSION_DATE_TITLE = 'Application Submitted:'
 
-    def self.stamp_pdf(stamped_template_path, form)
+    def self.stamp_pdf(stamped_template_path, form, current_loa)
       form_number = form.data['form_number']
       if FORM_REQUIRES_STAMP.include? form_number
         stamp_method = "stamp#{form_number.gsub('-', '')}".downcase
         send(stamp_method, stamped_template_path, form)
       end
 
-      current_time = Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S')
+      current_time = Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S') + ' '
+      auth_text = case current_loa
+                  when 3
+                    'Signee signed with an identity-verified account.'
+                  when 1
+                    'Signee signed in but hasn’t verified their identity.'
+                  else
+                    'Signee not signed in.'
+                  end
       stamp_text = SUBMISSION_TEXT + current_time
       desired_stamps = [[10, 10, stamp_text]]
-      stamp(desired_stamps, stamped_template_path, text_only: false)
+      stamp(desired_stamps, stamped_template_path, auth_text, text_only: false)
+
+      stamp_submission_date(stamped_template_path, form.submission_date_config)
     end
 
     def self.stamp264555(stamped_template_path, form)
@@ -25,7 +36,8 @@ module SimpleFormsApi
       desired_stamps.append([73, 390, 'X']) unless form.data['previous_sah_application']['has_previous_sah_application']
       desired_stamps.append([73, 355, 'X']) unless form.data['previous_hi_application']['has_previous_hi_application']
       desired_stamps.append([73, 320, 'X']) unless form.data['living_situation']['is_in_care_facility']
-      stamp(desired_stamps, stamped_template_path)
+      append_to_stamp = false
+      stamp(desired_stamps, stamped_template_path, append_to_stamp)
     end
 
     def self.stamp214142(stamped_template_path, form)
@@ -146,10 +158,10 @@ module SimpleFormsApi
       Common::FileHelpers.delete_file_if_exists(stamp_path) if defined?(stamp_path)
     end
 
-    def self.stamp(desired_stamps, stamped_template_path, text_only: true)
+    def self.stamp(desired_stamps, stamped_template_path, append_to_stamp, text_only: true)
       current_file_path = stamped_template_path
       desired_stamps.each do |x, y, text|
-        out_path = CentralMail::DatestampPdf.new(current_file_path).run(text:, x:, y:, text_only:)
+        out_path = CentralMail::DatestampPdf.new(current_file_path, append_to_stamp:).run(text:, x:, y:, text_only:)
         current_file_path = out_path
       end
       File.rename(current_file_path, stamped_template_path)
@@ -164,6 +176,33 @@ module SimpleFormsApi
     rescue
       Common::FileHelpers.delete_file_if_exists(out_path)
       raise
+    end
+
+    def self.stamp_submission_date(stamped_template_path, config)
+      if config[:should_stamp_date?]
+        date_title_stamp_position = config[:title_coords]
+        date_text_stamp_position = config[:text_coords]
+        page_configuration = [
+          { type: :new_page },
+          { type: :new_page },
+          { type: :new_page },
+          { type: :new_page }
+        ]
+        page_configuration[config[:page_number]] = { type: :text, position: date_title_stamp_position }
+
+        multistamp(stamped_template_path, SUBMISSION_DATE_TITLE, page_configuration, 12)
+
+        page_configuration = [
+          { type: :new_page },
+          { type: :new_page },
+          { type: :new_page },
+          { type: :new_page }
+        ]
+        page_configuration[config[:page_number]] = { type: :text, position: date_text_stamp_position }
+
+        multistamp(stamped_template_path, Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'), page_configuration,
+                   12)
+      end
     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -15,7 +15,7 @@ module SimpleFormsApi
         send(stamp_method, stamped_template_path, form)
       end
 
-      current_time = Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S') + ' '
+      current_time = "#{Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S')} "
       auth_text = case current_loa
                   when 3
                     'Signee signed with an identity-verified account.'
@@ -183,27 +183,26 @@ module SimpleFormsApi
       if config[:should_stamp_date?]
         date_title_stamp_position = config[:title_coords]
         date_text_stamp_position = config[:text_coords]
-        page_configuration = [
-          { type: :new_page },
-          { type: :new_page },
-          { type: :new_page },
-          { type: :new_page }
-        ]
+        page_configuration = default_page_configuration
         page_configuration[config[:page_number]] = { type: :text, position: date_title_stamp_position }
 
         multistamp(stamped_template_path, SUBMISSION_DATE_TITLE, page_configuration, 12)
 
-        page_configuration = [
-          { type: :new_page },
-          { type: :new_page },
-          { type: :new_page },
-          { type: :new_page }
-        ]
+        page_configuration = default_page_configuration
         page_configuration[config[:page_number]] = { type: :text, position: date_text_stamp_position }
 
         multistamp(stamped_template_path, Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'), page_configuration,
                    12)
       end
+    end
+
+    def self.default_page_configuration
+      [
+        { type: :new_page },
+        { type: :new_page },
+        { type: :new_page },
+        { type: :new_page }
+      ]
     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -161,7 +161,8 @@ module SimpleFormsApi
     def self.stamp(desired_stamps, stamped_template_path, append_to_stamp, text_only: true)
       current_file_path = stamped_template_path
       desired_stamps.each do |x, y, text|
-        out_path = CentralMail::DatestampPdf.new(current_file_path, append_to_stamp:).run(text:, x:, y:, text_only:)
+        out_path = CentralMail::DatestampPdf.new(current_file_path, append_to_stamp:).run(text:, x:, y:, text_only:,
+                                                                                          size: 9)
         current_file_path = out_path
       end
       File.rename(current_file_path, stamped_template_path)


### PR DESCRIPTION
## Summary
This PR adds two things to our filled PDFs:
1. Adds a datebox timestamp indicating to downstream services when the form was submitted.
2. Adds an auth status to the bottom of every page of the PDF indicating the authentication status of the user.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/949

## Testing done
Tests are passing and one new test written.

## Screenshots
Here are some example shots.
Datestamp:
<img width="1263" alt="Screenshot 2024-02-07 at 4 28 00 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/d4ea7a6c-041a-4cc1-b8d2-05d210f07b42">
Unauthenticated:
<img width="1283" alt="Screenshot 2024-02-07 at 4 34 46 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/d01b9448-3669-4cfc-ba1b-db655fea06bc">
Authenticated LOA3:
<img width="1299" alt="Screenshot 2024-02-07 at 4 33 50 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/fbd331c8-4b76-4914-ae40-8645b6910e96">
