### PR TITLE
74850 - Move dockerfile-k8s (same as Dockerfile in k8s branch) to master - allows building a k8s safe docker image while maintaining the existing dockerfile for review instances

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 
 Dangerfile @department-of-veterans-affairs/backend-review-group
 Dockerfile @department-of-veterans-affairs/backend-review-group
+Dockerfile-k8s @department-of-veterans-affairs/backend-review-group
 docker-compose* @department-of-veterans-affairs/backend-review-group
 Gemfile @department-of-veterans-affairs/backend-review-group
 Gemfile.lock @department-of-veterans-affairs/backend-review-group

--- a/Dockerfile-k8s
+++ b/Dockerfile-k8s
@@ -1,0 +1,72 @@
+FROM ruby:3.2.2-slim-bullseye AS rubyimg
+FROM rubyimg AS modules
+
+WORKDIR /tmp
+
+# Copy each module's Gemfile, gemspec, and version.rb files
+COPY modules/ modules/
+RUN find modules -type f ! \( -name Gemfile -o -name "*.gemspec" -o -path "*/lib/*/version.rb" \) -delete && \
+    find modules -type d -empty -delete
+
+FROM rubyimg
+
+# Allow for setting ENV vars via --build-arg
+ARG BUNDLE_ENTERPRISE__CONTRIBSYS__COM \
+  RAILS_ENV=development \
+  USER_ID=1000
+ENV RAILS_ENV=$RAILS_ENV \
+  BUNDLE_ENTERPRISE__CONTRIBSYS__COM=$BUNDLE_ENTERPRISE__CONTRIBSYS__COM \
+  BUNDLER_VERSION=2.4.9
+
+RUN groupadd --gid $USER_ID nonroot \
+  && useradd --uid $USER_ID --gid nonroot --shell /bin/bash --create-home nonroot --home-dir /app
+
+WORKDIR /app
+
+RUN echo "deb http://ftp.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install -y -t testing poppler-utils build-essential libpq-dev git curl wget ca-certificates-java file
+RUN dpkg --configure -a && apt-get install -y -t bullseye imagemagick pdftk \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Relax ImageMagick PDF security. See https://stackoverflow.com/a/59193253.
+RUN sed -i '/rights="none" pattern="PDF"/d' /etc/ImageMagick-6/policy.xml
+
+
+# Install fwdproxy.crt into trust store
+# Relies on update-ca-certificates being run in following step
+COPY config/ca-trust/*.crt /usr/local/share/ca-certificates/
+
+# Download VA Certs
+COPY ./import-va-certs.sh .
+RUN ./import-va-certs.sh
+
+COPY config/clamd.conf /etc/clamav/clamd.conf
+
+RUN mkdir -p /clamav_tmp && \
+    chown -R nonroot:nonroot /clamav_tmp && \
+    chmod 777 /clamav_tmp
+
+
+ENV LANG=C.UTF-8 \
+   BUNDLE_JOBS=4 \
+   BUNDLE_PATH=/usr/local/bundle/cache \
+   BUNDLE_RETRY=3
+
+RUN gem install bundler:${BUNDLER_VERSION} --no-document
+
+COPY --from=modules /tmp/modules modules/
+COPY Gemfile Gemfile.lock ./
+RUN bundle install \
+  && rm -rf /usr/local/bundle/cache/*.gem \
+  && find /usr/local/bundle/gems/ -name "*.c" -delete \
+  && find /usr/local/bundle/gems/ -name "*.o" -delete \
+  && find /usr/local/bundle/gems/ -name ".git" -type d -prune -execdir rm -rf {} +
+COPY --chown=nonroot:nonroot . .
+
+EXPOSE 3000
+
+USER nonroot
+
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
## Summary


- An additional dockerfile that builds a kubernetes safe docker image
- Platform Reliability Team

## Related issue(s)

- https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/74850

## Testing done

- [ ] *New code is covered by unit tests* - N/A
- Dockerfile is confirmed to build - github pipeline to arrive in later PR

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
no impact on site - dockerfile is un-referrences

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

Additional PRs to follow will include a helm chart and github workflows to build the docker image and the helm chart. This dockerfile.k8s file matches the file used to deploy Kubernetes based environments
