### PR TITLE
delete emis from inflections and exceptions

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -10,7 +10,6 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'CC'
   inflect.acronym 'DOD'
   inflect.acronym 'DGI' # Digital GI
-  inflect.acronym 'EMIS'
   inflect.acronym 'EVSS'
   inflect.acronym 'FHIR'
   inflect.acronym 'GIDS'

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -677,12 +677,6 @@ en:
         code: 'BGS_686c_SERVICE_403'
         detail: BGS service understood submisssion but could not process.
         status: 403
-      EMIS_HIST502:
-        <<: *external_defaults
-        title: Unexpected response body
-        code: 'EMIS_HIST502'
-        detail: EMIS service responded with something other than the expected array of service history hashes.
-        status: 502
       EMIS_STATUS502:
         <<: *external_defaults
         title: Unexpected response body


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- I'm on the Platform Product team

This PR deletes the last remaining emis references that the Platform is going to remove. The 10-10 team to handle emis mentions in [app/services/form1010cg/service.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/services/form1010cg/service.rb). And mobile backend engineers will handle references to [EMIS_STATUS502](https://github.com/search?q=repo%3Adepartment-of-veterans-affairs%2Fvets-api%20EMIS_STATUS502&type=code) (which is why I didn't delete it in `exceptions.en.yml`)

## Related issue(s)

- 7th and final part from: https://github.com/department-of-veterans-affairs/va.gov-team/issues/72200
- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/63326

## Testing done
va.gov locally builds and I'm able to log in (user 5–Frank) and user response is populated.

## What areas of the site does it impact?


## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.