### PR TITLE
Implement an alternate and non-blocking way of rate-limiting Representatives::Update jobs

### DIFF
--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -8,9 +8,6 @@ module Representatives
     include Sidekiq::Job
     include SentryLogging
 
-    PROD_SLICE_SIZE = 1000
-    OTHER_ENV_SLICE_SIZE = 30
-
     def perform
       file_content = fetch_file_content
       return unless file_content
@@ -35,7 +32,7 @@ module Representatives
 
         batch = Sidekiq::Batch.new
         batch.description = "Batching #{sheet} sheet data"
-        slice_size = Settings.vsp_environment == 'production' ? PROD_SLICE_SIZE : OTHER_ENV_SLICE_SIZE
+        slice_size = Settings.vsp_environment == 'production' ? 1000 : 30
 
         begin
           batch.jobs do

--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -36,7 +36,7 @@ module Representatives
         batch.jobs do
           data[sheet].each_slice(BATCH_SIZE) do |rows|
             rows.each do |row|
-              Representatives::Update.perform_async(row)
+              Representatives::Update.set(queue: 'low').perform_async(row)
             end
           end
         end

--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -38,7 +38,7 @@ module Representatives
         begin
           batch.jobs do
             data[sheet].each_slice(BATCH_SIZE) do |rows|
-              Representatives::UpdateBatch.perform_in(delay.minutes, rows)
+              Representatives::Update.perform_in(delay.minutes, rows)
               delay += 1
             end
           end

--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -36,7 +36,7 @@ module Representatives
         batch.jobs do
           data[sheet].each_slice(BATCH_SIZE) do |rows|
             rows.each do |row|
-              Representatives::Update.set(queue: 'low').perform_async(row)
+              Representatives::Update.perform_async(row)
             end
           end
         end

--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -35,11 +35,15 @@ module Representatives
         batch = Sidekiq::Batch.new
         batch.description = "Batching #{sheet} sheet data"
 
-        batch.jobs do
-          data[sheet].each_slice(BATCH_SIZE) do |rows|
-            Representatives::UpdateBatch.perform_in(delay.minutes, rows)
-            delay += 1
+        begin
+          batch.jobs do
+            data[sheet].each_slice(BATCH_SIZE) do |rows|
+              Representatives::UpdateBatch.perform_in(delay.minutes, rows)
+              delay += 1
+            end
           end
+        rescue => e
+          log_error("Error queuing address updates: #{e.message}")
         end
       end
     end

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -24,6 +24,8 @@ module Representatives
         next unless address_valid?(response)
 
         update_record(rep_data, response)
+      rescue Common::Exceptions::BackendServiceException => e
+        log_error("Representative address validation failed: #{e.message}")
       rescue => e
         log_error("Error updating representative: #{e.message}")
       end
@@ -127,7 +129,7 @@ module Representatives
     # Logs an error to Sentry.
     # @param error [Exception] The error object to be logged.
     def log_error(error)
-      log_message_to_sentry("Update error: #{error.message}", :error)
+      log_message_to_sentry("Representatives::Update error: #{error.message}", :error)
     end
   end
 end

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -25,9 +25,9 @@ module Representatives
 
         update_record(rep_data, response)
       rescue Common::Exceptions::BackendServiceException => e
-        log_error("Error, representative address validation failed. Rep id: #{rep_data['id']}, Error message: #{e.message}")
+        log_error("Error: representative address validation failed. Rep id: #{rep_data['id']}, Error message: #{e.message}")
       rescue => e
-        log_error("Error updating representative: #{e.message}")
+        log_error("Error: representative was not updated. Error message: #{e.message}")
       end
     rescue JSON::ParserError => e
       log_error(e)
@@ -127,9 +127,9 @@ module Representatives
     end
 
     # Logs an error to Sentry.
-    # @param error [Exception] The error object to be logged.
+    # @param error [Exception] The error string to be logged.
     def log_error(error)
-      log_message_to_sentry("Representatives::Update error: #{error.message}", :error)
+      log_message_to_sentry("Representatives::Update: #{error}", :error)
     end
   end
 end

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -17,7 +17,7 @@ module Representatives
     REDIS_RATE_LIMIT_KEY = 'rep_update_rate_limit'
     RATE_LIMIT_PERIOD = 60 # seconds
     RATE_LIMIT_COUNT = 30
-  
+
     def perform(json_data)
       if rate_limited?
         Representatives::Update.perform_async(json_data)
@@ -26,9 +26,9 @@ module Representatives
           data = JSON.parse(json_data)
           validation_address = build_validation_address(data['request_address'])
           response = validate_address(validation_address)
-  
+
           return unless address_valid?(response)
-  
+
           update_address_record(data, response)
           increment_rate_limit
         rescue JSON::ParserError => e
@@ -36,15 +36,15 @@ module Representatives
         end
       end
     end
-  
+
     private
-  
+
     def rate_limited?
       redis = redis_instance
       count = redis.get(REDIS_RATE_LIMIT_KEY).to_i
       count >= RATE_LIMIT_COUNT
     end
-  
+
     def increment_rate_limit
       redis = redis_instance
 
@@ -55,8 +55,6 @@ module Representatives
         redis.set(REDIS_RATE_LIMIT_KEY, 1, ex: RATE_LIMIT_PERIOD)
       end
     end
-
-    private
 
     def redis_instance
       @redis ||= Redis.new(REDIS_OPTIONS)

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -25,7 +25,7 @@ module Representatives
 
         update_record(rep_data, response)
       rescue Common::Exceptions::BackendServiceException => e
-        log_error("Error: representative address validation failed. Rep id: #{rep_data['id']}, Error message: #{e.message}")
+        log_error("Error: representative address validation failed. Rep id: #{rep_data['id']}, Error message: #{e.message}") # rubocop:disable Layout/LineLength
       rescue => e
         log_error("Error: representative was not updated. Error message: #{e.message}")
       end

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -25,7 +25,7 @@ module Representatives
 
         update_record(rep_data, response)
       rescue Common::Exceptions::BackendServiceException => e
-        log_error("Representative address validation failed: #{e.message}")
+        log_error("Error, representative address validation failed. Rep id: #{rep_data['id']}, Error message: #{e.message}")
       rescue => e
         log_error("Error updating representative: #{e.message}")
       end

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -85,7 +85,6 @@ module Representatives
     end
 
     # Updates the given record with the new address and other relevant attributes.
-    # @param record [ActiveRecord::Base] The record to be updated.
     # @param rep_data [Hash] Original rep_data containing the address and other details.
     # @param api_response [Hash] The response from the address validation service.
     def build_record_attributes(rep_data, api_response)

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -16,18 +16,16 @@ module Representatives
     # @param json_data [String] JSON string containing address data.
     def perform(reps_json)
       reps_data = JSON.parse(reps_json)
-    
+
       reps_data.each do |rep_data|
-        begin
-          validation_address = build_validation_address(rep_data['request_address'])
-          response = validate_address(validation_address)
-    
-          next unless address_valid?(response)
-    
-          update_record(rep_data, response)
-        rescue => e
-          log_error("Error updating representative: #{e.message}")
-        end
+        validation_address = build_validation_address(rep_data['request_address'])
+        response = validate_address(validation_address)
+
+        next unless address_valid?(response)
+
+        update_record(rep_data, response)
+      rescue => e
+        log_error("Error updating representative: #{e.message}")
       end
     rescue JSON::ParserError => e
       log_error(e)
@@ -81,7 +79,7 @@ module Representatives
           :error
         )
       else
-        record_attributes = build_record_attributes(record, rep_data, api_response)
+        record_attributes = build_record_attributes(rep_data, api_response)
         record.update(record_attributes)
       end
     end
@@ -90,7 +88,7 @@ module Representatives
     # @param record [ActiveRecord::Base] The record to be updated.
     # @param rep_data [Hash] Original rep_data containing the address and other details.
     # @param api_response [Hash] The response from the address validation service.
-    def build_record_attributes(record, rep_data, api_response)
+    def build_record_attributes(rep_data, api_response)
       address = api_response['candidate_addresses'].first['address']
       geocode = api_response['candidate_addresses'].first['geocode']
       meta = api_response['candidate_addresses'].first['address_meta_data']

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'redis'
 require 'sidekiq'
 require 'sentry_logging'
 require 'va_profile/models/validation_address'
@@ -12,21 +13,54 @@ module Representatives
     include Sidekiq::Job
     include SentryLogging
 
-    # Performs the job of parsing JSON data, validating the address, and updating the record.
-    # @param json_data [String] JSON string containing address data.
+    REDIS_OPTIONS = REDIS_CONFIG[:redis].to_h
+    REDIS_RATE_LIMIT_KEY = 'rep_update_rate_limit'
+    RATE_LIMIT_PERIOD = 60 # seconds
+    RATE_LIMIT_COUNT = 30
+  
     def perform(json_data)
-      data = JSON.parse(json_data)
-      validation_address = build_validation_address(data['request_address'])
-      response = validate_address(validation_address)
+      if rate_limited?
+        Representatives::Update.perform_async(json_data)
+      else
+        begin
+          data = JSON.parse(json_data)
+          validation_address = build_validation_address(data['request_address'])
+          response = validate_address(validation_address)
+  
+          return unless address_valid?(response)
+  
+          update_address_record(data, response)
+          increment_rate_limit
+        rescue JSON::ParserError => e
+          log_error(e)
+        end
+      end
+    end
+  
+    private
+  
+    def rate_limited?
+      redis = redis_instance
+      count = redis.get(REDIS_RATE_LIMIT_KEY).to_i
+      count >= RATE_LIMIT_COUNT
+    end
+  
+    def increment_rate_limit
+      redis = redis_instance
 
-      return unless address_valid?(response)
-
-      update_address_record(data, response)
-    rescue JSON::ParserError => e
-      log_error(e)
+      if redis.exists(REDIS_RATE_LIMIT_KEY)
+        redis.incr(REDIS_RATE_LIMIT_KEY)
+      else
+        # Expire the key after the rate limit period
+        redis.set(REDIS_RATE_LIMIT_KEY, 1, ex: RATE_LIMIT_PERIOD)
+      end
     end
 
     private
+
+    def redis_instance
+      @redis ||= Redis.new(REDIS_OPTIONS)
+    end
 
     # Builds a validation address object from the provided address data.
     # @param request_address [Hash] A hash containing address fields.

--- a/modules/veteran/spec/sidekiq/representatives/update_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/update_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Representatives::Update do
 
       it 'logs an error to Sentry' do
         expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-          "Update error: unexpected token at 'invalid json'", :error
+          "Representatives::Update: unexpected token at 'invalid json'", :error
         )
 
         subject.perform(invalid_json_data)

--- a/modules/veteran/spec/sidekiq/representatives/update_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/update_spec.rb
@@ -5,22 +5,24 @@ require 'rails_helper'
 RSpec.describe Representatives::Update do
   describe '#perform' do
     let(:json_data) do
-      { request_address: {
-          address_pou: 'abc',
-          address_line1: 'abc',
-          address_line2: 'abc',
-          address_line3: 'abc',
-          city: 'abc',
-          state_province: {
-            code: 'abc'
+      [
+        { request_address: {
+            address_pou: 'abc',
+            address_line1: 'abc',
+            address_line2: 'abc',
+            address_line3: 'abc',
+            city: 'abc',
+            state_province: {
+              code: 'abc'
+            },
+            zip_code5: 'abc',
+            zip_code4: 'abc',
+            country_code_iso3: 'abc'
           },
-          zip_code5: 'abc',
-          zip_code4: 'abc',
-          country_code_iso3: 'abc'
-        },
-        id:,
-        email_address: 'test@example.com',
-        phone_number: '999-999-9999' }.to_json
+          id:,
+          email_address: 'test@example.com',
+          phone_number: '999-999-9999' }
+      ].to_json
     end
     let(:api_response) do
       {


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/76836

## Summary
This Pull Request introduces an alternate approach to rate-limiting for the `Representatives::Update` jobs (instead of using  Sidekiq's `#window` rate-limiting feature). This method involves chunking an array of data rows - 1000 rows per job in production and 30 rows per job in other environments - and scheduling these jobs to execute sequentially, one minute apart.

By leveraging Sidekiq's `#perform_in` method instead of the `#window` rate-limiting option, we can manage the rate at which `Representatives::Update` jobs are processed. This method ensures that jobs are executed back-to-back in a non-blocking manner until the entire queue is processed. The `#perform_in` method allows us to specify a delay for each job's execution, enabling us to spread the job processing load evenly over time.

I tried to keep this a simple as possible for now. If there's an error in the process of updating a rep's info, we simply catch it and log it to Sentry (along with the rep's id); each job as a whole (or any reps in it) is not retried.

Thanks to Riley Anderson for suggesting `#perform_in`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76836

## Testing done
- Tests were updated

## Screenshots
Running locally, the jobs are batched in 1-minute increments:
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/9326247/4eb6e0e3-2895-4e29-8f53-f15e51128386)

## What areas of the site does it impact?
- The Find a Rep app, which is behind a feature flag
- Side - it adds ~20k jobs to sidekiq the first time it runs

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
