### PR TITLE
Track user identity for 21-10210

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -3,6 +3,7 @@
 module SimpleFormsApi
   class VBA2110210
     include Virtus.model(nullify_blank: true)
+    STATS_KEY = 'api.simple_forms_api.21_10210'
 
     attribute :data
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -37,7 +37,11 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity; end
+    def track_user_identity
+      identity = "#{data['claimant_type']} #{data['claim_ownership']}"
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('Simple forms api - 21-10210 submission user identity', identity:)
+    end
 
     private
 


### PR DESCRIPTION
## Summary
This PR lets us start tracking user identity for simple forms form 21-10210 in DataDog.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1097
