### PR TITLE
Include attorney and agent phone numbers when processing The Trexler File

### DIFF
--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -89,7 +89,7 @@ module Representatives
       record_attributes = build_record_attributes(address, geocode, meta)
                           .merge({ raw_address: data['request_address'].to_json })
       record_attributes[:email] = data['email_address']
-      record_attributes[:phone_number] = data['phone_number'] if data['type'] == 'Representatives'
+      record_attributes[:phone_number] = data['phone_number']
       record.update(record_attributes)
     end
 

--- a/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
+++ b/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
@@ -66,7 +66,6 @@ module Representatives
       zip_code5, zip_code4 = get_value(row, column_map, 'WorkZip')
 
       {
-        type: sheet_name,
         id: row[column_map['Number']],
         email_address: get_value(row, column_map, email_address_column_name(sheet_name)),
         phone_number: get_value(row, column_map, 'WorkNumber'),

--- a/modules/veteran/spec/sidekiq/representatives/update_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/update_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Representatives::Update do
            phone_number: '111-111-1111')
   end
 
-  def expect_updated_representative(representative, updates_phone_number:) # rubocop:disable Metrics/MethodLength
+  def expect_updated_representative(representative)
     expect(representative.address_line1).to eq('37N 1st St')
     expect(representative.address_line2).to be_nil
     expect(representative.address_line3).to be_nil
@@ -46,18 +46,12 @@ RSpec.describe Representatives::Update do
     expect(representative.location.x).to eq(-73.964956)
     expect(representative.location.y).to eq(40.717029)
     expect(representative.email).to eq('test@example.com')
-
-    if updates_phone_number
-      expect(representative.phone_number).to eq('999-999-9999')
-    else
-      expect(representative.phone_number).to eq('111-111-1111')
-    end
+    expect(representative.phone_number).to eq('999-999-9999')
   end
 
   describe '#perform' do
     let(:json_data) do
-      { type:,
-        request_address: {
+      { request_address: {
           address_pou: 'abc',
           address_line1: 'abc',
           address_line2: 'abc',
@@ -132,9 +126,8 @@ RSpec.describe Representatives::Update do
       end
     end
 
-    shared_examples 'an updater of representative information' do |type, updates_phone_number|
+    shared_examples 'an updater of representative information' do
       let(:id) { '123abc' }
-      let(:type) { type }
       let!(:representative) do
         create_representative
       end
@@ -144,7 +137,7 @@ RSpec.describe Representatives::Update do
           subject.perform(json_data)
 
           representative.reload
-          expect_updated_representative(representative, updates_phone_number:)
+          expect_updated_representative(representative)
         end
       end
 
@@ -173,15 +166,15 @@ RSpec.describe Representatives::Update do
     end
 
     context 'when processing a representative' do
-      include_examples 'an updater of representative information', 'Representatives', true
+      include_examples 'an updater of representative information'
     end
 
     context 'when processing an attorney' do
-      include_examples 'an updater of representative information', 'Attorneys', false
+      include_examples 'an updater of representative information'
     end
 
     context 'when processing a claims agent' do
-      include_examples 'an updater of representative information', 'Agents', false
+      include_examples 'an updater of representative information'
     end
   end
 end

--- a/modules/veteran/spec/sidekiq/representatives/update_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/update_spec.rb
@@ -3,52 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Representatives::Update do
-  def create_representative # rubocop:disable Metrics/MethodLength
-    create(:representative,
-           representative_id: '123abc',
-           first_name: 'Bob',
-           last_name: 'Law',
-           address_line1: '123 East Main St',
-           address_line2: 'Suite 1',
-           address_line3: 'Address Line 3',
-           address_type: 'DOMESTIC',
-           city: 'My City',
-           country_name: 'United States of America',
-           country_code_iso3: 'USA',
-           province: 'A Province',
-           international_postal_code: '12345',
-           state_code: 'ZZ',
-           zip_code: '12345',
-           zip_suffix: '6789',
-           lat: '39',
-           long: '-75',
-           email: 'email@example.com',
-           location: 'POINT(-75 39)',
-           phone_number: '111-111-1111')
-  end
-
-  def expect_updated_representative(representative)
-    expect(representative.address_line1).to eq('37N 1st St')
-    expect(representative.address_line2).to be_nil
-    expect(representative.address_line3).to be_nil
-    expect(representative.address_type).to eq('Domestic')
-    expect(representative.city).to eq('Brooklyn')
-    expect(representative.country_code_iso3).to eq('USA')
-    expect(representative.country_name).to eq('United States')
-    expect(representative.county_name).to eq('Kings')
-    expect(representative.county_code).to eq('36047')
-    expect(representative.province).to eq('New York')
-    expect(representative.state_code).to eq('NY')
-    expect(representative.zip_code).to eq('11249')
-    expect(representative.zip_suffix).to eq('3939')
-    expect(representative.lat).to eq(40.717029)
-    expect(representative.long).to eq(-73.964956)
-    expect(representative.location.x).to eq(-73.964956)
-    expect(representative.location.y).to eq(40.717029)
-    expect(representative.email).to eq('test@example.com')
-    expect(representative.phone_number).to eq('999-999-9999')
-  end
-
   describe '#perform' do
     let(:json_data) do
       { request_address: {
@@ -126,10 +80,30 @@ RSpec.describe Representatives::Update do
       end
     end
 
-    shared_examples 'an updater of representative information' do
+    context 'when updating a representative' do
       let(:id) { '123abc' }
       let!(:representative) do
-        create_representative
+        create(:representative,
+               representative_id: '123abc',
+               first_name: 'Bob',
+               last_name: 'Law',
+               address_line1: '123 East Main St',
+               address_line2: 'Suite 1',
+               address_line3: 'Address Line 3',
+               address_type: 'DOMESTIC',
+               city: 'My City',
+               country_name: 'United States of America',
+               country_code_iso3: 'USA',
+               province: 'A Province',
+               international_postal_code: '12345',
+               state_code: 'ZZ',
+               zip_code: '12345',
+               zip_suffix: '6789',
+               lat: '39',
+               long: '-75',
+               email: 'email@example.com',
+               location: 'POINT(-75 39)',
+               phone_number: '111-111-1111')
       end
 
       context 'when address is valid' do
@@ -137,7 +111,26 @@ RSpec.describe Representatives::Update do
           subject.perform(json_data)
 
           representative.reload
-          expect_updated_representative(representative)
+
+          expect(representative.address_line1).to eq('37N 1st St')
+          expect(representative.address_line2).to be_nil
+          expect(representative.address_line3).to be_nil
+          expect(representative.address_type).to eq('Domestic')
+          expect(representative.city).to eq('Brooklyn')
+          expect(representative.country_code_iso3).to eq('USA')
+          expect(representative.country_name).to eq('United States')
+          expect(representative.county_name).to eq('Kings')
+          expect(representative.county_code).to eq('36047')
+          expect(representative.province).to eq('New York')
+          expect(representative.state_code).to eq('NY')
+          expect(representative.zip_code).to eq('11249')
+          expect(representative.zip_suffix).to eq('3939')
+          expect(representative.lat).to eq(40.717029)
+          expect(representative.long).to eq(-73.964956)
+          expect(representative.location.x).to eq(-73.964956)
+          expect(representative.location.y).to eq(40.717029)
+          expect(representative.email).to eq('test@example.com')
+          expect(representative.phone_number).to eq('999-999-9999')
         end
       end
 
@@ -163,18 +156,6 @@ RSpec.describe Representatives::Update do
           subject.perform(json_data)
         end
       end
-    end
-
-    context 'when processing a representative' do
-      include_examples 'an updater of representative information'
-    end
-
-    context 'when processing an attorney' do
-      include_examples 'an updater of representative information'
-    end
-
-    context 'when processing a claims agent' do
-      include_examples 'an updater of representative information'
     end
   end
 end

--- a/modules/veteran/spec/sidekiq/representatives/xlsx_file_processor_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/xlsx_file_processor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Representatives::XlsxFileProcessor do
     let(:result) { xlsx_processor.process }
 
     context 'with valid data' do
-      let(:expected_keys) { %w[type id email_address request_address phone_number] }
+      let(:expected_keys) { %w[id email_address request_address phone_number] }
       let(:request_address_keys) do
         %w[address_pou address_line1 address_line2 address_line3 city state_province zip_code5 zip_code4
            country_code_iso3]


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/76291

## Summary
Include attorney and agent phone numbers when processing The Trexler File.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/76291

## Testing done
- Tests were updated

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- This only impacts the Find A Rep app which is currently being a feature flag.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
