### PR TITLE
[dbx-75526.2] add default state to form526 submissions

### DIFF
--- a/db/migrate/20240306150112_add_default_state_to_form526_submissions.rb
+++ b/db/migrate/20240306150112_add_default_state_to_form526_submissions.rb
@@ -1,0 +1,5 @@
+class AddDefaultStateToForm526Submissions < ActiveRecord::Migration[7.0]
+   def up
+     change_column_default :form526_submissions, :aasm_state, 'unprocessed'
+   end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_29_152705) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_06_150112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -603,7 +603,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_29_152705) do
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
     t.string "backup_submitted_claim_id", comment: "*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.This column will be nil for all submissions where a backup submission is not generated.It will have the central mail id for submissions where a backup submission is submitted."
-    t.string "aasm_state"
+    t.string "aasm_state", default: "unprocessed"
     t.index ["saved_claim_id"], name: "index_form526_submissions_on_saved_claim_id", unique: true
     t.index ["submitted_claim_id"], name: "index_form526_submissions_on_submitted_claim_id", unique: true
     t.index ["user_account_id"], name: "index_form526_submissions_on_user_account_id"


### PR DESCRIPTION
## Summary

This is PR 2 of 3 to add state to our `Form526Submission` model.  [It follows the first PR here](https://github.com/department-of-veterans-affairs/vets-api/pull/15736), per the [documentation about migrations and default values here](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-database-migrations#vets-apidatabasemigrations-Good.4)

- *This work is behind a feature toggle (flipper): NO
- add a default value of 'unprocessed' to our form526_submissions table in the `aasm_state` column

**NOTE: this is not a wholeistic solution for end-to-end tracking.** This work simply allows us a persistent, simple, queryable, and non-human-error-prone way to track submission state outside of the normal submission flow, ie remediation.  There is a pretty good chance that this will be replaced in the next year or so with a global UUID for submissions (at least that's the current thinking).

## Related issue(s)

- [Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/75526)
- [First PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15736)
- [Initial PR (deprecated) where the 3 PR structure was requested](https://github.com/department-of-veterans-affairs/vets-api/pull/15240)
- [Feature / Implementation Documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/implementation/form_526_state_machine.md)

## Testing done

- New code is covered by unit tests - No.  tests will be added in the next PR when model logic is added.  there is nothing to test.
- Model instantiated and manipulated, nothing else to test

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
