### PR TITLE
Rescue JWT errors in overide method

### DIFF
--- a/app/controllers/concerns/sign_in/audience_validator.rb
+++ b/app/controllers/concerns/sign_in/audience_validator.rb
@@ -24,6 +24,10 @@ module SignIn
       super
     rescue Errors::InvalidAudienceError => e
       render json: { errors: e }, status: :unauthorized
+    rescue Errors::AccessTokenExpiredError => e
+      render json: { errors: e }, status: :forbidden
+    rescue Errors::StandardError => e
+      handle_authenticate_error(e)
     end
 
     private


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Rescue JWT errors in overridden authentication method. These JWT errors are normal they just weren't getting handled correctly. 