### PR TITLE
POA v2: Adds mock data for POST /2122

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -791,6 +791,29 @@
       :path: "/services/benefits-documents/v1/documents/search"
       :file_path: "/lighthouse/claims_api/benefits_documents/search/default"
 
+# Lighthouse Local BGS
+- :name: "Lighthouse Local BGS"
+  :base_uri: <%= "#{URI(Settings.bgs.url).host}:#{URI(Settings.bgs.url).port}" %>
+  :endpoints:
+    - :method: :get
+      :path: "/PersonWebServiceBean/PersonWebService"
+      :file_path: "/lighthouse/local_bgs/person_web_service/find_poa_by_ptcpnt_id_wsdl"
+    - :method: :post
+      :path: "/PersonWebServiceBean/PersonWebService"
+      :file_path: "/lighthouse/local_bgs/person_web_service/find_poa_by_ptcpnt_id"
+    - :method: :get
+      :path: "/OrgWebServiceBean/OrgWebService"
+      :file_path: "/lighthouse/local_bgs/org_web_service/find_poa_history_by_ptcpnt_id_wsdl"
+    - :method: :post
+      :path: "/OrgWebServiceBean/OrgWebService"
+      :file_path: "/lighthouse/local_bgs/org_web_service/find_poa_history_by_ptcpnt_id"
+    - :method: :get
+      :path: "/ClaimantServiceBean/ClaimantWebService"
+      :file_path: "/lighthouse/local_bgs/claimant_web_service/find_poa_history_by_ptcpnt_id_wsdl"
+    - :method: :post
+      :path: "/ClaimantServiceBean/ClaimantWebService"
+      :file_path: "/lighthouse/local_bgs/claimant_web_service/find_poa_history_by_ptcpnt_id"
+
 # Lighthouse Benefits Documents API
 - :name: "Lighthouse Benefits Documents"
   :base_uri: <%= "#{URI(Settings.lighthouse.benefits_documents.host).host}:#{URI(Settings.lighthouse.benefits_documents.host).port}" %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -649,6 +649,8 @@ claims_api:
         aud_claim_url: ~
     host: https://sandbox-api.va.gov
     use_mocks: false
+  local_bgs:
+    use_mocks_for_v2: false
 
 connected_apps_api:
   connected_apps:

--- a/lib/bgs/power_of_attorney_verifier.rb
+++ b/lib/bgs/power_of_attorney_verifier.rb
@@ -2,9 +2,10 @@
 
 module BGS
   class PowerOfAttorneyVerifier
-    def initialize(user)
+    def initialize(user, v2: false)
       @user = user
-      @veteran = Veteran::User.new(@user)
+      @v2 = v2 || false
+      @veteran = Veteran::User.new(@user, v2:)
     end
 
     def current_poa

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney_controller.rb
@@ -165,7 +165,7 @@ module ClaimsApi
         end
 
         def current_poa
-          @current_poa ||= BGS::PowerOfAttorneyVerifier.new(target_veteran).current_poa
+          @current_poa ||= BGS::PowerOfAttorneyVerifier.new(target_veteran, v2: true).current_poa
         end
 
         def header_md5

--- a/modules/veteran/app/models/veteran/user.rb
+++ b/modules/veteran/app/models/veteran/user.rb
@@ -7,8 +7,9 @@ module Veteran
   class User < Base
     attr_accessor :power_of_attorney, :previous_power_of_attorney
 
-    def initialize(user)
+    def initialize(user, v2: false)
       @user = user
+      @v2 = v2 || false
 
       if current_poa_code.present?
         self.power_of_attorney = PowerOfAttorney.new(code: current_poa_code,
@@ -56,7 +57,8 @@ module Veteran
       external_key = "#{@user.first_name} #{@user.last_name}"
       @local_bgs_service ||= ClaimsApi::LocalBGS.new(
         external_uid: @user.mpi_icn,
-        external_key: external_key.presence || @user.mpi_icn
+        external_key: external_key.presence || @user.mpi_icn,
+        v2: @v2
       )
     end
   end


### PR DESCRIPTION
Adds BGS mocks for `POST /2122`

## Summary

Mock data should be used in sandbox when submitting 2122 form data in Lighthouse Claims POA v2 API

## Related issue(s)

Mock data was added for the BGS calls used to submit the form.

See [Mock Data](https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/458)

## Testing done

- Disabled Sidekiq locally
- Enabled mocking locally for `local_bgs` and `bgs` in `settings.local.yml`
- Sent a request to `http://localhost:3000/services/claims/v2/veterans/1012667145V762142/2122` with body:
```
{
    "data": {
        "type": "form/21-22",
        "attributes": {
            "serviceOrganization": {
                "poaCode": "067"
            }
        }
    }
}
```
- In the Rails console, I manually ran the following jobs:
  - `ClaimsApi::V1::PoaFormBuilderJob`
  - `ClaimsApi::PoaVBMSUpdater`

_Note_ The `ClaimsApi::PoaVBMSUpdater` job isn't using Local BGS, therefore, it doesn't seem possible to only mock v2 using `BGS::Service` since this service depends on the application configuration and can't be set at runtime


## What areas of the site does it impact?
Lighthouse Claims API

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
