### PR TITLE
76409 vha FSRs should not include vba reasons

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -54,6 +54,7 @@ module DebtsApi
       facility_form['facilityNum'] = @facility_num
       facility_form['personalIdentification']['fileNumber'] = @user.ssn
       add_compromise_amounts(facility_form, @copays)
+      aggregate_fsr_reasons(facility_form, @copays)
       facility_form.delete(DEBTS_KEY)
       facility_form = remove_form_delimiters(facility_form)
       combined_adjustments(facility_form)

--- a/modules/debts_api/spec/fixtures/fsr_forms/combined_fsr_form.json
+++ b/modules/debts_api/spec/fixtures/fsr_forms/combined_fsr_form.json
@@ -2,7 +2,7 @@
     "personal_identification": {
         "ssn": "1234",
         "file_number": "5678",
-        "fsr_reason": "waiver"
+        "fsr_reason": "waiver, compromise, monthly"
     },
     "personal_data": {
         "veteran_full_name": {
@@ -207,11 +207,13 @@
     "selected_debts_and_copays":[ 
         {
             "debt_type": "COPAY",
+            "resolution_option": "waiver",
             "p_h_amt_due": "100",
             "station": {"facilit_y_num": "123"}
         },
         {
             "debt_type": "COPAY",
+            "resolution_option": "waiver",
             "p_h_amt_due": "200",
             "station": {
                 "facilit_y_num": "123"
@@ -219,24 +221,25 @@
         },
         {
             "debt_type": "COPAY",
+            "resolution_option": "compromise",
             "p_h_amt_due": "300",
             "station": {
                 "facilit_y_num": "999"
             }
         },
         {
-            "current_ar":"541.67",
             "debt_type":"DEBT",
+            "resolution_option": "compromise",
+            "current_ar": "541.67",
             "deduction_code":"71",
-            "resolution_comment":"50",
-            "resolution_option": "monthly"
+            "resolution_comment":"50"
         },
         {
-            "current_ar":"1134.22",
             "debt_type":"DEBT",
+            "resolution_option": "monthly",
+            "current_ar": "1134.22",
             "deduction_code":"72",
-            "resolution_comment":"",
-            "resolution_option": "waiver"
+            "resolution_comment":""
         }
     ]
 }

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe DebtsApi::V0::FsrFormBuilder, type: :service do
       let(:builder) { described_class.new(combined_form_data, '123', user) }
 
       it 'aggregates fsr reasons' do
-        expect(builder.sanitized_form['personalIdentification']['fsrReason']).to eq('waiver')
-        expect(builder.user_form.form_data['personalIdentification']['fsrReason']).to eq('monthly, waiver')
+        expect(builder.sanitized_form['personalIdentification']['fsrReason']).to eq('waiver, compromise, monthly')
+        expect(builder.user_form.form_data['personalIdentification']['fsrReason']).to eq('waiver, compromise, monthly')
       end
     end
 
@@ -47,6 +47,16 @@ RSpec.describe DebtsApi::V0::FsrFormBuilder, type: :service do
       it 'updates vha form\'s additionalComments' do
         comments = builder.vha_forms.first.form_data.dig('additionalData', 'additionalComments')
         expect(comments.include?('Combined FSR')).to eq(true)
+      end
+
+      it 'does not give vha form vba form\'s reasons' do
+        vha_reasons = builder.vha_forms.first.form_data.dig('personalIdentification', 'fsrReason')
+        expect(vha_reasons).to eq('waiver')
+      end
+
+      it 'does not give vba form vha form\'s reasons' do
+        vba_reasons = builder.vba_form.form_data.dig('personalIdentification', 'fsrReason')
+        expect(vba_reasons).to eq('compromise, monthly')
       end
     end
 


### PR DESCRIPTION
## Summary
Currently, when building a vha form from a combined FSR we inadvertently use fsr reasons from both vha and vba. We should only be using reasons from vha copays for vha FSR submissions. 

## Related issue(s)
[76409](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/76409)

## Testing done
Specs added


## What areas of the site does it impact?
VHA financial status report submissions

## Acceptance criteria
VHA fsr (created from a combined fsr) will only use fsr reasons from its own copays. Not vba debts and not copays from other stations.
