### PR TITLE
Add a fallback zip code for 20-10207

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -28,7 +28,7 @@ module SimpleFormsApi
         'veteranFirstName' => @data.dig('veteran_full_name', 'first'),
         'veteranLastName' => @data.dig('veteran_full_name', 'last'),
         'fileNumber' => @data.dig('veteran_id', 'va_file_number').presence || @data.dig('veteran_id', 'ssn'),
-        'zipCode' => @data.dig('veteran_mailing_address', 'postal_code'),
+        'zipCode' => @data.dig('veteran_mailing_address', 'postal_code').presence || '00000',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP'


### PR DESCRIPTION
## Summary
Some paths for this form, 20-10207, do not involve the user giving their zip code. Therefore we need a fallback of `00000` so that metadata passes validation.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/910
