### PR TITLE
[Rated Disabilities] Update Rated disability discrepancy checks

### DIFF
--- a/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
+++ b/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
@@ -33,7 +33,7 @@ module V0
 
       ::Rails.logger.info(message, {
                             message_type: 'lh.rated_disabilities.length_discrepancy',
-                            revision: 3
+                            revision: 4
                           })
     end
 
@@ -73,7 +73,11 @@ module V0
     end
 
     def active?(rating)
-      rating['rating_end_date'].nil?
+      date = rating['rating_end_date']
+
+      # In order for the rating to be considered active,
+      # the date should be either nil or in the future
+      date.nil? || !Date.parse(date).past?
     end
 
     def service

--- a/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
+++ b/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
@@ -77,7 +77,7 @@ module V0
 
       # In order for the rating to be considered active,
       # the date should be either nil or in the future
-      date.nil? || !Date.parse(date).past?
+      date.nil? || Date.parse(date).future?
     end
 
     def service

--- a/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
+++ b/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe V0::RatedDisabilitiesDiscrepanciesController, type: :controller d
         expect(response).to have_http_status(:ok)
 
         # Lighthouse should return 3 items, but filter out the inactive one, so when comparing
-        # with EVSS (which should return 1 rating), there should be a discrepancy of 2 ratings
+        # with EVSS (which should return 1 rating), there should be a discrepancy of 1 ratings
         expect(Rails.logger).to have_received(:info).with(
           'Discrepancy of 1 disability ratings',
           { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 4 }
@@ -53,9 +53,9 @@ RSpec.describe V0::RatedDisabilitiesDiscrepanciesController, type: :controller d
 
         expect(response).to have_http_status(:ok)
 
-        # Lighthouse should return 5 total items, but filter out the deferred one,
+        # Lighthouse should return 4 total items, but filter out the deferred one,
         # so when comparing with EVSS (which should return 1 rating), there should be
-        # a discrepancy of 3 ratings
+        # a discrepancy of 2 ratings
         expect(Rails.logger).to have_received(:info).with(
           'Discrepancy of 2 disability ratings',
           { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 4 }

--- a/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
+++ b/spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe V0::RatedDisabilitiesDiscrepanciesController, type: :controller d
         # with EVSS (which should return 1 rating), there should be a discrepancy of 2 ratings
         expect(Rails.logger).to have_received(:info).with(
           'Discrepancy of 1 disability ratings',
-          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 3 }
+          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 4 }
         )
       end
 
@@ -53,12 +53,12 @@ RSpec.describe V0::RatedDisabilitiesDiscrepanciesController, type: :controller d
 
         expect(response).to have_http_status(:ok)
 
-        # Lighthouse should return 3 total items, but filter out the deferred one,
+        # Lighthouse should return 5 total items, but filter out the deferred one,
         # so when comparing with EVSS (which should return 1 rating), there should be
-        # a discrepancy of 1 rating
+        # a discrepancy of 3 ratings
         expect(Rails.logger).to have_received(:info).with(
-          'Discrepancy of 1 disability ratings',
-          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 3 }
+          'Discrepancy of 2 disability ratings',
+          { message_type: 'lh.rated_disabilities.length_discrepancy', revision: 4 }
         )
       end
     end

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_deferred_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_deferred_response.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 12 Feb 2024 02:22:38 GMT
+      - Tue, 27 Feb 2024 02:22:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
@@ -90,7 +90,6 @@ http_interactions:
       "legal_effective_date": "2018-03-27",
       "individual_ratings": [
         {
-          "description": "Service Connected",
           "decision": "Service Connected",
           "effective_date": "2018-03-27",
           "rating_end_date": null,
@@ -101,7 +100,6 @@ http_interactions:
           "diagnostic_text": "Diabetes mellitus0"
         },
         {
-          "description": "Service Connected",
           "decision": "Deferred",
           "effective_date": "2018-03-12",
           "rating_percentage": 30,
@@ -112,17 +110,27 @@ http_interactions:
         },
         {
           "decision": "Not Service Connected",
-          "effective_date": "2018-03-27",
+          "effective_date": null,
           "rating_end_date": null,
-          "rating_percentage": 50,
+          "rating_percentage": null,
+          "diagnostic_type_code": "5257",
+          "diagnostic_type_name": "Impairment of the knee, general",
+          "disability_rating_id": "3",
+          "diagnostic_text": "knee condition right"
+        },
+        {
+          "decision": "Not Service Connected",
+          "effective_date": null,
+          "rating_end_date": "2028-10-20",
+          "rating_percentage": null,
           "diagnostic_type_code": "1134",
           "diagnostic_type_name": "Schizophrenia, disorganized type",
-          "disability_rating_id": "2",
+          "disability_rating_id": "5",
           "diagnostic_text": "bilateral hearing loss"
         }
       ]
     }
   }
 }'
-  recorded_at: Mon, 12 Feb 2024 02:22:38 GMT
+  recorded_at: Tue, 27 Feb 2024 02:22:38 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary
Updating the check for active ratings to account for the fact that a rating with an end date in the future is still considered an active rating.

## Testing done
Added a new rating to the VCR cassette that has an end date in the future so that we could ensure that it is not filtered out by the `active?` check

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
