### PR TITLE
75563 allow facilityType param, update statsd

### DIFF
--- a/modules/check_in/app/controllers/check_in/v0/travel_claims_controller.rb
+++ b/modules/check_in/app/controllers/check_in/v0/travel_claims_controller.rb
@@ -16,7 +16,7 @@ module CheckIn
       end
 
       def permitted_params
-        params.require(:travel_claims).permit(:uuid, :appointment_date)
+        params.require(:travel_claims).permit(:uuid, :appointment_date, :facility_type)
       end
 
       def authorize

--- a/modules/check_in/app/controllers/check_in/v2/sessions_controller.rb
+++ b/modules/check_in/app/controllers/check_in/v2/sessions_controller.rb
@@ -33,7 +33,7 @@ module CheckIn
       end
 
       def permitted_params
-        params.require(:session).permit(:uuid, :dob, :last_name, :check_in_type)
+        params.require(:session).permit(:uuid, :dob, :last_name, :check_in_type, :facility_type)
       end
 
       private

--- a/modules/check_in/config/initializers/statsd.rb
+++ b/modules/check_in/config/initializers/statsd.rb
@@ -39,9 +39,6 @@ unless Rails.env.test?
       "api.#{metric_prefix(object.request.headers, object.request.params)}.v0.travel_claims.create.count"
     }
 
-    # CheckIn::V0::TravelClaimsController.statsd_measure :create, 'api.check_in.v0.travel_claims.create.measure'
-    # CheckIn::V0::TravelClaimsController.statsd_count_success :create, 'api.check_in.v0.travel_claims.create.count'
-
     # Measure the count/duration of GET/POST calls for services
     V2::Lorota::Client.extend(StatsD::Instrument)
     %i[token data].each do |method|

--- a/modules/check_in/config/initializers/statsd.rb
+++ b/modules/check_in/config/initializers/statsd.rb
@@ -9,6 +9,9 @@ unless Rails.env.test?
     CheckIn::V2::SessionsController.extend(StatsD::Instrument)
     CheckIn::V2::PatientCheckInsController.extend(StatsD::Instrument)
     CheckIn::V2::PreCheckInsController.extend(StatsD::Instrument)
+    CheckIn::V2::DemographicsController.extend(StatsD::Instrument)
+    CheckIn::V0::TravelClaimsController.extend(StatsD::Instrument)
+
     %i[show create].each do |method|
       CheckIn::V2::SessionsController.statsd_measure method, lambda { |object, _args|
         "api.#{metric_prefix(object.request.headers, object.request.params)}.v2.sessions.#{method}.measure"
@@ -16,19 +19,28 @@ unless Rails.env.test?
       CheckIn::V2::SessionsController.statsd_count_success method, lambda { |object, _args|
         "api.#{metric_prefix(object.request.headers, object.request.params)}.v2.sessions.#{method}.count"
       }
-      CheckIn::V2::PatientCheckInsController.statsd_measure method, "api.check_in.v2.checkins.#{method}.measure"
-      CheckIn::V2::PatientCheckInsController.statsd_count_success method, "api.check_in.v2.checkins.#{method}.count"
+      CheckIn::V2::PatientCheckInsController.statsd_measure method, lambda { |object, _args|
+        "api.#{metric_prefix(object.request.headers, object.request.params)}.v2.checkins.#{method}.measure"
+      }
+      CheckIn::V2::PatientCheckInsController.statsd_count_success method, lambda { |object, _args|
+        "api.#{metric_prefix(object.request.headers, object.request.params)}.v2.checkins.#{method}.count"
+      }
       CheckIn::V2::PreCheckInsController.statsd_measure method, "api.check_in.v2.pre_checkins.#{method}.measure"
       CheckIn::V2::PreCheckInsController.statsd_count_success method, "api.check_in.v2.pre_checkins.#{method}.count"
     end
 
-    CheckIn::V2::DemographicsController.extend(StatsD::Instrument)
     CheckIn::V2::DemographicsController.statsd_measure :update, 'api.check_in.v2.demographics.update.measure'
     CheckIn::V2::DemographicsController.statsd_count_success :update, 'api.check_in.v2.demographics.update.count'
 
-    CheckIn::V0::TravelClaimsController.extend(StatsD::Instrument)
-    CheckIn::V0::TravelClaimsController.statsd_measure :create, 'api.check_in.v0.travel_claims.create.measure'
-    CheckIn::V0::TravelClaimsController.statsd_count_success :create, 'api.check_in.v0.travel_claims.create.count'
+    CheckIn::V0::TravelClaimsController.statsd_measure :create, lambda { |object, _args|
+      "api.#{metric_prefix(object.request.headers, object.request.params)}.v0.travel_claims.create.measure"
+    }
+    CheckIn::V0::TravelClaimsController.statsd_count_success :create, lambda { |object, _args|
+      "api.#{metric_prefix(object.request.headers, object.request.params)}.v0.travel_claims.create.count"
+    }
+
+    # CheckIn::V0::TravelClaimsController.statsd_measure :create, 'api.check_in.v0.travel_claims.create.measure'
+    # CheckIn::V0::TravelClaimsController.statsd_count_success :create, 'api.check_in.v0.travel_claims.create.count'
 
     # Measure the count/duration of GET/POST calls for services
     V2::Lorota::Client.extend(StatsD::Instrument)
@@ -61,10 +73,12 @@ unless Rails.env.test?
 
   def metric_prefix(headers, params)
     check_in_param = params[:checkInType] || params.dig(:session, :check_in_type)
-    facility_type_param = params[:facilityType] || params.dig(:session, :facility_type)
+    facility_type_param = params[:facilityType] ||
+                          params.dig(:session, :facility_type) ||
+                          params.dig(:travel_claims, :facility_type)
 
     prefix = check_in_param == 'preCheckIn' ? 'pre_check_in' : 'check_in'
-    prefix = facility_type_param unless facility_type_param.nil?
+    prefix += ".#{facility_type_param}" unless facility_type_param.nil?
     prefix += '.synthetic' if headers.key?('Sec-Datadog')
     prefix
   end

--- a/modules/check_in/config/initializers/statsd.rb
+++ b/modules/check_in/config/initializers/statsd.rb
@@ -61,8 +61,10 @@ unless Rails.env.test?
 
   def metric_prefix(headers, params)
     check_in_param = params[:checkInType] || params.dig(:session, :check_in_type)
+    facility_type_param = params[:facilityType] || params.dig(:session, :facility_type)
 
     prefix = check_in_param == 'preCheckIn' ? 'pre_check_in' : 'check_in'
+    prefix = facility_type_param unless facility_type_param.nil?
     prefix += '.synthetic' if headers.key?('Sec-Datadog')
     prefix
   end


### PR DESCRIPTION
## Summary
This PR adds `facilityType` as allowed param for SessionsController. This param will be used to differentiate between OH and VistA sites for DataDog metrics. This PR also includes updates to statsd metric names to correctly report the metrics based on the facilityType.


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/75563

## Testing done
- local testing

## Acceptance criteria
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
