### PR TITLE
POA v2: Adds docs for checking POA status

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -64,7 +64,7 @@ module ClaimsApi
             )
           end
 
-          render json: poa, serializer: ClaimsApi::PowerOfAttorneySerializer
+          render json: poa, serializer: ClaimsApi::PowerOfAttorneySerializer, key_transform: :camel_lower
         end
 
         private

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -11434,6 +11434,7 @@
     "/veterans/{veteranId}/power-of-attorney/{id}": {
       "get": {
         "summary": "Checks status of Power of Attorney appointment form submission",
+        "description": "Gets the Power of Attorney appointment request status (21-22/21-22a)",
         "tags": [
           "Power of Attorney"
         ],
@@ -11473,19 +11474,234 @@
             "in": "path",
             "required": true,
             "example": "12e13134-7229-4e44-90ae-bcea2a4525fa",
-            "description": "Power of Attorney appointment request id",
+            "description": "The ID of the 21-22 submission",
             "schema": {
               "type": "string"
             }
           }
         ],
-        "description": "Gets the Power of Attorney appointment request status (21-22/21-22a)\n",
         "responses": {
           "200": {
-            "description": "Successful response"
+            "description": "Valid request response",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "id": "3479225d-e0b9-46ac-a3b1-65ae8fbb1cae",
+                    "type": "claimsApiPowerOfAttorneys",
+                    "attributes": {
+                      "status": "submitted",
+                      "dateRequestAccepted": "2024-02-08",
+                      "representative": {
+                        "serviceOrganization": {
+                          "poaCode": "074"
+                        }
+                      },
+                      "previousPoa": null
+                    }
+                  }
+                },
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Power of Attorney Submission UUID"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "status",
+                            "dateRequestAccepted",
+                            "representative"
+                          ],
+                          "properties": {
+                            "status": {
+                              "type": "string",
+                              "description": "Says if the power of attorney is pending, submitted, updated or errored",
+                              "enum": [
+                                "pending",
+                                "submitted",
+                                "updated",
+                                "errored"
+                              ]
+                            },
+                            "dateRequestAccepted": {
+                              "type": "string",
+                              "description": "Date request was first accepted",
+                              "format": "date"
+                            },
+                            "representative": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "required": [
+                                "serviceOrganization"
+                              ],
+                              "properties": {
+                                "serviceOrganization": {
+                                  "type": "object",
+                                  "additionalProperties": true,
+                                  "required": [
+                                    "poaCode"
+                                  ],
+                                  "properties": {
+                                    "poa_code": {
+                                      "type": "string",
+                                      "description": "Power of Attorney Code submitted for Veteran"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "previousPoa": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Current or Previous Power of Attorney Code submitted for Veteran"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Not authorized",
+                      "status": "401",
+                      "detail": "Not authorized"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find Power of Attorney with id: -1",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb:62:in `status'"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
           get "#{status_path}/#{poa.id}", params: nil, headers: auth_header
           json = JSON.parse(response.body)
 
-          expect(json['data']['type']).to eq('claims_api_power_of_attorneys')
+          expect(json['data']['type']).to eq('claimsApiPowerOfAttorneys')
           expect(json['data']['attributes']['status']).to eq('submitted')
         end
       end

--- a/spec/support/schemas/claims_api/v2/veterans/power_of_attorney/status.json
+++ b/spec/support/schemas/claims_api/v2/veterans/power_of_attorney/status.json
@@ -1,0 +1,66 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": ["data"],
+  "properties": {
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "attributes"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Power of Attorney Submission UUID"
+        },
+        "type": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "dateRequestAccepted", "representative"],
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Says if the power of attorney is pending, submitted, updated or errored",
+              "enum": [
+                "pending",
+                "submitted",
+                "updated",
+                "errored"
+              ]
+            },
+            "dateRequestAccepted": {
+              "type": "string",
+              "description": "Date request was first accepted",
+              "format": "date"
+            },
+            "representative": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["serviceOrganization"],
+              "properties": {
+                "serviceOrganization": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": ["poaCode"],
+                  "properties": {
+                    "poa_code": {
+                      "type": "string",
+                      "description": "Power of Attorney Code submitted for Veteran"
+                    }
+                  }
+                }
+              }
+            },
+            "previousPoa": {
+              "type": "string",
+              "nullable": true,
+              "description": "Current or Previous Power of Attorney Code submitted for Veteran"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Swagger docs for `GET /veterans/:veteranId/power-of-attorney/:id`

## Related issue(s)
[API-32126](https://jira.devops.va.gov/browse/API-32126)

## Testing done

- Postman
- Rspecs updated

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/534756/737182e8-53e8-4092-af11-0e23f67647f2)

![image](https://github.com/department-of-veterans-affairs/vets-api/assets/534756/9f2a871e-4ede-4f50-9064-6cd693692195)


## What areas of the site does it impact?
Claims API

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
