### PR TITLE
Swap Redis instance var for global var

### DIFF
--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -2,7 +2,7 @@
 
 # config/coverband.rb NOT in the initializers
 Coverband.configure do |config|
-  config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: Settings.redis.app_data.url))
+  config.store = Coverband::Adapters::RedisStore.new($redis)
   config.logger = Rails.logger
 
   # config options false, true. (defaults to false)

--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -39,7 +39,6 @@ require 'iam_ssoe_oauth/configuration'
 require 'vetext/service'
 
 Rails.application.reloader.to_prepare do
-
   redis_namespace = Redis::Namespace.new('breakers', redis: $redis)
 
   services = [

--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -39,10 +39,8 @@ require 'iam_ssoe_oauth/configuration'
 require 'vetext/service'
 
 Rails.application.reloader.to_prepare do
-  # Read the redis config, create a connection and a namespace for breakers
-  # .to_h because hashes from config_for don't support non-symbol keys
-  redis_options = REDIS_CONFIG[:redis].to_h
-  redis_namespace = Redis::Namespace.new('breakers', redis: Redis.new(redis_options))
+
+  redis_namespace = Redis::Namespace.new('breakers', redis: $redis)
 
   services = [
     DebtManagementCenter::DebtsConfiguration.instance.breakers_service,

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -8,9 +8,7 @@ class Rack::Attack
     end
   end
 
-  # .to_h because hashes from config_for don't support non-symbol keys
-  redis_options = REDIS_CONFIG[:redis].to_h
-  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.new(redis_options))
+  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new($redis)
 
   throttle('example/ip', limit: 1, period: 5.minutes) do |req|
     req.ip if req.path == '/v0/limited'

--- a/modules/meb_api/config/initializers/breakers.rb
+++ b/modules/meb_api/config/initializers/breakers.rb
@@ -10,7 +10,6 @@ require 'dgi/submission/configuration'
 require 'dgi/letters/configuration'
 
 Rails.application.reloader.to_prepare do
-
   redis_namespace = Redis::Namespace.new('breakers', redis: $redis)
 
   services = [

--- a/modules/meb_api/config/initializers/breakers.rb
+++ b/modules/meb_api/config/initializers/breakers.rb
@@ -10,10 +10,8 @@ require 'dgi/submission/configuration'
 require 'dgi/letters/configuration'
 
 Rails.application.reloader.to_prepare do
-  # Read the redis config, create a connection and a namespace for breakers
-  # .to_h because hashes from config_for don't support non-symbol keys
-  redis_options = REDIS_CONFIG[:redis].to_h
-  redis_namespace = Redis::Namespace.new('breakers', redis: Redis.new(redis_options))
+
+  redis_namespace = Redis::Namespace.new('breakers', redis: $redis)
 
   services = [
     MebApi::DGI::Configuration.instance.breakers_service,

--- a/modules/mobile/spec/services/messaging_client_spec.rb
+++ b/modules/mobile/spec/services/messaging_client_spec.rb
@@ -23,7 +23,7 @@ describe Mobile::V0::Messaging::Client do
                                      .to_return(status: 200, headers: { 'Token' => 'abcd1234z' })
         svc = Mobile::V0::Messaging::Client.new(session: { user_id: })
         svc.authenticate
-        expect(Redis.new.get(key)).to be_truthy
+        expect($redis.get(key)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
## Summary

- Some files particularly several initializers created a new redis instance based on `config/redis.yml`. Instead they should use the global instance variable `$redis`
- Changed `Redis.new(REDIS_CONFIG[:redis].to_hash)` to `$redis` 

## Testing done

- Full suite of tests passed 

## Acceptance criteria

- [ ] Cached values can be set, retrieved, deleted, etc
