### PR TITLE
VACMS-11875 Remove show_header_v2 flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -912,10 +912,6 @@ features:
     actor_type: user
     description: Enables the internationalization features for forms
     enable_in_development: true
-  show_header_v2:
-    action_type: user
-    description: Enables the new header
-    enable_in_development: true
   show_dgi_direct_deposit_1990EZ:
     actor_type: user
     description: Displays prefill enabled direct deposit component on 1990EZ form.


### PR DESCRIPTION
## Summary
Remove show_header_v2 flipper as it is not in use.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11875

## Testing done
[Searched the DSVA Github repos for code instances](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+show_header_v2&type=code) and removed the relevant code.