### PR TITLE
Updates Spool File Slack Alert Language

### DIFF
--- a/app/sidekiq/education_form/create_daily_spool_files.rb
+++ b/app/sidekiq/education_form/create_daily_spool_files.rb
@@ -100,7 +100,7 @@ module EducationForm
         if spool_file_event.successful_at.present?
           log_info("A spool file for #{region_id} on #{Time.zone.now.strftime('%m%d%Y')} was already created")
         else
-          log_submissions(records, filename)
+          log_submissions(records, filename, region)
           # create the single textual spool file
           contents = records.map(&:text).join(EducationForm::CreateDailySpoolFiles::WINDOWS_NOTEPAD_LINEBREAK)
 
@@ -109,7 +109,7 @@ module EducationForm
 
             ## Testing to see if writer is the cause for retry attempt failures
             ## If we get to this message, it's not the writer object
-            log_info("Successfully wrote to filename: #{filename}")
+            log_info("Successfully wrote to filename: #{filename} for region: #{region}")
 
             # send copy of staging spool files to testers
             # This mailer is intended to only work for development, staging and NOT production
@@ -190,8 +190,8 @@ module EducationForm
 
     # Useful for debugging which records were or were not sent over successfully,
     # in case of network failures.
-    def log_submissions(records, filename)
-      log_info("Writing #{records.count} application(s) to #{filename}")
+    def log_submissions(records, filename, region)
+      log_info("Writing #{records.count} application(s) to #{filename} for region: #{region}")
     end
 
     # Useful for alerting and monitoring the numbers of successfully send submissions


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- The job that manages the spool file submissions occasionally encounters failures. When a failure occurs, a notification is sent to Slack. It has been raised that the current phrasing of these alerts can be confusing.
- This work ensures that the "Processing" alert only surfaces in Slack when a spool file has not yet been created—and that condition is true when the retry_count evaluates to zero. 
- Therefore the log line is wrapped here in a conditional that checks for retry_count.zero?
- This work is being done on behalf of Product Platform team

## Related issue(s)

- Zenhub Ticket: [Update Language for Spool File Job Slack Alerts](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/70241)

## Testing done

- [ ] *New code is covered by unit tests*


## What areas of the site does it impact?
Spool file Job

## Acceptance criteria

- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


