### PR TITLE
Add confirmation email trigger for form 40-0247

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -514,6 +514,10 @@ features:
   form_526_required_identifiers_in_user_object:
     actor_type: user
     description: includes a mapping of booleans in the profile section of a serialized user indicating which ids are nil for the user
+  form40_0247_confirmation_email:
+    actor_type: user
+    description: Enables form 40-0247 email submission confirmation (VaNotify)
+    enable_in_development: true
   form5490_confirmation_email:
     actor_type: user
     description: Enables form 5490 email submission confirmation (VaNotify)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1252,6 +1252,7 @@ vanotify:
         form21_0845_confirmation_email: form21_0845_confirmation_email_template_id
         form21p_0847_confirmation_email: form21p_0847_confirmation_email_template_id
         form21_4142_confirmation_email: form21_4142_confirmation_email_template_id
+        form40_0247_confirmation_email: form40_0247_confirmation_email_template_id
         form526_confirmation_email: fake_template_id
         form526_submission_failed_email: fake_template_id
         form5490_confirmation_email: form5490_confirmation_email_template_id

--- a/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
@@ -135,7 +135,7 @@ module SimpleFormsApi
     def form40_0247_contact_info(form_data)
       # email address is optional field
       # when email is not entered, use current user's email
-      [form_data['applicant_email'].presence || @user&.email, form_data.dig('applicant_full_name', 'first')]
+      [form_data['applicant_email'].presence || @user&.va_profile_email, form_data.dig('applicant_full_name', 'first')]
     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
@@ -10,7 +10,8 @@ module SimpleFormsApi
       'vba_21_0972' => Settings.vanotify.services.va_gov.template_id.form21_0972_confirmation_email,
       'vba_21_4142' => Settings.vanotify.services.va_gov.template_id.form21_4142_confirmation_email,
       'vba_21_10210' => Settings.vanotify.services.va_gov.template_id.form21_10210_confirmation_email,
-      'vba_20_10206' => Settings.vanotify.services.va_gov.template_id.form20_10206_confirmation_email
+      'vba_20_10206' => Settings.vanotify.services.va_gov.template_id.form20_10206_confirmation_email,
+      'vba_40_0247' => Settings.vanotify.services.va_gov.template_id.form40_0247_confirmation_email
     }.freeze
     SUPPORTED_FORMS = TEMPLATE_IDS.keys
 
@@ -70,6 +71,10 @@ module SimpleFormsApi
                             return unless Flipper.enabled?(:form20_10206_confirmation_email)
 
                             form20_10206_contact_info(@form_data)
+                          when 'vba_40_0247'
+                            return unless Flipper.enabled?(:form40_0247_confirmation_email)
+
+                            form40_0247_contact_info(@form_data)
                           else
                             [nil, nil]
                           end
@@ -125,6 +130,12 @@ module SimpleFormsApi
       else
         [nil, nil]
       end
+    end
+
+    def form40_0247_contact_info(form_data)
+      # email address is optional field
+      # when email is not entered, use current user's email
+      [form_data['applicant_email'].presence || @user&.email, form_data.dig('applicant_full_name', 'first')]
     end
   end
 end

--- a/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
@@ -158,7 +158,7 @@ describe SimpleFormsApi::ConfirmationEmail do
           subject.send
 
           expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.email,
+            user.va_profile_email,
             'form40_0247_confirmation_email_template_id',
             {
               'first_name' => 'JOE',

--- a/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
@@ -101,6 +101,94 @@ describe SimpleFormsApi::ConfirmationEmail do
     end
   end
 
+  describe '40_0247' do
+    context 'when email is entered' do
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+
+      it 'sends the confirmation email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+
+        subject = described_class.new(
+          form_data: data,
+          form_number: 'vba_40_0247',
+          confirmation_number: 'confirmation_number'
+        )
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          'a@b.com',
+          'form40_0247_confirmation_email_template_id',
+          {
+            'first_name' => 'JOE',
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+            'confirmation_number' => 'confirmation_number'
+          }
+        )
+      end
+    end
+
+    context 'when email is omitted' do
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247-min.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+
+      context 'when user is signed in' do
+        let(:user) { create(:user, :loa3) }
+
+        it 'sends the confirmation email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          expect(data['applicant_email']).to be_nil
+
+          subject = described_class.new(
+            form_data: data,
+            form_number: 'vba_40_0247',
+            confirmation_number: 'confirmation_number',
+            user:
+          )
+
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            user.email,
+            'form40_0247_confirmation_email_template_id',
+            {
+              'first_name' => 'JOE',
+              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+              'confirmation_number' => 'confirmation_number'
+            }
+          )
+        end
+      end
+
+      context 'when user is not signed in' do
+        it 'does not send the confirmation email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          expect(data['applicant_email']).to be_nil
+
+          subject = described_class.new(
+            form_data: data,
+            form_number: 'vba_40_0247',
+            confirmation_number: 'confirmation_number',
+            user: nil
+          )
+
+          subject.send
+
+          expect(VANotify::EmailJob).not_to have_received(:perform_async)
+        end
+      end
+    end
+  end
+
   describe '21_0845' do
     let(:data) do
       fixture_path = Rails.root.join(


### PR DESCRIPTION
## Summary

- Create Trigger for Form 40-0247 Request a Presidential Memorial Certificate Submission Confirmation

## Related issue(s)

- https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/gh/department-of-veterans-affairs/vanotify-team/1225

## Testing done

- [X] *New code is covered by unit tests*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  -  `bundle exec rspec modules/simple_forms_api/spec/services/confirmation_email_spec.rb:104`


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
