### PR TITLE
Fixed feature toggle reference. find_a_rep => find_a_representative_enabled

### DIFF
--- a/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
+++ b/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'VSOAccreditedRepresentativesController', type: :request do
     let(:type) { 'veteran_service_officer' }
 
     before do
-      Flipper.enable(:find_a_rep)
+      Flipper.enable(:find_a_representative_enabled)
       # Create representatives
       create(:representative, representative_id: '111', poa_codes: %w[A12 A13], user_types: ['veteran_service_officer'],
                               long: -77.050552, lat: 38.820450, location: 'POINT(-77.050552 38.820450)',


### PR DESCRIPTION
## Summary

- There was a lingering feature toggle reference to `find_a_rep` which should be `find_a_representative_enabled`.
  
