### PR TITLE
API-34148 Non-veteran claimant flag in appeal metadata

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -91,8 +91,12 @@ module AppealsApi
       )
     end
 
+    def non_veteran_claimant?
+      claimant.signing_appellant?
+    end
+
     def signing_appellant
-      claimant.signing_appellant? ? claimant : veteran
+      non_veteran_claimant? ? claimant : veteran
     end
 
     def appellant_local_time
@@ -295,13 +299,14 @@ module AppealsApi
     end
 
     def assign_metadata
-      # retain original incoming non-pii form_data in metadata since this model's form_data is eventually removed
-      self.metadata = { form_data: { benefit_type: } }
-
-      metadata['central_mail_business_line'] = lob
-      metadata['potential_write_in_issue_count'] = contestable_issues.filter do |issue|
-        issue['attributes']['ratingIssueReferenceId'].blank?
-      end.count
+      self.metadata = {
+        central_mail_business_line: lob,
+        form_data: { benefit_type: },
+        non_veteran_claimant: non_veteran_claimant?,
+        potential_write_in_issue_count: contestable_issues.filter do |issue|
+          issue['attributes']['ratingIssueReferenceId'].blank?
+        end.count
+      }
     end
 
     private

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -98,8 +98,12 @@ module AppealsApi
       )
     end
 
+    def non_veteran_claimant?
+      claimant.signing_appellant?
+    end
+
     def signing_appellant
-      claimant.signing_appellant? ? claimant : veteran
+      non_veteran_claimant? ? claimant : veteran
     end
 
     def appellant_local_time
@@ -204,10 +208,13 @@ module AppealsApi
     end
 
     def assign_metadata
-      metadata['central_mail_business_line'] = lob
-      metadata['potential_write_in_issue_count'] = contestable_issues.filter do |issue|
-        issue['attributes']['ratingIssueReferenceId'].blank?
-      end.count
+      self.metadata = {
+        central_mail_business_line: lob,
+        non_veteran_claimant: non_veteran_claimant?,
+        potential_write_in_issue_count: contestable_issues.filter do |issue|
+          issue['attributes']['ratingIssueReferenceId'].blank?
+        end.count
+      }
     end
 
     def accepts_evidence?

--- a/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
+++ b/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
@@ -147,10 +147,6 @@ module AppealsApi
       data_attributes['claimantTypeOtherValue']&.strip
     end
 
-    def potential_pact_act
-      data_attributes&.dig('potentialPactAct') ? true : false
-    end
-
     def alternate_signer_first_name
       (auth_headers&.dig('X-Alternate-Signer-First-Name') || \
         form_data&.dig('data', 'attributes', 'alternateSigner', 'firstName'))&.strip

--- a/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
+++ b/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
@@ -65,13 +65,14 @@ module AppealsApi
     def assign_metadata
       return unless %w[v2 v0].include?(api_version&.downcase)
 
-      # retain original incoming non-pii form_data in metadata since this model's form_data is eventually removed
-      self.metadata = { form_data: { evidence_type: } }
-      metadata['form_data']['benefit_type'] = benefit_type
-      metadata['central_mail_business_line'] = lob
-      metadata['potential_write_in_issue_count'] = contestable_issues.filter do |issue|
-        issue['attributes']['ratingIssueReferenceId'].blank?
-      end.count
+      self.metadata = {
+        central_mail_business_line: lob,
+        form_data: { benefit_type:, evidence_type: },
+        non_veteran_claimant: non_veteran_claimant?,
+        potential_write_in_issue_count: contestable_issues.filter do |issue|
+          issue['attributes']['ratingIssueReferenceId'].blank?
+        end.count
+      }
     end
 
     def veteran
@@ -90,8 +91,12 @@ module AppealsApi
       )
     end
 
+    def non_veteran_claimant?
+      claimant.signing_appellant?
+    end
+
     def signing_appellant
-      claimant.signing_appellant? ? claimant : veteran
+      non_veteran_claimant? ? claimant : veteran
     end
 
     def appellant_local_time
@@ -140,6 +145,10 @@ module AppealsApi
 
     def claimant_type_other_text
       data_attributes['claimantTypeOtherValue']&.strip
+    end
+
+    def potential_pact_act
+      data_attributes&.dig('potentialPactAct') ? true : false
     end
 
     def alternate_signer_first_name

--- a/modules/appeals_api/spec/models/higher_level_review_spec.rb
+++ b/modules/appeals_api/spec/models/higher_level_review_spec.rb
@@ -17,6 +17,20 @@ describe AppealsApi::HigherLevelReview, type: :model do
       expect(hlr.metadata['form_data']['benefit_type']).to eq('fiduciary')
     end
 
+    describe 'non-veteran claimant flag' do
+      it 'saves non-veteran claimant status to metadata' do
+        expect(hlr.metadata['non_veteran_claimant']).to eq(false)
+      end
+
+      describe 'with non-veteran claimant' do
+        let(:hlr) { create(opts[:extra_factory]) }
+
+        it 'saves non-veteran claimant status to metadata' do
+          expect(hlr.metadata['non_veteran_claimant']).to eq(true)
+        end
+      end
+    end
+
     describe 'potential_write_in_issue_count' do
       it 'saves the correct value to metadata' do
         expect(hlr.metadata['potential_write_in_issue_count']).to eq(3)
@@ -119,6 +133,7 @@ describe AppealsApi::HigherLevelReview, type: :model do
 
     include_examples 'HLR metadata',
                      factory: :higher_level_review_v0,
+                     extra_factory: :extra_higher_level_review_v0,
                      form_data_fixture: 'higher_level_reviews/v0/valid_200996.json'
 
     describe '#veteran_icn' do
@@ -180,6 +195,7 @@ describe AppealsApi::HigherLevelReview, type: :model do
 
     include_examples 'HLR metadata',
                      factory: :higher_level_review_v2,
+                     extra_factory: :extra_higher_level_review_v2,
                      form_data_fixture: 'decision_reviews/v2/valid_200996.json'
 
     describe '#veteran_icn' do

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -13,6 +13,20 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
       expect(nod.metadata['central_mail_business_line']).to eq 'BVA'
     end
 
+    describe 'non-veteran claimant flag' do
+      it 'saves non-veteran claimant status to metadata' do
+        expect(nod.metadata['non_veteran_claimant']).to eq(false)
+      end
+
+      describe 'with non-veteran claimant' do
+        let(:nod) { create(opts[:extra_factory]) }
+
+        it 'saves non-veteran claimant status to metadata' do
+          expect(nod.metadata['non_veteran_claimant']).to eq(true)
+        end
+      end
+    end
+
     describe 'potential_write_in_issue_count' do
       context 'with no write-in issues' do
         it 'saves the correct value to metadata' do
@@ -403,6 +417,7 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
     describe 'metadata' do
       include_examples 'NOD metadata', {
         factory: :notice_of_disagreement_v2,
+        extra_factory: :extra_notice_of_disagreement_v2,
         form_data_fixture: 'decision_reviews/v2/valid_10182.json'
       }
     end
@@ -449,6 +464,7 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
     describe 'metadata' do
       include_examples 'NOD metadata', {
         factory: :notice_of_disagreement_v0,
+        extra_factory: :extra_notice_of_disagreement_v0,
         form_data_fixture: 'notice_of_disagreements/v0/valid_10182.json'
       }
     end

--- a/modules/appeals_api/spec/models/supplemental_claim_spec.rb
+++ b/modules/appeals_api/spec/models/supplemental_claim_spec.rb
@@ -96,6 +96,7 @@ describe AppealsApi::SupplementalClaim, type: :model do
       include_examples 'SC metadata',
                        api_version: 'V0',
                        factory: :supplemental_claim_v0,
+                       extra_factory: :extra_supplemental_claim_v0,
                        form_data_fixture: 'supplemental_claims/v0/valid_200995.json'
     end
 
@@ -136,6 +137,7 @@ describe AppealsApi::SupplementalClaim, type: :model do
       include_examples 'SC metadata',
                        api_version: 'V2',
                        factory: :minimal_supplemental_claim,
+                       extra_factory: :extra_supplemental_claim,
                        form_data_fixture: 'decision_reviews/v2/valid_200995.json'
     end
 


### PR DESCRIPTION
## Summary

- Adds a `non_veteran_claimant` field to the metadata of all three types of appeals (NOD, HLR, SC). Also adds a `non_veteran_claimant?` method to the appeals to support this.

## Related issue(s)

- [API-34148](https://jira.devops.va.gov/browse/API-34148)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- Higher-Level Reviews, Supplemental Claims, and Notice of Disagreements in the Decision Reveiws API v2 + the appeal-specific segmented APIs

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
