### PR TITLE
Validate access token audience

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -6,8 +6,13 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
   include ActionController::Cookies
   include SignIn::Authentication
+  include SignIn::AudienceValidator
 
-  included { before_action :authenticate, :set_session_expiration_header }
+  included do
+    before_action :authenticate, :set_session_expiration_header
+
+    validates_access_token_audience [Settings.sign_in.vaweb_client_id, ('vamock' if MockedAuthentication.mockable_env?)]
+  end
 
   protected
 

--- a/app/controllers/concerns/sign_in/audience_validator.rb
+++ b/app/controllers/concerns/sign_in/audience_validator.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SignIn
+  module AudienceValidator
+    extend ActiveSupport::Concern
+
+    included do
+      prepend Authentication
+      class_attribute :valid_audience # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+    end
+
+    class_methods do
+      def validates_access_token_audience(*audience)
+        return if audience.empty?
+
+        self.valid_audience = audience.flatten.compact
+      end
+    end
+
+    protected
+
+    def authenticate
+      validate_audience!
+      super
+    rescue Errors::InvalidAudienceError => e
+      render json: { errors: e }, status: :unauthorized
+    end
+
+    private
+
+    def validate_audience!
+      valid_audience = self.class.valid_audience
+
+      return if valid_audience.blank?
+      return if access_token.audience.any? { |aud| valid_audience.include?(aud) }
+
+      Rails.logger.error('[SignIn::AudienceValidator] Invalid audience',
+                         { invalid_audience: access_token.audience, valid_audience: })
+      raise Errors::InvalidAudienceError.new(message: 'Invalid audience')
+    end
+  end
+end

--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -15,7 +15,6 @@ module SignIn
     protected
 
     def authenticate
-      @access_token = authenticate_access_token
       @current_user = load_user_object
       validate_request_ip
       @current_user.present?
@@ -26,7 +25,6 @@ module SignIn
     end
 
     def load_user(skip_expiration_check: false)
-      @access_token = authenticate_access_token
       @current_user = load_user_object
       validate_request_ip
       @current_user.present?
@@ -37,6 +35,10 @@ module SignIn
     end
 
     private
+
+    def access_token
+      @access_token ||= authenticate_access_token
+    end
 
     def bearer_token
       header = request.authorization
@@ -55,7 +57,7 @@ module SignIn
     end
 
     def load_user_object
-      UserLoader.new(access_token: @access_token, request_ip: request.remote_ip).perform
+      UserLoader.new(access_token:, request_ip: request.remote_ip).perform
     end
 
     def handle_authenticate_error(error, access_token_cookie_name: Constants::Auth::ACCESS_TOKEN_COOKIE_NAME)

--- a/app/services/sign_in/errors.rb
+++ b/app/services/sign_in/errors.rb
@@ -64,5 +64,6 @@ module SignIn
     class InvalidAccessTokenAttributeError < StandardError; end
     class TermsOfUseNotAcceptedError < StandardError; end
     class CredentialLockedError < StandardError; end
+    class InvalidAudienceError < StandardError; end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -76,6 +76,8 @@ sign_in:
   mock_auth_url: http://localhost:3000/mocked_authentication/profiles
   mock_redirect_uri: http://localhost:3000/v0/sign_in/callback
   mockdata_sync_api_key: ~
+  vaweb_client_id: vaweb
+  vamobile_client_id: vamobile
 
 terms_of_use:
   current_version: v1

--- a/modules/mobile/app/controllers/mobile/application_controller.rb
+++ b/modules/mobile/app/controllers/mobile/application_controller.rb
@@ -3,7 +3,11 @@
 module Mobile
   class ApplicationController < SignIn::ApplicationController
     include Traceable
+    include SignIn::AudienceValidator
+
     service_tag 'mobile-app'
+    validates_access_token_audience Settings.sign_in.vamobile_client_id
+
     before_action :authenticate
     before_action :set_tags_and_extra_context
     skip_before_action :authenticate, only: :cors_preflight
@@ -30,6 +34,8 @@ module Mobile
     end
 
     def access_token
+      return super if sis_authentication?
+
       @access_token ||= bearer_token
     end
 

--- a/modules/mobile/spec/controllers/application_controller_spec.rb
+++ b/modules/mobile/spec/controllers/application_controller_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Mobile::ApplicationController, type: :controller do
       end
 
       context 'with Authentication-Method header value of SIS' do
-        let(:access_token) { create(:access_token) }
+        let(:access_token) { create(:access_token, audience: ['vamobile']) }
         let(:bearer_token) { SignIn::AccessTokenJwtEncoder.new(access_token:).perform }
         let!(:user) { create(:user, :loa3, uuid: access_token.user_uuid) }
 
@@ -183,6 +183,16 @@ RSpec.describe Mobile::ApplicationController, type: :controller do
           expect(response).to have_http_status(:ok)
           expect(controller.payload[:user_uuid]).to eq(access_token.user_uuid)
           expect(controller.payload[:session]).to eq(access_token.session_handle)
+        end
+
+        context 'when the access_token audience is invalid' do
+          let(:access_token) { create(:access_token, audience: ['invalid']) }
+
+          it 'returns unauthorized' do
+            get :index
+
+            expect(response).to have_http_status(:unauthorized)
+          end
         end
       end
     end

--- a/modules/mobile/spec/support/helpers/sis_session_helper.rb
+++ b/modules/mobile/spec/support/helpers/sis_session_helper.rb
@@ -2,7 +2,7 @@
 
 module SISSessionHelper
   def sis_access_token
-    @sis_access_token ||= create(:access_token)
+    @sis_access_token ||= create(:access_token, audience: ['vamobile'])
   end
 
   def sis_bearer_token

--- a/modules/mocked_authentication/lib/mocked_authentication.rb
+++ b/modules/mocked_authentication/lib/mocked_authentication.rb
@@ -3,4 +3,8 @@
 require 'mocked_authentication/version'
 require 'mocked_authentication/engine'
 
-module MockedAuthentication; end
+module MockedAuthentication
+  def self.mockable_env?
+    %w[test localhost development staging].include?(Settings.vsp_environment)
+  end
+end

--- a/spec/controllers/sign_in/audience_validator_spec.rb
+++ b/spec/controllers/sign_in/audience_validator_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::AudienceValidator do
+  controller(ApplicationController) do
+    validates_access_token_audience 'web123', 'mobile123'
+
+    def index
+      head :ok
+    end
+  end
+
+  let(:web_client_id) { 'web123' }
+  let(:mobile_client_id) { 'mobile123' }
+  let(:invalid_client_id) { 'invalid' }
+
+  let(:valid_access_token) { create(:access_token, audience: [web_client_id, mobile_client_id]) }
+  let(:invalid_access_token) { create(:access_token, audience: [invalid_client_id]) }
+  let!(:user) { create(:user, :loa3, uuid: valid_access_token.user_uuid) }
+  let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: valid_access_token).perform }
+
+  describe '#authenticate' do
+    before do
+      request.cookies[SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME] = access_token_cookie
+    end
+
+    context 'with a valid audience' do
+      it 'allows access' do
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with an invalid audience' do
+      let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: invalid_access_token).perform }
+      let(:expected_log_message) { '[SignIn::AudienceValidator] Invalid audience' }
+      let(:expected_log_payload) do
+        { invalid_audience: invalid_access_token.audience, valid_audience: valid_access_token.audience }
+      end
+      let(:expected_response_body) do
+        { errors: 'Invalid audience' }.to_json
+      end
+
+      before do
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'denies access' do
+        get :index
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to eq(expected_response_body)
+        expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
+      end
+    end
+
+    context 'when controller has no audience validation' do
+      let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: invalid_access_token).perform }
+
+      controller(SignIn::ApplicationController) do
+        def index
+          head :ok
+        end
+      end
+
+      it 'allows access to all audiences' do
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/factories/sign_in/access_tokens.rb
+++ b/spec/factories/sign_in/access_tokens.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     session_handle { create(:oauth_session).handle }
     client_id { create(:client_config).client_id }
     user_uuid { create(:user_account).id }
-    audience { 'some-audience' }
+    audience { ['some-audience'] }
     refresh_token_hash { SecureRandom.hex }
     parent_refresh_token_hash { SecureRandom.hex }
     anti_csrf_token { SecureRandom.hex }


### PR DESCRIPTION
## Summary
- Adds optional access_token audience validation check for sign-in service clients. To add this validation, include the `SignIn::AudienceVerifier` module where `SignIn::Authentication` is included (or  where `SignIn::ApplicationController` is inherited) and add the `client_ids` you want to accept to `validates_access_token_audience`.
- This check is to ensure that sign-in service tokens generated for other clients and resource servers aren't accepted in vets-api.

```ruby
class MyController
  include SignIn::Authentication
  include SignIn::AudienceVerifier

  validates_access_token_audience 'vaweb', 'vamock'
  # or an array
  # validates_access_token_audience ['vaweb', 'vamock']
end
```

or

```ruby
class MyController < SignIn::ApplicationController
  include SignIn::AudienceVerifier

   validates_access_token_audience 'vaweb'
end
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#75433
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2735
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2736

## Testing 
### Web
#### Success
- Start `vets-api` and `vets-website`
- Authenticate with [sign-in-service normally](http://localhost:3001/?oauth=true&next=loginModal)
  - You should be able to hit authenticated endpoints e.g. [http://localhost:3000/v0/user](http://localhost:3000/v0/user)
#### Audience validation failure
- Change the `validates_access_token_audience` in [app/controllers/concerns/authentication_and_sso_concerns.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/access-token-aud-check/app/controllers/concerns/authentication_and_sso_concerns.rb#L14) to `invalid`
    ```ruby
    validates_access_token_audience 'invalid'
    ```
    - restart server
    - Authenticate [with sign-in-service](http://localhost:3001/?oauth=true&next=loginModal)
    - when you hit an authenticated endpoint you should get a `401` [http://localhost:3000/v0/user](http://localhost:3000/v0/user)
       ```
       {"errors":[{"title":"Not authorized","detail":"Invalid audience","code":"401","status":"401"}]}
       ```
### Mobile
#### Success
- Start `vets-api`
- Authorize
   - In a browser with the network tab open go to:
    ```
    http://localhost:3000/v0/sign_in/authorize?type=idme&acr=loa3&client_id=vamobile&code_challenge=JNkFflCkxk1K6gQUf23P_5Ctl_T65_xkkOU_y-Cc2XI%3D&code_challenge_method=S256&state=c4addf6001661631d2524043ca31107e
    ```
  - Sign in
  - When you're redirected back look for `vamobile://login-success?code=` call in your network tab
  - Copy the code
- Get access token with code
   ```bash
    curl -0 -v POST http://localhost:3000/v0/sign_in/token \
    -H 'Content-Type: application/json' \
    -d @- <<'EOF'
    {
        "grant_type": "authorization_code",
        "code_verifier": "f2413353d83449c501b17e411d09ebb4",
        "code": "{{your_code}}",
    }
    EOF
   ```
- Make authenticated call to mobile route
    ```bash
    curl --location 'http://localhost:3000/mobile/v2/user' \
    --header 'Authentication-Method: SIS' \
    --header 'Authorization: Bearer {{your_access_token}}'
    ```
    - You should receive a response with user data.
#### Audience validation failure
- Test that non-mobile access_token is blocked.
   - Get access_token from a web login
     - Sign in on [vets-website ](http://localhost:3001/?next=loginModal&oauth=true)
     - grab `vagov_access_token` cookie
   - Make authenticated call to mobile route with that token
      ```bash
      curl --location 'http://localhost:3000/mobile/v2/user' \
      --header 'Authentication-Method: SIS' \
      --header 'Authorization: Bearer {{your_web_token}}'
      ```
  - You should get a 401 with this response:
     ```bash
     {"errors":[{"title":"Not authorized","detail":"Invalid audience","code":"401","status":"401"}]}
    ```

## What areas of the site does it impact?
Sign-in Service, Authentication

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

