### PR TITLE
Add get_intents_to_file endpoint

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -47,6 +47,17 @@ module SimpleFormsApi
         end
       end
 
+      def get_intents_to_file
+        intent_service = SimpleFormsApi::IntentToFile.new(icn)
+        existing_intents = intent_service.existing_intents
+
+        render json: {
+          compensation_intent: existing_intents['compensation'],
+          pension_intent: existing_intents['pension'],
+          survivor_intent: existing_intents['survivor']
+        }
+      end
+
       def authenticate
         super
       rescue Common::Exceptions::Unauthorized
@@ -137,7 +148,9 @@ module SimpleFormsApi
       end
 
       def should_authenticate
-        params[:form_number] == '21-0966' || params[:form_number] == '21-0845'
+        params[:form_number] == '21-0966' ||
+          params[:form_number] == '21-0845' ||
+          params[:action] == 'get_intents_to_file'
       end
 
       def icn

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -69,7 +69,7 @@ module SimpleFormsApi
       private
 
       def handle_210966_authenticated
-        intent_service = SimpleFormsApi::IntentToFile.new(params, icn)
+        intent_service = SimpleFormsApi::IntentToFile.new(icn, params)
         existing_intents = intent_service.existing_intents
         confirmation_number, expiration_date = intent_service.submit
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -4,11 +4,11 @@ require 'lighthouse/benefits_claims/service'
 
 module SimpleFormsApi
   class IntentToFile
-    attr_reader :params, :icn
+    attr_reader :icn, :params
 
-    def initialize(params, icn)
-      @params = params
+    def initialize(icn, params = {})
       @icn = icn
+      @params = params
     end
 
     def submit

--- a/modules/simple_forms_api/config/routes.rb
+++ b/modules/simple_forms_api/config/routes.rb
@@ -4,5 +4,6 @@ SimpleFormsApi::Engine.routes.draw do
   namespace :v1, defaults: { format: 'json' } do
     post '/simple_forms', to: 'uploads#submit'
     post '/simple_forms/submit_supporting_documents', to: 'uploads#submit_supporting_documents'
+    get '/simple_forms/get_intents_to_file', to: 'uploads#get_intents_to_file'
   end
 end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -321,9 +321,11 @@ RSpec.describe 'Forms uploader', type: :request do
             VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_survivor') do
               get '/simple_forms_api/v1/simple_forms/get_intents_to_file'
 
-              expect(JSON.parse(response.body)).to eq (
-                { "compensation_intent" => nil, "pension_intent" => nil, "survivor_intent" => nil }
-              )
+              expect(JSON.parse(response.body)).to eq {
+                'compensation_intent' => nil,
+                'pension_intent' => nil,
+                'survivor_intent' => nil
+              }
               expect(response).to have_http_status(:ok)
             end
           end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -321,11 +321,10 @@ RSpec.describe 'Forms uploader', type: :request do
             VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_survivor') do
               get '/simple_forms_api/v1/simple_forms/get_intents_to_file'
 
-              expect(JSON.parse(response.body)).to eq {
-                'compensation_intent' => nil,
-                'pension_intent' => nil,
-                'survivor_intent' => nil
-              }
+              parsed_response = JSON.parse(response.body)
+              expect(parsed_response['compensation_intent']).to eq nil
+              expect(parsed_response['pension_intent']).to eq nil
+              expect(parsed_response['survivor_intent']).to eq nil
               expect(response).to have_http_status(:ok)
             end
           end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -307,6 +307,85 @@ RSpec.describe 'Forms uploader', type: :request do
     end
   end
 
+  describe '#get_intents_to_file' do
+    before do
+      sign_in
+      allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
+      allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
+    end
+
+    describe 'no intents on file' do
+      it 'returns no intents' do
+        VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_pension') do
+            VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_survivor') do
+              get '/simple_forms_api/v1/simple_forms/get_intents_to_file'
+
+              expect(JSON.parse(response.body)).to eq (
+                { "compensation_intent" => nil, "pension_intent" => nil, "survivor_intent" => nil }
+              )
+              expect(response).to have_http_status(:ok)
+            end
+          end
+        end
+      end
+    end
+
+    describe 'compensation intent on file' do
+      it 'returns a compensation intent' do
+        VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_pension') do
+            VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_survivor') do
+              get '/simple_forms_api/v1/simple_forms/get_intents_to_file'
+
+              parsed_response = JSON.parse(response.body)
+              expect(parsed_response['compensation_intent']['type']).to eq 'compensation'
+              expect(parsed_response['pension_intent']).to eq nil
+              expect(parsed_response['survivor_intent']).to eq nil
+              expect(response).to have_http_status(:ok)
+            end
+          end
+        end
+      end
+    end
+
+    describe 'pension intent on file' do
+      it 'returns a pension intent' do
+        VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_pension') do
+            VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_survivor') do
+              get '/simple_forms_api/v1/simple_forms/get_intents_to_file'
+
+              parsed_response = JSON.parse(response.body)
+              expect(parsed_response['compensation_intent']).to eq nil
+              expect(parsed_response['pension_intent']['type']).to eq 'pension'
+              expect(parsed_response['survivor_intent']).to eq nil
+              expect(response).to have_http_status(:ok)
+            end
+          end
+        end
+      end
+    end
+
+    describe 'both intents on file' do
+      it 'returns a pension intent' do
+        VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_pension') do
+            VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response_survivor') do
+              get '/simple_forms_api/v1/simple_forms/get_intents_to_file'
+
+              parsed_response = JSON.parse(response.body)
+              expect(parsed_response['compensation_intent']['type']).to eq 'compensation'
+              expect(parsed_response['pension_intent']['type']).to eq 'pension'
+              expect(parsed_response['survivor_intent']).to eq nil
+              expect(response).to have_http_status(:ok)
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe 'email confirmations' do
     let(:confirmation_number) { 'some_confirmation_number' }
 

--- a/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
+++ b/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
@@ -19,7 +19,7 @@ describe SimpleFormsApi::IntentToFile do
 
     it 'returns no confirmation number and no expiration date if no new ITF is filed' do
       icn = 'fake-icn'
-      intent_to_file_service = SimpleFormsApi::IntentToFile.new(params, icn)
+      intent_to_file_service = SimpleFormsApi::IntentToFile.new(icn, params)
       expiration_date = 'fake-expiration-date'
       compensation_intent = {
         'data' => {
@@ -55,7 +55,7 @@ describe SimpleFormsApi::IntentToFile do
 
     it 'return the expiration date of a newly-created Intent To File' do
       icn = 'fake-icn'
-      intent_to_file_service = SimpleFormsApi::IntentToFile.new(params, icn)
+      intent_to_file_service = SimpleFormsApi::IntentToFile.new(icn, params)
       expiration_date = 'fake-expiration-date'
       id = 'fake-id'
       compensation_intent = {

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/intent_to_file/404_response_pension.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/intent_to_file/404_response_pension.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/claims/v2/veterans/123498767V234859/intent-to-file/pension
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Bearer test_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Resource not found
+    headers:
+      Date:
+      - Sun, 07 May 2023 12:45:29 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '31'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      X-Ratelimit-Remaining-Minute:
+      - '109'
+      Ratelimit-Limit:
+      - '120'
+      Ratelimit-Remaining:
+      - '109'
+      Www-Authenticate:
+      - Bearer
+      X-Kong-Response-Latency:
+      - '217'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+        "errors": [
+          {
+            "title": "Resource not found",
+            "detail": "No active pension intent to file found."
+          }
+        ]
+      }'
+  recorded_at: Sun, 07 May 2023 12:45:29 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/intent_to_file/404_response_survivor.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/intent_to_file/404_response_survivor.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/claims/v2/veterans/123498767V234859/intent-to-file/survivor
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Bearer test_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Resource not found
+    headers:
+      Date:
+      - Sun, 07 May 2023 12:45:29 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '31'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      X-Ratelimit-Remaining-Minute:
+      - '109'
+      Ratelimit-Limit:
+      - '120'
+      Ratelimit-Remaining:
+      - '109'
+      Www-Authenticate:
+      - Bearer
+      X-Kong-Response-Latency:
+      - '217'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+        "errors": [
+          {
+            "title": "Resource not found",
+            "detail": "No active survivor intent to file found."
+          }
+        ]
+      }'
+  recorded_at: Sun, 07 May 2023 12:45:29 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary
This PR adds a new endpoint to the Simple Forms API Controller: `get_intents_to_file`. This will return an object that contains all ITFs for the logged-in user.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1012
