### PR TITLE
[Rated Disabilities] Reworking logic for rated disability discrepancy checks

### DIFF
--- a/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
+++ b/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
@@ -9,6 +9,8 @@ module V0
     before_action { authorize :evss, :access? }
     before_action { authorize :lighthouse, :access? }
 
+    DECISION_ALLOWLIST = ['1151 Granted', 'Not Service Connected', 'Service Connected'].freeze
+
     def show
       lh_response = get_lh_rated_disabilities
       evss_response = get_evss_rated_disabilities
@@ -31,7 +33,7 @@ module V0
 
       ::Rails.logger.info(message, {
                             message_type: 'lh.rated_disabilities.length_discrepancy',
-                            revision: 2
+                            revision: 3
                           })
     end
 
@@ -55,15 +57,15 @@ module V0
 
       # We only want active ratings
       if response.dig('data', 'attributes', 'individual_ratings')
-        reject_deferred_ratings!(response['data']['attributes']['individual_ratings'])
+        filter_ratings_by_decision!(response['data']['attributes']['individual_ratings'])
         reject_inactive_ratings!(response['data']['attributes']['individual_ratings'])
       end
 
       response
     end
 
-    def reject_deferred_ratings!(ratings)
-      ratings.reject! { |rating| deferred?(rating) }
+    def filter_ratings_by_decision!(ratings)
+      ratings.select! { |rating| DECISION_ALLOWLIST.include?(rating) }
     end
 
     def reject_inactive_ratings!(ratings)

--- a/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
+++ b/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe V0::RatedDisabilitiesDiscrepanciesController, type: :controller d
         # with EVSS (which should return 1 rating), there should be a discrepancy of 2 ratings
         expect(Rails.logger).to have_received(:info).with(
           'Discrepancy of 1 disability ratings',
-          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 2 }
+          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 3 }
         )
       end
 
-      it 'filters out deferred ratings' do
+      it 'filters out ratings with unwanted decisions' do
         VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_deferred_response') do
           VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_tinnitus_max_rated') do
             get(:show)
@@ -57,7 +57,7 @@ RSpec.describe V0::RatedDisabilitiesDiscrepanciesController, type: :controller d
         # with EVSS (which should return 1 rating), there should be a discrepancy of 1 rating
         expect(Rails.logger).to have_received(:info).with(
           'Discrepancy of 1 disability ratings',
-          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 2 }
+          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 3 }
         )
       end
     end


### PR DESCRIPTION
## Summary
Previously we were just removing ratings that had a decision value of 'Deferred', but after pushing that change out it became apparent that there were several decision values that should be filtered out so adding an allowlist and including ratings that have a decision value that is included in the allowlist

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/76603

## Testing done
The logic didn't really change that much. Just needed to update the revision number so that I can differentiate these in the DataDog logs

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
