### PR TITLE
Check that path is not nil before checking for file existence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -803,6 +803,7 @@ lib/common/client/middleware/request/multipart_request.rb @department-of-veteran
 lib/common/client/middleware/request/remove_cookies.rb @department-of-veterans-affairs/backend-review-group
 lib/common/client/middleware/response/soap_parser.rb @department-of-veterans-affairs/backend-review-group
 lib/common/exceptions/open_id_service_error.rb @department-of-veterans-affairs/lighthouse-pivot
+lib/common/file_helpers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/debt_management_center @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/decision_review @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/decision_review_v1 @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/lib/common/file_helpers.rb
+++ b/lib/common/file_helpers.rb
@@ -5,7 +5,7 @@ module Common
     module_function
 
     def delete_file_if_exists(path)
-      File.delete(path) if File.exist?(path)
+      File.delete(path) if path && File.exist?(path)
     end
 
     def random_file_path


### PR DESCRIPTION
## Summary

This PR checks for a non-`nil` path before checking if a File at that path exists. We ran into a problem where `path` was `nil` and causing tests to break. If the `path` is `nil` then there should be nothing to delete anyway, so this seems harmless to me.