### PR TITLE
allows disabling uploads of supp documents for load tests

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_documents.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_documents.rb
@@ -19,7 +19,7 @@ module ClaimsApi
           claim_document = @claim.supporting_documents.build
           claim_document.set_file_data!(document, EVSS_DOCUMENT_TYPE, @params[:description])
           claim_document.save!
-          ClaimsApi::ClaimUploader.perform_async(claim_document.id)
+          ClaimsApi::ClaimUploader.perform_async(claim_document.id) unless Flipper.enabled? :claims_load_testing
         end
       end
 


### PR DESCRIPTION
## Summary
- Sets the existing flipper feature to also disable the upload to Benefits Documents so we can load test and not generate ~1,800 sidekiq jobs.

## Related issue(s)
- Can associate to Load Tests ticket - https://jira.devops.va.gov/browse/API-32188

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature