### PR TITLE
Update ssl configuration based on Rails.env

### DIFF
--- a/modules/claims_api/lib/pdf_generator_service/pdf_client.rb
+++ b/modules/claims_api/lib/pdf_generator_service/pdf_client.rb
@@ -16,7 +16,7 @@ module ClaimsApi
       path = Settings.claims_api.pdf_generator_526.path
       content_type = Settings.claims_api.pdf_generator_526.content_type
       conn = Faraday.new("#{url}#{path}",
-                         ssl: { verify: false },
+                         ssl: { verify: !Rails.env.development? },
                          headers: { 'Content-Type': content_type.to_s }) do |f|
         f.request :json
         f.response :raise_error


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Fix to address a security alert regarding the Faraday configuration for the pdf generator client, which was set to explicitly disable ssl verification.

## Related issue(s)

- [API-34167](https://jira.devops.va.gov/browse/API-34167)
- See also: https://github.com/department-of-veterans-affairs/vets-api/security/code-scanning/789

## Testing done

- Tested locally via Postman to confirm no self-signed certificate errors are present.


## What areas of the site does it impact?
modules/claims_api/lib/pdf_generator_service/pdf_client.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

