### PR TITLE
API-34434 Reject non-gateway requests to some APIs

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -30,6 +30,9 @@ features:
     actor_type: user
     description: Use lighthouse instead of EVSS to upload benefits documents.
     enable_in_development: false
+  benefits_require_gateway_origin:
+    actor_type: user
+    description: Requires that all requests made to endpoints in appeals_api, va_forms, and vba_documents be made through the gateway
   caregiver_use_facilities_API:
     actor_type: user
     description: Allow list of caregiver facilites to be fetched by way of the Facilities API.

--- a/modules/appeals_api/app/controllers/appeals_api/application_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/application_controller.rb
@@ -7,6 +7,7 @@ module AppealsApi
     skip_after_action :set_csrf_header
     before_action :deactivate_endpoint
     before_action :set_default_headers
+    before_action :require_gateway_origin
 
     def render_response(response)
       render json: response.body, status: response.status
@@ -34,6 +35,12 @@ module AppealsApi
     end
 
     DEFAULT_HEADERS = { 'Content-Language' => 'en-US' }.freeze
+
+    def require_gateway_origin
+      if Rails.env.production? && params[:source].blank? && Flipper.enabled?(:benefits_require_gateway_origin)
+        raise Common::Exceptions::Unauthorized
+      end
+    end
 
     def set_default_headers
       DEFAULT_HEADERS.each { |k, v| response.headers[k] = v }

--- a/modules/appeals_api/spec/controllers/application_controller_spec.rb
+++ b/modules/appeals_api/spec/controllers/application_controller_spec.rb
@@ -26,6 +26,43 @@ describe AppealsApi::ApplicationController, type: :controller do
     end
   end
 
+  describe '#require_gateway_origin' do
+    it 'does nothing by default' do
+      get(:index)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'with benefits_require_gateway_origin flag on' do
+      before do
+        allow(Flipper).to receive(:enabled?)
+          .with(:benefits_require_gateway_origin).and_return(true)
+      end
+
+      it 'does nothing when rails is not running in production mode' do
+        get(:index)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      context 'when rails runs in production mode' do
+        before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+        it 'rejects requests that did not come through the gateway' do
+          get(:index)
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+
+        it 'allows requests that came through the gateway' do
+          get(:index, params: { source: 'some-source-value' })
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
   describe 'deactivate_endpoint' do
     context 'when a sunset date is passed' do
       it 'returns a 404' do

--- a/modules/va_forms/app/controllers/va_forms/application_controller.rb
+++ b/modules/va_forms/app/controllers/va_forms/application_controller.rb
@@ -5,5 +5,12 @@ module VAForms
     service_tag 'lighthouse-forms'
     skip_before_action :verify_authenticity_token
     skip_after_action :set_csrf_header
+    before_action :require_gateway_origin
+
+    def require_gateway_origin
+      if Rails.env.production? && params[:source].blank? && Flipper.enabled?(:benefits_require_gateway_origin)
+        raise Common::Exceptions::Unauthorized
+      end
+    end
   end
 end

--- a/modules/vba_documents/app/controllers/vba_documents/application_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/application_controller.rb
@@ -5,6 +5,13 @@ module VBADocuments
     service_tag 'lighthouse-benefits-intake'
     skip_before_action :verify_authenticity_token
     skip_after_action :set_csrf_header
+    before_action :require_gateway_origin
+
+    def require_gateway_origin
+      if Rails.env.production? && params[:source].blank? && Flipper.enabled?(:benefits_require_gateway_origin)
+        raise Common::Exceptions::Unauthorized
+      end
+    end
 
     def set_tags_and_extra_context
       RequestStore.store['additional_request_attributes'] = { 'source' => 'vba_documents' }


### PR DESCRIPTION
## Summary
Updates APIs in the `appeals_api`, `va_forms`, and `vba_documents` modules so that they return an Unauthorized error if the request did not come through the gateway (only applies in production mode)

## Related issue(s)

- [API-34434](https://jira.devops.va.gov/browse/API-34434)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
- All endpoints in the modules listed above which inherit from their local `ApplicationController`s are affected

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
