### PR TITLE
Remove newline in 40-0247 simple form

### DIFF
--- a/modules/simple_forms_api/app/form_mappings/vba_40_0247.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_40_0247.json.erb
@@ -14,7 +14,7 @@
   "form1[0].#subform[0].Date1[0]": "<%= form.data['veteran_date_of_birth'] %>",
   "form1[0].#subform[0].Date1[1]": "<%= form.data['veteran_date_of_death'] %>",
   "form1[0].#subform[0].TextField1[2]": "<%= form.data.dig('applicant_full_name', 'first') + ' ' + (form.data.dig('applicant_full_name', 'middle') || '') + ' ' + form.data.dig('applicant_full_name', 'last') %>",
-  "form1[0].#subform[0].TextField4[0]": "<%= form.data.dig('applicant_address', 'street') + ', ' + (form.data.dig('applicant_address', 'street2') || '') + '\n' + form.data.dig('applicant_address', 'city') + ', ' + form.data.dig('applicant_address', 'state') + ' ' + form.data.dig('applicant_address', 'postal_code') + '\n' + form.data.dig('applicant_address', 'country') %>",
+  "form1[0].#subform[0].TextField4[0]": "<%= form.data.dig('applicant_address', 'street') + ', ' + (form.data.dig('applicant_address', 'street2') || '') + '\n' + form.data.dig('applicant_address', 'city') + ', ' + form.data.dig('applicant_address', 'state') + ' ' + form.data.dig('applicant_address', 'postal_code') + ' ' + form.data.dig('applicant_address', 'country') %>",
   "form1[0].#subform[0].TextField1[3]": "<%= form.data['applicant_phone'] %>",
   "form1[0].#subform[0].TextField1[4]": "<%= form.data['applicant_email'] %>",
   "form1[0].#subform[0].TextField2[0]": "<%= form.data['certificates'] %>",


### PR DESCRIPTION
## Summary
This PR removes a newline that was causing the address country to be cut off on the PDF itself. See screenshot below.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/957

## Screenshots
<img width="665" alt="Screenshot 2024-02-09 at 2 34 32 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/b9ae8a79-3b7b-4e63-a52f-a9a5ce812ca8">
