### PR TITLE
76701 temporarily halting mcp email notification

### DIFF
--- a/app/services/medical_copays/vbs/service.rb
+++ b/app/services/medical_copays/vbs/service.rb
@@ -92,7 +92,8 @@ module MedicalCopays
       end
 
       def send_statement_notifications(statements_json_byte)
-        CopayNotifications::ParseNewStatementsJob.perform_async(statements_json_byte)
+        # pausing until further notice
+        # CopayNotifications::ParseNewStatementsJob.perform_async(statements_json_byte)
       end
 
       def settings


### PR DESCRIPTION
## Summary
Stakeholders are requesting that we temporarily halt sending these email notifications.

## Related issue(s)
[76701](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/76701)

## Testing done
Specs green

## What areas of the site does it impact?
MCP notification emails

## Acceptance criteria
For the time being we should not be sending MCP notification emails 
