### PR TITLE
Pensions: handle partial dependents

### DIFF
--- a/lib/pdf_fill/forms/va21p527ez.rb
+++ b/lib/pdf_fill/forms/va21p527ez.rb
@@ -1502,7 +1502,7 @@ module PdfFill
             custodian_addresses[custodian_key] = build_custodian_hash_from_dependent(dependent)
           else
             custodian_addresses[custodian_key]['dependentsWithCustodianOverflow'] +=
-              ", #{dependent['fullName'].values.join(' ')}"
+              ", #{dependent['fullName']&.values&.join(' ')}"
           end
         end
         if custodian_addresses.any?
@@ -1520,7 +1520,7 @@ module PdfFill
                  })
           .merge({
                    'custodianAddressOverflow' => build_address_string(dependent['childAddress']),
-                   'dependentsWithCustodianOverflow' => dependent['fullName'].values.join(' ')
+                   'dependentsWithCustodianOverflow' => dependent['fullName']&.values&.join(' ')
                  })
       end
 

--- a/spec/lib/pdf_fill/forms/va21p527ez_spec.rb
+++ b/spec/lib/pdf_fill/forms/va21p527ez_spec.rb
@@ -58,4 +58,34 @@ describe PdfFill::Forms::Va21p527ez do
                                                                                 })
     end
   end
+
+  describe '#expand_dependent_children' do
+    it 'handles partially removed dependents' do
+      form_data = {
+        'dependents' => [
+          {
+            'childAddress' => {
+              'country' => 'US',
+              'city' => 'Cityville',
+              'street' => '100 Main St',
+              'state' => 'PA',
+              'postalCode' => '11111'
+            },
+            'personWhoLivesWithChild' => {
+              'last' => 'John',
+              'first' => 'Smith'
+            },
+            'monthlyPayment' => 1200
+          }
+        ]
+      }
+      form = described_class.new(form_data)
+      form.expand_dependent_children
+      updated_data = form.instance_variable_get('@form_data')
+      expect(updated_data['dependents'].length).to eq(1)
+      expect(updated_data['custodians'].length).to eq(1)
+      expect(updated_data['dependentChildrenInHousehold']).to eq('0')
+      expect(updated_data['dependentsNotWithYouAtSameAddress']).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- The following error is being thrown from a pension submission in production:
`Lighthouse::PensionBenefitIntakeJob FAILED! undefined method 'values' for nil:NilClass NoMethodError: undefined method 'values' for nil:NilClass /app/lib/pdf_fill/forms/va21p527ez.rb:1523: in 'build_custodian_hash_from_dependent': undefined method 'values' for nil:NilClass (NoMethodError)`. 
- This PR completes the first half of the acceptance criteria: A null dependent full name should not prevent the PDF from submitting successfully. The second half of the acceptance criteria will be handled in a follow-up vets-website PR.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75864

## Testing done

- [ ] New code is covered by unit tests
- [ ] Fill out the form with a dependent who does not live with the veteran. On the review page, change 'do you have any dependents?' to 'no', then submit the form. The PDF should submit successfully.

## What areas of the site does it impact?
Pensions Benefits

## Acceptance criteria

- A null dependent full name should not prevent the PDF from submitting successfully.

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
