### PR TITLE
Updates VAProfile Address Validation to Facilitate Breakers Metrics

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -30,6 +30,7 @@ require 'sm/configuration'
 require 'search/configuration'
 require 'search_typeahead/configuration'
 require 'search_click_tracking/configuration'
+require 'va_profile/address_validation/configuration'
 require 'va_profile/contact_information/configuration'
 require 'va_profile/communication/configuration'
 require 'va_profile/demographics/configuration'
@@ -71,6 +72,7 @@ Rails.application.reloader.to_prepare do
     MPI::Configuration.instance.breakers_service,
     Preneeds::Configuration.instance.breakers_service,
     SM::Configuration.instance.breakers_service,
+    VAProfile::AddressValidation::Configuration.instance.breakers_service,
     VAProfile::ContactInformation::Configuration.instance.breakers_service,
     VAProfile::Communication::Configuration.instance.breakers_service,
     VAProfile::Demographics::Configuration.instance.breakers_service,

--- a/lib/va_profile/address_validation/service.rb
+++ b/lib/va_profile/address_validation/service.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
+require 'common/client/concerns/monitoring'
 require 'common/exceptions'
 require 'va_profile/address_validation/configuration'
 require 'va_profile/address_validation/address_suggestions_response'
 require 'va_profile/service'
+require 'va_profile/stats'
 
 module VAProfile
   module AddressValidation
     # Wrapper for the VA profile address validation/suggestions API
     class Service < VAProfile::Service
+      include Common::Client::Concerns::Monitoring
+
+      STATSD_KEY_PREFIX = "#{VAProfile::Service::STATSD_KEY_PREFIX}.address_validation".freeze
       configuration VAProfile::AddressValidation::Configuration
 
       def initialize; end
@@ -17,9 +22,11 @@ module VAProfile
       # @return [VAProfile::AddressValidation::AddressSuggestionsResponse] response wrapper around address
       #   suggestions data
       def address_suggestions(address)
-        candidate_res = candidate(address)
+        with_monitoring do
+          candidate_res = candidate(address)
 
-        AddressSuggestionsResponse.new(candidate_res)
+          AddressSuggestionsResponse.new(candidate_res)
+        end
       end
 
       # @return [Hash] raw data from VA profile address validation API including


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This adds the necessary configuration to VAProfile::AddressValidation so that it produces metrics for the breakers charts in Datadog
- This work is being done on behalf of Product Platform

## Related issue(s)

- [Epic Ticket](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/74906)

## What areas of the site does it impact?
Datadog breakers charts

## Acceptance criteria
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)

