### PR TITLE
remove toggle profile_use_field_editing_page

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -785,10 +785,6 @@ features:
     description: Use experimental features for Profile application - Do not remove
     enable_in_development: true
     actor_type: user
-  profile_use_field_editing_page:
-    description: Use a single page route in Profile for editing or adding a field value
-    enable_in_development: true
-    actor_type: user
   profile_use_hub_page:
     description: Use a hub style page as the root page for the profile application
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Removes single toggle not used on vets-website anymore
- [FE PR that it was removed in](https://github.com/department-of-veterans-affairs/vets-website/pull/27744) has been merged and deployed

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/53549

## Testing done
- unit tests passing, only toggle is removed

## What areas of the site does it impact?

Profile - Authenticated Experience

## Acceptance criteria

- [x] toggle removed