### PR TITLE
Adding shared_sessions boolean column to the client_config table. Add…

### DIFF
--- a/db/migrate/20240213175114_add_shared_sessions_to_client_config.rb
+++ b/db/migrate/20240213175114_add_shared_sessions_to_client_config.rb
@@ -1,0 +1,5 @@
+class AddSharedSessionsToClientConfig < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { add_column :client_configs, :shared_sessions, :boolean, default: false, null: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -338,6 +338,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "access_token_attributes", default: [], array: true
     t.text "terms_of_use_url"
     t.text "enforced_terms"
+    t.boolean "shared_sessions", default: false, null: false
     t.index ["client_id"], name: "index_client_configs_on_client_id", unique: true
   end
 

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -13,6 +13,7 @@ vaweb.update!(authentication: SignIn::Constants::Auth::COOKIE,
               logout_redirect_uri: 'http://localhost:3001',
               enforced_terms: SignIn::Constants::Auth::VA_TERMS,
               terms_of_use_url: 'http://localhost:3001/terms-of-use',
+              shared_sessions: true,
               refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Config for VA flagship mobile Sign in Service client
@@ -46,6 +47,7 @@ vamock.update!(authentication: SignIn::Constants::Auth::MOCK,
                access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
                access_token_audience: 'va.gov',
                logout_redirect_uri: 'http://localhost:3001',
+               shared_sessions: true,
                refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Config for example external client using cookie auth
@@ -57,6 +59,7 @@ sample_client_web.update!(authentication: SignIn::Constants::Auth::COOKIE,
                           access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
                           access_token_audience: 'sample_client',
                           logout_redirect_uri: 'http://localhost:4567',
+                          shared_sessions: true,
                           refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Config for example external client using api auth


### PR DESCRIPTION
## Summary

Adding a shared sessions boolean for the auth oath project

## Related issue(s)

department-of-veterans-affairs/va.gov-team/75380

## Testing done

- [ x ] *New code is covered by unit tests*

## What areas of the site does it impact?
Client Config table adding another column.

## Acceptance criteria

- [ x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x ]  No error nor warning in the console.
- [x ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

