### PR TITLE
Updates the Breakers Metrics Configuration for VAProfile's Person Service

### DIFF
--- a/lib/va_profile/person/service.rb
+++ b/lib/va_profile/person/service.rb
@@ -7,6 +7,7 @@ require 'va_profile/contact_information/transaction_response'
 require 'va_profile/service'
 require 'va_profile/stats'
 require 'identity/parsers/gc_ids_constants'
+require_relative 'configuration'
 
 module VAProfile
   module Person


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Recently [VAProfile's Person service was updated](https://github.com/department-of-veterans-affairs/vets-api/pull/15446) to facilitate its breakers metrics appearing in Datadog's Breakers charts. However, those metrics are not surfacing. 
- The problem could be a configuration issue in the oode, or it's possible metrics haven't surfaced simply because the service hasn't received requests yet. 
- This PR attempts to resolve the issue if it's configuration-based.
- This work is being done for Platform Product.

## Related issue(s)

- [Ticket to Add Configuration to Person Service](https://github.com/department-of-veterans-affairs/vets-api/pull/15446)


## What areas of the site does it impact?
Datadog Breakers Charts

## Acceptance criteria
- [x]  Feature/bug has a monitor built into Datadog

