### PR TITLE
chore(ssl): Import new certificate used by benefits.vba.va.gov

### DIFF
--- a/import-va-certs.sh
+++ b/import-va-certs.sh
@@ -6,6 +6,7 @@ set -euo pipefail
     cd /usr/local/share/ca-certificates/
 
     curl -LO https://cacerts.digicert.com/DigiCertTLSRSASHA2562020CA1-1.crt.pem
+    curl -LO https://digicert.tbs-certificats.com/DigiCertGlobalG2TLSRSASHA2562020CA1.crt
 
     wget \
         --level=1 \


### PR DESCRIPTION
- Import new certificate used by downstream

```
* Host benefits.vba.va.gov:443 was resolved.
* IPv6: (none)
* IPv4: 10.205.6.38
*   Trying 10.205.6.38:443...
* Connected to benefits.vba.va.gov (10.205.6.38) port 443
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: ./DigiCertGlobalG2TLSRSASHA2562020CA1.crt
*  CApath: /etc/ssl/certs
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / RSASSA-PSS
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=Pennsylvania; L=Philadelphia; O=Department of Veterans Affairs; CN=benefits.vba.va.gov
*  start date: Feb 14 00:00:00 2024 GMT
*  expire date: Feb 21 23:59:59 2025 GMT
*  subjectAltName: host "benefits.vba.va.gov" matched cert's "benefits.vba.va.gov"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* using HTTP/1.x
```

---

## fixes

```
root@vets-api-sidekiq-7fd78d5896-t4jwk:/etc/ssl/certs# curl -I -S -vvv https://benefits.vba.va.gov
* Host benefits.vba.va.gov:443 was resolved.
* IPv6: (none)
* IPv4: 10.205.6.38
*   Trying 10.205.6.38:443...
* Connected to benefits.vba.va.gov (10.205.6.38) port 443
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS alert, unknown CA (560):
* SSL certificate problem: unable to get local issuer certificate
* Closing connection
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```