### PR TITLE
Remove org name search from FAR VSO (officer) name search

### DIFF
--- a/modules/veteran/app/controllers/veteran/v0/vso_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/vso_accredited_representatives_controller.rb
@@ -29,8 +29,8 @@ module Veteran
         fuzzy_search_threshold = Veteran::Service::Constants::FUZZY_SEARCH_THRESHOLD
 
         wrapped_query = Veteran::Service::Representative.from("(#{query.to_sql}) as veteran_representatives")
-        wrapped_query.where('word_similarity(?, veteran_representatives.full_name) >= ? OR EXISTS (SELECT 1 FROM unnest(veteran_representatives.organization_names) AS org_name WHERE word_similarity(?, org_name) >= ?)', # rubocop:disable Layout/LineLength
-                            search_phrase, fuzzy_search_threshold, search_phrase, fuzzy_search_threshold)
+        wrapped_query.where('word_similarity(?, veteran_representatives.full_name) >= ?', search_phrase,
+                            fuzzy_search_threshold)
       end
 
       def verify_type

--- a/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
+++ b/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
@@ -137,14 +137,6 @@ RSpec.describe 'VSOAccreditedRepresentativesController', type: :request do
       expect(parsed_response['data'].pluck('id')).to eq(%w[111 113])
     end
 
-    it 'returns accurate results for fuzzy searches on organization names linked to representatives' do
-      get path, params: { type:, lat:, long:, distance:, name: 'Alabama dept' }
-
-      parsed_response = JSON.parse(response.body)
-
-      expect(parsed_response['data'].pluck('id')).to eq(%w[111 113 114])
-    end
-
     it 'serializes with the correct model and distance' do
       get path, params: { type:, lat:, long:, distance:, name: 'Bob Law' }
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/76456


## Summary
- Remove organization name search from FAR VSO (where 'O' stands for 'Officer') name search.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76456

## Testing done
- Test for fuzzy name search on organizations was removed

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
FAR search (which is behind a feature flag)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
