### PR TITLE
Create accredited_representatives module with flag_accredited_representatives create endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -926,6 +926,7 @@ lib/vic @department-of-veterans-affairs/octo-identity
 lib/virtual_regional_office @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/vre @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/webhooks @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+modules/accredited_representatives @department-of-veterans-affairs/accredited-representation-management
 modules/appeals_api @department-of-veterans-affairs/lighthouse-banana-peels
 modules/apps_api @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/lighthouse-pivot
 modules/ask_va_api @department-of-veterans-affairs/ask-va-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ path 'modules' do
   gem 'mobile'
   gem 'mocked_authentication'
   gem 'my_health'
+  gem 'representation_management'
   gem 'simple_forms_api'
   gem 'test_user_dashboard'
   gem 'travel_pay'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ PATH
       rails
     my_health (0.1.0)
       rails
+    representation_management (0.1.0)
     simple_forms_api (0.1.0)
     test_user_dashboard (0.1.0)
       rails
@@ -1037,10 +1038,10 @@ GEM
 
 PLATFORMS
   java
-  ruby
   x64-mingw32
   x86-mingw32
   x86-mswin32
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -1178,6 +1179,7 @@ DEPENDENCIES
   rainbow
   redis
   redis-namespace
+  representation_management!
   request_store
   restforce
   rgeo-geojson

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -470,6 +470,7 @@ Rails.application.routes.draw do
   mount DebtsApi::Engine, at: '/debts_api'
   mount DhpConnectedDevices::Engine, at: '/dhp_connected_devices'
   mount FacilitiesApi::Engine, at: '/facilities_api'
+  mount RepresentationManagement::Engine, at: '/representation_management'
   mount SimpleFormsApi::Engine, at: '/simple_forms_api'
   mount HealthQuest::Engine, at: '/health_quest'
   mount IncomeLimits::Engine, at: '/income_limits'

--- a/modules/representation_management/Gemfile
+++ b/modules/representation_management/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Declare your gem's dependencies in representationmanagement.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+# To use a debugger
+# gem 'byebug', group: [:development, :test]

--- a/modules/representation_management/README.rdoc
+++ b/modules/representation_management/README.rdoc
@@ -1,0 +1,10 @@
+= RepresentationManagement
+TODO: Short description and motivation.
+
+== Installation
+Ensure the following line is in the root project's Gemfile:
+
+  gem 'representationmanagement', path: 'modules/representationmanagement'
+
+== License
+This module is open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/modules/representation_management/Rakefile
+++ b/modules/representation_management/Rakefile
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+require 'rdoc/task'
+
+RDoc::Task.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title    = 'RepresentationManagement'
+  rdoc.options << '--line-numbers'
+  rdoc.rdoc_files.include('README.md')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end
+
+load 'rails/tasks/statistics.rake'
+
+require 'bundler/gem_tasks'
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = false
+end
+
+task default: :test

--- a/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RepresentationManagement
+  module V0
+    class FlagAccreditedRepresentativesController < ApplicationController
+      service_tag 'lighthouse-veteran'
+      skip_before_action :authenticate
+      # before_action :feature_enabled
+
+      def create
+        flags = nil
+
+        begin
+          flags = create_flags
+
+          if flags.all?(&:valid?)
+            flags.each(&:save!)
+            render json: flags, each_serializer: RepresentationManagement::FlaggedVeteranRepresentativeContactDataSerializer,
+                   status: :created
+          else
+            raise ActiveRecord::Rollback, 'Invalid flags present'
+          end
+        rescue ActiveRecord::Rollback
+          render json: { errors: flags.map(&:errors).reject(&:empty?) }, status: :unprocessable_entity
+        rescue ArgumentError => e
+          render json: { errors: { flag_type: [e.message] } }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def create_flags
+        FlaggedVeteranRepresentativeContactData.transaction do
+          params[:flags].map do |flag_data|
+            FlaggedVeteranRepresentativeContactData.new(
+              flag_data.permit(:flag_type, :flagged_value).merge(
+                ip_address: request.remote_ip,
+                representative_id: params[:representative_id]
+              )
+            )
+          end
+        end
+      end
+
+      # def feature_enabled
+      #   routing_error unless Flipper.enabled?(:find_a_representative_flag_results_enabled)
+      # end
+    end
+  end
+end

--- a/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
@@ -15,8 +15,7 @@ module RepresentationManagement
 
           if flags.all?(&:valid?)
             flags.each(&:save!)
-            render json: flags, each_serializer: RepresentationManagement::FlaggedVeteranRepresentativeContactDataSerializer,
-                   status: :created
+            render json: flags, each_serializer: RepresentationManagement::FlaggedVeteranRepresentativeContactDataSerializer, status: :created # rubocop:disable Layout/LineLength
           else
             raise ActiveRecord::Rollback, 'Invalid flags present'
           end

--- a/modules/representation_management/app/models/representation_management/flagged_veteran_representative_contact_data.rb
+++ b/modules/representation_management/app/models/representation_management/flagged_veteran_representative_contact_data.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RepresentationManagement
+  class FlaggedVeteranRepresentativeContactData < ApplicationRecord
+    self.ignored_columns += ['flagged_value_updated']
+    self.table_name = 'flagged_veteran_representative_contact_data'
+
+    enum flag_type: { phone_number: 'phone_number', email: 'email', address: 'address', other: 'other' }, _suffix: true
+    validates :ip_address, :representative_id, :flag_type, :flagged_value, presence: true
+    validates :ip_address,
+              uniqueness: { scope: %i[representative_id flag_type flagged_value_updated_at], message: 'Combination of ip_address, representative_id, flag_type, and flagged_value_updated_at must be unique' } # rubocop:disable Rails/I18nLocaleTexts,Layout/LineLength
+  end
+end

--- a/modules/representation_management/app/serializers/representation_management/flagged_veteran_representative_contact_data_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/flagged_veteran_representative_contact_data_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RepresentationManagement
+  class FlaggedVeteranRepresentativeContactDataSerializer < ActiveModel::Serializer
+    attributes :ip_address, :representative_id, :flag_type, :flagged_value
+  end
+end

--- a/modules/representation_management/bin/rails
+++ b/modules/representation_management/bin/rails
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENGINE_ROOT = File.expand_path('../..', __dir__)
+ENGINE_PATH = File.expand_path('../../lib/representationmanagement/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/modules/representation_management/config/routes.rb
+++ b/modules/representation_management/config/routes.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+RepresentationManagement::Engine.routes.draw do
+end

--- a/modules/representation_management/config/routes.rb
+++ b/modules/representation_management/config/routes.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 RepresentationManagement::Engine.routes.draw do
+  namespace :v0, defaults: { format: 'json' } do
+    resources :flag_accredited_representatives, only: %i[create]
+  end
 end

--- a/modules/representation_management/lib/representation_management.rb
+++ b/modules/representation_management/lib/representation_management.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'representationmanagement/engine'
+require 'representation_management/engine'
 
 module RepresentationManagement
   # Your code goes here...

--- a/modules/representation_management/lib/representation_management.rb
+++ b/modules/representation_management/lib/representation_management.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'representationmanagement/engine'
+
+module RepresentationManagement
+  # Your code goes here...
+end

--- a/modules/representation_management/lib/representation_management/engine.rb
+++ b/modules/representation_management/lib/representation_management/engine.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RepresentationManagement
+  class Engine < ::Rails::Engine
+    isolate_namespace RepresentationManagement
+    config.generators.api_only = true
+
+    initializer 'model_core.factories', after: 'factory_bot.set_factory_paths' do
+      FactoryBot.definition_file_paths << File.expand_path('../../spec/factories', __dir__) if defined?(FactoryBot)
+    end
+  end
+end

--- a/modules/representation_management/lib/representation_management/version.rb
+++ b/modules/representation_management/lib/representation_management/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module RepresentationManagement
+  VERSION = '0.1.0'
+end

--- a/modules/representation_management/representation_management.gemspec
+++ b/modules/representation_management/representation_management.gemspec
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+
+# Maintain your gem's version:
+require 'representation_management/version'
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |spec|
+  spec.name        = 'representation_management'
+  spec.version     = RepresentationManagement::VERSION
+  spec.authors     = ['Holden Hinkle']
+  spec.email       = ['holden@holdenhinkle.com']
+  spec.homepage    = 'https://api.va.gov'
+  spec.summary     = 'An api.va.gov module'
+  spec.description = 'This module was auto-generated please update this description'
+  spec.license     = 'CC0-1.0'
+
+  spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
+end

--- a/modules/representation_management/spec/models/representation_management/flagged_veteran_representative_contact_data_spec.rb
+++ b/modules/representation_management/spec/models/representation_management/flagged_veteran_representative_contact_data_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RepresentationManagement::FlaggedVeteranRepresentativeContactData, type: :model do
+  describe 'validations' do
+    context 'ip_address' do
+      it 'is valid when ip_address is present' do
+        flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone_number',
+                                   flagged_value: '1234567890')
+        expect(flag).to be_valid
+      end
+
+      it 'is not valid when ip_address is missing' do
+        flag = described_class.new(ip_address: nil, representative_id: '1', flag_type: 'phone_number',
+                                   flagged_value: '1234567890')
+        expect(flag).not_to be_valid
+        expect(flag.errors[:ip_address]).to include("can't be blank")
+      end
+    end
+
+    context 'representative_id' do
+      it 'is valid when representative_id is present' do
+        flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone_number',
+                                   flagged_value: '1234567890')
+        expect(flag).to be_valid
+      end
+
+      it 'is not valid when representative_id is missing' do
+        flag = described_class.new(ip_address: '192.168.1.1', representative_id: nil, flag_type: 'phone_number',
+                                   flagged_value: '1234567890')
+        expect(flag).not_to be_valid
+        expect(flag.errors[:representative_id]).to include("can't be blank")
+      end
+    end
+
+    context 'flag_type' do
+      it 'is valid with a valid flag_type' do
+        %w[phone_number email address other].each do |flag_type|
+          flag = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type:,
+                                     flagged_value: "#{flag_type} value")
+          expect(flag).to be_valid
+        end
+      end
+
+      it 'raises ArgumentError with an invalid flag_type' do
+        expect do
+          described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'invalid_type',
+                              flagged_value: 'invalid_type value')
+        end.to raise_error(ArgumentError, /is not a valid flag_type/)
+      end
+    end
+
+    context 'uniqueness' do
+      before do
+        described_class.create!(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'email',
+                                flagged_value: 'example@email.com')
+      end
+
+      it 'is invalid when duplicating ip_address, representative_id, and flag_type of an existing record' do
+        duplicate = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'email',
+                                        flagged_value: 'example@email.com')
+        expect(duplicate).not_to be_valid
+      end
+
+      it 'is valid when changing only the ip_address while keeping representative_id and flag_type same' do
+        unique = described_class.new(ip_address: '192.168.1.2', representative_id: '1', flag_type: 'email',
+                                     flagged_value: 'example@email.com')
+        expect(unique).to be_valid
+      end
+
+      it 'is valid when changing only the representative_id while keeping ip_address and flag_type same' do
+        unique = described_class.new(ip_address: '192.168.1.1', representative_id: '2', flag_type: 'email',
+                                     flagged_value: 'example@email.com')
+        expect(unique).to be_valid
+      end
+
+      it 'is valid when changing only the flag_type while keeping ip_address and representative_id same' do
+        unique = described_class.new(ip_address: '192.168.1.1', representative_id: '1', flag_type: 'phone_number',
+                                     flagged_value: 'example@email.com')
+        expect(unique).to be_valid
+      end
+    end
+  end
+end

--- a/modules/representation_management/spec/requests/v0/flag_accredited_representatives_spec.rb
+++ b/modules/representation_management/spec/requests/v0/flag_accredited_representatives_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'FlagAccreditedRepresentativesController', type: :request do
+  describe 'POST #create' do
+    let(:base_path) { '/representation_management/v0/flag_accredited_representatives' }
+
+    context 'when submitting a single valid flag' do
+      let(:single_valid_flag_params) do
+        {
+          representative_id: '1',
+          flags: [{ flag_type: 'email', flagged_value: 'example@email.com' }]
+        }
+      end
+
+      it 'successfully creates a FlaggedVeteranRepresentativeContactData record' do
+        expect { post base_path, params: single_valid_flag_params }
+          .to change(RepresentationManagement::FlaggedVeteranRepresentativeContactData, :count).by(1)
+      end
+
+      it 'responds with a created status' do
+        post base_path, params: single_valid_flag_params
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the correct serialized data' do
+        post base_path, params: single_valid_flag_params
+        json_response_data = JSON.parse(response.body)['data']
+        expect(json_response_data).to be_an(Array)
+
+        flag_object = json_response_data.first
+        expect(flag_object).to include('id', 'type', 'attributes')
+
+        flag_object_attributes = flag_object['attributes']
+        expect(flag_object_attributes).to include('ip_address', 'representative_id', 'flag_type',
+                                                  'flagged_value')
+        expect(flag_object_attributes['representative_id']).to eq('1')
+        expect(flag_object_attributes['flag_type']).to eq('email')
+        expect(flag_object_attributes['flagged_value']).to eq('example@email.com')
+      end
+    end
+
+    context 'when submitting multiple valid flags' do
+      let(:multiple_valid_flags_params) do
+        {
+          representative_id: '1',
+          flags: [
+            { flag_type: 'email', flagged_value: 'example1@email.com' },
+            { flag_type: 'phone_number', flagged_value: '1234567890' }
+          ]
+        }
+      end
+
+      it 'successfully creates multiple FlaggedVeteranRepresentativeContactData records' do
+        expect { post base_path, params: multiple_valid_flags_params }
+          .to change(RepresentationManagement::FlaggedVeteranRepresentativeContactData, :count).by(2)
+      end
+
+      it 'responds with a created status for multiple flags' do
+        post base_path, params: multiple_valid_flags_params
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the correct serialized data for multiple flags' do
+        post base_path, params: multiple_valid_flags_params
+        json_response_data = JSON.parse(response.body)['data']
+
+        expect(json_response_data).to be_an(Array)
+        expect(json_response_data.length).to eq(2)
+        expect(json_response_data[0]['attributes']['flag_type']).to eq('email')
+        expect(json_response_data[1]['attributes']['flag_type']).to eq('phone_number')
+      end
+    end
+
+    context 'when submitting invalid flags' do
+      let(:invalid_flags_params) do
+        {
+          representative_id: nil,
+          flags: [{ flag_type: 'invalid_type', flagged_value: 'example@email.com' }]
+        }
+      end
+
+      it 'does not create any FlaggedVeteranRepresentativeContactData records' do
+        expect { post base_path, params: invalid_flags_params }
+          .not_to change(RepresentationManagement::FlaggedVeteranRepresentativeContactData, :count)
+      end
+
+      it 'responds with an unprocessable entity status' do
+        post base_path, params: invalid_flags_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns appropriate error messages' do
+        post base_path, params: invalid_flags_params
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to have_key('errors')
+        expect(json_response['errors']['flag_type']).to be_an(Array)
+        expect(json_response['errors']['flag_type'].first).to include('is not a valid flag_type')
+      end
+    end
+
+    context 'when submitting a mix of valid and invalid flags' do
+      let(:mixed_valid_and_invalid_flags_params) do
+        {
+          representative_id: '1',
+          flags: [
+            { flag_type: 'email', flagged_value: 'valid@email.com' },
+            { flag_type: 'invalid_type', flagged_value: 'invalid@example.com' }
+          ]
+        }
+      end
+
+      it 'does not create any FlaggedVeteranRepresentativeContactData records' do
+        expect { post base_path, params: mixed_valid_and_invalid_flags_params }
+          .not_to change(RepresentationManagement::FlaggedVeteranRepresentativeContactData, :count)
+      end
+
+      it 'responds with an unprocessable entity status' do
+        post base_path, params: mixed_valid_and_invalid_flags_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns appropriate error messages for mixed valid and invalid flags' do
+        post base_path, params: mixed_valid_and_invalid_flags_params
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to have_key('errors')
+        expect(json_response['errors']['flag_type']).to be_an(Array)
+        expect(json_response['errors']['flag_type'].first).to include('is not a valid flag_type')
+      end
+    end
+  end
+end

--- a/modules/representation_management/spec/spec_helper.rb
+++ b/modules/representation_management/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Configure Rails Envinronment
+ENV['RAILS_ENV'] = 'test'
+
+require 'rspec/rails'
+
+RSpec.configure { |config| config.use_transactional_fixtures = true }

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -69,6 +69,7 @@ class SimpleCovHelper
     add_group 'DebtsApi', 'modules/debts_api/'
     add_group 'DhpConnectedDevices', 'modules/dhp_connected_devices/'
     add_group 'FacilitiesApi', 'modules/facilities_api/'
+    add_group 'RepresentationManagement', 'modules/representation_management/'
     add_group 'SimpleFormsApi', 'modules/simple_forms_api/'
     add_group 'HealthQuest', 'modules/health_quest'
     add_group 'IncomeLimits', 'modules/income_limits/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,7 @@ unless ENV['NOCOVERAGE']
     add_group 'DebtsApi', 'modules/debts_api/'
     add_group 'DhpConnectedDevices', 'modules/dhp_connected_devices/'
     add_group 'FacilitiesApi', 'modules/facilities_api/'
+    add_group 'RepresentationManagement', 'modules/representation_management/'
     add_group 'SimpleFormsApi', 'modules/simple_forms_api/'
     add_group 'HealthQuest', 'modules/health_quest/'
     add_group 'IncomeLimits', 'modules/income_limits/'


### PR DESCRIPTION
## Summary
- Create `accredited_representatives ` module for us to move all of our 'Find a Rep' and 'Appoint a Rep' code into
- Fix CSRF issue in 'veteran' module by moving our code to our own, not-lighthouse module

## Related issue(s)
- Resolves https://app.zenhub.com/workspaces/accredited-representation-management-team-64d0dc51d3e8f4788ac6ef96/issues/gh/department-of-veterans-affairs/va.gov-team/75311
- Start https://github.com/department-of-veterans-affairs/va.gov-team/issues/75019

## Testing done
- Tests were updated

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This is a test to see if moving the `flag_accredited_representatives` endpoint out of the `veteran` module fixes the `csrf` issue we've been dealing. It this works, we'll need to delete this code from the veteran website.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
