### PR TITLE
API-34293-system-scopes

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
@@ -21,6 +21,10 @@ module ClaimsApi
       skip_before_action :verify_authenticity_token
       skip_after_action :set_csrf_header
       before_action :authenticate, except: %i[schema]
+      before_action { permit_scopes %w[system/claim.read] if request.get? }
+      before_action except: %i[generate_pdf] do
+        permit_scopes %w[system/claim.write] if request.post? || request.put?
+      end
 
       def schema
         render json: { data: [ClaimsApi::FormSchemas.new(schema_version: 'v2').schemas[self.class::FORM_NUMBER]] }

--- a/modules/claims_api/spec/requests/v2/veterans/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/claims_request_spec.rb
@@ -1371,6 +1371,28 @@ RSpec.describe 'Claims', type: :request do
           end
         end
       end
+
+      context 'scopes' do
+        let(:invalid_scopes) { %w[system/526-pdf.override] }
+        let(:claims_show_scopes) { %w[claim.write claim.read] }
+
+        context 'submission to generatePDF' do
+          it 'returns a 200 response when successful' do
+            mock_ccg_for_fine_grained_scope(claims_show_scopes) do |auth_header|
+              post claims_show_path, params: data, headers: auth_header
+              expect(response.header['Content-Disposition']).to include('filename')
+              expect(response).to have_http_status(:ok)
+            end
+          end
+
+          it 'returns a 401 unauthorized with incorrect scopes' do
+            mock_ccg_for_fine_grained_scope(invalid_scopes) do |auth_header|
+              post claims_show_path, params: data, headers: auth_header
+              expect(response).to have_http_status(:unauthorized)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/modules/claims_api/spec/requests/v2/veterans/evidence_waiver_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/evidence_waiver_request_spec.rb
@@ -112,6 +112,29 @@ RSpec.describe 'Evidence Waiver 5103', type: :request,
               end
             end
           end
+
+          context 'scopes' do
+            let(:invalid_scopes) { %w[system/526-pdf.override] }
+            let(:ews_scopes) { %w[system/claim.write] }
+
+            context 'evidence waiver' do
+              it 'returns a 200 response when successful' do
+                mock_ccg_for_fine_grained_scope(ews_scopes) do |auth_header|
+                  VCR.use_cassette('bgs/benefit_claim/update_5103_200') do
+                    post sub_path, headers: auth_header
+                    expect(response).to have_http_status(:ok)
+                  end
+                end
+              end
+
+              it 'returns a 401 unauthorized with incorrect scopes' do
+                mock_ccg_for_fine_grained_scope(invalid_scopes) do |auth_header|
+                  post sub_path, headers: auth_header
+                  expect(response).to have_http_status(:unauthorized)
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/modules/claims_api/spec/requests/v2/veterans/intent_to_files_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/intent_to_files_request_spec.rb
@@ -317,6 +317,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
       let(:itf_submit_path) { "/services/claims/v2/veterans/#{veteran_id}/intent-to-file" }
       let(:scopes) { %w[system/claim.write] }
+      let(:invalid_scopes) { %w[system/526-pdf.override] }
 
       let(:data) do
         {
@@ -345,6 +346,13 @@ RSpec.describe 'IntentToFiles', type: :request do
             mock_ccg(scopes) do |auth_header|
               post itf_submit_path, params: data, headers: auth_header
               expect(response.status).to eq(200)
+            end
+          end
+
+          it 'returns a 401 unauthorized with incorrect scopes' do
+            mock_ccg_for_fine_grained_scope(invalid_scopes) do |auth_header|
+              post itf_submit_path, params: data, headers: auth_header
+              expect(response).to have_http_status(:unauthorized)
             end
           end
         end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *Team Dash*
- Adds system scopes to v2, except for 526 generate_pdf


## Related issue(s)

- [API-34293](https://jira.devops.va.gov/browse/API-34293)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change: blanket scopes
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing* Use Postman to test each v2 service, changing the scopes



## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/application_controller.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
