### PR TITLE
Updating find a rep feature toggle names

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -453,7 +453,7 @@ features:
     actor_type: user
     description: Enables Find a Representative tool
     enable_in_development: true
-  flag_a_representative:
+  find_a_representative_flag_results_enabled:
     actor_type: user
     description: Enables flag a rep for Find a Rep
     enable_in_development: true

--- a/config/features.yml
+++ b/config/features.yml
@@ -449,9 +449,9 @@ features:
     actor_type: user
     description: Enables new review page navigation for users completing the Financial Status Report (FSR) form.
     enable_in_development: true
-  find_a_representative:
+  find_a_representative_enabled:
     actor_type: user
-    description: Enables frontend of Find a Representative
+    description: Enables Find a Representative tool
     enable_in_development: true
   find_a_representative_enable_api:
     actor_type: user

--- a/config/features.yml
+++ b/config/features.yml
@@ -453,6 +453,10 @@ features:
     actor_type: user
     description: Enables Find a Representative tool
     enable_in_development: true
+  find_a_representative_enable_frontend:
+    actor_type: user
+    description: Enables Find a Representative frontend
+    enable_in_development: true
   find_a_representative_flag_results_enabled:
     actor_type: user
     description: Enables flag a rep for Find a Rep

--- a/config/features.yml
+++ b/config/features.yml
@@ -453,14 +453,6 @@ features:
     actor_type: user
     description: Enables Find a Representative tool
     enable_in_development: true
-  find_a_representative_enable_api:
-    actor_type: user
-    description: Enables the Find a Rep search endpoint
-    enable_in_development: true
-  find_a_representative_enable_frontend:
-    actor_type: user
-    description: Enables frontend of Find a Representative
-    enable_in_development: true
   flag_a_representative:
     actor_type: user
     description: Enables flag a rep for Find a Rep

--- a/modules/veteran/app/controllers/veteran/v0/base_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/base_accredited_representatives_controller.rb
@@ -77,7 +77,7 @@ module Veteran
       end
 
       def feature_enabled
-        routing_error unless Flipper.enabled?(:find_a_representative_enable_api)
+        routing_error unless Flipper.enabled?(:find_a_representative_enabled)
       end
 
       def verify_sort

--- a/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
@@ -43,7 +43,7 @@ module Veteran
       end
 
       def feature_enabled
-        routing_error unless Flipper.enabled?(:flag_a_representative)
+        routing_error unless Flipper.enabled?(:find_a_representative_flag_results_enabled)
       end
     end
   end

--- a/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
@@ -4,6 +4,7 @@ module Veteran
   module V0
     class FlagAccreditedRepresentativesController < ApplicationController
       service_tag 'lighthouse-veteran'
+      skip_before_action :verify_authenticity_token
       skip_before_action :authenticate
       before_action :feature_enabled
 

--- a/modules/veteran/spec/requests/v0/base_accredited_representatives_shared_spec.rb
+++ b/modules/veteran/spec/requests/v0/base_accredited_representatives_shared_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.shared_examples 'base_accredited_representatives_controller_shared_examples' do |path, type|
   context 'when find a rep is disabled' do
     before do
-      Flipper.disable(:find_a_representative_enable_api)
+      Flipper.disable(:find_a_representative_enabled)
     end
 
     it 'returns a not found routing error' do
@@ -22,7 +22,7 @@ RSpec.shared_examples 'base_accredited_representatives_controller_shared_example
 
   context 'when find a rep is enabled' do
     before do
-      Flipper.enable(:find_a_representative_enable_api)
+      Flipper.enable(:find_a_representative_enabled)
     end
 
     context 'when a required param is missing' do


### PR DESCRIPTION
## Summary
We are consolidating our feature toggles so that client and api share the same toggles for any given feature. Names and references have been updated in this PR. 

Leaving `find_a_representative_enable_frontend` as is until this PR is merged + references have been updated in vets-website. 

This PR also includes a temporary workaround to a 403 error associated with `our flag_accredited_representative` endpoint. Skipping verify_authenticity_token circumvents the issue, but is not a viable solution from a security perspective. This change is being introduced temporarily so that the ARM team can QA Find a Rep's UI and functionality. It does not impact production and it will be reverted. 

To reproduce:
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74241

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Find a Representative staging instance. This app is not live in prod. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
