### PR TITLE
Submit to Central Submission Process if Pdf Submission Fails

### DIFF
--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -112,8 +112,10 @@ module BGS
     end
 
     def external_key
-      @external_key ||= key = common_name.presence || email
-      key.first(Constants::EXTERNAL_KEY_MAX_LENGTH)
+      @external_key ||= begin
+        key = common_name.presence || email
+        key.first(Constants::EXTERNAL_KEY_MAX_LENGTH)
+      end
     end
 
     def get_form_hash_686c

--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -81,7 +81,7 @@ module BGS
       )
       # This is now set to perform sync to catch errors and proceed to CentralForm submission in case of failure
     rescue => e
-      submit_to_central_service(claim:, encrypted_vet_info:)
+      submit_to_central_service(claim:)
 
       raise e
     end

--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -13,7 +13,8 @@ module BGS
                 :email,
                 :icn,
                 :participant_id,
-                :uuid
+                :uuid,
+                :file_number
 
     def initialize(user)
       @first_name = user.first_name
@@ -35,32 +36,11 @@ module BGS
       service.claimant.find_dependents_by_participant_id(participant_id, ssn) || { persons: [] }
     end
 
-    # rubocop:disable Metrics/MethodLength
     def submit_686c_form(claim)
       Rails.logger.info('BGS::DependentService running!', { user_uuid: uuid, saved_claim_id: claim.id, icn: })
-      bgs_person = service.people.find_person_by_ptcpnt_id(participant_id) || service.people.find_by_ssn(ssn) # rubocop:disable Rails/DynamicFindBy
-      file_number = bgs_person[:file_nbr]
-      # BGS's file number is supposed to be an eight or nine-digit string, and
-      # our code is built upon the assumption that this is the case. However,
-      # we've seen cases where BGS returns a file number with dashes
-      # (e.g. XXX-XX-XXXX). In this case specifically, we can simply strip out
-      # the dashes and proceed with form submission.
-      file_number = file_number.delete('-') if file_number =~ /\A\d{3}-\d{2}-\d{4}\z/
-      form_hash_686c = get_form_hash_686c(file_number:)
-      # The `validate_*!` calls below will raise errors if we have an invalid
-      # file number, or if the file number and SSN don't match. Even if this is
-      # the case, we still want to submit a PDF to the veteran's VBMS eFolder.
-      # This is because we are currently relying on the presence of a PDF and
-      # absence of a BGS-established claim to identify cases where Form 686c-674
-      # submission failed.
 
-      encrypted_vet_info = KmsEncrypted::Box.new.encrypt(form_hash_686c.to_json)
-      submit_pdf_job_id = VBMS::SubmitDependentsPdfJob.perform_async(
-        claim.id,
-        encrypted_vet_info,
-        claim.submittable_686?,
-        claim.submittable_674?
-      )
+      encrypted_vet_info = KmsEncrypted::Box.new.encrypt(get_form_hash_686c.to_json)
+      submit_pdf_job(claim:, encrypted_vet_info:)
 
       if claim.submittable_686? || claim.submittable_674?
         # Previously, we would wait until `BGS::Service#create_person`'s call to
@@ -70,30 +50,21 @@ module BGS
         # detailing this specific file number / SSN error, and is therefore unable
         # to distinguish this error from others in our Sentry dashboards. That is
         # why I am deliberately raising these errors here.
-        validate_file_number_format!(file_number:)
-        validate_file_number_matches_ssn!(file_number:)
-        submit_form_job_id = if claim.submittable_686?
-                               BGS::SubmitForm686cJob.perform_async(
-                                 uuid, @icn, claim.id, encrypted_vet_info
-                               )
-                             else
-                               BGS::SubmitForm674Job.perform_async(
-                                 uuid, @icn, claim.id, encrypted_vet_info
-                               )
-                             end
+
+        perform_file_number_validations!(file_number:)
+        submit_form_job_id = submit_to_standard_service(claim:, encrypted_vet_info:)
         Rails.logger.info('BGS::DependentService succeeded!', { user_uuid: uuid, saved_claim_id: claim.id, icn: })
       end
 
       {
-        submit_pdf_job_id:,
         submit_form_job_id:
       }
     rescue => e
       Rails.logger.error('BGS::DependentService failed!', { user_uuid: uuid, saved_claim_id: claim.id, icn:, error: e.message }) # rubocop:disable Layout/LineLength
       log_exception_to_sentry(e, { icn:, uuid: }, { team: Constants::SENTRY_REPORTING_TEAM })
+
       raise e
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 
@@ -101,14 +72,71 @@ module BGS
       @service ||= BGS::Services.new(external_uid: icn, external_key:)
     end
 
-    def external_key
-      @external_key ||= begin
-        key = common_name.presence || email
-        key.first(Constants::EXTERNAL_KEY_MAX_LENGTH)
+    def submit_pdf_job(claim:, encrypted_vet_info:)
+      VBMS::SubmitDependentsPdfJob.perform_sync(
+        claim.id,
+        encrypted_vet_info,
+        claim.submittable_686?,
+        claim.submittable_674?
+      )
+      # This is now set to perform sync to catch errors and proceed to CentralForm submission in case of failure
+    rescue => e
+      submit_to_central_service(claim:, encrypted_vet_info:)
+
+      raise e
+    end
+
+    def submit_to_standard_service(claim:, encrypted_vet_info:)
+      if claim.submittable_686?
+        BGS::SubmitForm686cJob.perform_async(
+          uuid, icn, claim.id, encrypted_vet_info
+        )
+      else
+        BGS::SubmitForm674Job.perform_async(
+          uuid, icn, claim.id, encrypted_vet_info
+        )
       end
     end
 
-    def get_form_hash_686c(file_number:)
+    def submit_to_central_service(claim:)
+      vet_info = JSON.parse(claim.form)['dependents_application']
+
+      if Flipper.enabled?(:dependents_central_submission)
+        user = BGS::SubmitForm686cJob.generate_user_struct(vet_info)
+        CentralMail::SubmitCentralForm686cJob.perform_async(claim.id,
+                                                            KmsEncrypted::Box.new.encrypt(vet_info.to_json),
+                                                            KmsEncrypted::Box.new.encrypt(user.to_h.to_json))
+      else
+        DependentsApplicationFailureMailer.build(user).deliver_now if user&.email.present? # rubocop:disable Style/IfInsideElse
+      end
+    end
+
+    def external_key
+      @external_key ||= key = common_name.presence || email
+      key.first(Constants::EXTERNAL_KEY_MAX_LENGTH)
+    end
+
+    def get_form_hash_686c
+      bgs_person = service.people.find_person_by_ptcpnt_id(participant_id) || service.people.find_by_ssn(ssn) # rubocop:disable Rails/DynamicFindBy
+      @file_number = bgs_person[:file_nbr]
+      # BGS's file number is supposed to be an eight or nine-digit string, and
+      # our code is built upon the assumption that this is the case. However,
+      # we've seen cases where BGS returns a file number with dashes
+      # (e.g. XXX-XX-XXXX). In this case specifically, we can simply strip out
+      # the dashes and proceed with form submission.
+      @file_number = file_number.delete('-') if file_number =~ /\A\d{3}-\d{2}-\d{4}\z/
+
+      # The `validate_*!` calls below will raise errors if we have an invalid
+      # file number, or if the file number and SSN don't match. Even if this is
+      # the case, we still want to submit a PDF to the veteran's VBMS eFolder.
+      # This is because we are currently relying on the presence of a PDF and
+      # absence of a BGS-established claim to identify cases where Form 686c-674
+      # submission failed.
+
+      generate_hash_from_details
+    end
+
+    def generate_hash_from_details
       {
         'veteran_information' => {
           'full_name' => {
@@ -127,6 +155,11 @@ module BGS
           'icn' => icn
         }
       }
+    end
+
+    def perform_file_number_validations!(file_number:)
+      validate_file_number_format!(file_number:)
+      validate_file_number_matches_ssn!(file_number:)
     end
 
     def validate_file_number_format!(file_number:)

--- a/modules/mobile/spec/request/dependents_request_spec.rb
+++ b/modules/mobile/spec/request/dependents_request_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe 'dependents', type: :request do
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '796043735' })
+        allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync)
       end
 
       it 'returns job ids' do
@@ -83,19 +84,18 @@ RSpec.describe 'dependents', type: :request do
           post('/mobile/v0/dependents', params: test_form, headers: sis_headers)
         end
         expect(response).to have_http_status(:accepted)
-        submit_pdf_job_id = VBMS::SubmitDependentsPdfJob.jobs.first['jid']
         submit_form_job_id = BGS::SubmitForm686cJob.jobs.first['jid']
-        expect(response.parsed_body).to eq({ 'data' => { 'submitPdfJobId' => submit_pdf_job_id,
-                                                         'submitFormJobId' => submit_form_job_id } })
+        expect(response.parsed_body).to eq({ 'data' => { 'submitFormJobId' => submit_form_job_id } })
       end
     end
 
-    context 'with failed async job perform' do
+    context 'with failed sync job perform' do
       before do
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
-        allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_async)
+        allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync)
           .and_raise(Common::Exceptions::BackendServiceException)
+        allow_any_instance_of(BGS::DependentService).to receive(:submit_to_central_service)
       end
 
       it 'returns error' do

--- a/spec/controllers/v0/dependents_applications_controller_spec.rb
+++ b/spec/controllers/v0/dependents_applications_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe V0::DependentsApplicationsController do
   describe 'POST create' do
     context 'with valid params' do
       before do
+        allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync)
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '796043735' })

--- a/spec/services/bgs/dependent_service_spec.rb
+++ b/spec/services/bgs/dependent_service_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe BGS::DependentService do
         service = BGS::DependentService.new(user)
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '796043735' })
         expect_any_instance_of(BGS::PersonWebService).to receive(:find_person_by_ptcpnt_id)
+        allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync)
 
         service.submit_686c_form(claim)
       end
@@ -57,7 +58,7 @@ RSpec.describe BGS::DependentService do
             user.uuid, user.icn, claim.id,
             encrypted_vet_info
           )
-          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
             claim.id, encrypted_vet_info, true,
             true
           )
@@ -77,7 +78,7 @@ RSpec.describe BGS::DependentService do
             user.uuid, user.icn, claim.id,
             encrypted_vet_info
           )
-          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
             claim.id, encrypted_vet_info, true,
             true
           )
@@ -95,7 +96,7 @@ RSpec.describe BGS::DependentService do
           user.uuid, user.icn, claim.id,
           encrypted_vet_info
         )
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info,
           true, true
         )
@@ -114,7 +115,7 @@ RSpec.describe BGS::DependentService do
           anything
         )
         expect(BGS::SubmitForm686cJob).not_to receive(:perform_async)
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info,
           true, true
         )
@@ -133,7 +134,7 @@ RSpec.describe BGS::DependentService do
           anything
         )
         expect(BGS::SubmitForm686cJob).not_to receive(:perform_async)
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info,
           true, true
         )
@@ -152,7 +153,7 @@ RSpec.describe BGS::DependentService do
           anything
         )
         expect(BGS::SubmitForm686cJob).not_to receive(:perform_async)
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info,
           true, true
         )
@@ -187,6 +188,7 @@ RSpec.describe BGS::DependentService do
     end
 
     it 'calls find_person_by_participant_id' do
+      allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync)
       VCR.use_cassette('bgs/dependent_service/submit_686c_form') do
         service = BGS::DependentService.new(user)
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '796043735' })
@@ -205,7 +207,7 @@ RSpec.describe BGS::DependentService do
             user.uuid, user.icn, claim.id,
             encrypted_vet_info
           )
-          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
             claim.id, encrypted_vet_info, false,
             true
           )
@@ -225,7 +227,7 @@ RSpec.describe BGS::DependentService do
             user.uuid, user.icn, claim.id,
             encrypted_vet_info
           )
-          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+          expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
             claim.id, encrypted_vet_info, false,
             true
           )
@@ -243,7 +245,7 @@ RSpec.describe BGS::DependentService do
           user.uuid, user.icn, claim.id,
           encrypted_vet_info
         )
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info, false,
           true
         )
@@ -262,7 +264,7 @@ RSpec.describe BGS::DependentService do
           anything
         )
         expect(BGS::SubmitForm674Job).not_to receive(:perform_async)
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info, false,
           true
         )
@@ -281,7 +283,7 @@ RSpec.describe BGS::DependentService do
           anything
         )
         expect(BGS::SubmitForm674Job).not_to receive(:perform_async)
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info, false,
           true
         )
@@ -300,7 +302,7 @@ RSpec.describe BGS::DependentService do
           anything
         )
         expect(BGS::SubmitForm674Job).not_to receive(:perform_async)
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync).with(
           claim.id, encrypted_vet_info, false,
           true
         )


### PR DESCRIPTION
## Summary
- Perform pdf submission synchronously
- Rescue pdf submission error and submit to central submission
- Still raise error to Dependent Service for logging
- Rearrange most of submit code to allow for LoC linting

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76139

## Testing done
- [x] *New code is covered by unit tests*
- This was tested through console, dependent service was called with an existing claim and checked logs so that on failure of Pdf job the central job was attempted to be submitted

##
Functionally this shouldn't change anything for the site, most logic is kept consistent except to submit to central process in case of failure

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  ~Documentation has been updated (link to documentation)~
- [x]  ~No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs~
- [x]  ~Feature/bug has a monitor built into Datadog or Grafana (if applicable)~
- [x]  ~If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected~
- [x]  ~I added a screenshot of the developed feature~