### PR TITLE
Update Access Token audience to support auto-auth

### DIFF
--- a/app/services/sign_in/access_token_audience_generator.rb
+++ b/app/services/sign_in/access_token_audience_generator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module SignIn
+  class AccessTokenAudienceGenerator
+    SHARED_SESSION_CLIENT_IDS_CACHE_KEY = 'sis_shared_sessions_client_ids'
+
+    def initialize(client_config:)
+      @client_config = client_config
+    end
+
+    def perform
+      generate_audience
+    end
+
+    private
+
+    attr_reader :client_config
+
+    def generate_audience
+      return shared_session_client_ids if client_config.shared_sessions?
+
+      [client_config.client_id]
+    end
+
+    def shared_session_client_ids
+      @shared_session_client_ids ||= Rails.cache.fetch(SHARED_SESSION_CLIENT_IDS_CACHE_KEY, expires_in: 5.minutes) do
+        ClientConfig.where(shared_sessions: true).pluck(:client_id)
+      end
+    end
+  end
+end

--- a/app/services/sign_in/session_creator.rb
+++ b/app/services/sign_in/session_creator.rb
@@ -134,7 +134,7 @@ module SignIn
     end
 
     def audience
-      @audience ||= client_config.access_token_audience
+      @audience ||= AccessTokenAudienceGenerator.new(client_config:).perform
     end
 
     def client_config

--- a/app/services/sign_in/session_refresher.rb
+++ b/app/services/sign_in/session_refresher.rb
@@ -85,7 +85,7 @@ module SignIn
     def create_access_token
       AccessToken.new(
         session_handle: session.handle,
-        client_id: session.client_id,
+        client_id:,
         user_uuid: refresh_token.user_uuid,
         audience:,
         refresh_token_hash: get_hash(child_refresh_token.to_json),
@@ -117,11 +117,15 @@ module SignIn
     end
 
     def audience
-      @audience ||= client_config.access_token_audience
+      @audience ||= AccessTokenAudienceGenerator.new(client_config:).perform
     end
 
     def client_config
-      @client_config ||= SignIn::ClientConfig.find_by!(client_id: session.client_id)
+      @client_config ||= SignIn::ClientConfig.find_by!(client_id:)
+    end
+
+    def client_id
+      @client_id ||= session.client_id
     end
 
     def get_hash(object)

--- a/spec/services/sign_in/access_token_audience_generator_spec.rb
+++ b/spec/services/sign_in/access_token_audience_generator_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::AccessTokenAudienceGenerator do
+  subject(:generator) { described_class.new(client_config:) }
+
+  describe '#perform' do
+    let!(:shared_client1) { create(:client_config, shared_sessions: true) }
+    let!(:shared_client2) { create(:client_config, shared_sessions: true) }
+    let!(:non_shared_client) { create(:client_config, shared_sessions: false) }
+
+    before do
+      Rails.cache.clear
+    end
+
+    context 'when the client_id is part of shared session client IDs' do
+      let(:client_config) { shared_client1 }
+      let(:expected_audience) { [shared_client1.client_id, shared_client2.client_id] }
+
+      it 'returns all shared session client IDs as the audience' do
+        expect(generator.perform).to match_array(expected_audience)
+      end
+    end
+
+    context 'when the client_id is not part of shared session client IDs' do
+      let(:client_config) { non_shared_client }
+      let(:expected_audience) { [non_shared_client.client_id] }
+
+      it 'returns only the client_id as the audience' do
+        expect(generator.perform).to match_array(expected_audience)
+      end
+    end
+
+    context 'when the shared session client IDs are cached' do
+      let(:client_config) { shared_client1 }
+
+      it 'does not query the database' do
+        expect(SignIn::ClientConfig).to receive(:where).once.and_call_original
+
+        generator.perform
+        generator.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Update AccessToken `aud` to include an array of all client_ids that share_sessions. If a client does not share sessions it is the only one in the `aud` array.

The shared session `client_ids` are cached for 24 hours. It is 30% faster to read from the cache vs querying the database. This is called ~300,000 times per day and will increase as we add more clients. 

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#75383

## Testing done
- seed database - `rails db:seed`
- Sign-in using oauth=true
- grab `vagov_access_token` from cookies
- decode token in rails console:
   ```ruby
   JWT.decode vagov_access_token, OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)), true, { algorithm: 'RS256' }
   ```
- You should see an array of client_ids in `aud` - `["vamock", "sample_client_web", "vaweb"]`

- Change `vaweb` to not share sessions in rails console:
  ```ruby
   SignIn::ClientConfig.find_by(client_id: 'vaweb').update(shared_sessions: false)
  ```
- Repeat the steps
- decoded token `aud` should be `["vaweb"]`

## What areas of the site does it impact?
Sign-in Service, Authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
