### PR TITLE
Employee-Experience: Update path for EP Merge App within VRO

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1544,7 +1544,7 @@ virtual_regional_office:
   evidence_pdf_path: evidence-pdf
   ctn_classification_path: classifier
   max_cfi_path: employee-experience/max-ratings
-  ep_merge_path: employee-experience/merge
+  ep_merge_path: employee-experience-ep-merge-app/merge
 
 # Settings for Test User Dashboard modules
 test_user_dashboard:

--- a/spec/support/vcr_cassettes/virtual_regional_office/ep_merge.yml
+++ b/spec/support/vcr_cassettes/virtual_regional_office/ep_merge.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8120/employee-experience/merge
+    uri: http://localhost:8120/employee-experience-ep-merge-app/merge
     body:
       encoding: UTF-8
       string: '{"pending_claim_id":12345,"ep400_claim_id":12346}'
@@ -32,6 +32,6 @@ http_interactions:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"job":{"job_id":"01234567-89ab-cdef-0123-456789abcdef"}}'
+      string: '{"job":{"job_id":"501e5148-c737-45c1-b648-1788f7b72f96","pending_claim_id":12345,"ep400_claim_id":12346,"state":"PENDING","created_at":"2024-02-08T15:24:36.739515","updated_at":"2024-02-08T15:24:36.739515"}}'
   recorded_at: Thu, 10 Aug 2023 19:52:24 GMT
 recorded_with: VCR 6.2.0

--- a/spec/support/vcr_cassettes/virtual_regional_office/ep_merge_failure.yml
+++ b/spec/support/vcr_cassettes/virtual_regional_office/ep_merge_failure.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8120/employee-experience/merge
+    uri: http://localhost:8120/employee-experience-ep-merge-app/merge
     body:
       encoding: UTF-8
       string: '{"pending_claim_id":12345,"ep400_claim_id":12346}'


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Updates endpoint for vets-api to send requests to the EP Merge App in VRO
- I am part of the Claims Fast-Tracking crew's Employee Experience team. We work closely with the Disability Experience team which owns this code.
- The API call is behind a new feature toggle disability_526_ep_merge_api which will remain disabled in production for the near future.

## Related issue(s)
Allows testing of Ep Merge App as discussed in this ticket:
* https://github.com/department-of-veterans-affairs/abd-vro/issues/2092

## Testing done
Updated rspecs
E2E testing in staging / VBMS UAT is planned once the VRO API server portion is complete

## What areas of the site does it impact?
None as the feature is still toggled OFF

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)