### PR TITLE
VAOS Add Feature Toggle for MAP STS OAuth Token

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1044,6 +1044,10 @@ features:
     actor_type: user
     description: Allows updates to the static landing widget on the Public Websites page
     enable_in_development: true
+  va_online_scheduling_sts_oauth_token:
+    actor_type: user
+    description: Allows toggling of MAP STS OAuth token for VAOS
+    enable_in_development: true
   va_online_scheduling_GA4_migration:
     actor_type: user
     description: Toggle for the GA4 events migration work.


### PR DESCRIPTION
## Summary

This adds a feature toggle,  **va_online_scheduling_sts_oauth_token** , for work needed to replace the current JWT token with the new MAP STS OAuth token service.

The feature toggle flag will be removed once the current VAOS JWT token service is replaced with the MAP STS OAuth service.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/76148
