### PR TITLE
75498 add feature flag for travel claims for Cerner sites

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -132,6 +132,10 @@ features:
     actor_type: user
     description: Enables travel reimbursement workflow for day-of check-in application.
     enable_in_development: true
+  check_in_experience_cerner_travel_claims_enabled:
+    actor_type: user
+    description: Enables travel claims filing for Oracle Health (Cerner) sites
+    enable_in_development: true
   check_in_experience_travel_logic:
     actor_type: user
     description: Enables the travel reimbursement logic


### PR DESCRIPTION
## Summary
This PR adds a feature flag for enabling the functionality of filing travel claims for Oracle Health sites

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75498

## Testing done
NA

