### PR TITLE
Adds Metrics to Datadog Breakers Charts for VAProfile's Military Personnel Service

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -32,6 +32,7 @@ require 'search_typeahead/configuration'
 require 'search_click_tracking/configuration'
 require 'va_profile/contact_information/configuration'
 require 'va_profile/communication/configuration'
+require 'va_profile/military_personnel/configuration'
 require 'va_profile/veteran_status/configuration'
 require 'iam_ssoe_oauth/configuration'
 require 'vetext/service'
@@ -70,6 +71,7 @@ Rails.application.reloader.to_prepare do
     SM::Configuration.instance.breakers_service,
     VAProfile::ContactInformation::Configuration.instance.breakers_service,
     VAProfile::Communication::Configuration.instance.breakers_service,
+    VAProfile::MilitaryPersonnel::Configuration.instance.breakers_service,
     VAProfile::VeteranStatus::Configuration.instance.breakers_service,
     Search::Configuration.instance.breakers_service,
     SearchTypeahead::Configuration.instance.breakers_service,

--- a/lib/va_profile/military_personnel/service.rb
+++ b/lib/va_profile/military_personnel/service.rb
@@ -13,6 +13,7 @@ module VAProfile
     class Service < VAProfile::Service
       include Common::Client::Concerns::Monitoring
 
+      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.military_personnel".freeze
       configuration VAProfile::MilitaryPersonnel::Configuration
 
       OID = '2.16.840.1.113883.3.42.10001.100001.12'


### PR DESCRIPTION
### Summary 

VAProfile's services should be represented in Platform's Datadog breakers charts, but some services are missing.

This PR adds logging to VAProfile's Military Personnel service so that its metrics will appear in the Datadog breakers charts. Subsequent PRs related to this work will be submitted for other services that need it. 

- Not behind a feature toggle
- This work is being done on behalf of the Product Platform team.

### Related issue(s)
- [Current epic](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74906) - shows scope of this work
- [Current ticket](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74921) - documents the work in this PR
- [Previous related ticket](https://github.com/department-of-veterans-affairs/vets-api/pull/15304)

#### Testing done
Once merged, will monitor breakers charts to determine if the service and its metrics are now visible.

#### What areas of the site does it impact?
This should impact Datadog's breakers charts dashboard.

#### Acceptance criteria
- [X] Has a monitor built into Datadog