### PR TITLE
arf-76642 add benefits-accredited-rep-facing to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1940,4 +1940,4 @@ spec/lib/logging/third_party_transaction_spec.rb @department-of-veterans-affairs
 spec/requests/va_profile/contacts_request_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 /helmCharts @department-of-veterans-affairs/backend-review-group
 /.github/workflows/build-and-publish.yaml @department-of-veterans-affairs/backend-review-group
-modules/accredited_representatives @department-of-veterans-affairs/benefits-accredited-rep-facing
+modules/accredited_representatives @department-of-veterans-affairs/benefits-accredited-rep-facing @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
## Summary
[Zenhub: Add team to CODEOWNERS in vets-api#76642](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/76642)

Branched off of https://github.com/department-of-veterans-affairs/vets-api/pull/15602/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5, which adds the benefits-accredited-rep-facing module mentioned in this PR.

Related Platform request [here](https://dsva.slack.com/archives/CBU0KDSB1/p1708458198340129).