### PR TITLE
remove toggle for hub page

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -799,10 +799,6 @@ features:
     description: Use experimental features for Profile application - Do not remove
     enable_in_development: true
     actor_type: user
-  profile_use_hub_page:
-    description: Use a hub style page as the root page for the profile application
-    enable_in_development: true
-    actor_type: user
   profile_use_vafsc:
     description: Use VA Forms System Core for forms instead of schema based forms
     actor_type: user


### PR DESCRIPTION
## Summary

- Hub page in profile has been fully rolled out in production, so cleaning up toggle for it.
- FE PR already has been done and merged

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/72259

## Testing done

- Tested locally and verified that FE code already has been removed