### PR TITLE
Update access_token_cookie domain, refactor setting cookies

### DIFF
--- a/spec/services/sign_in/token_serializer_spec.rb
+++ b/spec/services/sign_in/token_serializer_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe SignIn::TokenSerializer do
           expires: refresh_token_expiration,
           path:,
           secure:,
-          httponly:
+          httponly:,
+          domain: :all
         }
       end
       let(:expected_refresh_token_cookie) do
@@ -80,7 +81,8 @@ RSpec.describe SignIn::TokenSerializer do
           expires: refresh_token_expiration,
           secure:,
           domain:,
-          httponly: httponly_info_cookie
+          httponly: httponly_info_cookie,
+          path:
         }
       end
       let(:access_token_cookie_name) { SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME }
@@ -182,7 +184,8 @@ RSpec.describe SignIn::TokenSerializer do
           expires: refresh_token_expiration,
           path:,
           secure:,
-          httponly:
+          httponly:,
+          domain: :all
         }
       end
       let(:expected_refresh_token_cookie) do
@@ -209,7 +212,8 @@ RSpec.describe SignIn::TokenSerializer do
           expires: refresh_token_expiration,
           secure:,
           domain:,
-          httponly: httponly_info_cookie
+          httponly: httponly_info_cookie,
+          path:
         }
       end
       let(:access_token_cookie_name) { SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME }


### PR DESCRIPTION
## Summary
Set access_token cookie domain to :all. This will set the domain to the root e.g. `.va.gov`. Refactor setting cookies.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#76745

## Testing done

- Sign in with SiS and check the cookies

## What areas of the site does it impact?
Sign-in service, authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
