### PR TITLE
Revert "Create before_action to explicitly set csrf token, remove verify_auth…"

### DIFF
--- a/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/flag_accredited_representatives_controller.rb
@@ -4,9 +4,9 @@ module Veteran
   module V0
     class FlagAccreditedRepresentativesController < ApplicationController
       service_tag 'lighthouse-veteran'
-      before_action :enable_csrf_protection
-      before_action :feature_enabled
+      skip_before_action :verify_authenticity_token
       skip_before_action :authenticate
+      before_action :feature_enabled
 
       def create
         flags = nil
@@ -29,10 +29,6 @@ module Veteran
       end
 
       private
-
-      def enable_csrf_protection
-        set_csrf_header
-      end
 
       def create_flags
         FlaggedVeteranRepresentativeContactData.transaction do


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#15596

Getting this again:

```
{
    "errors": [
        {
            "title": "Forbidden",
            "detail": "Invalid Authenticity Token",
            "code": "403",
            "status": "403"
        }
    ]
}
```