### PR TITLE
VAOS Set Appointment Cancellable Flag to False for Lovell Appointments

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -288,7 +288,7 @@ module VAOS
       end
 
       def lovell_appointment?(appt)
-        return false unless appt.is_a?(Hash) && appt.key?(:location_id) && appt[:location_id].is_a?(String)
+        return false if appt.nil? || appt[:location_id].nil?
 
         appt[:location_id].start_with?('556')
       end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1048,25 +1048,23 @@ describe VAOS::V2::AppointmentsService do
   end
 
   describe 'lovell_appointment?' do
-    it 'returns false if the argument is not a hash' do
-      expect(subject.send(:lovell_appointment?, 'not a hash')).to eq(false)
-      expect(subject.send(:lovell_appointment?, 123)).to eq(false)
+    it 'returns false when the appointment is nil' do
+      expect(subject.send(:lovell_appointment?, nil)).to eq(false)
     end
 
-    it 'returns false if the hash has no :location_id key' do
-      expect(subject.send(:lovell_appointment?, { id: '123' })).to eq(false)
+    it 'returns false when the appointment location id is missing' do
+      appointment = { id: '123456' }
+      expect(subject.send(:lovell_appointment?, appointment)).to eq(false)
     end
 
-    it 'returns false if :location_id value is not a string' do
-      expect(subject.send(:lovell_appointment?, { location_id: 456 })).to eq(false)
+    it 'returns true if the appointment is a Lovell appointment' do
+      appointment = { location_id: '556', id: '123456' }
+      expect(subject.send(:lovell_appointment?, appointment)).to eq(true)
     end
 
-    it 'returns false if :location_id does not start with 556' do
-      expect(subject.send(:lovell_appointment?, { location_id: '123ABC' })).to eq(false)
-    end
-
-    it 'returns true if :location_id is a string that starts with 556' do
-      expect(subject.send(:lovell_appointment?, { location_id: '556GA' })).to eq(true)
+    it 'returns false if the appointment is not a Lovell appointment' do
+      appointment = { location_id: '983', id: '123456' }
+      expect(subject.send(:lovell_appointment?, appointment)).to eq(false)
     end
   end
 end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1046,4 +1046,27 @@ describe VAOS::V2::AppointmentsService do
       end
     end
   end
+
+  describe 'lovell_appointment?' do
+    it 'returns false if the argument is not a hash' do
+      expect(subject.send(:lovell_appointment?, 'not a hash')).to eq(false)
+      expect(subject.send(:lovell_appointment?, 123)).to eq(false)
+    end
+
+    it 'returns false if the hash has no :location_id key' do
+      expect(subject.send(:lovell_appointment?, { id: '123' })).to eq(false)
+    end
+
+    it 'returns false if :location_id value is not a string' do
+      expect(subject.send(:lovell_appointment?, { location_id: 456 })).to eq(false)
+    end
+
+    it 'returns false if :location_id does not start with 556' do
+      expect(subject.send(:lovell_appointment?, { location_id: '123ABC' })).to eq(false)
+    end
+
+    it 'returns true if :location_id is a string that starts with 556' do
+      expect(subject.send(:lovell_appointment?, { location_id: '556GA' })).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION

## Summary

In this PR, logic was added to identify any appointment that is a 'Lovell appointment' and subsequently set its 'cancellable' attribute to 'false'. A Lovell appointment is identified if the location_id of the appointment starts with "556". The logic was added to **VAOS::V2::AppointmentsService#get_appointments** and **VAOS::V2::AppointmentService#get_appointment**. A new method **VAOS::V2::AppointmentsService#lovell_appointment?** was added to identify Lovell appointments. 

This is behind the feature toggle, **va_online_scheduling_cancellation_exclusion**. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/75512


## Testing done

- [X] *New code is covered by unit tests*
- The appointment cancellable was left as is before the change. The change sets the appointment cancellable flag to false if the appointment is a Lovell appointment (location_id starts with 556.

