### PR TITLE
Revert "[DBX-75526.1] add aasm_state column to form526 subs"

### DIFF
--- a/db/migrate/20240229150823_add_state_to_form_526_submissions.rb
+++ b/db/migrate/20240229150823_add_state_to_form_526_submissions.rb
@@ -1,5 +1,0 @@
-class AddStateToForm526Submissions < ActiveRecord::Migration[7.0]
-  def change
-    add_column :form526_submissions, :aasm_state, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_29_152705) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_26_235237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -603,7 +603,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_29_152705) do
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
     t.string "backup_submitted_claim_id", comment: "*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.This column will be nil for all submissions where a backup submission is not generated.It will have the central mail id for submissions where a backup submission is submitted."
-    t.string "aasm_state"
     t.index ["saved_claim_id"], name: "index_form526_submissions_on_saved_claim_id", unique: true
     t.index ["submitted_claim_id"], name: "index_form526_submissions_on_submitted_claim_id", unique: true
     t.index ["user_account_id"], name: "index_form526_submissions_on_user_account_id"


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#15736

[vets-api](https://argocd.vfs.va.gov/applications/vets-api-prod) is failing to sync because of the error:
```
PG::LockNotAvailable: ERROR:  canceling statement due to lock timeout

/app/db/migrate/20240229150823_add_state_to_form_526_submissions.rb:3:in `change'

Caused by:
ActiveRecord::LockWaitTimeout: PG::LockNotAvailable: ERROR:  canceling statement due to lock timeout (ActiveRecord::LockWaitTimeout)
```