### PR TITLE
Add Lighthouse Service History and Eligibility API to betamocks config

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -790,6 +790,13 @@
     - :method: :post
       :path: "/services/benefits-documents/v1/documents/search"
       :file_path: "/lighthouse/claims_api/benefits_documents/search/default"
+    # Service History and Eligibility API V2
+    - :method: :get
+      :path: "/services/veteran_verification/v2/disability_rating/*"
+      :file_path: "/lighthouse/veteran_verification/rated_disabilities"
+      :cache_multiple_responses:
+        :uid_location: "url"
+        :uid_locator: "\/services/veteran_verification/v2/disability_rating\/(.+)"
 
 # Lighthouse Benefits Documents API
 - :name: "Lighthouse Benefits Documents"


### PR DESCRIPTION
## Summary
Adds the Lighthouse Service History and Eligibility `rated_disabilities` endpoint to betamocks config

- *This work is behind a feature toggle (flipper):* **NO**

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
