### PR TITLE
feat: add 1990meb VA Notify confirmation email

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -514,6 +514,10 @@ features:
     actor_type: user
     description: Enables form 40-0247 email submission confirmation (VaNotify)
     enable_in_development: true
+  form1990meb_confirmation_email:
+    actor_type: user
+    description: Enables form 1990meb email submission confirmation (VaNotify)
+    enable_in_development: true
   form5490_confirmation_email:
     actor_type: user
     description: Enables form 5490 email submission confirmation (VaNotify)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1247,6 +1247,9 @@ vanotify:
         form0994_extra_action_confirmation_email: form0994_extra_action_confirmation_email_template_id
         form1990_confirmation_email: form1990_confirmation_email_template_id
         form1990e_confirmation_email: form1990e_confirmation_email_template_id
+        form1990meb_approved_confirmation_email: form1990meb_approved_confirmation_email_template_id
+        form1990meb_offramp_confirmation_email: form1990meb_offramp_confirmation_email_template_id
+        form1990meb_denied_confirmation_email: form1990meb_denied_confirmation_email_template_id
         form1995_confirmation_email: form1995_confirmation_email_template_id
         form21_0972_confirmation_email: form21_0972_confirmation_email_template_id
         form21_10203_confirmation_email: form21_10203_confirmation_email_template_id

--- a/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
@@ -6,6 +6,7 @@ require 'dgi/submission/service'
 require 'dgi/enrollment/service'
 require 'dgi/contact_info/service'
 require 'dgi/exclusion_period/service'
+require 'bgs/service'
 
 module MebApi
   module V0

--- a/modules/meb_api/app/workers/meb_api/v0/submit_1990meb_form_confirmation.rb
+++ b/modules/meb_api/app/workers/meb_api/v0/submit_1990meb_form_confirmation.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+require 'dgi/claimant/service'
+require 'dgi/status/service'
+
+module MebApi
+  module V0
+    class Submit1990mebFormConfirmation
+      include Sidekiq::Worker
+      include SentryLogging
+      sidekiq_options retry: 14
+
+      def perform(user_uuid, email, first_name)
+        @current_user = User.find(user_uuid)
+
+        VANotify::EmailJob.perform_async(
+          email,
+          confirmation_email_template_id,
+          {
+            'first_name' => first_name,
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y')
+          }
+        )
+      end
+
+      private
+
+      def confirmation_email_template_id
+        claimant_service = MebApi::DGI::Claimant::Service.new(@current_user)
+        claimant_response = claimant_service.get_claimant_info
+        claimant_id = claimant_response['claimant_id']
+        claim_status_service = MebApi::DGI::Status::Service.new(@current_user)
+        claim_status_response = claim_status_service.get_claim_status({ latest: false }, claimant_id)
+        claim_status = claim_status_response['claim_status']
+
+        if claim_status.eql? 'ELIGIBLE'
+          Settings.vanotify.services.va_gov.template_id.form1990meb_approved_confirmation_email
+        elsif claim_status.eql? 'DENIED'
+          Settings.vanotify.services.va_gov.template_id.form1990meb_denied_confirmation_email
+        else
+          Settings.vanotify.services.va_gov.template_id.form1990meb_offramp_confirmation_email
+        end
+      end
+    end
+  end
+end

--- a/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
@@ -147,5 +147,113 @@ Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
         end
       end
     end
+
+    describe 'POST /meb_api/v0/submit_claim' do
+      let(:claimant_params) do
+        {
+          form_id: 1,
+          education_benefit: {
+            claimant: {
+              first_name: 'Herbert',
+              middle_name: 'Hoover',
+              last_name: 'Hoover',
+              date_of_birth: '1980-03-11',
+              contact_info: {
+                address_line1: '503 upper park',
+                address_line2: '',
+                city: 'falls church',
+                zipcode: '22046',
+                email_address: 'hhover@test.com',
+                address_type: 'DOMESTIC',
+                mobile_phone_number: '4409938894',
+                country_code: 'US',
+                state_code: 'VA'
+              },
+              notification_method: 'EMAIL'
+            }
+          },
+          relinquished_benefit: {
+            eff_relinquish_date: '2021-10-15',
+            relinquished_benefit: 'Chapter30'
+          },
+          additional_considerations: {
+            active_duty_kicker: 'N/A',
+            academy_rotc_scholarship: 'YES',
+            reserve_kicker: 'N/A',
+            senior_rotc_scholarship: 'YES',
+            active_duty_dod_repay_loan: 'YES'
+          },
+          comments: {
+            disagree_with_service_period: false
+          },
+          direct_deposit: {
+            account_number: '123123123123',
+            account_type: 'savings',
+            routing_number: '123123123'
+          }
+        }
+      end
+
+      context 'confirmation email' do
+        it 'delegates to submit_0994_form_confirmation job' do
+          VCR.use_cassette('dgi/submit_claim') do
+            allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+
+            post '/meb_api/v0/submit_claim', params: claimant_params
+
+            expect(MebApi::V0::Submit1990mebFormConfirmation).to have_received(:perform_async)
+              .with('b2fab2b5-6af0-45e1-a9e2-394347af91ef', 'hhover@test.com', 'HERBERT')
+          end
+        end
+
+        it 'does not delegate when claim submission fails' do
+          VCR.use_cassette('dgi/submit_claim_failure') do
+            allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+
+            response = post '/meb_api/v0/submit_claim', params: claimant_params
+
+            expect(response).to be(503)
+            expect(MebApi::V0::Submit1990mebFormConfirmation).not_to have_received(:perform_async)
+          end
+        end
+
+        it 'does not delegate when feature is disabled' do
+          VCR.use_cassette('dgi/submit_claim') do
+            allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+            Flipper.disable(:form1990meb_confirmation_email)
+
+            post '/meb_api/v0/submit_claim', params: claimant_params
+
+            expect(MebApi::V0::Submit1990mebFormConfirmation).not_to have_received(:perform_async)
+
+            Flipper.enable(:form1990meb_confirmation_email)
+          end
+        end
+
+        it 'does not delegate when email is missing' do
+          VCR.use_cassette('dgi/submit_claim') do
+            claimant_params_without_email = {
+              **claimant_params,
+              education_benefit: {
+                **claimant_params[:education_benefit],
+                claimant: {
+                  **claimant_params[:education_benefit][:claimant],
+                  contact_info: {
+                    **claimant_params[:education_benefit][:claimant][:contact_info],
+                    email_address: nil
+                  }
+                }
+              }
+            }
+
+            allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+
+            post '/meb_api/v0/submit_claim', params: claimant_params_without_email
+
+            expect(MebApi::V0::Submit1990mebFormConfirmation).not_to have_received(:perform_async)
+          end
+        end
+      end
+    end
   end
 end

--- a/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
@@ -198,6 +198,7 @@ Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
         it 'delegates to submit_0994_form_confirmation job' do
           VCR.use_cassette('dgi/submit_claim') do
             allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+            expect_any_instance_of(BGS::Service).to receive(:get_ch33_dd_eft_info).and_return({})
 
             post '/meb_api/v0/submit_claim', params: claimant_params
 
@@ -209,6 +210,7 @@ Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
         it 'does not delegate when claim submission fails' do
           VCR.use_cassette('dgi/submit_claim_failure') do
             allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+            expect_any_instance_of(BGS::Service).to receive(:get_ch33_dd_eft_info).and_return({})
 
             response = post '/meb_api/v0/submit_claim', params: claimant_params
 
@@ -220,6 +222,7 @@ Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
         it 'does not delegate when feature is disabled' do
           VCR.use_cassette('dgi/submit_claim') do
             allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+            expect_any_instance_of(BGS::Service).to receive(:get_ch33_dd_eft_info).and_return({})
             Flipper.disable(:form1990meb_confirmation_email)
 
             post '/meb_api/v0/submit_claim', params: claimant_params
@@ -247,6 +250,7 @@ Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
             }
 
             allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+            expect_any_instance_of(BGS::Service).to receive(:get_ch33_dd_eft_info).and_return({})
 
             post '/meb_api/v0/submit_claim', params: claimant_params_without_email
 

--- a/spec/support/vcr_cassettes/dgi/get_claim_status_denied.yml
+++ b/spec/support/vcr_cassettes/dgi/get_claim_status_denied.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://jenkins.ld.afsp.io:32512/vets-service/v1/claimType/Chapter33/claimants/claimantId
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"796121200"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - removed
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 15 Jun 2022 18:42:37 GMT
+    body:
+      encoding: UTF-8
+      string: '{"claimantId":600000001}'
+  recorded_at: Wed, 15 Jun 2022 18:42:36 GMT
+- request:
+    method: get
+    uri: https://jenkins.ld.afsp.io:32512/vets-service/v1/claimant/600000001/claimType/Chapter33/claimstatus?latest=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - removed
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 15 Jun 2022 18:42:37 GMT
+    body:
+      encoding: UTF-8
+      string: '{"claimantId":600000001,"claimServiceId":99000000113358369,"claimStatus":"DENIED","confirmationNumber":null,"receivedDate":"2022-06-13"}'
+  recorded_at: Thu, 07 Sep 2023 19:36:00 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/dgi/get_claim_status_in_progress.yml
+++ b/spec/support/vcr_cassettes/dgi/get_claim_status_in_progress.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://jenkins.ld.afsp.io:32512/vets-service/v1/claimType/Chapter33/claimants/claimantId
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"796121200"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - removed
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 15 Jun 2022 18:42:37 GMT
+    body:
+      encoding: UTF-8
+      string: '{"claimantId":600000001}'
+  recorded_at: Wed, 15 Jun 2022 18:42:36 GMT
+- request:
+    method: get
+    uri: https://jenkins.ld.afsp.io:32512/vets-service/v1/claimant/600000001/claimType/Chapter33/claimstatus?latest=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - removed
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 15 Jun 2022 18:42:37 GMT
+    body:
+      encoding: UTF-8
+      string: '{"claimantId":600000001,"claimServiceId":99000000113358369,"claimStatus":"IN_PROGRESS","confirmationNumber":null,"receivedDate":"2022-06-13"}'
+  recorded_at: Thu, 07 Sep 2023 19:36:00 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/dgi/submit_claim_failure.yml
+++ b/spec/support/vcr_cassettes/dgi/submit_claim_failure.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://jenkins.ld.afsp.io:32512/vets-service/v1/claimType/Chapter33/claimsubmission
+    body:
+      encoding: UTF-8
+      string: '{"claimant":{"claimantId":99900000200000000,"suffix":"","dateOfBirth":"1970-01-01","firstName":"Hoover","lastName":"Hoover","middleName":"Hoover","notificationMethod":"EMAIL","contactInfo":{"addressLine1":"503
+        upper park","addressLine2":"","city":"falls church","zipcode":"22046","emailAddress":"hhover@test.com","addressType":"DOMESTIC","mobilePhoneNumber":"4409938894","homePhoneNumber":null,"countryCode":"US","stateCode":"VA"},"preferredContact":"EMAIL"},"relinquishedBenefit":{"effRelinquishDate":"2021-10-15","relinquishedBenefit":"Chapter30"},"additionalConsiderations":{"activeDutyKicker":"N/A","reserveKicker":"N/A","academyRotcScholarship":"YES","seniorRotcScholarship":"YES","activeDutyDodRepayLoan":"YES","terminalLeave":null},"comments":{"disagreeWithServicePeriod":true}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - removed
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 424
+      message: 'An unexpected error has occurred'
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 13 Jul 2023 18:43:30 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Thu, 13 Jul 2023 18:43:30 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Summary

- Adds template id settings for form 1990meb confirmation email templates
- Adds trigger for calling new sidekiq 1990meb confirmation email job
- Adds sidekiq job for fetching form 1990meb submission status and sending email
- Adds VCR yml files for test cases

## Related issue(s)
https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/gh/department-of-veterans-affairs/vanotify-team/1010

## Testing done

- Updated education_benefits_spec
- Added spec for new sidekiq job class

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).