### PR TITLE
Set feature toggle actor_type to cookie_id

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -448,6 +448,10 @@ features:
     actor_type: user
     description: Enables new review page navigation for users completing the Financial Status Report (FSR) form.
     enable_in_development: true
+  find_a_representative_enabled:
+    actor_type: cookie_id
+    description: Generic toggle for gating Find a Rep
+    enable_in_development: true
   find_a_representative_enable_api:
     actor_type: user
     description: Enables all Find a Representative api endpoints


### PR DESCRIPTION
## Summary

- find_a_representative_enabled actor_type is now cookie_id

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77825
