### PR TITLE
VACMS-11861 Remove cerner_allow_partial_facilities flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -52,9 +52,6 @@ features:
     actor_type: user
     description: Enables access to the 10-10EZR application in prod for the purposes of conducting user reasearch
     enable_in_development: true
-  cerner_allow_partial_facilities:
-    actor_type: user
-    description: This will allow cerner facilities to be set to partially cerner or all cerner.
   cerner_transition_556_t30:
     actor_type: user
     description: This will control the content that will be in effect 30 days prior to transition.


### PR DESCRIPTION
## Summary
Remove cerner_allow_partial_facilities flipper as it is not in use.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11861

## Testing done
Searched the DSVA Github repos for code instances ([for "cerner_allow_partial_facilities"](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cerner_allow_partial_facilities&type=code) and ["cernerAllowPartialFacilities"](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cernerAllowPartialFacilities&type=code)) and removed the relevant code.