### PR TITLE
73557: All IVC Forms - Upload forms and separated PDF attachments into S3

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -24,16 +24,18 @@ module SimpleFormsApi
 
     def handle_attachments(file_path)
       attachments = get_attachments
-      new_file_names = [file_path]
+      file_paths = [file_path]
 
       if attachments.count.positive?
         attachments.each_with_index do |attachment, index|
           new_file_name = "vha_10_10d-tmp#{index + 1}.pdf"
           new_file_path = File.join(File.dirname(attachment), new_file_name)
           File.rename(attachment, new_file_path)
-          new_file_names << new_file_name
+          file_paths << new_file_path
         end
       end
+
+      file_paths
     end
 
     def submission_date_config


### PR DESCRIPTION
## Summary
Recently, we removed the combing of PDFs for 10-10D and separated them by attachment for S3 upload. This PR aims to get those attachments cleaning to an S3 bucket.

- Update vha_10_10d model to return file_paths instead of file_names
- Update UploadsController to handle multiple PDFs instead of just the compiled one at the end.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/73557

## Testing done
- Manual browser testing
- Test suite

## Screenshots
`vha_10_10d1.pdf` is the optional PDF
<img width="477" alt="Screenshot 2024-02-29 at 2 00 21 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/1422922/f9c4db8b-ce2e-4c32-9ae1-12a4f33028b8">

## What areas of the site does it impact?
- IVC Forms only

## Acceptance criteria
- needed for all IVC forms and attachments (including 10-10d, 10-7959f-1 and 2, and 10-7959a and c and other CHAMPVA forms
- the files need to be separated and available on PEGA S3