### PR TITLE
VAOS Add Feature Toggle for Excluding Captain James A. Lovell from Online Scheduling Cancellations

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1007,6 +1007,10 @@ features:
     actor_type: user
     description: Permits the exclusion of Lovell sites from being scheduled prior to Oracle Health cutover
     enable_in_development: true
+  va_online_scheduling_cancellation_exclusion:
+    actor_type: user
+    description: Permits the exclusion of Lovell sites from cancellations prior to Oracle Health cutover
+    enable_in_development: true
   va_online_scheduling_cancel:
     actor_type: user
     description: Allows veterans to cancel VA appointments


### PR DESCRIPTION
## Summary

This adds a feature toggle, va_online_scheduling_cancellation_exclusion, for work needed to exclude Lovell sites from having appointments cancelled before the sites are converted over to Oracle Health (Cerner).

The feature toggle flag will be removed once the Lovell sites switch from VistA to Oracle Health. This conversion process is expected to take approximately 30 days. Lovell has requested that no appointments be cancelled via VAOS 30 days prior to their cutover.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75510