### PR TITLE
Mobile: Raise error on upstream service error. 

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/awards_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/awards_controller.rb
@@ -8,6 +8,8 @@ module Mobile
     class AwardsController < ApplicationController
       def index
         award_data = regular_award_service.get_awards
+        raise Common::Exceptions::BackendServiceException, 'MOBL_502_upstream_error' unless award_data
+
         award_data.merge!(pension_award_service.get_awards_pension.body['awards_pension']&.transform_keys(&:to_sym))
         award_data[:id] = current_user.uuid
         awards = Mobile::V0::Award.new(award_data)

--- a/modules/mobile/spec/request/awards_request_spec.rb
+++ b/modules/mobile/spec/request/awards_request_spec.rb
@@ -60,5 +60,18 @@ RSpec.describe Mobile::V0::AwardsController, type: :request do
           'netWorthLimit' => 129_094 }
       )
     end
+
+    context 'when upstream service returns error' do
+      it 'returns error' do
+        allow_any_instance_of(BGS::AwardsService).to receive(:get_awards).and_return(false)
+        get '/mobile/v0/awards', headers: sis_headers
+
+        error = { 'errors' => [{ 'title' => 'Bad Gateway',
+                                 'detail' => 'Received an an invalid response from the upstream server',
+                                 'code' => 'MOBL_502_upstream_error', 'status' => '502' }] }
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response.parsed_body).to eq(error)
+      end
+    end
   end
 end


### PR DESCRIPTION

## Summary
when the awards service fails, it returns a false boolean rather then an error. This changes the mobile controller to expect that and re-raise an error. 
## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/7931

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
