### PR TITLE
Remove flipper indexes from schema

### DIFF
--- a/db/migrate/20240214215514_add_flipper_indexes.rb
+++ b/db/migrate/20240214215514_add_flipper_indexes.rb
@@ -1,8 +1,0 @@
-class AddFlipperIndexes < ActiveRecord::Migration[7.0]
-  disable_ddl_transaction!
-
-  def change
-    add_index :flipper_features, :key, unique: true, algorithm: :concurrently
-    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, algorithm: :concurrently
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -327,7 +327,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.boolean "anti_csrf", null: false
     t.text "redirect_uri", null: false
     t.interval "access_token_duration", null: false
-    t.string "access_token_audience"
+    t.string "access_token_audience", null: false
     t.interval "refresh_token_duration", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -327,7 +327,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.boolean "anti_csrf", null: false
     t.text "redirect_uri", null: false
     t.interval "access_token_duration", null: false
-    t.string "access_token_audience", null: false
+    t.string "access_token_audience"
     t.interval "refresh_token_duration", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -896,7 +896,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "service_account_id", null: false
     t.text "description", null: false
     t.text "scopes", null: false, array: true
-    t.string "access_token_audience"
+    t.string "access_token_audience", null: false
     t.interval "access_token_duration", null: false
     t.string "certificates", array: true
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_14_215514) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -541,7 +541,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_215514) do
     t.string "key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
   create_table "flipper_gates", force: :cascade do |t|
@@ -550,7 +549,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_215514) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
@@ -898,7 +896,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_215514) do
     t.string "service_account_id", null: false
     t.text "description", null: false
     t.text "scopes", null: false, array: true
-    t.string "access_token_audience", null: false
+    t.string "access_token_audience"
     t.interval "access_token_duration", null: false
     t.string "certificates", array: true
     t.datetime "created_at", precision: 6, null: false

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -167,7 +167,6 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
     it '204s when given an empty category' do
       VCR.use_cassette('okta/verification-scopes', match_requests_on: %i[method path]) do
         get '/services/apps/v0/directory/scopes/empty_category'
-        puts response.body
         expect(response).to have_http_status(:no_content)
       end
     end


### PR DESCRIPTION
## Summary

Remove migration file that added indexes to flipper tables

The indexes were already added but are not in the schema