### PR TITLE
Added state + territory abbreviations. Should only allow state codes …

### DIFF
--- a/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
+++ b/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
@@ -1,5 +1,64 @@
 # frozen_string_literal: true
 
+US_STATES_TERRITORIES = {
+  'AL' => true,
+  'AK' => true,
+  'AZ' => true,
+  'AR' => true,
+  'CA' => true,
+  'CO' => true,
+  'CT' => true,
+  'DE' => true,
+  'FL' => true,
+  'GA' => true,
+  'HI' => true,
+  'ID' => true,
+  'IL' => true,
+  'IN' => true,
+  'IA' => true,
+  'KS' => true,
+  'KY' => true,
+  'LA' => true,
+  'ME' => true,
+  'MD' => true,
+  'MA' => true,
+  'MI' => true,
+  'MN' => true,
+  'MS' => true,
+  'MO' => true,
+  'MT' => true,
+  'NE' => true,
+  'NV' => true,
+  'NH' => true,
+  'NJ' => true,
+  'NM' => true,
+  'NY' => true,
+  'NC' => true,
+  'ND' => true,
+  'OH' => true,
+  'OK' => true,
+  'OR' => true,
+  'PA' => true,
+  'RI' => true,
+  'SC' => true,
+  'SD' => true,
+  'TN' => true,
+  'TX' => true,
+  'UT' => true,
+  'VT' => true,
+  'VA' => true,
+  'WA' => true,
+  'WV' => true,
+  'WI' => true,
+  'WY' => true,
+  'AS' => true, # American Samoa
+  'DC' => true, # District of Columbia
+  'GU' => true, # Guam
+  'MP' => true, # Northern Mariana Islands
+  'PR' => true, # Puerto Rico
+  'VI' => true  # U.S. Virgin Islands
+}.freeze
+
 module Representatives
   class XlsxFileProcessor
     include SentryLogging
@@ -39,6 +98,10 @@ module Representatives
 
       xlsx.sheet(sheet_name).each_with_index do |row, index|
         next if index.zero? || row.length < column_map.length
+
+        state_code = get_value(row, column_map, 'WorkState')
+
+        next unless US_STATES_TERRITORIES[state_code]
 
         data << create_json_data(row, sheet_name, column_map)
       end

--- a/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
+++ b/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
@@ -1,67 +1,67 @@
 # frozen_string_literal: true
 
-US_STATES_TERRITORIES = {
-  'AL' => true,
-  'AK' => true,
-  'AZ' => true,
-  'AR' => true,
-  'CA' => true,
-  'CO' => true,
-  'CT' => true,
-  'DE' => true,
-  'FL' => true,
-  'GA' => true,
-  'HI' => true,
-  'ID' => true,
-  'IL' => true,
-  'IN' => true,
-  'IA' => true,
-  'KS' => true,
-  'KY' => true,
-  'LA' => true,
-  'ME' => true,
-  'MD' => true,
-  'MA' => true,
-  'MI' => true,
-  'MN' => true,
-  'MS' => true,
-  'MO' => true,
-  'MT' => true,
-  'NE' => true,
-  'NV' => true,
-  'NH' => true,
-  'NJ' => true,
-  'NM' => true,
-  'NY' => true,
-  'NC' => true,
-  'ND' => true,
-  'OH' => true,
-  'OK' => true,
-  'OR' => true,
-  'PA' => true,
-  'RI' => true,
-  'SC' => true,
-  'SD' => true,
-  'TN' => true,
-  'TX' => true,
-  'UT' => true,
-  'VT' => true,
-  'VA' => true,
-  'WA' => true,
-  'WV' => true,
-  'WI' => true,
-  'WY' => true,
-  'AS' => true, # American Samoa
-  'DC' => true, # District of Columbia
-  'GU' => true, # Guam
-  'MP' => true, # Northern Mariana Islands
-  'PR' => true, # Puerto Rico
-  'VI' => true  # U.S. Virgin Islands
-}.freeze
-
 module Representatives
   class XlsxFileProcessor
     include SentryLogging
+
+    US_STATES_TERRITORIES = {
+      'AL' => true,
+      'AK' => true,
+      'AZ' => true,
+      'AR' => true,
+      'CA' => true,
+      'CO' => true,
+      'CT' => true,
+      'DE' => true,
+      'FL' => true,
+      'GA' => true,
+      'HI' => true,
+      'ID' => true,
+      'IL' => true,
+      'IN' => true,
+      'IA' => true,
+      'KS' => true,
+      'KY' => true,
+      'LA' => true,
+      'ME' => true,
+      'MD' => true,
+      'MA' => true,
+      'MI' => true,
+      'MN' => true,
+      'MS' => true,
+      'MO' => true,
+      'MT' => true,
+      'NE' => true,
+      'NV' => true,
+      'NH' => true,
+      'NJ' => true,
+      'NM' => true,
+      'NY' => true,
+      'NC' => true,
+      'ND' => true,
+      'OH' => true,
+      'OK' => true,
+      'OR' => true,
+      'PA' => true,
+      'RI' => true,
+      'SC' => true,
+      'SD' => true,
+      'TN' => true,
+      'TX' => true,
+      'UT' => true,
+      'VT' => true,
+      'VA' => true,
+      'WA' => true,
+      'WV' => true,
+      'WI' => true,
+      'WY' => true,
+      'AS' => true, # American Samoa
+      'DC' => true, # District of Columbia
+      'GU' => true, # Guam
+      'MP' => true, # Northern Mariana Islands
+      'PR' => true, # Puerto Rico
+      'VI' => true  # U.S. Virgin Islands
+    }.freeze
 
     SHEETS_TO_PROCESS = %w[Agents Attorneys Representatives].freeze
 

--- a/modules/veteran/spec/sidekiq/representatives/xlsx_file_processor_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/xlsx_file_processor_spec.rb
@@ -77,5 +77,20 @@ RSpec.describe Representatives::XlsxFileProcessor do
         expect(xlsx_processor).to have_received(:log_message_to_sentry).with(expected_log_message, :error)
       end
     end
+
+    context 'with state code validation' do
+      it 'processes only rows with valid state codes' do
+        valid_states = Representatives::XlsxFileProcessor::US_STATES_TERRITORIES.keys
+
+        result.each_value do |value_array|
+          value_array.each do |json_string|
+            json_object = JSON.parse(json_string)
+            state_code = json_object.dig('request_address', 'state_province', 'code')
+
+            expect(valid_states).to include(state_code) unless state_code.nil?
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION

## Summary

- Added state + territory abbreviations. Should only process state codes from this list to prevent eg military postal codes, foreign country addresses, etc from populating in Find a Representative results. 

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75704

## Testing done

- [ ] *New code is covered by unit tests*
