### PR TITLE
Filter Unwanted Errors from Retrying (Dependents Forms)

### DIFF
--- a/app/sidekiq/bgs/job.rb
+++ b/app/sidekiq/bgs/job.rb
@@ -5,6 +5,14 @@ require 'bgs/utilities/helpers'
 module BGS
   class Job
     include BGS::Utilities::Helpers
+    FILTERED_ERRORS = [
+      'insertBenefitClaim: Invalid zipcode.',
+      'Maximum number of EPs reached for this bnftClaimTypeCd',
+      'This update is being elevated for additional review due to an Incident Flash associated with this Beneficiary',
+      'ORA-20099: Error - File Number and Social Security number are different',
+      'ORA-00001: unique constraint',
+      'The length of the EXTERNAL_UID or EXTERNAL_KEY exceeds the maximum'
+    ].freeze
 
     def in_progress_form_copy(in_progress_form)
       return nil if in_progress_form.blank?

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -37,7 +37,7 @@ module BGS
     rescue => e
       handle_filtered_errors!(e:, icn:, encrypted_user_struct_hash:, encrypted_vet_info:)
 
-      Rails.logger.warn("BGS::SubmitForm674Job received error, retrying...",
+      Rails.logger.warn('BGS::SubmitForm674Job received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
       salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
@@ -48,8 +48,8 @@ module BGS
       filter = FILTERED_ERRORS.any? { |filtered| e.message.include?(filtered) || e.cause&.message&.include?(filtered) }
       return unless filter
 
-      Rails.logger.warn("BGS::SubmitForm674Job received error, skipping retries...",
-        { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
+      Rails.logger.warn('BGS::SubmitForm674Job received error, skipping retries...',
+                        { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
 
       vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
       self.class.send_backup_submission(encrypted_user_struct_hash, vet_info, saved_claim_id)

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -56,7 +56,7 @@ module BGS
       raise Sidekiq::JobRetry::Skip
     end
 
-    def instance_params(encrypted_vet_info, encrypted_user_struct_hash, user_uuid, saved_claim_id)
+    def instance_params(encrypted_vet_info, icn, encrypted_user_struct_hash, user_uuid, saved_claim_id)
       @vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
       @user = BGS::SubmitForm674Job.generate_user_struct(encrypted_user_struct_hash, @vet_info)
       @icn = icn

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -35,7 +35,7 @@ module BGS
       in_progress_form&.destroy
       Rails.logger.info('BGS::SubmitForm674Job succeeded!', { user_uuid:, saved_claim_id:, icn: })
     rescue => e
-      handle_filtered_errors!(e)
+      handle_filtered_errors!(e:, icn:, encrypted_user_struct_hash:, encrypted_vet_info:)
 
       Rails.logger.warn("BGS::SubmitForm674Job received error, retrying...",
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
@@ -44,7 +44,7 @@ module BGS
       raise
     end
 
-    def handle_filtered_errors!(e)
+    def handle_filtered_errors!(e:, icn:, encrypted_user_struct_hash:, encrypted_vet_info:)
       filter = FILTERED_ERRORS.any? { |filtered| e.message.include?(filtered) || e.cause&.message&.include?(filtered) }
       return unless filter
 

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -35,19 +35,25 @@ module BGS
       in_progress_form&.destroy
       Rails.logger.info('BGS::SubmitForm674Job succeeded!', { user_uuid:, saved_claim_id:, icn: })
     rescue => e
-      filter = FILTERED_ERRORS.any? { |filtered| e.message.include?(filtered) || e.cause&.message&.include?(filtered) }
-      Rails.logger.warn("BGS::SubmitForm674Job received error, #{filter ? 'skipping' : 'retrying'}...",
+      handle_filtered_errors!(e)
+
+      Rails.logger.warn("BGS::SubmitForm674Job received error, retrying...",
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
       salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
-
-      if filter
-        vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
-        self.class.send_backup_submission(encrypted_user_struct_hash, vet_info, saved_claim_id)
-        raise Sidekiq::JobRetry::Skip
-      end
-
       raise
+    end
+
+    def handle_filtered_errors!(e)
+      filter = FILTERED_ERRORS.any? { |filtered| e.message.include?(filtered) || e.cause&.message&.include?(filtered) }
+      return unless filter
+
+      Rails.logger.warn("BGS::SubmitForm674Job received error, skipping retries...",
+        { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
+
+      vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
+      self.class.send_backup_submission(encrypted_user_struct_hash, vet_info, saved_claim_id)
+      raise Sidekiq::JobRetry::Skip
     end
 
     def instance_params(encrypted_vet_info, encrypted_user_struct_hash, user_uuid, saved_claim_id)

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -35,12 +35,12 @@ module BGS
       in_progress_form&.destroy
       Rails.logger.info('BGS::SubmitForm674Job succeeded!', { user_uuid:, saved_claim_id:, icn: })
     rescue => e
+      salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
       handle_filtered_errors!(e:, encrypted_user_struct_hash:, encrypted_vet_info:)
 
       Rails.logger.warn('BGS::SubmitForm674Job received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
-      salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
       raise
     end
 

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -50,11 +50,12 @@ module BGS
       in_progress_form&.destroy
       Rails.logger.info('BGS::SubmitForm686cJob succeeded!', { user_uuid:, saved_claim_id:, icn: })
     rescue => e
-      Rails.logger.warn('BGS::SubmitForm686cJob received error, retrying...',
-                        { user_uuid:, saved_claim_id:, icn:, error: e.message })
+      filter = FILTERED_ERRORS.any? { |filtered| e.message.include?(filtered) || e.cause&.message&.include?(filtered) }
+      Rails.logger.warn("BGS::SubmitForm686cJob received error, #{filter ? 'skipping' : 'retrying'}...",
+                        { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
       salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
-      raise
+      raise unless filter
     end
 
     def self.generate_user_struct(vet_info)

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -37,19 +37,19 @@ module BGS
     rescue => e
       handle_filtered_errors!(e:, icn:, encrypted_vet_info:)
 
-      Rails.logger.warn("BGS::SubmitForm686cJob received error, retrying...",
+      Rails.logger.warn('BGS::SubmitForm686cJob received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
       salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
       raise
     end
-    
+
     def handle_filtered_errors!(e:, icn:, encrypted_vet_info:)
       filter = FILTERED_ERRORS.any? { |filtered| e.message.include?(filtered) || e.cause&.message&.include?(filtered) }
       return unless filter
 
-      Rails.logger.warn("BGS::SubmitForm686cJob received error, skipping retries...",
-        { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
+      Rails.logger.warn('BGS::SubmitForm686cJob received error, skipping retries...',
+                        { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
 
       vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
       self.class.send_backup_submission(vet_info, saved_claim_id)

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -35,7 +35,7 @@ module BGS
       in_progress_form&.destroy
       Rails.logger.info('BGS::SubmitForm686cJob succeeded!', { user_uuid:, saved_claim_id:, icn: })
     rescue => e
-      handle_filtered_errors!(e)
+      handle_filtered_errors!(e:, icn:, encrypted_vet_info:)
 
       Rails.logger.warn("BGS::SubmitForm686cJob received error, retrying...",
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
@@ -44,7 +44,7 @@ module BGS
       raise
     end
     
-    def handle_filtered_errors!(e)
+    def handle_filtered_errors!(e:, icn:, encrypted_vet_info:)
       filter = FILTERED_ERRORS.any? { |filtered| e.message.include?(filtered) || e.cause&.message&.include?(filtered) }
       return unless filter
 

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -18,14 +18,8 @@ module BGS
       vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
       Rails.logger.error('BGS::SubmitForm686cJob failed, retries exhausted!',
                          { user_uuid:, saved_claim_id:, icn:, error: })
-      if Flipper.enabled?(:dependents_central_submission)
-        user ||= BGS::SubmitForm686cJob.generate_user_struct(vet_info)
-        CentralMail::SubmitCentralForm686cJob.perform_async(saved_claim_id,
-                                                            KmsEncrypted::Box.new.encrypt(vet_info.to_json),
-                                                            KmsEncrypted::Box.new.encrypt(user.to_h.to_json))
-      else
-        DependentsApplicationFailureMailer.build(user).deliver_now if user&.email.present? # rubocop:disable Style/IfInsideElse
-      end
+
+      BGS::SubmitForm686cJob.send_backup_submission(vet_info, saved_claim_id)
     end
 
     def perform(user_uuid, icn, saved_claim_id, encrypted_vet_info)
@@ -35,12 +29,7 @@ module BGS
       in_progress_form = InProgressForm.find_by(form_id: FORM_ID, user_uuid:)
       @in_progress_copy = in_progress_form_copy(in_progress_form)
 
-      claim_data = normalize_names_and_addresses!(valid_claim_data)
-
-      BGS::Form686c.new(user, claim).submit(claim_data)
-
-      # If Form 686c job succeeds, then enqueue 674 job.
-      BGS::SubmitForm674Job.perform_async(user_uuid, icn, saved_claim_id, encrypted_vet_info, KmsEncrypted::Box.new.encrypt(user.to_h.to_json)) if claim.submittable_674? # rubocop:disable Layout/LineLength
+      submit_forms
 
       send_confirmation_email
       in_progress_form&.destroy
@@ -51,7 +40,12 @@ module BGS
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
       salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
-      raise Sidekiq::JobRetry::Skip if filter
+
+      if filter
+        vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
+        self.class.send_backup_submission(vet_info, saved_claim_id)
+        raise Sidekiq::JobRetry::Skip
+      end
 
       raise
     end
@@ -80,16 +74,32 @@ module BGS
       )
     end
 
+    def self.send_backup_submission(vet_info, saved_claim_id)
+      if Flipper.enabled?(:dependents_central_submission)
+        user = generate_user_struct(vet_info)
+        CentralMail::SubmitCentralForm686cJob.perform_async(saved_claim_id,
+                                                            KmsEncrypted::Box.new.encrypt(vet_info.to_json),
+                                                            KmsEncrypted::Box.new.encrypt(user.to_h.to_json))
+      else
+        DependentsApplicationFailureMailer.build(user).deliver_now if user&.email.present? # rubocop:disable Style/IfInsideElse
+      end
+    end
+
     private
 
-    def valid_claim_data
+    def submit_forms
       @claim = SavedClaim::DependencyClaim.find(saved_claim_id)
 
       claim.add_veteran_info(vet_info)
 
       raise Invalid686cClaim unless claim.valid?(:run_686_form_jobs)
 
-      claim.formatted_686_data(vet_info)
+      claim_data = normalize_names_and_addresses!(claim.formatted_686_data(vet_info))
+
+      BGS::Form686c.new(user, claim).submit(claim_data)
+
+      # If Form 686c job succeeds, then enqueue 674 job.
+      BGS::SubmitForm674Job.perform_async(user_uuid, icn, saved_claim_id, encrypted_vet_info, KmsEncrypted::Box.new.encrypt(user.to_h.to_json)) if claim.submittable_674? # rubocop:disable Layout/LineLength
     end
 
     def send_confirmation_email

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -29,7 +29,7 @@ module BGS
       in_progress_form = InProgressForm.find_by(form_id: FORM_ID, user_uuid:)
       @in_progress_copy = in_progress_form_copy(in_progress_form)
 
-      submit_forms
+      submit_forms(encrypted_vet_info)
 
       send_confirmation_email
       in_progress_form&.destroy
@@ -94,7 +94,7 @@ module BGS
 
     private
 
-    def submit_forms
+    def submit_forms(encrypted_vet_info)
       @claim = SavedClaim::DependencyClaim.find(saved_claim_id)
 
       claim.add_veteran_info(vet_info)

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -35,12 +35,12 @@ module BGS
       in_progress_form&.destroy
       Rails.logger.info('BGS::SubmitForm686cJob succeeded!', { user_uuid:, saved_claim_id:, icn: })
     rescue => e
+      salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
       handle_filtered_errors!(e:, encrypted_vet_info:)
 
       Rails.logger.warn('BGS::SubmitForm686cJob received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
-      salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
       raise
     end
 

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -29,12 +29,8 @@ module BGS
     end
 
     def perform(user_uuid, icn, saved_claim_id, encrypted_vet_info)
-      @vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
       Rails.logger.info('BGS::SubmitForm686cJob running!', { user_uuid:, saved_claim_id:, icn: })
-
-      @user = BGS::SubmitForm686cJob.generate_user_struct(@vet_info)
-      @user_uuid = user_uuid
-      @saved_claim_id = saved_claim_id
+      instance_params(encrypted_vet_info, user_uuid, saved_claim_id)
 
       in_progress_form = InProgressForm.find_by(form_id: FORM_ID, user_uuid:)
       @in_progress_copy = in_progress_form_copy(in_progress_form)
@@ -55,7 +51,16 @@ module BGS
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
       log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
       salvage_save_in_progress_form(FORM_ID, user_uuid, @in_progress_copy) if @in_progress_copy.present?
-      raise unless filter
+      raise Sidekiq::JobRetry::Skip if filter
+
+      raise
+    end
+
+    def instance_params(encrypted_vet_info, user_uuid, saved_claim_id)
+      @vet_info = JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_vet_info))
+      @user = BGS::SubmitForm686cJob.generate_user_struct(@vet_info)
+      @user_uuid = user_uuid
+      @saved_claim_id = saved_claim_id
     end
 
     def self.generate_user_struct(vet_info)

--- a/spec/sidekiq/bgs/submit_form674_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form674_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'sidekiq/job_retry'
 
 RSpec.describe BGS::SubmitForm674Job, type: :job do
   let(:user) { FactoryBot.create(:evss_user, :loa3) }
@@ -111,7 +112,7 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
 
       expect do
         subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end.not_to raise_error
+      end.to raise_error(Sidekiq::JobRetry::Skip)
     end
   end
 end

--- a/spec/sidekiq/bgs/submit_form686c_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_job_spec.rb
@@ -106,5 +106,18 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
 
       expect { job }.to raise_error(BGS::SubmitForm686cJob::Invalid686cClaim)
     end
+
+    it 'filters based on error cause' do
+      expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit) { raise_nested_err }
+
+      expect { job }.not_to raise_error
+    end
   end
+end
+
+def raise_nested_err
+  raise BGS::SubmitForm686cJob::Invalid686cClaim, 'A very specific error occurred: insertBenefitClaim: Invalid zipcode.'
+rescue
+  raise BGS::SubmitForm686cJob::Invalid686cClaim, 'A Generic Error Occurred'
 end

--- a/spec/sidekiq/bgs/submit_form686c_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'sidekiq/job_retry'
 
 RSpec.describe BGS::SubmitForm686cJob, type: :job do
   let(:job) { subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info) }
@@ -111,7 +112,7 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
       expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
       expect(client_stub).to receive(:submit) { raise_nested_err }
 
-      expect { job }.not_to raise_error
+      expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
     end
   end
 end


### PR DESCRIPTION
## Summary
- When certain errors are detected in the error stack, immediately skip retries for 686c and 674 submissions

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/72204

## Testing done
- Run job asynchronously in console with specific errors forced to be raised
- Check in logs and Sidekiq web UI to ensure job isn't retried and retries_exhausted block still runs

## What areas of the site does it impact?
Site not impacted

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  ~Documentation has been updated (link to documentation)~
- [x]  ~No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs~
- [x]  ~Feature/bug has a monitor built into Datadog or Grafana (if applicable)~
- [x]  ~If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected~
- [x]  ~I added a screenshot of the developed feature
