### PR TITLE
MHV-53689: Not entered in error flag added to all medical records calls

### DIFF
--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -89,7 +89,8 @@ module MedicalRecords
     def list_allergies
       bundle = fhir_search(FHIR::AllergyIntolerance,
                            {
-                             search: { parameters: { patient: patient_fhir_id, 'clinical-status': 'active' } },
+                             search: { parameters: { patient: patient_fhir_id, 'clinical-status': 'active',
+                                                     'verification-status:not': 'entered-in-error' } },
                              headers: { 'Cache-Control': 'no-cache' }
                            })
       sort_bundle(bundle, :recordedDate, :desc)
@@ -102,7 +103,7 @@ module MedicalRecords
     def list_vaccines
       bundle = fhir_search(FHIR::Immunization,
                            {
-                             search: { parameters: { patient: patient_fhir_id } },
+                             search: { parameters: { patient: patient_fhir_id, 'status:not': 'entered-in-error' } },
                              headers: { 'Cache-Control': 'no-cache' }
                            })
       sort_bundle(bundle, :occurrenceDateTime, :desc)
@@ -114,24 +115,31 @@ module MedicalRecords
 
     def list_vitals
       loinc_codes = "#{BLOOD_PRESSURE},#{BREATHING_RATE},#{HEART_RATE},#{HEIGHT},#{TEMPERATURE},#{WEIGHT}"
-      bundle = fhir_search(FHIR::Observation, search: { parameters: { patient: patient_fhir_id, code: loinc_codes } })
+      bundle = fhir_search(FHIR::Observation,
+                           search: { parameters: { patient: patient_fhir_id, code: loinc_codes,
+                                                   'status:not': 'entered-in-error' } })
       sort_bundle(bundle, :effectiveDateTime, :desc)
     end
 
     def list_conditions
-      bundle = fhir_search(FHIR::Condition, search: { parameters: { patient: patient_fhir_id } })
+      bundle = fhir_search(FHIR::Condition,
+                           search: { parameters: { patient: patient_fhir_id,
+                                                   'verification-status:not': 'entered-in-error' } })
       sort_bundle(bundle, :recordedDate, :desc)
     end
 
     def get_condition(condition_id)
-      fhir_search(FHIR::Condition, search: { parameters: { _id: condition_id, _include: '*' } })
+      fhir_search(FHIR::Condition,
+                  search: { parameters: { _id: condition_id, _include: '*',
+                                          'verification-status:not': 'entered-in-error' } })
     end
 
     def list_clinical_notes
       loinc_codes = "#{PHYSICIAN_PROCEDURE_NOTE},#{DISCHARGE_SUMMARY},#{CONSULT_RESULT}"
       bundle = fhir_search(FHIR::DocumentReference,
                            {
-                             search: { parameters: { patient: patient_fhir_id, type: loinc_codes } },
+                             search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
+                                                     'status:not': 'entered-in-error' } },
                              headers: { 'Cache-Control': 'no-cache' }
                            })
 
@@ -157,7 +165,8 @@ module MedicalRecords
     end
 
     def get_diagnostic_report(record_id)
-      fhir_search(FHIR::DiagnosticReport, search: { parameters: { _id: record_id, _include: '*' } })
+      fhir_search(FHIR::DiagnosticReport,
+                  search: { parameters: { _id: record_id, _include: '*', 'status:not': 'entered-in-error' } })
     end
 
     ##
@@ -214,7 +223,8 @@ module MedicalRecords
     #
     def list_labs_chemhem_diagnostic_report
       fhir_search(FHIR::DiagnosticReport,
-                  search: { parameters: { patient: patient_fhir_id, category: 'LAB' } })
+                  search: { parameters: { patient: patient_fhir_id, category: 'LAB',
+                                          'status:not': 'entered-in-error' } })
     end
 
     ##
@@ -225,7 +235,9 @@ module MedicalRecords
     #
     def list_labs_other_diagnostic_report
       loinc_codes = "#{MICROBIOLOGY},#{PATHOLOGY}"
-      fhir_search(FHIR::DiagnosticReport, search: { parameters: { patient: patient_fhir_id, code: loinc_codes } })
+      fhir_search(FHIR::DiagnosticReport,
+                  search: { parameters: { patient: patient_fhir_id, code: loinc_codes,
+                                          'status:not': 'entered-in-error' } })
     end
 
     ##
@@ -237,7 +249,8 @@ module MedicalRecords
     def list_labs_document_reference
       loinc_codes = "#{EKG},#{RADIOLOGY}"
       fhir_search(FHIR::DocumentReference,
-                  search: { parameters: { patient: patient_fhir_id, type: loinc_codes } })
+                  search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
+                                          'status:not': 'entered-in-error' } })
     end
 
     ##

--- a/spec/support/vcr_cassettes/mr_client/get_a_health_condition.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_health_condition.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&_id=39274&_include=*"
+      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&_id=39274&_include=*&verification-status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_health_condition_error.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_health_condition_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?patient&verification-status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/Condition?patient"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_health_condition_error.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_health_condition_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?patient"
+      uri: "<MHV_MR_HOST>/fhir/Condition?patient&verification-status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_allergies.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_allergies.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952"
+      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952&verification-status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_chemhem_labs.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_chemhem_labs.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=2952"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=2952&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11506-3,18842-5,11488-4"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11506-3,18842-5,11488-4&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11506-3,18842-5,11488-4&status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=3102&status:not=entered-in-error&type=11506-3,18842-5,11488-4"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=3102&status:not=entered-in-error&type=11506-3,18842-5,11488-4"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&status:not=entered-in-error&type=11506-3,18842-5,11488-4"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_diagreport_labs.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_diagreport_labs.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&code=79381-0,60567-5&patient=2952"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&code=79381-0,60567-5&patient=2952&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_docref_labs.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_docref_labs.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11524-6,18748-4"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11524-6,18748-4&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_docref_labs.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_docref_labs.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11524-6,18748-4&status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&status:not=entered-in-error&type=11524-6,18748-4"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=2952"
+      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=2952&verification-status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions_error.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_health_conditions_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=39254"
+      uri: "<MHV_MR_HOST>/fhir/Condition?_count=9999&patient=39254&verification-status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_labs_and_tests.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_labs_and_tests.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=258974"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=258974&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_vaccines.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_vaccines.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Immunization?_count=9999&patient=2952"
+      uri: "<MHV_MR_HOST>/fhir/Immunization?_count=9999&patient=2952&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_vitals.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_vitals.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/Observation?_count=9999&code=85354-9,9279-1,8867-4,8302-2,8310-5,29463-7&patient=2952"
+      uri: "<MHV_MR_HOST>/fhir/Observation?_count=9999&code=85354-9,9279-1,8867-4,8302-2,8310-5,29463-7&patient=2952&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_single_lab_or_test.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_single_lab_or_test.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&_id=40766&_include=*"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&_id=40766&_include=*&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_full_list_of_labs_and_tests.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_full_list_of_labs_and_tests.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=49006"
+      uri: "<MHV_MR_HOST>/fhir/DiagnosticReport?_count=9999&category=LAB&patient=49006&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_multiple_fhir_pages.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_multiple_fhir_pages.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952"
+      uri: "<MHV_MR_HOST>/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=2952&verification-status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""


### PR DESCRIPTION
## Summary
All MR list calls have been modified to retrieve only records that are marked as "not entered in error". 

Domains that use the flag as `verification-status:not=entered-in-error`:
1. Allergies (AllergyIntolerance)
2. Health conditions (Condition)

Domains that use the flag as `status:not=entered-in-error`:
1. Vaccines (Immunization)
2. Summaries and notes (DocumentReference)
3. Vitals (Observation)
4. Labs and tests (DiagnosticReport, DocumentReference)

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-53689
<img width="914" alt="Screenshot 2024-02-28 at 2 38 53 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/107576133/005cd3a2-4556-4f7f-8037-3f00e13628a5">

## Testing done
All medical records tests involving a search type call have been modified to use the "not entered in error" flag, respective to their usage of the flag by domain. 

All domains were manually tested to verify the usability of the flag. Labs/tests and health conditions could only be verified to the extent of not causing errors because there is no data available to verify for them at this time. 

## Screenshots
No UI changes.

## What areas of the site does it impact?
MHV Medical records

## Acceptance criteria
AC1  "not entered-in-error" has been added to the search criteria when requesting lists of MRs

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
