### PR TITLE
Updates VAProfile's Veteran Status Logging for Breakers Chart

### DIFF
--- a/lib/va_profile/veteran_status/service.rb
+++ b/lib/va_profile/veteran_status/service.rb
@@ -14,9 +14,9 @@ module VAProfile
     class Service < VAProfile::Service
       include Common::Client::Concerns::Monitoring
 
+      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.veteran_status".freeze
       configuration VAProfile::VeteranStatus::Configuration
 
-      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.veteran_status".freeze
       OID = '2.16.840.1.113883.3.42.10001.100001.12' # double check swagger
       AAID = '^NI^200DOD^USDOD' # double check swagger.
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- An [earlier PR instantiated metrics logging](https://github.com/department-of-veterans-affairs/vets-api/pull/15304/files) in Datadog for the Veteran Status service. However, in order to work, the additional line needs to be moved above the configuration call. 

## Related issue(s)

- [Zenhub Epic](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74906)

## Testing done

- [ ] Once merged, will confirm this metric appears in Datadog


## What areas of the site does it impact?
Should affect Datadog metrics

## Acceptance criteria

- [X]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)



