### PR TITLE
Remove a stubbed method that broke PDF saving

### DIFF
--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -188,7 +188,6 @@ RSpec.describe 'Forms uploader', type: :request do
             data = JSON.parse(fixture_path.read)
             attachment = double
             allow(attachment).to receive(:to_pdf).and_return(pdf_path)
-            allow(CombinePDF).to receive(:load).and_return([])
 
             expect(PersistentAttachment).to receive(:where).with(guid: ['a-random-uuid']).and_return([attachment])
 


### PR DESCRIPTION
## Summary
This PR removes a stubbed method call that we actually need to be working correctly in the test environment. I'm honestly not sure how this line got in here in the first place but shout out to @ksantiagoBAH for making me aware of it!