### PR TITLE
split pdf

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -25,13 +25,8 @@ module SimpleFormsApi
     def handle_attachments(file_path)
       attachments = get_attachments
       if attachments.count.positive?
-        combined_pdf = CombinePDF.new
-        combined_pdf << CombinePDF.load(file_path)
         attachments.each do |attachment|
-          combined_pdf << CombinePDF.load(attachment)
         end
-
-        combined_pdf.save file_path
       end
     end
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -27,6 +27,7 @@ module SimpleFormsApi
       if attachments.count.positive?
         attachments.each do |attachment|
         end
+        combined_pdf.save file_path
       end
     end
 


### PR DESCRIPTION
PEGA team requested that the attachments should be separated from the VA forms. Currenty, all attachments are included in the forms in 1 attachment. This PR will separate the attachments from the main form

## Related issue(s)

None. This is a unique case. It will affect all other IVC forms

## Testing done

- [x ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- Prior to the change, the 1010d form had 1 pdf with all the attachments combined.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

Nothing in production. It will affect 1010d only

## Acceptance criteria

- [ x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x ]  No error nor warning in the console.
- [x ]  Events are being sent to the appropriate logging solution
- [x ]  Documentation has been updated (link to documentation)
- [x ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

