### PR TITLE
MHV-55039-Update-Refill-Logic

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/prescriptions_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/prescriptions_controller.rb
@@ -178,7 +178,7 @@ module MyHealth
           disp_status = item.disp_status
           sorted_dispensed_date = item.sorted_dispensed_date.to_date
 
-          next true if disp_status == 'Active'
+          next true if ['Active', 'Active: Submitted'].include?(disp_status)
           next true if item.is_refillable
           next true if %w[Expired Discontinued].include?(disp_status) &&
                        sorted_dispensed_date >= six_months_from_today &&

--- a/modules/my_health/app/controllers/my_health/v1/prescriptions_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/prescriptions_controller.rb
@@ -61,9 +61,7 @@ module MyHealth
 
       def list_refillable_prescriptions
         resource = collection_resource
-        resource.data = resource.data.select do |item|
-          item.is_refillable || (item.refill_status == 'active' && item.refill_remaining&.zero?)
-        end
+        resource.data = filter_data_by_refill_and_renew(resource.data)
         render json: resource.data,
                serializer: CollectionSerializer,
                each_serializer: PrescriptionDetailsSerializer,
@@ -170,6 +168,24 @@ module MyHealth
         }
         new_metadata = resource.metadata.merge('sort' => sort_metadata)
         Common::Collection.new(PrescriptionDetails, data: sorted_data, metadata: new_metadata)
+      end
+
+      def filter_data_by_refill_and_renew(data)
+        six_months_from_today = Time.zone.today - 6.months
+        zero_date = Date.new(0, 1, 1)
+
+        data.select do |item|
+          disp_status = item.disp_status
+          sorted_dispensed_date = item.sorted_dispensed_date.to_date
+
+          next true if disp_status == 'Active'
+          next true if item.is_refillable
+          next true if %w[Expired Discontinued].include?(disp_status) &&
+                       sorted_dispensed_date >= six_months_from_today &&
+                       sorted_dispensed_date != zero_date
+
+          false
+        end
       end
     end
   end

--- a/modules/my_health/spec/request/v1/prescriptions_request_spec.rb
+++ b/modules/my_health/spec/request/v1/prescriptions_request_spec.rb
@@ -134,9 +134,16 @@ RSpec.describe 'prescriptions', type: :request do
         VCR.use_cassette('rx_client/prescriptions/gets_a_list_of_refillable_prescriptions') do
           get '/my_health/v1/prescriptions/list_refillable_prescriptions'
         end
+        six_months_from_today = Time.zone.today - 6.months
+        zero_date = Date.new(0, 1, 1)
+
         response_data = JSON.parse(response.body)['data']
         response_data.each do |prescription|
-          if prescription['is_refillable'] || (prescription['refill_status'] == 'active' && prescription['refill_remaining']&.zero?)
+          if prescription['is_refillable'] || prescription['refill_status'] == 'active' ||
+             (%w[Expired Discontinued].include?(prescription['disp_status']) &&
+             prescription['sorted_dispensed_date'] >= six_months_from_today &&
+             prescription['sorted_dispensed_date'] != zero_date)
+
             expect(prescription).to be_included
           end
         end

--- a/modules/my_health/spec/request/v1/prescriptions_request_spec.rb
+++ b/modules/my_health/spec/request/v1/prescriptions_request_spec.rb
@@ -139,10 +139,11 @@ RSpec.describe 'prescriptions', type: :request do
 
         response_data = JSON.parse(response.body)['data']
         response_data.each do |prescription|
-          if prescription['is_refillable'] || prescription['refill_status'] == 'active' ||
-             (%w[Expired Discontinued].include?(prescription['disp_status']) &&
-             prescription['sorted_dispensed_date'] >= six_months_from_today &&
-             prescription['sorted_dispensed_date'] != zero_date)
+          sorted_dispensed_date = prescription['rxRfRecords']&.dig(0, 1, 0) || prescription['dispensedDate']
+          if prescription['isRefillable'] || ['Active', 'Active: Submitted'].include?(prescription['dispStatus']) ||
+             (%w[Expired Discontinued].include?(prescription['dispStatus']) &&
+             sorted_dispensed_date >= six_months_from_today &&
+             sorted_dispensed_date != zero_date)
 
             expect(prescription).to be_included
           end


### PR DESCRIPTION
## Summary

- Updated renewable rx logic to include expired, discontinued meds for up to 6 months

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-55039
>In the prescriptions you may need to renew sections, the showing # should reflect all recently expired, discontinued, and meds that ran out of refills for the last 6 months

## Testing done

- New code is covered by unit test
- Ran tests locally

## What areas of the site does it impact?
MHV medications app refill page

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
