### PR TITLE
Remove 'Build AMI' and 'Deploy Staging' steps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@ Dockerfile-k8s @department-of-veterans-affairs/backend-review-group
 docker-compose* @department-of-veterans-affairs/backend-review-group
 Gemfile @department-of-veterans-affairs/backend-review-group
 Gemfile.lock @department-of-veterans-affairs/backend-review-group
+Jenkinsfile @department-of-veterans-affairs/backend-review-group
 Makefile @department-of-veterans-affairs/backend-review-group
 app/controllers/appeals_base_controller.rb @department-of-veterans-affairs/backend-review-group
 app/controllers/appeals_base_controller_v1.rb @department-of-veterans-affairs/backend-review-group

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,36 +41,6 @@ pipeline {
         ], wait: false
       }
     }
-
-    stage('Build AMI') {
-      when { anyOf { branch staging_branch; branch main_branch } }
-
-      steps {
-        // hack to get the commit hash, some plugin is swallowing git variables and I can't figure out which one
-        script {
-          commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
-        }
-
-        build job: 'builds/vets-api', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit),
-          booleanParam(name: 'release', value: false),
-        ], wait: true
-      }
-    }
-
-    stage('Deploy staging') {
-      when { branch staging_branch }
-
-      steps {
-        build job: 'deploys/vets-api-server-vagov-staging', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          booleanParam(name: 'migration_status', value: true),
-          stringParam(name: 'ref', value: commit),
-        ], wait: false
-
-      }
-    }
   }
   post {
     always {


### PR DESCRIPTION
this has been failing on [commits to master](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) because we deleted the vets-api build (on purpose). This CI action is not needed.

![image](https://github.com/department-of-veterans-affairs/vets-api/assets/41602677/8971efff-0649-4a38-b211-8ba4f107dd2f)
