### PR TITLE
FAR: Change phone `flag_type` from `phone` to `phone_number`.

### DIFF
--- a/modules/veteran/app/models/veteran/flagged_veteran_representative_contact_data.rb
+++ b/modules/veteran/app/models/veteran/flagged_veteran_representative_contact_data.rb
@@ -5,7 +5,7 @@ module Veteran
     self.ignored_columns += ['flagged_value_updated']
     self.table_name = 'flagged_veteran_representative_contact_data'
 
-    enum flag_type: { phone: 'phone', email: 'email', address: 'address', other: 'other' }, _suffix: true
+    enum flag_type: { phone_number: 'phone_number', email: 'email', address: 'address', other: 'other' }, _suffix: true
     validates :ip_address, :representative_id, :flag_type, :flagged_value, presence: true
     validates :ip_address,
               uniqueness: { scope: %i[representative_id flag_type flagged_value_updated_at], message: 'Combination of ip_address, representative_id, flag_type, and flagged_value_updated_at must be unique' } # rubocop:disable Rails/I18nLocaleTexts,Layout/LineLength

--- a/modules/veteran/spec/models/veteran/flagged_veteran_representative_contact_data_spec.rb
+++ b/modules/veteran/spec/models/veteran/flagged_veteran_representative_contact_data_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Veteran::FlaggedVeteranRepresentativeContactData, type: :model do
   describe 'validations' do
     context 'ip_address' do
       it 'is valid when ip_address is present' do
-        flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone',
+        flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone_number',
                                    flagged_value: '1234567890')
         expect(flag).to be_valid
       end
 
       it 'is not valid when ip_address is missing' do
-        flag = described_class.new(ip_address: nil, representative_id: '1', flag_type: 'phone',
+        flag = described_class.new(ip_address: nil, representative_id: '1', flag_type: 'phone_number',
                                    flagged_value: '1234567890')
         expect(flag).not_to be_valid
         expect(flag.errors[:ip_address]).to include("can't be blank")
@@ -21,13 +21,13 @@ RSpec.describe Veteran::FlaggedVeteranRepresentativeContactData, type: :model do
 
     context 'representative_id' do
       it 'is valid when representative_id is present' do
-        flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone',
+        flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone_number',
                                    flagged_value: '1234567890')
         expect(flag).to be_valid
       end
 
       it 'is not valid when representative_id is missing' do
-        flag = described_class.new(ip_address: '192.168.1.1', representative_id: nil, flag_type: 'phone',
+        flag = described_class.new(ip_address: '192.168.1.1', representative_id: nil, flag_type: 'phone_number',
                                    flagged_value: '1234567890')
         expect(flag).not_to be_valid
         expect(flag.errors[:representative_id]).to include("can't be blank")
@@ -36,7 +36,7 @@ RSpec.describe Veteran::FlaggedVeteranRepresentativeContactData, type: :model do
 
     context 'flag_type' do
       it 'is valid with a valid flag_type' do
-        %w[phone email address other].each do |flag_type|
+        %w[phone_number email address other].each do |flag_type|
           flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type:,
                                      flagged_value: "#{flag_type} value")
           expect(flag).to be_valid
@@ -76,7 +76,7 @@ RSpec.describe Veteran::FlaggedVeteranRepresentativeContactData, type: :model do
       end
 
       it 'is valid when changing only the flag_type while keeping ip_address and representative_id same' do
-        unique = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone',
+        unique = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone_number',
                                      flagged_value: 'example@email.com')
         expect(unique).to be_valid
       end


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/76533

## Summary
- Change phone `flag_type` from `phone` to `phone_number`.

## Related issue(s)
-  https://github.com/department-of-veterans-affairs/va.gov-team/issues/76533

## Testing done
- Tests updated

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
