### PR TITLE
Add mhv-landing-page to list of frontend apps in StatsD middleware

### DIFF
--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -67,6 +67,7 @@ class StatsdMiddleware
     login-page
     medical-copays
     messages
+    mhv-landing-page
     my-documents
     my-health-account-validation
     order-form-2346


### PR DESCRIPTION
## Summary
Adding the `mhv-landing-page` app to the list of front end app names in the StatsD middleware. This should stop logs like [this](https://vagov.ddog-gov.com/logs?query=env%3Aeks-prod%20%40message_content%3A%2AHTTP_SOURCE_APP_NAME%2A%20%40message_content%3A%2A%5C%5Bmhv%5C-landing%5C-page%5C%5D%2A&cols=host%2Cservice)

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
