### PR TITLE
add toggle for credential retirement messaging and alerts

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -773,6 +773,9 @@ features:
     actor_type: user
     description: Hides disability comp and pen section of the Profile - Direct Deposit page during a service outage
     enable_in_development: false
+  profile_show_credential_retirement_messaging:
+    actor_type: user
+    description: Show/hide MHV and DS Logon credential retirement messaging in profile
   profile_show_email_notification_settings:
     actor_type: user
     description: Show/Hide the email channel based notification settings in profile


### PR DESCRIPTION
## Summary

Adds a toggle for the Profile team to use

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/73357

## Testing done

- Toggle tested locally


## Acceptance criteria

- [x]  Toggle added

