### PR TITLE
Create before_action to explicitly set csrf token, remove verify_auth…

### DIFF
--- a/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
@@ -4,9 +4,9 @@ module Veteran
   module V0
     class FlagAccreditedRepresentativesController < ApplicationController
       service_tag 'lighthouse-veteran'
-      skip_before_action :verify_authenticity_token
-      skip_before_action :authenticate
+      before_action :enable_csrf_protection
       before_action :feature_enabled
+      skip_before_action :authenticate
 
       def create
         flags = nil
@@ -29,6 +29,10 @@ module Veteran
       end
 
       private
+
+      def enable_csrf_protection
+        set_csrf_header
+      end
 
       def create_flags
         FlaggedVeteranRepresentativeContactData.transaction do


### PR DESCRIPTION
…enticity_token skip_before_action

References https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311


## Summary
csrf protection is disabled for the rep flagging endpoint due to an error. This PR is an attempt to fix this error when csrf protection is enabled

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311

## Testing done
No new texts

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- Find a Rep, which is behind a feature flag

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
