### PR TITLE
VACMS-11872 Remove show_new_view_test_lab_results_page flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -979,9 +979,6 @@ features:
   show_new_secure_messaging_page:
     actor_type: user
     description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/secure-messaging/
-  show_new_view_test_lab_results_page:
-    actor_type: user
-    description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/view-test-and-lab-results/
   show_updated_fry_dea_app:
     actor_type: user
     description: Show the new version of the Fry/DEA form.


### PR DESCRIPTION
## Summary
Remove show_new_view_test_lab_results_page flipper as it is not in use.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11872

## Testing done
[Searched the DSVA Github repos for code instances](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+show_new_view_test_lab_results_page&type=code) and removed the relevant code.