### PR TITLE
API-33857: Add a `change_history` JSONB Field to the `va_forms_forms` Table

### DIFF
--- a/db/migrate/20240312194623_add_change_history_to_va_forms_forms.rb
+++ b/db/migrate/20240312194623_add_change_history_to_va_forms_forms.rb
@@ -1,0 +1,5 @@
+class AddChangeHistoryToVAFormsForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :va_forms_forms, :change_history, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_12_162510) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_12_194623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -1113,6 +1113,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_12_162510) do
     t.float "ranking"
     t.string "tags"
     t.date "last_sha256_change"
+    t.jsonb "change_history"
     t.index ["valid_pdf"], name: "index_va_forms_forms_on_valid_pdf"
   end
 


### PR DESCRIPTION
## Summary
This PR adds a `change_history` JSON field to the `va_forms_forms` table via a database migration, which builds upon #15887. This field is nullable and will track the history of SHA-256 changes that have occurred for a particular form. Future PRs will use this new field, populating and exposing it in our Forms API endpoints. The field is being added in order to reduce our usage of the `paper_trail` gem.

My team (Lighthouse Team Banana Peels) maintains the `va_forms` module.

## Related issue(s)
- [API-33857](https://jira.devops.va.gov/browse/API-33857)

## Testing done
Confirmed that the database migration completed successfully and that our endpoints do not return this data just yet.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `va_forms` module only.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution – N/A
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested.