### PR TITLE
Created a VANotify status endpoint for Pension IPF Notification

### DIFF
--- a/app/controllers/v1/pension_ipf_callbacks_controller.rb
+++ b/app/controllers/v1/pension_ipf_callbacks_controller.rb
@@ -27,12 +27,12 @@ module V1
         begin
           PensionIpfNotification.create!(payload:)
         rescue ActiveRecord::RecordInvalid => e
-          log_formatted(**log_params.merge(is_success: false), params: { exception_message: e.message })
+          log_formatted(**log_params(payload).merge(is_success: false), params: { exception_message: e.message })
           return render json: { message: 'failed' }
         end
       end
 
-      log_formatted(**log_params.merge(is_success: true))
+      log_formatted(**log_params(payload).merge(is_success: true))
       render json: { message: 'success' }
     end
 
@@ -60,7 +60,7 @@ module V1
       Settings.dig(:pension_ipf_vanotify_status_callback, :bearer_token)
     end
 
-    def log_params
+    def log_params(payload)
       {
         key: :callbacks,
         form_id: '21P-527EZ',

--- a/app/controllers/v1/pension_ipf_callbacks_controller.rb
+++ b/app/controllers/v1/pension_ipf_callbacks_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'decision_review_v1/utilities/logging_utils'
+
+module V1
+  class PensionIpfCallbacksController < ApplicationController
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+    include DecisionReviewV1::Appeals::LoggingUtils
+
+    service_tag 'pension-ipf-callbacks'
+
+    skip_before_action :verify_authenticity_token, only: [:create]
+    skip_before_action :authenticate, only: [:create]
+    skip_after_action :set_csrf_header, only: [:create]
+    before_action :authenticate_header, only: [:create]
+
+    STATUSES_TO_IGNORE = %w[sent delivered temporary-failure].freeze
+
+    def create
+      return render json: nil, status: :not_found unless Flipper.enabled? :pension_ipf_callbacks_endpoint
+
+      payload = JSON.parse(request.body.string)
+
+      log_params = {
+        key: :callbacks,
+        form_id: '21P-527EZ',
+        user_uuid: nil,
+        upstream_system: 'VANotify',
+        body: payload.merge('to' => '<FILTERED>') # scrub PII from logs
+      }
+
+      # save encrypted request body in database table for non-successful notifications
+      payload_status = payload['status']&.downcase
+      if STATUSES_TO_IGNORE.exclude? payload_status
+        begin
+          PensionIpfNotification.create!(payload:)
+        rescue ActiveRecord::RecordInvalid => e
+          log_formatted(**log_params.merge(is_success: false), params: { exception_message: e.message })
+          return render json: { message: 'failed' }
+        end
+      end
+
+      log_formatted(**log_params.merge(is_success: true))
+      render json: { message: 'success' }
+    end
+
+    private
+
+    def authenticate_header
+      authenticate_user_with_token || authenticity_error
+    end
+
+    def authenticate_user_with_token
+      Rails.logger.info('pension-ipf-callbacks-69766 - Received request, authenticating')
+      authenticate_with_http_token do |token|
+        return false if bearer_token_secret.nil?
+
+        token == bearer_token_secret
+      end
+    end
+
+    def authenticity_error
+      Rails.logger.info('pension-ipf-callbacks-69766 - Failed to authenticate request')
+      render json: { message: 'Invalid credentials' }, status: :unauthorized
+    end
+
+    def bearer_token_secret
+      Settings.dig(:pension_ipf_vanotify_status_callback, :bearer_token)
+    end
+  end
+end

--- a/app/controllers/v1/pension_ipf_callbacks_controller.rb
+++ b/app/controllers/v1/pension_ipf_callbacks_controller.rb
@@ -21,14 +21,6 @@ module V1
 
       payload = JSON.parse(request.body.string)
 
-      log_params = {
-        key: :callbacks,
-        form_id: '21P-527EZ',
-        user_uuid: nil,
-        upstream_system: 'VANotify',
-        body: payload.merge('to' => '<FILTERED>') # scrub PII from logs
-      }
-
       # save encrypted request body in database table for non-successful notifications
       payload_status = payload['status']&.downcase
       if STATUSES_TO_IGNORE.exclude? payload_status
@@ -66,6 +58,16 @@ module V1
 
     def bearer_token_secret
       Settings.dig(:pension_ipf_vanotify_status_callback, :bearer_token)
+    end
+
+    def log_params
+      {
+        key: :callbacks,
+        form_id: '21P-527EZ',
+        user_uuid: nil,
+        upstream_system: 'VANotify',
+        body: payload.merge('to' => '<FILTERED>') # scrub PII from logs
+      }
     end
   end
 end

--- a/app/models/pension_ipf_notification.rb
+++ b/app/models/pension_ipf_notification.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'json_marshal/marshaller'
+
+class PensionIpfNotification < ApplicationRecord
+  serialize :payload, JsonMarshal::Marshaller
+
+  has_kms_key
+  has_encrypted :payload, key: :kms_key, **lockbox_options
+
+  validates(:payload, presence: true)
+
+  before_save :serialize_payload
+
+  private
+
+  def serialize_payload
+    self.payload = payload.to_json unless payload.is_a?(String)
+  end
+end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1285,6 +1285,10 @@ features:
     actor_type: user
     description: NOD VANotify notification callbacks endpoint
     enable_in_development: true
+  pension_ipf_callbacks_endpoint:
+    actor_type: user
+    description: Pension IPF VANotify notification callbacks endpoint
+    enable_in_development: true
   hlr_browser_monitoring_enabled:
     actor_type: user
     description: HLR Datadog RUM monitoring

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -437,6 +437,7 @@ Rails.application.routes.draw do
 
     scope format: false do
       resources :nod_callbacks, only: [:create]
+      resources :pension_ipf_callbacks, only: [:create]
     end
   end
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -428,3 +428,6 @@ travel_pay:
   subscription_key: 'api_key'
   base_url: 'https://btsss.gov'
   service_name: 'BTSSS-API'
+
+pension_ipf_vanotify_status_callback:
+  bearer_token: bearer_token_secret

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,13 +22,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "account_login_stats", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "idme_at"
-    t.datetime "myhealthevet_at"
-    t.datetime "dslogon_at"
+    t.datetime "idme_at", precision: nil
+    t.datetime "myhealthevet_at", precision: nil
+    t.datetime "dslogon_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "current_verification"
-    t.datetime "logingov_at"
+    t.datetime "logingov_at", precision: nil
     t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
     t.index ["current_verification"], name: "index_account_login_stats_on_current_verification"
     t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
@@ -42,8 +42,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "idme_uuid"
     t.string "icn"
     t.string "edipi"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "sec_id"
     t.string "logingov_uuid"
     t.index ["icn"], name: "index_accounts_on_icn"
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -119,8 +119,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "appeals_api_higher_level_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status", default: "pending", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "code"
     t.string "detail"
     t.string "source"
@@ -157,7 +157,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "to"
     t.string "statusable_type"
     t.string "statusable_id"
-    t.datetime "status_update_time"
+    t.datetime "status_update_time", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code"
@@ -191,8 +191,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status"
     t.string "transaction_id"
     t.string "transaction_status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -220,8 +220,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.jsonb "feedback"
     t.jsonb "access"
     t.string "fingerprint"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.boolean "mobile"
     t.string "active_status"
@@ -242,8 +242,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "claims_api_auto_established_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.integer "evss_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "md5"
     t.string "source"
     t.string "flashes", default: [], array: true
@@ -296,8 +296,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status"
     t.string "current_poa"
     t.string "md5"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "vbms_new_document_version_ref_id"
     t.string "vbms_document_series_ref_id"
     t.string "vbms_error_message"
@@ -314,8 +314,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "auto_established_claim_id"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -350,8 +350,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "email_confirmation_id"
     t.string "enrollment_id"
     t.string "batch_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "raw_form_data_ciphertext"
     t.text "eligibility_info_ciphertext"
     t.text "form_data_ciphertext"
@@ -365,8 +365,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
     t.string "sid"
     t.uuid "account_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "expanded", default: false, null: false
     t.boolean "sequestered", default: false, null: false
     t.string "email_confirmation_id"
@@ -376,6 +376,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "encrypted_kms_key"
     t.index ["account_id", "created_at"], name: "index_covid_vaccine_registry_submissions_2"
     t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true
+  end
+
+  create_table "credential_adoption_email_records", force: :cascade do |t|
+    t.string "icn", null: false
+    t.string "email_address", null: false
+    t.string "email_template_id", null: false
+    t.datetime "email_triggered_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_address"], name: "index_credential_adoption_email_records_on_email_address"
+    t.index ["email_template_id"], name: "index_credential_adoption_email_records_on_email_template_id"
+    t.index ["icn"], name: "index_credential_adoption_email_records_on_icn"
   end
 
   create_table "deprecated_user_accounts", force: :cascade do |t|
@@ -414,8 +426,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "code", null: false
     t.string "medical_term", null: false
     t.string "lay_term"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["code"], name: "index_disability_contentions_on_code", unique: true
     t.index ["lay_term"], name: "index_disability_contentions_on_lay_term", opclass: :gin_trgm_ops, using: :gin
     t.index ["medical_term"], name: "index_disability_contentions_on_medical_term", opclass: :gin_trgm_ops, using: :gin
@@ -426,19 +438,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "unit"
     t.geography "polygon", limit: {:srid=>4326, :type=>"st_polygon", :geographic=>true}, null: false
     t.string "vha_facility_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "min"
     t.integer "max"
-    t.datetime "vssc_extract_date", default: "2001-01-01 00:00:00"
+    t.datetime "vssc_extract_date", precision: nil, default: "2001-01-01 00:00:00"
     t.index ["polygon"], name: "index_drivetime_bands_on_polygon", using: :gist
   end
 
   create_table "education_benefits_claims", id: :serial, force: :cascade do |t|
-    t.datetime "submitted_at"
-    t.datetime "processed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "submitted_at", precision: nil
+    t.datetime "processed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "regional_processing_office", null: false
     t.string "form_type", default: "1990"
     t.integer "saved_claim_id", null: false
@@ -451,8 +463,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "education_benefits_submissions", id: :serial, force: :cascade do |t|
     t.string "region", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "chapter33", default: false, null: false
     t.boolean "chapter30", default: false, null: false
     t.boolean "chapter1606", default: false, null: false
@@ -478,8 +490,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.datetime "updated_at", null: false
     t.boolean "poa"
     t.integer "remaining_entitlement"
-    t.datetime "denial_email_sent_at"
-    t.datetime "confirmation_email_sent_at"
+    t.datetime "denial_email_sent_at", precision: nil
+    t.datetime "confirmation_email_sent_at", precision: nil
     t.text "auth_headers_json_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -491,8 +503,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "evss_claims", id: :serial, force: :cascade do |t|
     t.integer "evss_id", null: false
     t.json "data", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "user_uuid", null: false
     t.json "list_data", default: {}, null: false
     t.boolean "requested_decision", default: false, null: false
@@ -509,8 +521,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "gate_name"
     t.string "value"
     t.string "user"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["feature_name"], name: "index_feature_toggle_events_on_feature_name"
   end
 
@@ -523,12 +535,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.datetime "updated_at", null: false
     t.datetime "flagged_value_updated_at"
     t.index ["ip_address", "representative_id", "flag_type", "flagged_value_updated_at"], name: "index_unique_constraint_fields", unique: true
+    t.index ["ip_address", "representative_id", "flag_type"], name: "index_unique_flagged_veteran_representative", unique: true
   end
 
   create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
@@ -536,14 +549,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "feature_key", null: false
     t.string "key", null: false
     t.text "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
     t.string "carma_case_id", limit: 18, null: false
-    t.datetime "accepted_at", null: false
+    t.datetime "accepted_at", precision: nil, null: false
     t.json "metadata"
     t.json "attachments"
     t.datetime "created_at", null: false
@@ -570,7 +583,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status", null: false
     t.string "error_class"
     t.string "error_message"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.jsonb "bgjob_errors", default: {}
     t.index ["bgjob_errors"], name: "index_form526_job_statuses_on_bgjob_errors", using: :gin
     t.index ["form526_submission_id"], name: "index_form526_job_statuses_on_form526_submission_id"
@@ -582,8 +595,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "saved_claim_id", null: false
     t.integer "submitted_claim_id"
     t.boolean "workflow_complete", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "multiple_birls", comment: "*After* a SubmitForm526 Job fails, a lookup is done to see if the veteran has multiple BIRLS IDs. This field gets set to true if that is the case. If the initial submit job succeeds, this field will remain false whether or not the veteran has multiple BIRLS IDs --so this field cannot technically be used to sum all Form526 veterans that have multiple BIRLS. This field /can/ give us an idea of how often having multiple BIRLS IDs is a problem."
     t.text "auth_headers_json_ciphertext"
     t.text "form_json_ciphertext"
@@ -615,8 +628,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "form_attachments", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "guid", null: false
     t.string "type", null: false
     t.text "file_data_ciphertext"
@@ -658,9 +671,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "edipi", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.datetime "dob", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "dob", precision: nil, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "ssn_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["edipi"], name: "index_gibs_not_found_users_on_edipi"
@@ -682,15 +695,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "msa", null: false
     t.string "msa_name"
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
 
   create_table "health_care_applications", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "pending", null: false
     t.string "form_submission_id_string"
     t.string "timestamp"
@@ -712,18 +725,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "id_card_announcement_subscriptions", id: :serial, force: :cascade do |t|
     t.string "email", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_id_card_announcement_subscriptions_on_email", unique: true
   end
 
   create_table "in_progress_forms", id: :serial, force: :cascade do |t|
     t.string "user_uuid", null: false
     t.string "form_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.json "metadata"
-    t.datetime "expires_at"
+    t.datetime "expires_at", precision: nil
     t.text "form_data_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -741,19 +754,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|
     t.string "edipi", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["edipi"], name: "index_invalid_letter_address_edipis_on_edipi"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
     t.string "pagerduty_id"
     t.string "external_service"
-    t.datetime "start_time"
-    t.datetime "end_time"
+    t.datetime "start_time", precision: nil
+    t.datetime "end_time", precision: nil
     t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["end_time"], name: "index_maintenance_windows_on_end_time"
     t.index ["pagerduty_id"], name: "index_maintenance_windows_on_pagerduty_id"
     t.index ["start_time"], name: "index_maintenance_windows_on_start_time"
@@ -788,8 +801,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.uuid "handle", null: false
     t.uuid "user_account_id", null: false
     t.string "hashed_refresh_token", null: false
-    t.datetime "refresh_expiration", null: false
-    t.datetime "refresh_creation", null: false
+    t.datetime "refresh_expiration", precision: nil, null: false
+    t.datetime "refresh_creation", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_verification_id", null: false
@@ -825,10 +838,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.uuid "guid"
     t.string "type"
     t.string "form_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "saved_claim_id"
-    t.datetime "completed_at"
+    t.datetime "completed_at", precision: nil
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["guid"], name: "index_persistent_attachments_on_guid", unique: true
@@ -839,8 +852,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "personal_information_logs", id: :serial, force: :cascade do |t|
     t.jsonb "data", null: false
     t.string "error_class", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["created_at"], name: "index_personal_information_logs_on_created_at"
     t.index ["error_class"], name: "index_personal_information_logs_on_error_class"
   end
@@ -852,7 +865,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.bigint "query_hash"
     t.float "total_time"
     t.bigint "calls"
-    t.datetime "captured_at"
+    t.datetime "captured_at", precision: nil
     t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
   end
 
@@ -861,7 +874,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "schema"
     t.text "relation"
     t.bigint "size"
-    t.datetime "captured_at"
+    t.datetime "captured_at", precision: nil
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
@@ -870,22 +883,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "application_uuid"
     t.string "return_description", null: false
     t.integer "return_code"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["application_uuid"], name: "index_preneed_submissions_on_application_uuid", unique: true
     t.index ["tracking_number"], name: "index_preneed_submissions_on_tracking_number", unique: true
   end
 
   create_table "saved_claims", id: :serial, force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "form_id"
     t.uuid "guid", null: false
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.string "uploaded_forms", default: [], array: true
-    t.datetime "itf_datetime"
+    t.datetime "itf_datetime", precision: nil
+    t.string "uploaded_forms", array: true
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
@@ -918,7 +931,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "rpo"
     t.integer "number_of_submissions"
     t.string "filename"
-    t.datetime "successful_at"
+    t.datetime "successful_at", precision: nil
     t.integer "retry_attempt", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -931,8 +944,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "description", null: false
     t.integer "state_id", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -952,7 +965,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "add_ninety_day_hospital_copay"
     t.integer "outpatient_basic_care_copay"
     t.integer "outpatient_specialty_copay"
-    t.datetime "threshold_effective_date"
+    t.datetime "threshold_effective_date", precision: nil
     t.integer "aid_and_attendance_threshold"
     t.integer "outpatient_preventive_copay"
     t.integer "medication_copay"
@@ -963,8 +976,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "inpatient_per_diem"
     t.string "description"
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -975,8 +988,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "fips_code", null: false
     t.integer "country_id", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -988,8 +1001,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "state_id", null: false
     t.integer "county_number", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -1005,8 +1018,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "test_user_dashboard_tud_account_availability_logs", force: :cascade do |t|
     t.string "account_uuid"
-    t.datetime "checkout_time"
-    t.datetime "checkin_time"
+    t.datetime "checkout_time", precision: nil
+    t.datetime "checkin_time", precision: nil
     t.boolean "has_checkin_error"
     t.boolean "is_manual_checkin"
     t.datetime "created_at", null: false
@@ -1020,12 +1033,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "middle_name"
     t.string "last_name"
     t.string "gender"
-    t.datetime "birth_date"
+    t.datetime "birth_date", precision: nil
     t.integer "ssn"
     t.string "phone"
     t.string "email"
     t.string "password"
-    t.datetime "checkout_time"
+    t.datetime "checkout_time", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "services"
@@ -1038,8 +1051,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "user_acceptable_verified_credentials", force: :cascade do |t|
-    t.datetime "acceptable_verified_credential_at"
-    t.datetime "idme_verified_credential_at"
+    t.datetime "acceptable_verified_credential_at", precision: nil
+    t.datetime "idme_verified_credential_at", precision: nil
     t.uuid "user_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1070,7 +1083,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "logingov_uuid"
     t.string "mhv_uuid"
     t.string "dslogon_uuid"
-    t.datetime "verified_at"
+    t.datetime "verified_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "backing_idme_uuid"
@@ -1092,15 +1105,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.date "last_revision_on"
     t.integer "pages"
     t.string "sha256"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "valid_pdf", default: false
     t.text "form_usage"
     t.text "form_tool_intro"
     t.string "form_tool_url"
     t.string "form_type"
     t.string "language"
-    t.datetime "deleted_at"
+    t.datetime "deleted_at", precision: nil
     t.string "related_forms", array: true
     t.jsonb "benefit_categories"
     t.string "form_details_url"
@@ -1147,8 +1160,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "s3_deleted"
     t.string "consumer_name"
     t.uuid "consumer_id"
@@ -1159,6 +1172,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.index ["guid"], name: "index_vba_documents_upload_submissions_on_guid"
     t.index ["s3_deleted"], name: "index_vba_documents_upload_submissions_on_s3_deleted"
     t.index ["status"], name: "index_vba_documents_upload_submissions_on_status"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at", precision: nil
+    t.text "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   create_table "veteran_device_records", force: :cascade do |t|
@@ -1176,8 +1200,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "name"
     t.string "phone"
     t.string "state", limit: 2
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "address_type"
     t.string "city"
     t.string "country_code_iso3"
@@ -1207,8 +1231,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "last_name"
     t.string "email"
     t.string "phone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "poa_codes", default: [], array: true
     t.string "user_types", default: [], array: true
     t.text "ssn_ciphertext"
@@ -1242,8 +1266,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "vic_submissions", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "pending", null: false
     t.uuid "guid", null: false
     t.json "response"
@@ -1273,10 +1297,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "vye_awards", force: :cascade do |t|
     t.integer "user_info_id"
     t.string "cur_award_ind"
-    t.datetime "award_begin_date"
-    t.datetime "award_end_date"
+    t.datetime "award_begin_date", precision: nil
+    t.datetime "award_end_date", precision: nil
     t.integer "training_time"
-    t.datetime "payment_date"
+    t.datetime "payment_date", precision: nil
     t.decimal "monthly_rate"
     t.string "begin_rsn"
     t.string "end_rsn"
@@ -1313,7 +1337,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "ssn_ciphertext"
     t.string "claim_no_ciphertext"
     t.string "doc_type"
-    t.datetime "queue_date"
+    t.datetime "queue_date", precision: nil
     t.string "rpo"
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
@@ -1339,9 +1363,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "stub_nm_ciphertext"
     t.string "mr_status"
     t.string "rem_ent"
-    t.datetime "cert_issue_date"
-    t.datetime "del_date"
-    t.datetime "date_last_certified"
+    t.datetime "cert_issue_date", precision: nil
+    t.datetime "del_date", precision: nil
+    t.datetime "date_last_certified", precision: nil
     t.integer "rpo_code"
     t.string "fac_code"
     t.decimal "payment_amt"
@@ -1371,8 +1395,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "change_flag"
     t.integer "rpo_code"
     t.boolean "rpo_flag"
-    t.datetime "act_begin"
-    t.datetime "act_end"
+    t.datetime "act_begin", precision: nil
+    t.datetime "act_end", precision: nil
     t.string "source_ind"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -378,18 +378,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true
   end
 
-  create_table "credential_adoption_email_records", force: :cascade do |t|
-    t.string "icn", null: false
-    t.string "email_address", null: false
-    t.string "email_template_id", null: false
-    t.datetime "email_triggered_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email_address"], name: "index_credential_adoption_email_records_on_email_address"
-    t.index ["email_template_id"], name: "index_credential_adoption_email_records_on_email_template_id"
-    t.index ["icn"], name: "index_credential_adoption_email_records_on_icn"
-  end
-
   create_table "deprecated_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id"
     t.bigint "user_verification_id"
@@ -1171,17 +1159,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.index ["guid"], name: "index_vba_documents_upload_submissions_on_guid"
     t.index ["s3_deleted"], name: "index_vba_documents_upload_submissions_on_s3_deleted"
     t.index ["status"], name: "index_vba_documents_upload_submissions_on_status"
-  end
-
-  create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
-    t.bigint "item_id", null: false
-    t.string "event", null: false
-    t.string "whodunnit"
-    t.text "object"
-    t.datetime "created_at"
-    t.text "object_changes"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   create_table "veteran_device_records", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,13 +22,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "account_login_stats", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "idme_at", precision: nil
-    t.datetime "myhealthevet_at", precision: nil
-    t.datetime "dslogon_at", precision: nil
+    t.datetime "idme_at"
+    t.datetime "myhealthevet_at"
+    t.datetime "dslogon_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "current_verification"
-    t.datetime "logingov_at", precision: nil
+    t.datetime "logingov_at"
     t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
     t.index ["current_verification"], name: "index_account_login_stats_on_current_verification"
     t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
@@ -42,8 +42,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "idme_uuid"
     t.string "icn"
     t.string "edipi"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "sec_id"
     t.string "logingov_uuid"
     t.index ["icn"], name: "index_accounts_on_icn"
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -119,8 +119,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "appeals_api_higher_level_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status", default: "pending", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "code"
     t.string "detail"
     t.string "source"
@@ -157,7 +157,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "to"
     t.string "statusable_type"
     t.string "statusable_id"
-    t.datetime "status_update_time", precision: nil
+    t.datetime "status_update_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code"
@@ -191,8 +191,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status"
     t.string "transaction_id"
     t.string "transaction_status"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -220,8 +220,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.jsonb "feedback"
     t.jsonb "access"
     t.string "fingerprint"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.boolean "mobile"
     t.string "active_status"
@@ -242,8 +242,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "claims_api_auto_established_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.integer "evss_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "md5"
     t.string "source"
     t.string "flashes", default: [], array: true
@@ -296,8 +296,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status"
     t.string "current_poa"
     t.string "md5"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "vbms_new_document_version_ref_id"
     t.string "vbms_document_series_ref_id"
     t.string "vbms_error_message"
@@ -314,8 +314,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "auto_established_claim_id"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -350,8 +350,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "email_confirmation_id"
     t.string "enrollment_id"
     t.string "batch_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "raw_form_data_ciphertext"
     t.text "eligibility_info_ciphertext"
     t.text "form_data_ciphertext"
@@ -365,8 +365,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
     t.string "sid"
     t.uuid "account_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "expanded", default: false, null: false
     t.boolean "sequestered", default: false, null: false
     t.string "email_confirmation_id"
@@ -382,7 +382,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "icn", null: false
     t.string "email_address", null: false
     t.string "email_template_id", null: false
-    t.datetime "email_triggered_at", precision: nil
+    t.datetime "email_triggered_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_credential_adoption_email_records_on_email_address"
@@ -426,8 +426,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "code", null: false
     t.string "medical_term", null: false
     t.string "lay_term"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["code"], name: "index_disability_contentions_on_code", unique: true
     t.index ["lay_term"], name: "index_disability_contentions_on_lay_term", opclass: :gin_trgm_ops, using: :gin
     t.index ["medical_term"], name: "index_disability_contentions_on_medical_term", opclass: :gin_trgm_ops, using: :gin
@@ -438,19 +438,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "unit"
     t.geography "polygon", limit: {:srid=>4326, :type=>"st_polygon", :geographic=>true}, null: false
     t.string "vha_facility_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "min"
     t.integer "max"
-    t.datetime "vssc_extract_date", precision: nil, default: "2001-01-01 00:00:00"
+    t.datetime "vssc_extract_date", default: "2001-01-01 00:00:00"
     t.index ["polygon"], name: "index_drivetime_bands_on_polygon", using: :gist
   end
 
   create_table "education_benefits_claims", id: :serial, force: :cascade do |t|
-    t.datetime "submitted_at", precision: nil
-    t.datetime "processed_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "submitted_at"
+    t.datetime "processed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "regional_processing_office", null: false
     t.string "form_type", default: "1990"
     t.integer "saved_claim_id", null: false
@@ -463,8 +463,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "education_benefits_submissions", id: :serial, force: :cascade do |t|
     t.string "region", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "chapter33", default: false, null: false
     t.boolean "chapter30", default: false, null: false
     t.boolean "chapter1606", default: false, null: false
@@ -490,8 +490,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.datetime "updated_at", null: false
     t.boolean "poa"
     t.integer "remaining_entitlement"
-    t.datetime "denial_email_sent_at", precision: nil
-    t.datetime "confirmation_email_sent_at", precision: nil
+    t.datetime "denial_email_sent_at"
+    t.datetime "confirmation_email_sent_at"
     t.text "auth_headers_json_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -503,8 +503,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "evss_claims", id: :serial, force: :cascade do |t|
     t.integer "evss_id", null: false
     t.json "data", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "user_uuid", null: false
     t.json "list_data", default: {}, null: false
     t.boolean "requested_decision", default: false, null: false
@@ -521,8 +521,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "gate_name"
     t.string "value"
     t.string "user"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feature_name"], name: "index_feature_toggle_events_on_feature_name"
   end
 
@@ -535,13 +535,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.datetime "updated_at", null: false
     t.datetime "flagged_value_updated_at"
     t.index ["ip_address", "representative_id", "flag_type", "flagged_value_updated_at"], name: "index_unique_constraint_fields", unique: true
-    t.index ["ip_address", "representative_id", "flag_type"], name: "index_unique_flagged_veteran_representative", unique: true
   end
 
   create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
@@ -549,14 +548,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "feature_key", null: false
     t.string "key", null: false
     t.text "value"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
     t.string "carma_case_id", limit: 18, null: false
-    t.datetime "accepted_at", precision: nil, null: false
+    t.datetime "accepted_at", null: false
     t.json "metadata"
     t.json "attachments"
     t.datetime "created_at", null: false
@@ -583,7 +582,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status", null: false
     t.string "error_class"
     t.string "error_message"
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "updated_at", null: false
     t.jsonb "bgjob_errors", default: {}
     t.index ["bgjob_errors"], name: "index_form526_job_statuses_on_bgjob_errors", using: :gin
     t.index ["form526_submission_id"], name: "index_form526_job_statuses_on_form526_submission_id"
@@ -595,8 +594,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "saved_claim_id", null: false
     t.integer "submitted_claim_id"
     t.boolean "workflow_complete", default: false, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "multiple_birls", comment: "*After* a SubmitForm526 Job fails, a lookup is done to see if the veteran has multiple BIRLS IDs. This field gets set to true if that is the case. If the initial submit job succeeds, this field will remain false whether or not the veteran has multiple BIRLS IDs --so this field cannot technically be used to sum all Form526 veterans that have multiple BIRLS. This field /can/ give us an idea of how often having multiple BIRLS IDs is a problem."
     t.text "auth_headers_json_ciphertext"
     t.text "form_json_ciphertext"
@@ -628,8 +627,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "form_attachments", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "guid", null: false
     t.string "type", null: false
     t.text "file_data_ciphertext"
@@ -671,9 +670,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "edipi", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.datetime "dob", precision: nil, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "dob", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "ssn_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["edipi"], name: "index_gibs_not_found_users_on_edipi"
@@ -695,15 +694,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "msa", null: false
     t.string "msa_name"
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
 
   create_table "health_care_applications", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "state", default: "pending", null: false
     t.string "form_submission_id_string"
     t.string "timestamp"
@@ -725,18 +724,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "id_card_announcement_subscriptions", id: :serial, force: :cascade do |t|
     t.string "email", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_id_card_announcement_subscriptions_on_email", unique: true
   end
 
   create_table "in_progress_forms", id: :serial, force: :cascade do |t|
     t.string "user_uuid", null: false
     t.string "form_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.json "metadata"
-    t.datetime "expires_at", precision: nil
+    t.datetime "expires_at"
     t.text "form_data_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -754,19 +753,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|
     t.string "edipi", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["edipi"], name: "index_invalid_letter_address_edipis_on_edipi"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
     t.string "pagerduty_id"
     t.string "external_service"
-    t.datetime "start_time", precision: nil
-    t.datetime "end_time", precision: nil
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.string "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["end_time"], name: "index_maintenance_windows_on_end_time"
     t.index ["pagerduty_id"], name: "index_maintenance_windows_on_pagerduty_id"
     t.index ["start_time"], name: "index_maintenance_windows_on_start_time"
@@ -801,8 +800,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.uuid "handle", null: false
     t.uuid "user_account_id", null: false
     t.string "hashed_refresh_token", null: false
-    t.datetime "refresh_expiration", precision: nil, null: false
-    t.datetime "refresh_creation", precision: nil, null: false
+    t.datetime "refresh_expiration", null: false
+    t.datetime "refresh_creation", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_verification_id", null: false
@@ -838,10 +837,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.uuid "guid"
     t.string "type"
     t.string "form_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "saved_claim_id"
-    t.datetime "completed_at", precision: nil
+    t.datetime "completed_at"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["guid"], name: "index_persistent_attachments_on_guid", unique: true
@@ -852,8 +851,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "personal_information_logs", id: :serial, force: :cascade do |t|
     t.jsonb "data", null: false
     t.string "error_class", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_personal_information_logs_on_created_at"
     t.index ["error_class"], name: "index_personal_information_logs_on_error_class"
   end
@@ -865,7 +864,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.bigint "query_hash"
     t.float "total_time"
     t.bigint "calls"
-    t.datetime "captured_at", precision: nil
+    t.datetime "captured_at"
     t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
   end
 
@@ -874,7 +873,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "schema"
     t.text "relation"
     t.bigint "size"
-    t.datetime "captured_at", precision: nil
+    t.datetime "captured_at"
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
@@ -883,22 +882,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "application_uuid"
     t.string "return_description", null: false
     t.integer "return_code"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["application_uuid"], name: "index_preneed_submissions_on_application_uuid", unique: true
     t.index ["tracking_number"], name: "index_preneed_submissions_on_tracking_number", unique: true
   end
 
   create_table "saved_claims", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "form_id"
     t.uuid "guid", null: false
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.datetime "itf_datetime", precision: nil
-    t.string "uploaded_forms", array: true
+    t.string "uploaded_forms", default: [], array: true
+    t.datetime "itf_datetime"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
@@ -931,7 +930,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "rpo"
     t.integer "number_of_submissions"
     t.string "filename"
-    t.datetime "successful_at", precision: nil
+    t.datetime "successful_at"
     t.integer "retry_attempt", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -944,8 +943,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "description", null: false
     t.integer "state_id", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -965,7 +964,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "add_ninety_day_hospital_copay"
     t.integer "outpatient_basic_care_copay"
     t.integer "outpatient_specialty_copay"
-    t.datetime "threshold_effective_date", precision: nil
+    t.datetime "threshold_effective_date"
     t.integer "aid_and_attendance_threshold"
     t.integer "outpatient_preventive_copay"
     t.integer "medication_copay"
@@ -976,8 +975,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "inpatient_per_diem"
     t.string "description"
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -988,8 +987,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "fips_code", null: false
     t.integer "country_id", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -1001,8 +1000,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "state_id", null: false
     t.integer "county_number", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -1018,8 +1017,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "test_user_dashboard_tud_account_availability_logs", force: :cascade do |t|
     t.string "account_uuid"
-    t.datetime "checkout_time", precision: nil
-    t.datetime "checkin_time", precision: nil
+    t.datetime "checkout_time"
+    t.datetime "checkin_time"
     t.boolean "has_checkin_error"
     t.boolean "is_manual_checkin"
     t.datetime "created_at", null: false
@@ -1033,12 +1032,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "middle_name"
     t.string "last_name"
     t.string "gender"
-    t.datetime "birth_date", precision: nil
+    t.datetime "birth_date"
     t.integer "ssn"
     t.string "phone"
     t.string "email"
     t.string "password"
-    t.datetime "checkout_time", precision: nil
+    t.datetime "checkout_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "services"
@@ -1051,8 +1050,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "user_acceptable_verified_credentials", force: :cascade do |t|
-    t.datetime "acceptable_verified_credential_at", precision: nil
-    t.datetime "idme_verified_credential_at", precision: nil
+    t.datetime "acceptable_verified_credential_at"
+    t.datetime "idme_verified_credential_at"
     t.uuid "user_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1083,7 +1082,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "logingov_uuid"
     t.string "mhv_uuid"
     t.string "dslogon_uuid"
-    t.datetime "verified_at", precision: nil
+    t.datetime "verified_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "backing_idme_uuid"
@@ -1105,15 +1104,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.date "last_revision_on"
     t.integer "pages"
     t.string "sha256"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "valid_pdf", default: false
     t.text "form_usage"
     t.text "form_tool_intro"
     t.string "form_tool_url"
     t.string "form_type"
     t.string "language"
-    t.datetime "deleted_at", precision: nil
+    t.datetime "deleted_at"
     t.string "related_forms", array: true
     t.jsonb "benefit_categories"
     t.string "form_details_url"
@@ -1160,8 +1159,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "s3_deleted"
     t.string "consumer_name"
     t.uuid "consumer_id"
@@ -1180,7 +1179,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at", precision: nil
+    t.datetime "created_at"
     t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
@@ -1200,8 +1199,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "name"
     t.string "phone"
     t.string "state", limit: 2
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "address_type"
     t.string "city"
     t.string "country_code_iso3"
@@ -1231,8 +1230,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "last_name"
     t.string "email"
     t.string "phone"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "poa_codes", default: [], array: true
     t.string "user_types", default: [], array: true
     t.text "ssn_ciphertext"
@@ -1266,8 +1265,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "vic_submissions", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "state", default: "pending", null: false
     t.uuid "guid", null: false
     t.json "response"
@@ -1297,10 +1296,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "vye_awards", force: :cascade do |t|
     t.integer "user_info_id"
     t.string "cur_award_ind"
-    t.datetime "award_begin_date", precision: nil
-    t.datetime "award_end_date", precision: nil
+    t.datetime "award_begin_date"
+    t.datetime "award_end_date"
     t.integer "training_time"
-    t.datetime "payment_date", precision: nil
+    t.datetime "payment_date"
     t.decimal "monthly_rate"
     t.string "begin_rsn"
     t.string "end_rsn"
@@ -1337,7 +1336,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "ssn_ciphertext"
     t.string "claim_no_ciphertext"
     t.string "doc_type"
-    t.datetime "queue_date", precision: nil
+    t.datetime "queue_date"
     t.string "rpo"
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
@@ -1363,9 +1362,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "stub_nm_ciphertext"
     t.string "mr_status"
     t.string "rem_ent"
-    t.datetime "cert_issue_date", precision: nil
-    t.datetime "del_date", precision: nil
-    t.datetime "date_last_certified", precision: nil
+    t.datetime "cert_issue_date"
+    t.datetime "del_date"
+    t.datetime "date_last_certified"
     t.integer "rpo_code"
     t.string "fac_code"
     t.decimal "payment_amt"
@@ -1395,8 +1394,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "change_flag"
     t.integer "rpo_code"
     t.boolean "rpo_flag"
-    t.datetime "act_begin", precision: nil
-    t.datetime "act_end", precision: nil
+    t.datetime "act_begin"
+    t.datetime "act_end"
     t.string "source_ind"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/v1/pension_ipf_callbacks_controller_spec.rb
+++ b/spec/controllers/v1/pension_ipf_callbacks_controller_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V1::PensionIpfCallbacksController, type: :controller do
+  let(:status) { 'delivered' }
+  let(:params) do
+    {
+      id: '6ba01111-f3ee-4a40-9d04-234asdfb6abab9c',
+      reference: nil,
+      to: 'test@test.com',
+      status:,
+      created_at: '2023-01-10T00:04:25.273410Z',
+      completed_at: '2023-01-10T00:05:33.255911Z',
+      sent_at: '2023-01-10T00:04:25.775363Z',
+      notification_type: 'email',
+      status_reason: '',
+      provider: 'sendgrid'
+    }
+  end
+
+  describe '#create' do
+    before do
+      request.headers['Authorization'] = "Bearer #{Settings.pension_ipf_vanotify_status_callback.bearer_token}"
+      Flipper.enable(:pension_ipf_callbacks_endpoint)
+      allow(PensionIpfNotification).to receive(:create!)
+    end
+
+    context 'with payload' do
+      context 'if status is delivered' do
+        it 'returns success and does not save a record of the payload' do
+          post(:create, params:, as: :json)
+
+          expect(PensionIpfNotification).not_to receive(:create!)
+
+          expect(response).to have_http_status(:ok)
+
+          res = JSON.parse(response.body)
+          expect(res['message']).to eq 'success'
+        end
+      end
+
+      context 'if status is a failure that will not retry' do
+        let(:status) { 'permanent-failure' }
+
+        it 'returns success' do
+          post(:create, params:, as: :json)
+
+          expect(response).to have_http_status(:ok)
+
+          res = JSON.parse(response.body)
+          expect(res['message']).to eq 'success'
+        end
+
+        context 'and the record failed to save' do
+          before do
+            allow(PensionIpfNotification).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+          end
+
+          it 'returns failed' do
+            post(:create, params:, as: :json)
+
+            expect(response).to have_http_status(:ok)
+
+            res = JSON.parse(response.body)
+            expect(res['message']).to eq 'failed'
+          end
+        end
+      end
+    end
+  end
+
+  describe 'authentication' do
+    context 'with missing Authorization header' do
+      it 'returns 401' do
+        request.headers['Authorization'] = nil
+        post(:create, params:, as: :json)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with invalid Authorization header' do
+      it 'returns 401' do
+        request.headers['Authorization'] = 'Bearer foo'
+        post(:create, params:, as: :json)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/factories/pension_ipf_notifications.rb
+++ b/spec/factories/pension_ipf_notifications.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :pension_ipf_notification do
+    payload do
+      {
+        id: '6ba01111-f3ee-4a40-9d04-234asdfb6abab9c',
+        reference: nil,
+        to: 'test@test.com',
+        status: 'delivered',
+        created_at: '2023-01-10T00:04:25.273410Z',
+        completed_at: '2023-01-10T00:05:33.255911Z',
+        sent_at: '2023-01-10T00:04:25.775363Z',
+        notification_type: 'email',
+        status_reason: '',
+        provider: 'pinpoint'
+      }
+    end
+  end
+end

--- a/spec/models/pension_ipf_notification_spec.rb
+++ b/spec/models/pension_ipf_notification_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PensionIpfNotification, type: :model do
+  let(:pension_ipf_notification) { build(:pension_ipf_notification) }
+
+  describe 'payload encryption' do
+    it 'encrypts the payload field' do
+      expect(subject).to encrypt_attr(:payload)
+    end
+  end
+
+  describe 'validations' do
+    it 'validates presence of payload' do
+      expect_attr_valid(pension_ipf_notification, :payload)
+      pension_ipf_notification.payload = nil
+      expect_attr_invalid(pension_ipf_notification, :payload, "can't be blank")
+    end
+  end
+
+  describe '#serialize_payload' do
+    let(:payload) do
+      { a: 1 }
+    end
+
+    it 'serializes payload as json' do
+      pension_ipf_notification.payload = payload
+      pension_ipf_notification.save!
+
+      expect(pension_ipf_notification.payload).to eq(payload.to_json)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES, the `pension_ipf_callbacks_endpoint` flipper*
- created a new notification status callback to be used for the pension IPF reminder notification that will be sent.
- Persists and logs notification status for any given transaction ID. PII is scrubbed from the logs.
- Pension Benefits team to own this work.
- The template is ready so once this is deployed to production and the endpoint is configured in VANotify, we can turn on the flipper.

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/69766)
- [*Link to epic if not included in ticket*](https://app.zenhub.com/workspaces/benefits-pension-64e775aaa6b1ca1ed49b2ede/issues/gh/department-of-veterans-affairs/va.gov-team/69766)
- [*PR for migration changes*](https://github.com/department-of-veterans-affairs/vets-api/pull/15884)
- [*Link to our email trigger script*](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/pull/1532)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- In order to test this locally, first add the following to `config/settings/development.yml`
```
pension_ipf_vanotify_status_callback:
  bearer_token: bearer_token_secret
```
- Then run this curl command to hit the endpoint with mock data:
```
curl -L -X POST 'localhost:3000/v1/pension_ipf_callbacks' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer token=bearer_token_secret' \
--data-raw '{
   "id": "6ba01111-f3ee-4a40-9d04-234asdfb6abab9c",
   "reference": null,
   "to": "test@test.com",
   "status": "permanent-failure",
   "created_at": "2023-01-10T00:04:25.273410Z",
   "completed_at": "2023-01-10T00:05:33.255911Z",
   "sent_at": "2023-01-10T00:04:25.775363Z",
   "notification_type": "email",
   "status_reason": "Failed to deliver email due to hard bounce",
   "provider": "pinpoint"
}'
```
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
    - Once this is deployed, need to coordinate with the VANotify team to configure this endpoint for the template we plan on using. Once configuration is complete, we can enable the flipper and curl the endpoint in production with mock data to test. Once it's confirmed to be working, we will run our script to trigger our email. 

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/54864006/3ff3dd31-dfd1-497c-a1ce-cce4c4a87cae)

## What areas of the site does it impact?
No other areas of the code were touched, as this is a standalone endpoint.

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

## Requested Feedback
One thing to consider is to create a polymorphic table for notification statuses, with a `type` attribute, as notification callbacks become more prevalent.
