### PR TITLE
Disable user profile email in form 40-0247

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
@@ -74,7 +74,7 @@ module SimpleFormsApi
                           when 'vba_40_0247'
                             return unless Flipper.enabled?(:form40_0247_confirmation_email)
 
-                            form40_0247_contact_info(@form_data)
+                            [@form_data['applicant_email'], @form_data.dig('applicant_full_name', 'first')]
                           else
                             [nil, nil]
                           end
@@ -130,12 +130,6 @@ module SimpleFormsApi
       else
         [nil, nil]
       end
-    end
-
-    def form40_0247_contact_info(form_data)
-      # email address is optional field
-      # when email is not entered, use current user's email
-      [form_data['applicant_email'].presence || @user&.va_profile_email, form_data.dig('applicant_full_name', 'first')]
     end
   end
 end

--- a/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
@@ -144,7 +144,7 @@ describe SimpleFormsApi::ConfirmationEmail do
       context 'when user is signed in' do
         let(:user) { create(:user, :loa3) }
 
-        it 'sends the confirmation email' do
+        it 'does not send the confirmation email' do
           allow(VANotify::EmailJob).to receive(:perform_async)
           expect(data['applicant_email']).to be_nil
 
@@ -157,15 +157,7 @@ describe SimpleFormsApi::ConfirmationEmail do
 
           subject.send
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.va_profile_email,
-            'form40_0247_confirmation_email_template_id',
-            {
-              'first_name' => 'JOE',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => 'confirmation_number'
-            }
-          )
+          expect(VANotify::EmailJob).not_to have_received(:perform_async)
         end
       end
 


### PR DESCRIPTION
## Summary

- Form 40-0247's disabled for authentication and doesn't load user data for current session. 
- Decided to send confirmation email only when user fills in email field in the form

## Related issue(s)

- [Jira Ticket](https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/gh/department-of-veterans-affairs/vanotify-team/1225)
- [Previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15614)

## Testing done

- [X] *New code is covered by unit tests*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

