### PR TITLE
API-33994-remove-personal-info-log

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -185,10 +185,9 @@ module ClaimsApi
                ::Faraday::TimeoutError,
                Faraday::ParsingError,
                Breakers::OutageException => e
-          req = { auth: auth_headers, form: form_attributes, source: source_name, auto_claim: auto_claim.as_json }
-          PersonalInformationLog.create(
-            error_class: "validate_form_526 #{e.class.name}", data: { request: req, error: e.try(:as_json) || e }
-          )
+          claims_v1_logging('validate_form_526',
+                            message: "rescuing in validate_form_526, claim_id: #{auto_claim.id}" \
+                                     "#{e.class.name}, error: #{e.try(:as_json) || e}")
           raise e
         end
         # rubocop:enable Metrics/MethodLength

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -1038,8 +1038,6 @@ RSpec.describe 'Disability Claims ', type: :request do
                       allow_any_instance_of(ClaimsApi::EVSSService::Base)
                         .to receive(:validate).and_raise(error_klass)
                       post path, params: data, headers: headers.merge(auth_header)
-                      expect(PersonalInformationLog.count).to be_positive
-                      expect(PersonalInformationLog.last.error_class).to eq("validate_form_526 #{error_klass.name}")
                     end
                   end
                 end


### PR DESCRIPTION
## Summary

- Removes personal info log

## Related issue(s)
[API-33994](https://jira.devops.va.gov/browse/API-33994)

## Testing done

 - rspec
 - postman

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
	modified:   modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature