### PR TITLE
MHV-53689: Revert: Added not entered in error flag to all MR list calls (#15729)

### DIFF
--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -268,9 +268,7 @@ module MedicalRecords
     # @return [FHIR::ClientReply]
     #
     def fhir_search_query(fhir_model, params)
-      params[:search][:parameters]
-        .merge!(_count: DEFAULT_COUNT)
-        .merge!('verification-status:not': 'entered-in-error')
+      params[:search][:parameters].merge!(_count: DEFAULT_COUNT)
       result = fhir_client.search(fhir_model, params)
       handle_api_errors(result) if result.resource.nil?
       result

--- a/spec/support/vcr_cassettes/mr_client/get_a_health_condition.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_health_condition.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&_id=39274&_include=*&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&_id=39274&_include=*"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_allergies.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_allergies.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_chemhem_labs.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_chemhem_labs.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=2952&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=2952"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11506-3,18842-5,11488-4&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11506-3,18842-5,11488-4"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_diagreport_labs.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_diagreport_labs.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&code=79381-0,60567-5&patient=2952&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&code=79381-0,60567-5&patient=2952"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_docref_labs.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_docref_labs.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11524-6,18748-4&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11524-6,18748-4"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=2952&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=2952"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions_error.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=39254&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=39254"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_labs_and_tests.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_labs_and_tests.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=258974&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=258974"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_vaccines.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_vaccines.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Immunization?_count=9999&patient=2952&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/Immunization?_count=9999&patient=2952"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_vitals.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_vitals.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Observation?_count=9999&code=85354-9,9279-1,8867-4,8302-2,8310-5,29463-7&patient=2952&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/Observation?_count=9999&code=85354-9,9279-1,8867-4,8302-2,8310-5,29463-7&patient=2952"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_single_lab_or_test.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_single_lab_or_test.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&_id=40766&_include=*&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&_id=40766&_include=*"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_full_list_of_labs_and_tests.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_full_list_of_labs_and_tests.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=49006&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=49006"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_multiple_fhir_pages.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_multiple_fhir_pages.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952"
       body:
         encoding: US-ASCII
         string: ""


### PR DESCRIPTION
This reverts commit f6ec2978ab57a5def7ac3cb3dd2726b1c2240121.

## Summary

- Rolling back a commit that caused errors when viewing Vaccines or Notes.

## Related issue(s)

Original PR: https://github.com/department-of-veterans-affairs/vets-api/pull/15729

## Testing done

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
