### PR TITLE
Add flag to enable direct deposit for education benefits

### DIFF
--- a/app/swagger/swagger/requests/profile.rb
+++ b/app/swagger/swagger/requests/profile.rb
@@ -42,8 +42,9 @@ module Swagger
                       has_no_fiduciary_assigned
                       is_not_deceased
                       has_payment_address
+                      is_edu_claim_available
                     ]
-                    property :can_update_direct_deposit, type: :boolean, example: true, description: 'Must be true to view payment account information'
+                    property :can_update_direct_deposit, type: :boolean, example: true, description: 'Must be true to view C&P direct deposit information'
                     property :is_corp_available, type: :boolean, example: true, description: ''
                     property :is_corp_rec_found, type: :boolean, example: true, description: ''
                     property :has_no_bdn_payments, type: :boolean, example: true, description: ''
@@ -54,6 +55,7 @@ module Swagger
                     property :has_no_fiduciary_assigne, type: :boolean, example: true, description: ''
                     property :is_not_decease, type: :boolean, example: true, description: ''
                     property :has_payment_address, type: :boolean, example: true, description: ''
+                    property :is_edu_claim_available, type: :boolean, example: true, description: 'Must be true to view EDU direct deposit information'
                   end
 
                   property :payment_account do

--- a/lib/lighthouse/direct_deposit/control_information.rb
+++ b/lib/lighthouse/direct_deposit/control_information.rb
@@ -15,7 +15,8 @@ module Lighthouse
                     :has_mailing_address,
                     :has_no_fiduciary_assigned,
                     :is_not_deceased,
-                    :has_payment_address
+                    :has_payment_address,
+                    :is_edu_claim_available
     end
   end
 end

--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
       end
     end
 
+    context 'when missing education benefits flag' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('lighthouse/direct_deposit/show/200_missing_edu_flag') do
+          get(:show)
+        end
+
+        expect(response).to have_http_status(:ok)
+
+        json = JSON.parse(response.body)
+        control_info = json['data']['attributes']['control_information']
+        expect(control_info['is_edu_claim_available']).to be_nil
+      end
+    end
+
     context 'when has restrictions' do
       it 'control info has flags set to false' do
         VCR.use_cassette('lighthouse/direct_deposit/show/200_has_restrictions') do

--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
         control_info = json['data']['attributes']['control_information']
 
         expect(control_info['can_update_direct_deposit']).to be(true)
+        expect(control_info['is_edu_claim_available']).to be(true)
       end
 
       it 'does not return errors' do
@@ -65,6 +66,7 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
         json = JSON.parse(response.body)['data']['attributes']
         expect(json['control_information']['can_update_direct_deposit']).to be(false)
         expect(json['control_information']['has_payment_address']).to be(false)
+        expect(json['control_information']['is_edu_claim_available']).to be(false)
       end
     end
 

--- a/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/200_has_restrictions.yml
+++ b/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/200_has_restrictions.yml
@@ -60,6 +60,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"paymentAccount":{"accountType":"CHECKING","accountNumber":"1234567890","financialInstitutionRoutingNumber":"031000503","financialInstitutionName":"WELLS
-        FARGO BANK"},"controlInformation":{"canUpdateDirectDeposit":false,"isCorpAvailable":true,"isCorpRecFound":true,"hasNoBdnPayments":true,"hasIndentity":true,"hasIndex":true,"isCompetent":true,"hasMailingAddress":true,"hasNoFiduciaryAssigned":true,"isNotDeceased":true,"hasPaymentAddress":false}}'
+        FARGO BANK"},"controlInformation":{"canUpdateDirectDeposit":false,"isCorpAvailable":true,"isCorpRecFound":true,"hasNoBdnPayments":true,"hasIndentity":true,"hasIndex":true,"isCompetent":true,"hasMailingAddress":true,"hasNoFiduciaryAssigned":true,"isNotDeceased":true,"hasPaymentAddress":false,"isEduClaimAvailable":false}}'
   recorded_at: Thu, 23 Feb 2023 21:47:59 GMT
 recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/200_missing_edu_flag.yml
+++ b/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/200_missing_edu_flag.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/direct-deposit-management/v1/direct-deposit?icn=1012666073V986297
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Bearer abcdefghijklmnop
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 23 Feb 2023 21:47:59 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      Ratelimit-Remaining:
+      - '58'
+      Ratelimit-Reset:
+      - '7'
+      Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining-Minute:
+      - '58'
+      Content-Language:
+      - en-US
+      Pragma:
+      - no-cache
+      - no-cache
+      X-Kong-Upstream-Latency:
+      - '5345'
+      X-Kong-Proxy-Latency:
+      - '2'
+      Via:
+      - kong/3.0.2
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cache-Control:
+      - no-cache, no-store
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"paymentAccount":{"accountType":"CHECKING","accountNumber":"1234567890","financialInstitutionRoutingNumber":"031000503","financialInstitutionName":"WELLS
+        FARGO BANK"},"controlInformation":{"canUpdateDirectDeposit":true,"isCorpAvailable":true,"isCorpRecFound":true,"hasNoBdnPayments":true,"hasIndentity":true,"hasIndex":true,"isCompetent":true,"hasMailingAddress":true,"hasNoFiduciaryAssigned":true,"isNotDeceased":true,"hasPaymentAddress":true}}'
+  recorded_at: Thu, 23 Feb 2023 21:47:59 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/200_valid.yml
+++ b/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/200_valid.yml
@@ -60,6 +60,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"paymentAccount":{"accountType":"CHECKING","accountNumber":"1234567890","financialInstitutionRoutingNumber":"031000503","financialInstitutionName":"WELLS
-        FARGO BANK"},"controlInformation":{"canUpdateDirectDeposit":true,"isCorpAvailable":true,"isCorpRecFound":true,"hasNoBdnPayments":true,"hasIndentity":true,"hasIndex":true,"isCompetent":true,"hasMailingAddress":true,"hasNoFiduciaryAssigned":true,"isNotDeceased":true,"hasPaymentAddress":true}}'
+        FARGO BANK"},"controlInformation":{"canUpdateDirectDeposit":true,"isCorpAvailable":true,"isCorpRecFound":true,"hasNoBdnPayments":true,"hasIndentity":true,"hasIndex":true,"isCompetent":true,"hasMailingAddress":true,"hasNoFiduciaryAssigned":true,"isNotDeceased":true,"hasPaymentAddress":true,"isEduClaimAvailable":true}}'
   recorded_at: Thu, 23 Feb 2023 21:47:59 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary
Lighthouse will be adding an additional control flag (`isEduClaimAvailable`) to the Direct Deposit API GET response that will be used to determine if a user can add or update Direct Deposit for Education Benefits.


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/76716

## Testing done
Updated disability compensation controller specs.