### PR TITLE
[CST] [DDL] Added document type metadata logging to DDL and added a unit test for it

### DIFF
--- a/app/controllers/v0/claim_letters_controller.rb
+++ b/app/controllers/v0/claim_letters_controller.rb
@@ -9,6 +9,7 @@ module V0
 
     def index
       docs = service.get_letters
+      log_metadata_to_datadog(docs)
 
       render json: docs
     end
@@ -38,6 +39,16 @@ module V0
       doctypes << '706' if Flipper.enabled?(:cst_include_ddl_5103_letters, @current_user)
       doctypes << '858' if Flipper.enabled?(:cst_include_ddl_5103_letters, @current_user)
       doctypes
+    end
+
+    def log_metadata_to_datadog(docs)
+      docs_metadata = []
+      docs.each do |d|
+        docs_metadata << { doc_type: d[:doc_type], type_description: d[:type_description] }
+      end
+      ::Rails.logger.info('DDL Document Types Metadata',
+                          { message_type: 'ddl.doctypes_metadata',
+                            document_type_metadata: docs_metadata })
     end
   end
 end

--- a/spec/controllers/v0/claim_letters_controller_spec.rb
+++ b/spec/controllers/v0/claim_letters_controller_spec.rb
@@ -92,4 +92,40 @@ RSpec.describe V0::ClaimLettersController, type: :controller do
       expect(response.header['Content-Disposition']).to include("filename=\"#{filename}\"")
     end
   end
+
+  context 'DDL Logging' do
+    before do
+      Flipper.enable(:cst_include_ddl_5103_letters)
+      Flipper.enable(:cst_include_ddl_boa_letters)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it 'logs metadata of document types to DataDog' do
+      get(:index)
+      expect(Rails.logger)
+        .to have_received(:info)
+        .with('DDL Document Types Metadata',
+              { message_type: 'ddl.doctypes_metadata',
+                document_type_metadata: [
+                  { doc_type: '27',
+                    type_description: 'Board Of Appeals Decision Letter' },
+                  { doc_type: '858',
+                    type_description: 'Custom 5103 Notice' },
+                  { doc_type: '706',
+                    type_description: '5103/DTA Letter' },
+                  { doc_type: '184',
+                    type_description: 'Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)' },
+                  { doc_type: '184',
+                    type_description: 'Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)' },
+                  { doc_type: '184',
+                    type_description: 'Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)' },
+                  { doc_type: '704',
+                    type_description: 'Standard 5103 Notice' },
+                  { doc_type: '184',
+                    type_description: 'Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)' },
+                  { doc_type: '184',
+                    type_description: 'Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)' }
+                ] })
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Added DataDog logging into DDL so we can track that the descriptions of the documents found within their metadata matches what we think those doctypes should be.

Fulfills what's requested by this ticket: [Log metadata of document type for each DDL document to DataDog](https://github.com/department-of-veterans-affairs/va.gov-team/issues/77937)

## Related issue(s)

- [Log metadata of document type for each DDL document to DataDog](https://github.com/department-of-veterans-affairs/va.gov-team/issues/77937)

## Testing done

- [x] *New code is covered by unit tests*

