### PR TITLE
10-10CG - eMIS Deprecation: Remove unused code referencing eMIS

### DIFF
--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -53,16 +53,12 @@ module Form1010cg
       # The Form1010cg::Submission
       @submission   = submission
 
-      # Store for the search results we will run on MVI and eMIS
+      # Store for the search results we will run on MPI
       @cache = {
         # [form_subject]: String          - The person's ICN
         # [form_subject]: NOT_FOUND       - This person could not be found in MVI
         # [form_subject]: nil             - An MVI search has not been conducted for this person
-        icns: {},
-        # [form_subject]: true            - This person is a veteran
-        # [form_subject]: false           - This person's veteran status cannot be confirmed
-        # [form_subject]: nil             - An eMIS search has not been conducted for this person
-        veteran_statuses: {}
+        icns: {}
       }
     end
 
@@ -108,9 +104,9 @@ module Form1010cg
         }
       end
 
-      # Disabling the veteran status search since there is an issue with searching emis
+      # Disabling the veteran status search since there is an issue with searching
       # for a veteran status using an ICN. Only edipi works. Consider adding this back in
-      # once ICN searches work or we refactor our veteran status serach to use the edipi.
+      # once ICN searches work or we refactor our veteran status search to use the edipi.
       metadata[:veteran][:is_veteran] = false
       metadata
     end

--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -56,8 +56,8 @@ module Form1010cg
       # Store for the search results we will run on MPI
       @cache = {
         # [form_subject]: String          - The person's ICN
-        # [form_subject]: NOT_FOUND       - This person could not be found in MVI
-        # [form_subject]: nil             - An MVI search has not been conducted for this person
+        # [form_subject]: NOT_FOUND       - This person could not be found in MPI
+        # [form_subject]: nil             - An MPI search has not been conducted for this person
         icns: {}
       }
     end


### PR DESCRIPTION

## Summary
Remove unused code referencing eMIS

- *(Which team do you work for, does your team own the maintenance of this component?)*
I work for the 1010 team

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/67941

## Testing done

- [x] *New code is covered by unit tests*

will test in staging

## What areas of the site does it impact?
1010cg form

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
