### PR TITLE
Increase FUZZY_SEARCH_THRESHOLD from .3 to .5

### DIFF
--- a/modules/veteran/app/models/veteran/service/constants.rb
+++ b/modules/veteran/app/models/veteran/service/constants.rb
@@ -7,7 +7,7 @@ module Veteran
       DEFAULT_MAX_MILES = 50
       DEFAULT_MAX_DISTANCE = DEFAULT_MAX_MILES * METERS_PER_MILE
 
-      FUZZY_SEARCH_THRESHOLD = 0.3 # pg_search's default
+      FUZZY_SEARCH_THRESHOLD = 0.5 # pg_search's default
 
       MAX_PER_PAGE = 100
     end

--- a/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
+++ b/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'VSOAccreditedRepresentativesController', type: :request do
 
       parsed_response = JSON.parse(response.body)
 
-      expect(parsed_response['data'].pluck('id')).to eq(%w[111 113])
+      expect(parsed_response['data'].pluck('id')).to eq(%w[111])
     end
 
     it 'serializes with the correct model and distance' do


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/76099

## Summary
Increase `FUZZY_SEARCH_THRESHOLD` from `.3` to `.5`

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76099

## Testing done
- Tests updated
- We're going to spot check the results in staging to see what affect this change has on them

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- FAR search, which is behind a feature flag

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
