### PR TITLE
8057: change cerner transitioning facility id to 979 in lower environ…

### DIFF
--- a/modules/mobile/app/serializers/mobile/v2/user_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v2/user_serializer.rb
@@ -22,8 +22,9 @@ module Mobile
 
       # this is a temporary fix
       def transitioning_facility?(user)
+        cerner_facility_id = Settings.vsp_environment == 'production' ? '556' : '979'
         Flipper.enabled?(:mobile_cerner_transition, user) &&
-          user.va_treatment_facility_ids.include?('556')
+          user.vha_facility_ids.include?(cerner_facility_id)
       end
 
       UserStruct = Struct.new(

--- a/modules/mobile/spec/request/v2/user_request_spec.rb
+++ b/modules/mobile/spec/request/v2/user_request_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'user', type: :request do
 
     describe 'has_facility_transitioning_to_cerner' do
       context 'with feature flag off and user\'s va_treatment_facility_ids contains the hardcoded facility id' do
-        let!(:user) { sis_user(idme_uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef', vha_facility_ids: ['556']) }
+        let!(:user) { sis_user(idme_uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef', vha_facility_ids: ['979']) }
 
         before { Flipper.disable(:mobile_cerner_transition) }
         after { Flipper.enable(:mobile_cerner_transition) }
@@ -59,7 +59,7 @@ RSpec.describe 'user', type: :request do
       end
 
       context 'with feature flag on and user\'s va_treatment_facility_ids contains the hardcoded facility id' do
-        let!(:user) { sis_user(idme_uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef', vha_facility_ids: ['556']) }
+        let!(:user) { sis_user(idme_uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef', vha_facility_ids: ['979']) }
 
         before { Flipper.enable(:mobile_cerner_transition) }
 


### PR DESCRIPTION
## Summary

Changes the cerner transitioning facility id for lower environments.

## Related issue(s)

https://app.zenhub.com/workspaces/va-mobile-60f1a34998bc75000f2a489f/issues/gh/department-of-veterans-affairs/va-mobile-app/8057

## Testing done
Specs. Will be tested in staging. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

