### PR TITLE
avs empty state validation

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -239,9 +239,9 @@ module VAOS
       #
       # @return [nil] This method does not explicitly return a value. It modifies the `appt`.
       def fetch_avs_and_update_appt_body(appt)
-        # Testing AVS error message using the below id - remove after testing is complete
+        # Testing AVS empty state using the below id - remove after testing is complete
         if appt[:id] == AVS_APPT_TEST_ID
-          appt[:avs_path] = AVS_ERROR_MESSAGE
+          appt[:avs_path] = nil
         else
           avs_link = get_avs_link(appt)
           appt[:avs_path] = avs_link

--- a/modules/vaos/spec/request/v2/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/v2/appointments_request_spec.rb
@@ -162,9 +162,9 @@ RSpec.describe VAOS::V2::AppointmentsController, type: :request, skip_mvi: true 
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
 
-            # TODO: currently appointment id 192308 is being used to trigger an avs error message;
+            # TODO: currently appointment id 192308 is being used to trigger an avs empty state;
             # switch back this field to expect avs_path after testing on id 192308 is complete
-            expect(data[0]['attributes']['avsPath']).to eq(avs_error_message)
+            expect(data[0]['attributes']['avsPath']).to be_nil
 
             expect(response).to match_camelized_response_schema('vaos/v2/appointments', { strict: false })
           end
@@ -402,7 +402,7 @@ RSpec.describe VAOS::V2::AppointmentsController, type: :request, skip_mvi: true 
               data = JSON.parse(response.body)['data']
 
               expect(data['id']).to eq('192308')
-              expect(data['attributes']['avsPath']).to eq(avs_error_message)
+              expect(data['attributes']['avsPath']).to be_nil
             end
           end
         end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -884,7 +884,7 @@ describe VAOS::V2::AppointmentsService do
 
       it 'returns an error message in the avs field of the appointment response' do
         subject.send(:fetch_avs_and_update_appt_body, appt_no_avs)
-        expect(appt_no_avs[:avs_path]).to eq(avs_error_message)
+        expect(appt_no_avs[:avs_path]).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Summary

- this work updates an avs appointment test id to return an empty field in order to help the frontend validate this use case

## Related issue(s)

- GH#75801

## Testing

- updated relevant avs tests to check against empty field, ran regression tests
