### PR TITLE
Skip flakey PdfFiller spec

### DIFF
--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -5,8 +5,8 @@ require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::PdfFiller do
   def self.test_pdf_fill(form_number, test_payload = form_number)
-    it 'fills out a PDF from a templated JSON file' do
-      pending('skipping tests due to inconsistent behavior constantly blocking PRs to master')
+    xit 'fills out a PDF from a templated JSON file' do
+      # skipping these tests due to inconsistent behavior constantly blocking PRs to master
 
       expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
 

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -6,6 +6,8 @@ require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe SimpleFormsApi::PdfFiller do
   def self.test_pdf_fill(form_number, test_payload = form_number)
     it 'fills out a PDF from a templated JSON file' do
+      pending('skipping tests due to inconsistent behavior constantly blocking PRs to master')
+
       expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
 
       # remove the pdf if it already exists


### PR DESCRIPTION
## Summary

- This spec has been failing often in PRs created to master for a couple months now. An example run can be found [here](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/8138397192/job/22239117552?pr=15762)
- The respective team is currently investigating it, but we can't have this blocking engineers from submitting PRs anymore.

## Related issue(s)

- 