### PR TITLE
Convert uploads controller log to a preferable format

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -113,8 +113,8 @@ module SimpleFormsApi
           SimpleFormsApi::PdfStamper.stamp4010007_uuid(confirmation_number) if form_id == 'vba_40_10007'
 
           Rails.logger.info(
-            "Simple forms api - sent to benefits intake: #{params[:form_number]},
-              status: #{status}, uuid #{confirmation_number}"
+            'Simple forms api - sent to benefits intake',
+            { form_number: params[:form_number], status:, uuid: confirmation_number }
           )
         end
 


### PR DESCRIPTION
## Summary
This PR partially reverts an unintentional change whereby a log was switched back from including a hash to being string interpolated. I prefer the hash format.