### PR TITLE
Migration: Remove required constraint from client_configs.access_token_audience

### DIFF
--- a/db/migrate/20240214212613_remove_required_constraint_from_client_config_access_token_audience.rb
+++ b/db/migrate/20240214212613_remove_required_constraint_from_client_config_access_token_audience.rb
@@ -1,0 +1,5 @@
+class RemoveRequiredConstraintFromClientConfigAccessTokenAudience < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :client_configs, :access_token_audience, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_13_195759) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -327,7 +327,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_13_195759) do
     t.boolean "anti_csrf", null: false
     t.text "redirect_uri", null: false
     t.interval "access_token_duration", null: false
-    t.string "access_token_audience", null: false
+    t.string "access_token_audience"
     t.interval "refresh_token_duration", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION

## Summary
Remove client_configs.access_token_audience required constraint. this is in preparation to remove this column

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#75383

## Testing
- migrate database - `rails db:migrate`

## What areas of the site does it impact?
Sign-in service