### PR TITLE
Remove ICN from Simple Forms logging

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -70,7 +70,7 @@ module SimpleFormsApi
         {
           intent_type: type,
           form_number: params[:form_number],
-          error: e,
+          error: e
         }
       )
       nil

--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -71,7 +71,6 @@ module SimpleFormsApi
           intent_type: type,
           form_number: params[:form_number],
           error: e,
-          icn:
         }
       )
       nil


### PR DESCRIPTION
## Summary

This PR removes the spot in the Simple Forms API where ICNs are logged to DataDog. [Per the announcement here](https://dsva.slack.com/archives/C01CJV0L9PS/p1707259837989739?thread_ts=1707155247.260139&cid=C01CJV0L9PS), ICNs are now considered PII.
