### PR TITLE
Remove surviving dependent as first party for 21-0966

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -221,7 +221,7 @@ module SimpleFormsApi
       end
 
       def first_party?
-        %w[VETERAN SURVIVING_DEPENDENT].include?(params[:preparer_identification])
+        %w[VETERAN].include?(params[:preparer_identification])
       end
 
       def get_form_id

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -221,7 +221,7 @@ module SimpleFormsApi
       end
 
       def first_party?
-        %w[VETERAN].include?(params[:preparer_identification])
+        params[:preparer_identification] == 'VETERAN'
       end
 
       def get_form_id

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Forms uploader', type: :request do
                 VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_survivor') do
                   VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_compensation_200_response') do
                     fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
-                                                    'vba_21_0966-min.json')
+                                                   'vba_21_0966-min.json')
                     data = JSON.parse(fixture_path.read)
                     data['preparer_identification'] = 'VETERAN'
 

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -110,22 +110,20 @@ RSpec.describe 'Forms uploader', type: :request do
       end
 
       describe 'request with intent to file' do
-        describe 'veteran or surviving dependent' do
-          %w[VETERAN SURVIVING_DEPENDENT].each do |identification|
-            it 'makes the request with an intent to file' do
-              VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response') do
-                VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_pension') do
-                  VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_survivor') do
-                    VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_compensation_200_response') do
-                      fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
-                                                     'vba_21_0966-min.json')
-                      data = JSON.parse(fixture_path.read)
-                      data['preparer_identification'] = identification
+        describe 'veteran' do
+          it 'makes the request with an intent to file' do
+            VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/404_response') do
+              VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_pension') do
+                VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response_survivor') do
+                  VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_compensation_200_response') do
+                    fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
+                                                    'vba_21_0966-min.json')
+                    data = JSON.parse(fixture_path.read)
+                    data['preparer_identification'] = 'VETERAN'
 
-                      post '/simple_forms_api/v1/simple_forms', params: data
+                    post '/simple_forms_api/v1/simple_forms', params: data
 
-                      expect(response).to have_http_status(:ok)
-                    end
+                    expect(response).to have_http_status(:ok)
                   end
                 end
               end


### PR DESCRIPTION
## Summary
This PR modified the definition of `first_party?` to include _only_ veterans (and exclude surviving dependents). This will cause more users to have PDFs generated for them rather than going down the ITF API path.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1086