### PR TITLE
Change EP400 Merge special issue to EMP

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -15,7 +15,7 @@ module Form526ClaimFastTrackingConcern
 
   DISABILITIES_WITH_MAX_CFI = [ClaimFastTracking::DiagnosticCodes::TINNITUS].freeze
   EP_MERGE_BASE_CODES = %w[010 110 020 030 040].freeze
-  EP_MERGE_SPECIAL_ISSUE = 'RRD'
+  EP_MERGE_SPECIAL_ISSUE = 'EMP'
   OPEN_STATUSES = ['CLAIM RECEIVED', 'UNDER REVIEW', 'GATHERING OF EVIDENCE', 'REVIEW OF EVIDENCE'].freeze
 
   def send_rrd_alert_email(subject, message, error = nil, to = Settings.rrd.alerts.recipients)

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
               end
               submission.reload
               expect(submission.read_metadata(:ep_merge_pending_claim_id)).to eq('600114692') # from claims.yml
-              expect(submission.disabilities.first).to include('specialIssues' => ['RRD'])
+              expect(submission.disabilities.first).to include('specialIssues' => ['EMP'])
               expect(Flipper).to have_received(:enabled?).with(:disability_526_ep_merge_api, User).once
             end
           end


### PR DESCRIPTION
## Summary
- This work is behind a feature toggle: `disability_526_ep_merge_api`
- This PR changes the name of the special issue used to identify claims eligible for EP400 Merge. The new and final value of the special issue will be `EMP`. For context, see the nearly-identical previous PR #15654
- I am part of the Claims Fast-Tracking crew's Employee Experience team. We work closely with the Disability Experience team which owns this code.

## Related issue(s)
- department-of-veterans-affairs/abd-vro#2641
- department-of-veterans-affairs/abd-vro#2646

## Testing done
- [x] Updated existing specs to reflect the updated special issue
- Prior to this change, the old behavior would add an `RRD` special issue to eligible claims.
- The Employee Exp team will be conducting end-to-end testing with the VRO team to verify that everything is working.

## What areas of the site does it impact?
- No behavior change

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
