### PR TITLE
[CST] [DDL] [Backend] Added 5103 letters to DDL

### DIFF
--- a/app/controllers/v0/claim_letters_controller.rb
+++ b/app/controllers/v0/claim_letters_controller.rb
@@ -30,9 +30,13 @@ module V0
     # 27: Board Of Appeals Decision Letter
     # 184: Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)
     # 339: Rating Decision Letter
+    # 65: Standard 5103 Notice
+    # 68: 5103/DTA Letter
     def allowed_doctypes
       doctypes = %w[184]
       doctypes << '27' if Flipper.enabled?(:cst_include_ddl_boa_letters, @user)
+      doctypes << '65' if Flipper.enabled?(:cst_include_ddl_5103_letters, @user)
+      doctypes << '68' if Flipper.enabled?(:cst_include_ddl_5103_letters, @user)
       doctypes
     end
   end

--- a/app/controllers/v0/claim_letters_controller.rb
+++ b/app/controllers/v0/claim_letters_controller.rb
@@ -29,7 +29,6 @@ module V0
 
     # 27: Board Of Appeals Decision Letter
     # 184: Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)
-    # 339: Rating Decision Letter
     # 65: Standard 5103 Notice
     # 68: 5103/DTA Letter
     def allowed_doctypes

--- a/config/features.yml
+++ b/config/features.yml
@@ -171,6 +171,10 @@ features:
     actor_type: user
     description: When enabled, the Download Decision Letters feature includes Board of Appeals decision letters
     enable_in_development: true
+  cst_include_ddl_5103_letters:
+    actor_type: user
+    description: When enabled, the Download Decision Letters feature includes 5103 letters
+    enable_in_development: true
   cst_use_new_claim_cards:
     actor_type: user
     description: When enabled, claims status tool uses the new claim card designs

--- a/lib/claim_letters/claim_letter_test_data.rb
+++ b/lib/claim_letters/claim_letter_test_data.rb
@@ -140,6 +140,36 @@ module ClaimLetterTestData
       alt_doc_types: '',
       restricted: false,
       upload_date: Date.new(2022,12,23)
+    ),
+    OpenStruct.new(
+      document_id: '{27832B64-2D88-4DEE-9F6F-DF80E4CAAA90}',
+      series_id: '{350C072A-90A1-43A7-AD50-A5C9C54C357D}',
+      version: '1',
+      type_description: 'Standard 5103 Notice',
+      type_id: '65',
+      doc_type: '65',
+      subject: nil,
+      received_at: Date.new(2022,8,22),
+      source: 'VBMS',
+      mime_type: 'application/pdf',
+      alt_doc_types: '',
+      restricted: false,
+      upload_date: Date.new(2022,8,23)
+    ),
+    OpenStruct.new(
+      document_id: '{27832B64-2D88-4DEE-9F6F-DF80E4CAAA91}',
+      series_id: '{350C072A-90A1-43A7-AD50-A5C9C54C357E}',
+      version: '1',
+      type_description: '5103/DTA Letter',
+      type_id: '68',
+      doc_type: '68',
+      subject: nil,
+      received_at: Date.new(2023,1,22),
+      source: 'VBMS',
+      mime_type: 'application/pdf',
+      alt_doc_types: '',
+      restricted: false,
+      upload_date: Date.new(2023,1,23)
     )
   ].freeze
 end

--- a/spec/controllers/v0/claim_letters_controller_spec.rb
+++ b/spec/controllers/v0/claim_letters_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
   describe '#index when "cst_include_ddl_boa_letters" feature flag is enabled' do
     before do
       Flipper.enable(:cst_include_ddl_boa_letters)
+      Flipper.disable(:cst_include_ddl_5103_letters)
     end
 
     it 'lists correct documents' do
@@ -42,34 +43,22 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
   describe '#index when "cst_include_ddl_5103_letters" feature flag is enabled' do
     before do
       Flipper.enable(:cst_include_ddl_5103_letters)
-    end
-
-    it 'lists correct documents' do
-      get(:index)
-      letters = JSON.parse(response.body)
-      allowed_letters = letters.select { |d| d['doc_type'] == '184' || d['doc_type'] == '65' || d['doc_type'] == '68' }
-
-      expect(allowed_letters.length).to eql(letters.length)
-    end
-  end
-
-  describe '#index when "cst_include_ddl_boa_letters" feature flag is disabled' do
-    before do
       Flipper.disable(:cst_include_ddl_boa_letters)
     end
 
     it 'lists correct documents' do
       get(:index)
       letters = JSON.parse(response.body)
-      allowed_letters = letters.select { |d| d['doc_type'] == '184' }
+      allowed_letters = letters.select { |d| d['doc_type'] == '65' || d['doc_type'] == '68' || d['doc_type'] == '184' }
 
       expect(allowed_letters.length).to eql(letters.length)
     end
   end
 
-  describe '#index when "cst_include_ddl_5103_letters" feature flag is disabled' do
+  describe '#index when "cst_include_ddl_5103_letters" and "cst_include_ddl_boa_letters" feature flags are disabled' do
     before do
       Flipper.disable(:cst_include_ddl_5103_letters)
+      Flipper.disable(:cst_include_ddl_boa_letters)
     end
 
     it 'lists correct documents' do

--- a/spec/controllers/v0/claim_letters_controller_spec.rb
+++ b/spec/controllers/v0/claim_letters_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
     end
   end
 
-  describe '#index when "cst_include_ddl_boa_letters" feature flag is enabled' do
+  describe '#index when "cst_include_ddl_boa_letters" feature flag is enabled and "cst_include_ddl_5103_letters" is disabled' do
     before do
       Flipper.enable(:cst_include_ddl_boa_letters)
       Flipper.disable(:cst_include_ddl_5103_letters)
@@ -40,7 +40,7 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
     end
   end
 
-  describe '#index when "cst_include_ddl_5103_letters" feature flag is enabled' do
+  describe '#index when "cst_include_ddl_5103_letters" feature flag is enabled and "cst_include_ddl_boa_letters" is disabled' do
     before do
       Flipper.enable(:cst_include_ddl_5103_letters)
       Flipper.disable(:cst_include_ddl_boa_letters)

--- a/spec/controllers/v0/claim_letters_controller_spec.rb
+++ b/spec/controllers/v0/claim_letters_controller_spec.rb
@@ -39,9 +39,37 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
     end
   end
 
+  describe '#index when "cst_include_ddl_5103_letters" feature flag is enabled' do
+    before do
+      Flipper.enable(:cst_include_ddl_5103_letters)
+    end
+
+    it 'lists correct documents' do
+      get(:index)
+      letters = JSON.parse(response.body)
+      allowed_letters = letters.select { |d| d['doc_type'] == '184' || d['doc_type'] == '65' || d['doc_type'] == '68' }
+
+      expect(allowed_letters.length).to eql(letters.length)
+    end
+  end
+
   describe '#index when "cst_include_ddl_boa_letters" feature flag is disabled' do
     before do
       Flipper.disable(:cst_include_ddl_boa_letters)
+    end
+
+    it 'lists correct documents' do
+      get(:index)
+      letters = JSON.parse(response.body)
+      allowed_letters = letters.select { |d| d['doc_type'] == '184' }
+
+      expect(allowed_letters.length).to eql(letters.length)
+    end
+  end
+
+  describe '#index when "cst_include_ddl_5103_letters" feature flag is disabled' do
+    before do
+      Flipper.disable(:cst_include_ddl_5103_letters)
     end
 
     it 'lists correct documents' do

--- a/spec/controllers/v0/claim_letters_controller_spec.rb
+++ b/spec/controllers/v0/claim_letters_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
     end
   end
 
-  describe '#index when "cst_include_ddl_boa_letters" feature flag is enabled and "cst_include_ddl_5103_letters" is disabled' do
+  describe '#index when "cst_include_ddl_boa_letters" is enabled and "cst_include_ddl_5103_letters" is disabled' do
     before do
       Flipper.enable(:cst_include_ddl_boa_letters)
       Flipper.disable(:cst_include_ddl_5103_letters)
@@ -40,7 +40,7 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
     end
   end
 
-  describe '#index when "cst_include_ddl_5103_letters" feature flag is enabled and "cst_include_ddl_boa_letters" is disabled' do
+  describe '#index when "cst_include_ddl_5103_letters" is enabled and "cst_include_ddl_boa_letters" is disabled' do
     before do
       Flipper.enable(:cst_include_ddl_5103_letters)
       Flipper.disable(:cst_include_ddl_boa_letters)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- Created `cst_include_ddl_5103_letters` feature toggle
- Updated `app/controllers/v0/claim_letters_controller.rb` to include `5130` doctypes when `cst_include_ddl_5103_letters` is enabled
- Updated `spec/controllers/v0/claim_letters_controller_spec.rb` unit test

## Related issue(s)

- [Add 5103 letter(s) to DDL #72464](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72464)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
CST DDL

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

