### PR TITLE
Delete emis references from Identity-owned files

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -303,7 +303,7 @@ class User < Common::RedisStore
     @mpi = nil
   end
 
-  # emis attributes
+  # VA Profile attributes
   delegate :military_person?, to: :veteran_status
   delegate :veteran?, to: :veteran_status
 

--- a/app/services/users/exception_handler.rb
+++ b/app/services/users/exception_handler.rb
@@ -75,13 +75,6 @@ module Users
       )
     end
 
-    def emis_error(type)
-      error_template.merge(
-        description: "#{error.class}, #{RESPONSE_STATUS[type]}",
-        status: error.status.to_i
-      )
-    end
-
     def title_error(_type)
       error_template.merge(
         description: "#{error.class}, 404 Veteran Status title not found",

--- a/lib/vic/id_card_attribute_error.rb
+++ b/lib/vic/id_card_attribute_error.rb
@@ -4,7 +4,7 @@ require 'common/exceptions/base_error'
 
 module VIC
   class IDCardAttributeError < Common::Exceptions::BaseError
-    VIC002 = { status: 403, code: 'VIC002', detail: 'No EDIPI or not found in eMIS' }.freeze
+    VIC002 = { status: 403, code: 'VIC002', detail: 'No EDIPI or not found in VA Profile' }.freeze
     VIC010 = { status: 403, code: 'VIC010', detail: 'Could not verify Veteran status' }.freeze
     NOT_ELIGIBLE = {
       status: 403,

--- a/spec/requests/authentication/standard_authentication_spec.rb
+++ b/spec/requests/authentication/standard_authentication_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'authenticating loa3 user', type: :request, order: :defined do
     end
   end
 
-  xit 'does the tests', :aggregate_failures, :skip_mvi, :skip_emis do
+  xit 'does the tests', :aggregate_failures, :skip_mvi do
     EPISODES.each_with_index do |episode, _index|
       Timecop.freeze(episode.recorded_at) do
         VCR.use_cassette(OUTBOUND_CASSETTE, record: :new_episodes) do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- I'm on the Platform Product team

This PR renames or removes strings, comments, etc. that needed cleaning up. This is scoped to files owned by the Identity team. 

## Related issue(s)

- Part 6 from: https://github.com/department-of-veterans-affairs/va.gov-team/issues/72200
- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/63326

## Testing done
va.gov locally builds and I'm able to log in (user 5–Frank) and user response is populated.

## What areas of the site does it impact?
The only impactful modification changes an error string from VIC.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.