### PR TITLE
Add maintenence_windows to /v0/backend_statuses

### DIFF
--- a/app/controllers/v0/backend_statuses_controller.rb
+++ b/app/controllers/v0/backend_statuses_controller.rb
@@ -12,8 +12,9 @@ module V0
     # show only looks at GI bill scheduled downtime (and gets no data from PagerDuty)
     def index
       statuses = ExternalServicesRedis::Status.new.fetch_or_cache
+      maintenance_windows = MaintenanceWindow.end_after(Time.zone.now)
 
-      render json: statuses, serializer: BackendStatusesSerializer
+      render json: statuses, maintenance_windows:, serializer: BackendStatusesSerializer
     end
 
     # GET /v0/backend_statuses/:service

--- a/app/serializers/backend_statuses_serializer.rb
+++ b/app/serializers/backend_statuses_serializer.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 class BackendStatusesSerializer < ActiveModel::Serializer
-  attributes :reported_at, :statuses
+  attributes :reported_at, :statuses, :maintenance_windows
 
   def id
     nil
+  end
+
+  def maintenance_windows
+    return [] unless @instance_options[:maintenance_windows]
+
+    ActiveModel::Serializer::CollectionSerializer.new(@instance_options[:maintenance_windows],
+                                                      serializer: MaintenanceWindowSerializer)
   end
 end

--- a/app/swagger/swagger/requests/backend_statuses.rb
+++ b/app/swagger/swagger/requests/backend_statuses.rb
@@ -42,6 +42,25 @@ module Swagger
                                example: '2019-03-21T16:54:34.000Z'
                     end
                   end
+                  property :maintenance_windows do
+                    key :type, :array
+                    items do
+                      property :id, type: :integer, example: 1
+                      property :external_service, type: :string, example: 'idme'
+                      property :start_time,
+                               type: :string,
+                               description: 'The start time of the maintenance window',
+                               example: '2024-02-17T09:00:00.000Z'
+                      property :end_time,
+                               type: :string,
+                               description: 'The end time of the maintenance window',
+                               example: '2024-02-17T10:00:00.000Z'
+                      property :description,
+                               type: :string,
+                               description: 'The description of the maintenance window',
+                               example: 'ID.me will be down for maintenance'
+                    end
+                  end
                 end
               end
             end

--- a/spec/support/schemas/backend_statuses.json
+++ b/spec/support/schemas/backend_statuses.json
@@ -21,6 +21,20 @@
                 }
               },
               "type": "array"
+            },
+            "maintenance_windows": {
+              "description": "Array of external service maintenance windows",
+              "items": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "external_service": { "type": "string" },
+                    "start": { "type": "string" },
+                    "end": { "type": "string" },
+                    "description": { "type": "string" }
+                }
+              },
+              "type": "array"
             }
           },
           "type": "object"

--- a/spec/support/schemas_camelized/backend_statuses.json
+++ b/spec/support/schemas_camelized/backend_statuses.json
@@ -33,6 +33,20 @@
                 }
               },
               "type": "array"
+            },
+            "maintenanceWindows": {
+              "description": "Array of external service maintenance windows",
+              "items": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "external_service": { "type": "string" },
+                    "start": { "type": "string" },
+                    "end": { "type": "string" },
+                    "description": { "type": "string" }
+                }
+              },
+              "type": "array"
             }
           },
           "type": "object"


### PR DESCRIPTION
## Summary
Add `maintenance_windows` to `backend_statuses` response. This does not change the existing structure, it adds an additional `maintenance_windows` array inside attributes. This is to avoid making multiple api calls for downtime banners and notifications. 

```json
{
  "data": {
    "id": "",
    "type": "pagerduty_external_services_responses",
    "attributes": {
      "reported_at": "2024-02-15T20:02:39.000Z",
      "statuses": [
        {
          "service": "Appeals",
          "service_id": "appeals",
          "status": "active",
          "last_incident_timestamp": "2024-01-30T02:07:40.000Z"
        },
        ...
      ],
      "maintenance_windows": [
        {
          "id": 716,
          "external_service": "idme",
          "start_time": "2024-02-17T09:00:00.000Z",
          "end_time": "2024-02-17T10:00:00.000Z",
          "description": ""
        },
        {
          "id": 715,
          "external_service": "",
          "start_time": "2024-02-17T09:00:00.000Z",
          "end_time": "2024-02-17T10:00:00.000Z",
          "description": ""
        },
        {
          "id": 713,
          "external_service": "evss",
          "start_time": "2024-02-18T20:00:00.000Z",
          "end_time": "2024-02-19T00:00:00.000Z",
          "description": ""
        }
      ]
    }
  }
}
```

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#76365

## Testing 
- start rails server
- navigate to localhost:3000/v0/backend_statuses ( you may have to create `MaintenanceWindow` objects in the console)


## What areas of the site does it impact?
backend_statuses