### PR TITLE
Use LOA2 instead of LOA3 for datebox timestamp logic

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -19,7 +19,7 @@ module SimpleFormsApi
       auth_text = case current_loa
                   when 3
                     'Signee signed with an identity-verified account.'
-                  when 1
+                  when 2
                     'Signee signed in but hasn’t verified their identity.'
                   else
                     'Signee not signed in.'


### PR DESCRIPTION
## Summary
This PR fixes an issue where we wanted to target LOA2 instead of LOA1 for certain messaging on the PDFs.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/949
