### PR TITLE
Add feature flag for HCA Toxic Exposure questions

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -48,6 +48,9 @@ features:
   hca_sigi_enabled:
     actor_type: user
     description: Enables Self-Identifying Gender Identity question for health care applicants.
+  hca_tera_enabled:
+    actor_type: user
+    description: Enables Toxic Exposure questions for health care applicants.
   hca_use_facilities_API:
     actor_type: user
     description: Allow list of medical care facilites to be fetched by way of the Facilities API.


### PR DESCRIPTION
## Summary
This PR adds a feature flag for the 10-10EZ application to be able to toggle a new set of form questions around Toxic Exposure Veterans may have had during service.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#74969

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs