### PR TITLE
Add domain to access_token cookie delete

### DIFF
--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -360,7 +360,7 @@ module V0
     end
 
     def delete_cookies
-      cookies.delete(SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME)
+      cookies.delete(SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME, domain: :all)
       cookies.delete(SignIn::Constants::Auth::REFRESH_TOKEN_COOKIE_NAME)
       cookies.delete(SignIn::Constants::Auth::ANTI_CSRF_COOKIE_NAME)
       cookies.delete(SignIn::Constants::Auth::INFO_COOKIE_NAME, domain: Settings.sign_in.info_cookie_domain)


### PR DESCRIPTION
## Summary
Add domain to access_token cookie delete. From the [docs](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html)
```
Please note that if you specify a :domain when setting a cookie, you must also specify the domain when deleting the cookie:
```
## Related issue(s)
-  department-of-veterans-affairs/va.gov-team#76745
- department-of-veterans-affairs/vets-api#15626

## Testing 
- Sign in with SiS
- Logout
- Kinda hard to test on localhost but documentation supports it and `:all` is accepted

