### PR TITLE
Flipper Update Generator Fix

### DIFF
--- a/db/migrate/20240223173647_add_flipper_indexes.rb
+++ b/db/migrate/20240223173647_add_flipper_indexes.rb
@@ -1,0 +1,12 @@
+class AddFlipperIndexes < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    if ActiveRecord::Base.connection.execute("SELECT * FROM pg_indexes WHERE indexname = 'index_flipper_features_on_key';").count == 0
+      add_index :flipper_features, :key, unique: true, algorithm: :concurrently
+    end
+    if ActiveRecord::Base.connection.execute("SELECT * FROM pg_indexes WHERE indexname = 'index_flipper_gates_on_feature_key_and_key_and_value';").count == 0
+      add_index :flipper_gates, [:feature_key, :key, :value], unique: true, algorithm: :concurrently
+    end
+  end
+end

--- a/db/migrate/20240223183025_create_flipper_tables.rb
+++ b/db/migrate/20240223183025_create_flipper_tables.rb
@@ -1,0 +1,5 @@
+class CreateFlipperTables < ActiveRecord::Migration[7.0]
+  def change
+    # This file is need to prevent 'rails generate flipper:update' from creating another migration file
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_23_173647) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_23_183025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_23_173647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -25,8 +25,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.datetime "idme_at"
     t.datetime "myhealthevet_at"
     t.datetime "dslogon_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "current_verification"
     t.datetime "logingov_at"
     t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
@@ -85,16 +85,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "decision_review_evidence_attachment_guid"
     t.string "appeal_submission_id"
     t.string "lighthouse_upload_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "appeal_submissions", force: :cascade do |t|
     t.string "user_uuid"
     t.string "submitted_appeal_uuid"
     t.string "type_of_appeal"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "board_review_option"
     t.text "upload_metadata_ciphertext"
     t.text "encrypted_kms_key"
@@ -105,8 +105,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "appeals_api_evidence_submissions", force: :cascade do |t|
     t.string "supportable_type"
     t.string "supportable_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "source"
     t.uuid "guid", null: false
     t.integer "upload_submission_id", null: false
@@ -135,8 +135,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   end
 
   create_table "appeals_api_notice_of_disagreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
@@ -158,8 +158,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "statusable_type"
     t.string "statusable_id"
     t.datetime "status_update_time"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "code"
     t.string "detail"
     t.index ["statusable_type", "statusable_id"], name: "status_update_id_type_index"
@@ -172,8 +172,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "source"
     t.string "pdf_version"
     t.string "api_version"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "form_data_ciphertext"
     t.text "auth_headers_ciphertext"
     t.text "encrypted_kms_key"
@@ -266,8 +266,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.uuid "claim_id", null: false
     t.string "claim_type", null: false
     t.string "consumer_label", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["claim_id"], name: "index_claims_api_claim_submissions_on_claim_id"
   end
 
@@ -275,8 +275,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.text "auth_headers_ciphertext"
     t.text "encrypted_kms_key"
     t.string "cid"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "status"
     t.string "vbms_error_message"
     t.string "bgs_error_message"
@@ -288,8 +288,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "claims_api_intent_to_files", force: :cascade do |t|
     t.string "status"
     t.string "cid"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "claims_api_power_of_attorneys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -329,8 +329,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.interval "access_token_duration", null: false
     t.string "access_token_audience"
     t.interval "refresh_token_duration", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "logout_redirect_uri"
     t.boolean "pkce"
     t.string "certificates", array: true
@@ -383,8 +383,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "email_address", null: false
     t.string "email_template_id", null: false
     t.datetime "email_triggered_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_credential_adoption_email_records_on_email_address"
     t.index ["email_template_id"], name: "index_credential_adoption_email_records_on_email_template_id"
     t.index ["icn"], name: "index_credential_adoption_email_records_on_icn"
@@ -393,8 +393,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "deprecated_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id"
     t.bigint "user_verification_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id"], name: "index_deprecated_user_accounts_on_user_account_id", unique: true
     t.index ["user_verification_id"], name: "index_deprecated_user_accounts_on_user_verification_id", unique: true
   end
@@ -402,8 +402,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "devices", force: :cascade do |t|
     t.string "key"
     t.string "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["key"], name: "index_devices_on_key", unique: true
   end
 
@@ -417,8 +417,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.text "description"
     t.string "privacy_url"
     t.string "tos_url"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["name"], name: "index_directory_applications_on_name", unique: true
   end
 
@@ -486,8 +486,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.bigint "education_benefits_claim_id"
     t.string "automated_decision_state", default: "init"
     t.string "user_uuid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "poa"
     t.integer "remaining_entitlement"
     t.datetime "denial_email_sent_at"
@@ -541,6 +541,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
   create_table "flipper_gates", force: :cascade do |t|
@@ -549,6 +550,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
@@ -556,8 +558,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.datetime "accepted_at", null: false
     t.json "metadata"
     t.json "attachments"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "claim_guid", null: false
     t.index ["carma_case_id"], name: "index_form1010cg_submissions_on_carma_case_id", unique: true
     t.index ["claim_guid"], name: "index_form1010cg_submissions_on_claim_guid", unique: true
@@ -568,8 +570,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.integer "tax_year", null: false
     t.jsonb "form_data_ciphertext", null: false
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["veteran_icn", "tax_year"], name: "index_form1095_bs_on_veteran_icn_and_tax_year", unique: true
   end
 
@@ -612,8 +614,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.text "form_json_ciphertext", null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "user_account_id"
     t.jsonb "public_metadata"
     t.integer "state", default: 0
@@ -639,8 +641,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "aasm_state"
     t.string "error_message"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["form_submission_id"], name: "index_form_submission_attempts_on_form_submission_id"
   end
 
@@ -652,8 +654,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.bigint "saved_claim_id"
     t.bigint "in_progress_form_id"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.jsonb "form_data_ciphertext"
     t.index ["benefits_intake_uuid"], name: "index_form_submissions_on_benefits_intake_uuid"
     t.index ["in_progress_form_id"], name: "index_form_submissions_on_in_progress_form_id"
@@ -708,8 +710,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "user_uuid"
     t.string "appointment_id"
     t.string "questionnaire_response_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "questionnaire_response_data_ciphertext"
     t.text "user_demographics_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -742,8 +744,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
 
   create_table "inherited_proof_verified_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id"], name: "index_inherited_proof_verified_user_accounts_on_user_account_id", unique: true
   end
 
@@ -770,16 +772,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "mhv_opt_in_flags", force: :cascade do |t|
     t.uuid "user_account_id"
     t.string "feature", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feature"], name: "index_mhv_opt_in_flags_on_feature"
     t.index ["user_account_id"], name: "index_mhv_opt_in_flags_on_user_account_id"
   end
 
   create_table "mobile_users", force: :cascade do |t|
     t.string "icn", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "vet360_link_attempts"
     t.boolean "vet360_linked"
     t.index ["icn"], name: "index_mobile_users_on_icn", unique: true
@@ -788,8 +790,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "nod_notifications", force: :cascade do |t|
     t.text "payload_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "oauth_sessions", force: :cascade do |t|
@@ -798,8 +800,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "hashed_refresh_token", null: false
     t.datetime "refresh_expiration", null: false
     t.datetime "refresh_creation", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_verification_id", null: false
     t.string "credential_email"
     t.string "client_id", null: false
@@ -817,8 +819,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "template_id", null: false
     t.string "va_profile_id", null: false
     t.boolean "dismissed", default: false, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["va_profile_id", "dismissed"], name: "show_onsite_notifications_index"
   end
 
@@ -899,8 +901,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "access_token_audience", null: false
     t.interval "access_token_duration", null: false
     t.string "certificates", array: true
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "access_token_user_attributes", default: [], array: true
     t.index ["service_account_id"], name: "index_service_account_configs_on_service_account_id", unique: true
   end
@@ -911,8 +913,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "filename"
     t.datetime "successful_at"
     t.integer "retry_attempt", default: 0
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["rpo", "filename"], name: "index_spool_file_events_uniqueness", unique: true
   end
 
@@ -989,8 +991,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.uuid "user_account_id", null: false
     t.string "agreement_version", null: false
     t.integer "response", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id"], name: "index_terms_of_use_agreements_on_user_account_id"
   end
 
@@ -1000,8 +1002,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.datetime "checkin_time"
     t.boolean "has_checkin_error"
     t.boolean "is_manual_checkin"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["account_uuid"], name: "tud_account_availability_logs"
   end
 
@@ -1017,8 +1019,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "email"
     t.string "password"
     t.datetime "checkout_time"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "services"
     t.string "loa"
     t.uuid "idme_uuid"
@@ -1032,8 +1034,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.datetime "acceptable_verified_credential_at"
     t.datetime "idme_verified_credential_at"
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["acceptable_verified_credential_at"], name: "index_user_avc_on_acceptable_verified_credential_at"
     t.index ["idme_verified_credential_at"], name: "index_user_avc_on_idme_verified_credential_at"
     t.index ["user_account_id"], name: "index_user_acceptable_verified_credentials_on_user_account_id", unique: true
@@ -1041,8 +1043,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
 
   create_table "user_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "icn"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["icn"], name: "index_user_accounts_on_icn", unique: true
   end
 
@@ -1050,8 +1052,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.bigint "user_verification_id"
     t.text "credential_email_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_verification_id"], name: "index_user_credential_emails_on_user_verification_id", unique: true
   end
 
@@ -1062,8 +1064,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "mhv_uuid"
     t.string "dslogon_uuid"
     t.datetime "verified_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "backing_idme_uuid"
     t.boolean "locked", default: false, null: false
     t.index ["backing_idme_uuid"], name: "index_user_verifications_on_backing_idme_uuid"
@@ -1105,8 +1107,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "va_notify_in_progress_reminders_sent", force: :cascade do |t|
     t.string "form_id", null: false
     t.uuid "user_account_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_account_id", "form_id"], name: "index_in_progress_reminders_sent_user_account_form_id", unique: true
     t.index ["user_account_id"], name: "index_va_notify_in_progress_reminders_sent_on_user_account_id"
   end
@@ -1116,8 +1118,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.jsonb "git_item"
     t.boolean "notified", default: false
     t.string "label"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["notified", "label"], name: "index_vba_documents_git_items_on_notified_and_label"
     t.index ["url"], name: "index_vba_documents_git_items_on_url", unique: true
   end
@@ -1126,8 +1128,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.integer "month", null: false
     t.integer "year", null: false
     t.jsonb "stats", default: {}
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["month", "year"], name: "index_vba_documents_monthly_stats_uniqueness", unique: true
   end
 
@@ -1165,8 +1167,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.bigint "device_id", null: false
     t.boolean "active", default: true, null: false
     t.string "icn", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["device_id"], name: "index_veteran_device_records_on_device_id"
     t.index ["icn", "device_id"], name: "index_veteran_device_records_on_icn_and_device_id", unique: true
   end
@@ -1263,8 +1265,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.text "state_ciphertext"
     t.text "zip_code_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_address_changes_on_user_info_id"
   end
 
@@ -1281,8 +1283,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.string "type_training"
     t.integer "number_hours"
     t.string "type_hours"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_awards_on_user_info_id"
   end
 
@@ -1301,8 +1303,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.text "bank_name_ciphertext"
     t.text "bank_phone_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_direct_deposit_changes_on_user_info_id"
   end
 
@@ -1314,8 +1316,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.datetime "queue_date"
     t.string "rpo"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["ssn_digest"], name: "index_vye_pending_documents_on_ssn_digest"
   end
 
@@ -1344,8 +1346,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.decimal "payment_amt"
     t.string "indicator"
     t.text "encrypted_kms_key"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["icn"], name: "index_vye_user_infos_on_icn"
     t.index ["ssn_digest"], name: "index_vye_user_infos_on_ssn_digest"
   end
@@ -1359,8 +1361,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.datetime "act_begin"
     t.datetime "act_end"
     t.string "source_ind"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_info_id"], name: "index_vye_verifications_on_user_info_id"
   end
 
@@ -1374,8 +1376,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
   create_table "webhooks_notification_attempts", force: :cascade do |t|
     t.boolean "success", default: false
     t.jsonb "response", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "webhooks_notifications", force: :cascade do |t|
@@ -1388,8 +1390,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.jsonb "msg", null: false
     t.integer "final_attempt_id"
     t.integer "processing"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["api_name", "consumer_id", "api_guid", "event", "final_attempt_id"], name: "index_wh_notify"
     t.index ["final_attempt_id", "api_name", "event", "api_guid"], name: "index_wk_notify_processing"
   end
@@ -1400,8 +1402,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_212613) do
     t.uuid "consumer_id", null: false
     t.uuid "api_guid"
     t.jsonb "events", default: {"subscriptions"=>[]}
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["api_name", "consumer_id", "api_guid"], name: "index_webhooks_subscription", unique: true
   end
 


### PR DESCRIPTION
## Summary

The recent flipper upgrade 1.2.2 is causing confusion by generating a warning when you run a rails command such as `rails console`:

> Your database needs migrated to use the latest Flipper features.
> Run `rails generate flipper:update` and `rails db:migrate`.

If you run `rails generate flipper:update` it will generate a migration file for `CreateFlipperTables` and `db:migrate` will fail because the tables already exist. The warning is resolved _just_ with `rails db:migrate`

CreateFlipperTables isn't being properly skipped because the migration file doesn't exist in `db/migrate`

- Added CreateFlipperTables migration file to the flipper generator from creating a new migration file. 
- Added a migration for flipper indexes that only runs if the indexes don't exist. 
- Because I reset my database, `precision: 6` was removed on the subsequent migration command. This is an intended behavior as of Rails 7.0.2. It's also not necessary because 6 is the default precision. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76851

## Testing done

- Manual testing (no specs necessary)