### PR TITLE
Updates VAProfile's Veteran Status Logging

### DIFF
--- a/lib/va_profile/health_benefit/service.rb
+++ b/lib/va_profile/health_benefit/service.rb
@@ -4,13 +4,11 @@ require 'va_profile/health_benefit/configuration'
 require 'va_profile/health_benefit/associated_persons_response'
 require 'va_profile/models/associated_person'
 
-
 module VAProfile
   module HealthBenefit
     class Service < VAProfile::Service
       include Common::Client::Concerns::Monitoring
 
-      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.veteran_status".freeze
       configuration VAProfile::HealthBenefit::Configuration
 
       OID = '1.2.3' # placeholder


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This work is behind a feature toggle (flipper): No
- A [followup to an earlier PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15452), this adds VAProfile's Veteran Status service to our breakers initializers for logging in Datadog

## Related issue(s)

- [ZenHub Epic](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74906)

## What areas of the site does it impact?
*Datadog's metrics

## Acceptance criteria

- [ ]  Events are being sent to the appropriate logging solution

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
