### PR TITLE
Add ruby platform back to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,11 +592,7 @@ GEM
     libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
-    libddwaf (1.14.0.0.0-arm64-darwin)
-      ffi (~> 1.0)
     libddwaf (1.14.0.0.0-java)
-      ffi (~> 1.0)
-    libddwaf (1.14.0.0.0-x86_64-darwin)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
@@ -1048,13 +1044,11 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-23
   java
+  ruby
   x64-mingw32
   x86-mingw32
   x86-mswin32
-  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## Summary
`ruby` platform was unintentionally removed [here](https://github.com/department-of-veterans-affairs/vets-api/commit/bd5ff6f2ea5804651951ed27be114759077064f6#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fL1042). 
As a result the following platforms have been added:

- [arm64-darwin-22](https://github.com/department-of-veterans-affairs/vets-api/commit/bd5ff6f2ea5804651951ed27be114759077064f6#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR1048)
- [arm64-darwin-23](https://github.com/department-of-veterans-affairs/vets-api/commit/adc882e729da036c601ff13259ac64b650916465#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR1048)
- [x86_64-darwin-22](https://github.com/department-of-veterans-affairs/vets-api/commit/9581871a66f986493b1ca2a3f35d15d408417978#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR1056)


These can also be removed since these platforms can also use `ruby`. In order for these to not be added again, users with gems downloaded from these platforms will need to run:
```bash
bundle install --redownload
```
