### PR TITLE
Try to (somewhat) properly resolve the flaky test in PDFFiller

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -21,8 +21,12 @@ module SimpleFormsApi
       pdftk = PdfForms.new(Settings.binaries.pdftk)
       FileUtils.copy(template_form_path, stamped_template_path)
       PdfStamper.stamp_pdf(stamped_template_path, form, current_loa)
-      pdftk.fill_form(stamped_template_path, generated_form_path, mapped_data, flatten: true)
-      generated_form_path
+      if File.exist? stamped_template_path
+        pdftk.fill_form(stamped_template_path, generated_form_path, mapped_data, flatten: true)
+        generated_form_path
+      else
+        raise "stamped template file does not exist: #{stamped_template_path}"
+      end
     ensure
       Common::FileHelpers.delete_file_if_exists(stamped_template_path) if defined?(stamped_template_path)
     end

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -5,9 +5,7 @@ require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::PdfFiller do
   def self.test_pdf_fill(form_number, test_payload = form_number)
-    xit 'fills out a PDF from a templated JSON file' do
-      # skipping these tests due to inconsistent behavior constantly blocking PRs to master
-
+    it 'fills out a PDF from a templated JSON file' do
       expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
 
       # remove the pdf if it already exists


### PR DESCRIPTION
## Summary
This PR adds a conditional clause to test if a file exists before we try to access it. I'm adding this because we've had a flaky test around this line of the implementation. This change is unlikely to actually fix the flakiness but might make debugging easier.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/77299

## Testing done

Relevant tests are re-enabled.
