### PR TITLE
Coverband Config with Redis

### DIFF
--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -2,7 +2,7 @@
 
 # config/coverband.rb NOT in the initializers
 Coverband.configure do |config|
-  config.store = Coverband::Adapters::RedisStore.new($redis)
+  config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: Settings.redis.app_data.url))
   config.logger = Rails.logger
 
   # config options false, true. (defaults to false)


### PR DESCRIPTION
## Summary

- Fix redis instantiation in coverband config file (revert to previous)

## Related issue(s)

- None

## Testing done

- Manual testing

## Acceptance criteria

- [X]  Coverband correctly loads at `/coverband`

