### PR TITLE
Remove unnecessary puts

### DIFF
--- a/modules/appeals_api/spec/requests/v2/supplemental_claims_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v2/supplemental_claims_controller_spec.rb
@@ -301,9 +301,6 @@ describe AppealsApi::V2::DecisionReviews::SupplementalClaimsController, type: :r
 
         post(path, params: mod_data.to_json, headers:)
 
-        puts parsed['errors'][0]['title']
-        puts parsed['errors'][0]['meta']['missing_fields'][0]
-
         expect(response.status).to eq(422)
         expect(parsed['errors'][0]['title']).to eq('Missing required fields')
         expect(parsed['errors'][0]['meta']['missing_fields'][0]).to eq('retrieveFrom')

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -167,7 +167,6 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
     it '204s when given an empty category' do
       VCR.use_cassette('okta/verification-scopes', match_requests_on: %i[method path]) do
         get '/services/apps/v0/directory/scopes/empty_category'
-        puts response.body
         expect(response).to have_http_status(:no_content)
       end
     end

--- a/modules/my_health/spec/request/v1/threads_request_spec.rb
+++ b/modules/my_health/spec/request/v1/threads_request_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe 'Threads Integration', type: :request do
           patch "/my_health/v1/messaging/threads/#{thread_id}/move?folder_id=0"
         end
 
-        puts response
         expect(response).to be_successful
         expect(response).to have_http_status(:no_content)
       end

--- a/spec/requests/connected_applications_request_spec.rb
+++ b/spec/requests/connected_applications_request_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe 'Connected Applications API endpoint' do
     it 'deletes all the grants by app' do
       VCR.use_cassette('lighthouse/auth/client_credentials/revoke_consent_204', allow_playback_repeats: true) do
         delete '/v0/profile/connected_applications/0oa2ey2m6kEL2897N2p7'
-        puts response.body
         expect(response).to have_http_status(:no_content)
       end
     end


### PR DESCRIPTION
## Summary

- Remove `puts response.body` in `modules/apps_api/spec/requests/v0/application_directory_request_spec.rb`
- Remove `puts response` in `modules/my_health/spec/request/v1/threads_request_spec.rb`
- Remove 2 `puts` in `modules/appeals_api/spec/requests/v2/supplemental_claims_controller_spec.rb`

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76887

## Testing done

- No new tests created
