### PR TITLE
VACMS-11859 Removing old Cerner feature toggles

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -61,21 +61,9 @@ features:
   cerner_transition_556_t5:
     actor_type: user
     description: This will control the content that will be in effect 5 days prior to transition.
-  cerner_override_463:
-    actor_type: user
-    description: This will show the Cerner facility 463 as `isCerner`.
-  cerner_override_531:
-    actor_type: user
-    description: This will show the Cerner facility 531 as `isCerner`.
-  cerner_override_648:
-    actor_type: user
-    description: This will show the Cerner facility 648 as `isCerner`.
   cerner_override_653:
     actor_type: user
     description: This will show the Cerner facility 653 as `isCerner`.
-  cerner_override_663:
-    actor_type: user
-    description: This will show the Cerner facility 663 as `isCerner`.
   cerner_override_668:
     actor_type: user
     description: This will show the Cerner facility 668 as `isCerner`.


### PR DESCRIPTION
## Summary
Remove these flippers that are no longer in use:
- cerner_override_463
- cerner_override_531
- cerner_override_648
- cerner_override_663

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11859

## Testing done
Searched the DSVA Github repos for code instances and removed the relevant code:
- [cerner_override_463](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cerner_override_463&type=code)
- [cerner_override_531](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cerner_override_531&type=code)
- [cerner_override_648](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cerner_override_648&type=code)
- [cerner_override_663](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cerner_override_663&type=code)