### PR TITLE
[DBX-75526.1] add aasm_state column to form526 subs

### DIFF
--- a/db/migrate/20240229150823_add_state_to_form_526_submissions.rb
+++ b/db/migrate/20240229150823_add_state_to_form_526_submissions.rb
@@ -1,0 +1,5 @@
+class AddStateToForm526Submissions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :form526_submissions, :aasm_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_26_235237) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_29_152705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -603,6 +603,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_26_235237) do
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
     t.string "backup_submitted_claim_id", comment: "*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.This column will be nil for all submissions where a backup submission is not generated.It will have the central mail id for submissions where a backup submission is submitted."
+    t.string "aasm_state"
     t.index ["saved_claim_id"], name: "index_form526_submissions_on_saved_claim_id", unique: true
     t.index ["submitted_claim_id"], name: "index_form526_submissions_on_submitted_claim_id", unique: true
     t.index ["user_account_id"], name: "index_form526_submissions_on_user_account_id"


### PR DESCRIPTION
[Top level documentation for this improvement is here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/implementation/form_526_state_machine.md)

## Summary

- [per the documentation](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-database-migrations#vets-apidatabasemigrations-Good.4), the Form 526 State machine is being broken into 3 migrations.  This is the first which adds the requisite column to our form526 submission DB table.
- A subsequent PR will add the default state value
- A subsequent PR will add the model and implementation logic


## Related issue(s)

- [Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/75526)
- [Documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/implementation/form_526_state_machine.md)

## Testing done

- There is nothing to test, as this is bare bones, core rails functionality

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

