### PR TITLE
Fix bug with trexler file processing

### DIFF
--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -37,7 +37,8 @@ module Representatives
         begin
           batch.jobs do
             data[sheet].each_slice(slice_size) do |rows|
-              Representatives::Update.perform_in(delay.minutes, rows)
+              json_rows = rows.to_json
+              Representatives::Update.perform_in(delay.minutes, json_rows)
               delay += 1
             end
           end

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -27,10 +27,10 @@ module Representatives
       rescue Common::Exceptions::BackendServiceException => e
         log_error("Error: representative address validation failed. Rep id: #{rep_data['id']}, Error message: #{e.message}") # rubocop:disable Layout/LineLength
       rescue => e
-        log_error("Error: representative was not updated. Error message: #{e.message}")
+        log_error("Error: representative was not updated. Rep id: #{rep_data['id']}, Error message: #{e.message}")
       end
-    rescue JSON::ParserError => e
-      log_error(e)
+    rescue => e
+      log_error("Error: There was an error processing this job. Error message: #{e.message}")
     end
 
     private

--- a/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
+++ b/modules/veteran/app/sidekiq/representatives/xlsx_file_processor.rb
@@ -103,7 +103,7 @@ module Representatives
 
         next unless US_STATES_TERRITORIES[state_code]
 
-        data << create_json_data(row, sheet_name, column_map)
+        data << process_row(row, sheet_name, column_map)
       end
 
       data
@@ -120,12 +120,12 @@ module Representatives
       end
     end
 
-    # Creates JSON data for a given row based on the sheet name and column map.
-    # @param row [Array] The row data to be transformed into JSON.
+    # Creates a hash for a given row based on the sheet name and column map.
+    # @param row [Array] The row data to be transformed into a hash.
     # @param sheet_name [String] The name of the sheet being processed.
     # @param column_map [Hash] The column index map for the sheet.
-    # @return [String] The JSON representation of the row data.
-    def create_json_data(row, sheet_name, column_map)
+    # @return [String] The hash representation of the row data.
+    def process_row(row, sheet_name, column_map)
       zip_code5, zip_code4 = get_value(row, column_map, 'WorkZip')
 
       {
@@ -143,9 +143,9 @@ module Representatives
           zip_code4:,
           country_code_iso3: 'US'
         }
-      }.to_json
+      }
     rescue => e
-      log_error("Error transforming data to JSON for #{sheet_name}: #{e.message}")
+      log_error("Error transforming data to hash for #{sheet_name}: #{e.message}")
     end
 
     def get_value(row, column_map, column_name)

--- a/modules/veteran/spec/sidekiq/representatives/update_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/update_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Representatives::Update do
 
       it 'logs an error to Sentry' do
         expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-          "Representatives::Update: unexpected token at 'invalid json'", :error
+          "Representatives::Update: Error: There was an error processing this job. Error message: unexpected token at 'invalid json'", :error # rubocop:disable Layout/LineLength
         )
 
         subject.perform(invalid_json_data)

--- a/modules/veteran/spec/sidekiq/representatives/xlsx_file_processor_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/xlsx_file_processor_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Representatives::XlsxFileProcessor do
     let(:result) { xlsx_processor.process }
 
     context 'with valid data' do
-      let(:expected_keys) { %w[id email_address request_address phone_number] }
+      let(:expected_keys) { %i[id email_address request_address phone_number] }
       let(:request_address_keys) do
-        %w[address_pou address_line1 address_line2 address_line3 city state_province zip_code5 zip_code4
+        %i[address_pou address_line1 address_line2 address_line3 city state_province zip_code5 zip_code4
            country_code_iso3]
       end
 
@@ -34,13 +34,12 @@ RSpec.describe Representatives::XlsxFileProcessor do
         expect(result.keys).to include('Agents', 'Attorneys', 'Representatives')
 
         result.each_value do |value_array|
-          expect(value_array).to all(be_a(String))
+          expect(value_array).to all(be_a(Hash))
 
-          value_array.each do |json_string|
-            json_object = JSON.parse(json_string)
-            expect(json_object.keys).to match_array(expected_keys)
-            expect(json_object['request_address'].keys).to match_array(request_address_keys)
-            check_values(json_object)
+          value_array.each do |row|
+            expect(row.keys).to match_array(expected_keys)
+            expect(row[:request_address].keys).to match_array(request_address_keys)
+            check_values(row)
           end
         end
       end
@@ -83,9 +82,8 @@ RSpec.describe Representatives::XlsxFileProcessor do
         valid_states = Representatives::XlsxFileProcessor::US_STATES_TERRITORIES.keys
 
         result.each_value do |value_array|
-          value_array.each do |json_string|
-            json_object = JSON.parse(json_string)
-            state_code = json_object.dig('request_address', 'state_province', 'code')
+          value_array.each do |row|
+            state_code = row.dig('request_address', 'state_province', 'code')
 
             expect(valid_states).to include(state_code) unless state_code.nil?
           end


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/77024


## Summary
This PR updates `Representatives::XlsxFileProcessor` to return arrays of hashes for each sheet instead of arrays of JSON strings.

Key Changes
- Data Structure Update: Changed XlsxFileProcessor output from JSON strings to a more direct and manageable array of hashes format.
- Sidekiq Job Serialization: Adjusted job enqueueing to serialize array slices of hashes into JSON strings just once, preventing double serialization and simplifying the process.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77024

## Testing done
- Tests were updated

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
