### PR TITLE
[Rated Disabilities] Updating logic for Rated Disabilities Discrepancies checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1866,7 +1866,7 @@ spec/support/vcr_cassettes/lighthouse/benefits_intake/200_lighthouse_intake_bulk
 spec/support/vcr_cassettes/lighthouse/benefits_intake/200_lighthouse_intake_bulk_status_report_success.yml @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/lighthouse/claims/200_response.yml @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/dbex-trex
 spec/support/vcr_cassettes/lighthouse/direct_deposit @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/dbex-trex  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/lighthouse/veteran_verification @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/support/vcr_cassettes/lighthouse/veteran_verification @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/map @department-of-veterans-affairs/octo-identity
 spec/support/vcr_cassettes/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
+++ b/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
@@ -52,18 +52,18 @@ module V0
 
       # We only want active ratings
       if response.dig('data', 'attributes', 'individual_ratings')
-        remove_inactive_ratings!(response['data']['attributes']['individual_ratings'])
+        reject_deferred_ratings!(response['data']['attributes']['individual_ratings'])
       end
 
       response
     end
 
-    def remove_inactive_ratings!(ratings)
-      ratings.select! { |rating| active?(rating) }
+    def reject_deferred_ratings!(ratings)
+      ratings.reject! { |rating| deferred?(rating) }
     end
 
-    def active?(rating)
-      rating['rating_end_date'].nil?
+    def deferred?(rating)
+      rating['decision'] == 'Deferred'
     end
 
     def service

--- a/spec/controllers/v0/rated_disabilities_controller_spec.rb
+++ b/spec/controllers/v0/rated_disabilities_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe V0::RatedDisabilitiesController, type: :controller do
         # VCR Cassette should have 3 items in the individual_ratings array, only 2 should
         # be "active"
         parsed_body = JSON.parse(response.body)
-        expect(parsed_body.dig('data', 'attributes', 'individual_ratings').length).to eq(2)
+        expect(parsed_body.dig('data', 'attributes', 'individual_ratings').length).to eq(3)
       end
     end
 

--- a/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
+++ b/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
@@ -36,8 +36,25 @@ RSpec.describe V0::RatedDisabilitiesDiscrepanciesController, type: :controller d
 
         expect(response).to have_http_status(:ok)
 
-        # Lighthouse should return 2 items, EVSS should return 1, so there should be a discrepancy
-        # of 1 disability rating
+        # Lighthouse should return 3 items, EVSS should return 1, so there should be a discrepancy
+        # of 2 disability rating
+        expect(Rails.logger).to have_received(:info).with(
+          'Discrepancy of 2 disability ratings',
+          { message_type: 'lh.rated_disabilities.length_discrepancy' }
+        )
+      end
+
+      it 'filters out deferred ratings' do
+        VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_deferred_response') do
+          VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_tinnitus_max_rated') do
+            get(:show)
+          end
+        end
+
+        expect(response).to have_http_status(:ok)
+
+        # Lighthouse should return 3 items, but filter out the deferred one, so when comparing
+        # with EVSS (which should return 1 rating), there should be a discrepancy of 1 rating
         expect(Rails.logger).to have_received(:info).with(
           'Discrepancy of 1 disability ratings',
           { message_type: 'lh.rated_disabilities.length_discrepancy' }

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_deferred_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_deferred_response.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Oct 2023 17:22:38 GMT
+      - Mon, 12 Feb 2024 02:22:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
@@ -102,9 +102,8 @@ http_interactions:
         },
         {
           "description": "Service Connected",
-          "decision": "Service Connected",
+          "decision": "Deferred",
           "effective_date": "2018-03-12",
-          "rating_end_date": null,
           "rating_percentage": 30,
           "diagnostic_type_code": "6260",
           "diagnostic_type_name": "Tinnitus",          
@@ -125,5 +124,5 @@ http_interactions:
     }
   }
 }'
-  recorded_at: Wed, 11 Oct 2023 17:22:38 GMT
+  recorded_at: Mon, 12 Feb 2024 02:22:38 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary
Lighthouse updated their Rated Disabilities endpoint in production. It no longer returns inactive ratings so we can remove that check, but they now return ratings that have a `decision` value of 'Deferred`. This PR updates the controllers logic to filter out deferred ratings so that we can determine if there are any other discrepancies

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75855

## Testing done
Updated the VCR cassettes as LH doesn't return ratings with a `rating_end_date` not set to `null`. Also checking that deferred ratings are actually filtered out

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
