### PR TITLE
[CST] Replacing the va_eauth_pid header with the Veterans participant ID

### DIFF
--- a/app/services/evss_claim_service.rb
+++ b/app/services/evss_claim_service.rb
@@ -98,16 +98,17 @@ class EVSSClaimService
 
   def supplement_auth_headers(claim_id, headers)
     # Assuming this header has a value of "", we want to get the Veteran
-    # associated with the claims' file number. We can get this by fetching
+    # associated with the claims' participant ID. We can get this by fetching
     # the claim details from BGS and looking at the Participant ID of the
-    # Veteran and then calling BGS again to get the Veterans' details via
-    # said Participant ID
+    # Veteran associated with the claim
     blank_header = headers['va_eauth_birlsfilenumber'].blank?
     if blank_header
       claim = get_claim(claim_id)
       veteran_participant_id = claim[:benefit_claim_details_dto][:ptcpnt_vet_id]
-      person = bgs_service.people.find_person_by_ptcpnt_id(veteran_participant_id)
-      headers['va_eauth_birlsfilenumber'] = person[:file_nbr]
+      headers['va_eauth_pid'] = veteran_participant_id
+      # va_eauth_pnid maps to the users SSN. Using this here so that the header
+      # has a value
+      headers['va_eauth_birlsfilenumber'] = headers['va_eauth_pnid']
     end
 
     blank_header
@@ -117,7 +118,8 @@ class EVSSClaimService
     ::Rails.logger.info('Supplementing EVSS headers', {
                           message_type: "evss.#{task}.no_birls_id",
                           claim_id:,
-                          job_id:
+                          job_id:,
+                          revision: 2
                         })
   end
 

--- a/spec/services/evss_claim_service_spec.rb
+++ b/spec/services/evss_claim_service_spec.rb
@@ -41,15 +41,12 @@ RSpec.describe EVSSClaimService do
     let(:service) { described_class.new(user) }
     # rubocop:disable Style/HashSyntax
     let(:claim) { { :benefit_claim_details_dto => { :ptcpnt_vet_id => '234567891' } } }
-    let(:person) { { :file_nbr => '123456789' } }
     # rubocop:enable Style/HashSyntax
     let(:claim_service) { BGS::EbenefitsBenefitClaimsStatus }
-    let(:people_service) { BGS::PersonWebService }
 
     before do
       allow(Rails.logger).to receive(:info)
       allow_any_instance_of(claim_service).to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(claim)
-      allow_any_instance_of(people_service).to receive(:find_person_by_ptcpnt_id).and_return(person)
     end
 
     describe '#request_decision' do
@@ -61,15 +58,16 @@ RSpec.describe EVSSClaimService do
         job_id = job['jid']
         job_args = job['args'][0]
 
-        header = job_args['va_eauth_birlsfilenumber']
-        expect(header).to eq('123456789')
+        header = job_args['va_eauth_pid']
+        expect(header).to eq('234567891')
 
         expect(Rails.logger)
           .to have_received(:info)
           .with('Supplementing EVSS headers', {
                   message_type: 'evss.request_decision.no_birls_id',
                   claim_id: 1,
-                  job_id:
+                  job_id:,
+                  revision: 2
                 })
       end
     end
@@ -98,15 +96,16 @@ RSpec.describe EVSSClaimService do
         job_id = job['jid']
         job_args = job['args'][0]
 
-        header = job_args['va_eauth_birlsfilenumber']
-        expect(header).to eq('123456789')
+        header = job_args['va_eauth_pid']
+        expect(header).to eq('234567891')
 
         expect(Rails.logger)
           .to have_received(:info)
           .with('Supplementing EVSS headers', {
                   message_type: 'evss.document_upload.no_birls_id',
                   claim_id: 1,
-                  job_id:
+                  job_id:,
+                  revision: 2
                 })
       end
     end


### PR DESCRIPTION
## Summary
This is the third attempt to fix issues related to EVSS::RequestDecision and EVSS::DocumentUpload job failures. Replacing the `va_eauth_pid` header with the Veterans participant ID as this is what EVSS uses to look up the Filenumber of the Veteran whose eFolder documents should be placed in.

## Testing done
Updated specs to account for changes made in the service

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
