### PR TITLE
Adds Metrics to Datadog Breakers Charts for VAProfile's Military Personnel Service

### DIFF
--- a/lib/va_profile/military_personnel/service.rb
+++ b/lib/va_profile/military_personnel/service.rb
@@ -13,9 +13,9 @@ module VAProfile
     class Service < VAProfile::Service
       include Common::Client::Concerns::Monitoring
 
+      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.military_personnel".freeze
       configuration VAProfile::MilitaryPersonnel::Configuration
 
-      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.military_personnel".freeze
       OID = '2.16.840.1.113883.3.42.10001.100001.12'
       AAID = '^NI^200DOD^USDOD'
 


### PR DESCRIPTION
### Summary 

VAProfile's services should be represented in Platform's breakers charts, but some services are missing.

This PR adds logging to VAProfile's Military Personnel service so that its metrics will appear in the Datadog breakers charts. Subsequent PRs related to this work will be submitted—one for each service that needs to be added.

- Not behind a feature toggle
- This work is being done on behalf of the Product Platform team.

### Related issue(s)
- [Current epic](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74906) - shows scope of this work
- [Current ticket](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74921) - documents the work in this PR
- [Previous related ticket](https://github.com/department-of-veterans-affairs/vets-api/pull/15304)

#### Testing done
Once merged, will monitor Breakers Charts in staging to determine if the service and its metrics are now visible.

#### What areas of the site does it impact?
This should impact Datadog's breakers charts dashboard.

#### Acceptance criteria
- [X] Has a monitor built into Datadog