### PR TITLE
FAR flag_accredited_representatives endpoint - add before_action :feature_enabled

### DIFF
--- a/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
@@ -4,8 +4,8 @@ module RepresentationManagement
   module V0
     class FlagAccreditedRepresentativesController < ApplicationController
       service_tag 'lighthouse-veteran'
-      skip_before_action :authenticate
       before_action :feature_enabled
+      skip_before_action :authenticate
 
       def create
         flags = nil

--- a/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
@@ -5,7 +5,7 @@ module RepresentationManagement
     class FlagAccreditedRepresentativesController < ApplicationController
       service_tag 'lighthouse-veteran'
       skip_before_action :authenticate
-      # before_action :feature_enabled
+      before_action :feature_enabled
 
       def create
         flags = nil
@@ -41,9 +41,9 @@ module RepresentationManagement
         end
       end
 
-      # def feature_enabled
-      #   routing_error unless Flipper.enabled?(:find_a_representative_flag_results_enabled)
-      # end
+      def feature_enabled
+        routing_error unless Flipper.enabled?(:find_a_representative_flag_results_enabled)
+      end
     end
   end
 end


### PR DESCRIPTION
References https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311


## Summary
Put the `flag_accredited_representatives` endpoint behind the `find_a_representative_flag_results_enabled` feature flag.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- Find a Rep search, currently behind a feature flag

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
