### PR TITLE
76818: Fix parameter name for NodSendEmailJob

### DIFF
--- a/app/sidekiq/decision_review/nod_send_email_job.rb
+++ b/app/sidekiq/decision_review/nod_send_email_job.rb
@@ -15,9 +15,9 @@ module DecisionReview
       user_uuid: nil
     }.freeze
 
-    def perform(email_address, template_id, customisation, line_num)
+    def perform(email_address, template_id, personalisation, line_num)
       notify_client = VaNotify::Service.new(Settings.vanotify.services.benefits_decision_review.api_key)
-      notify_client.send_email({ email_address:, template_id:, customisation: })
+      notify_client.send_email({ email_address:, template_id:, personalisation: })
 
       log_formatted(**LOG_PARAMS, is_success: true, params: { line_num: })
     rescue => e

--- a/spec/sidekiq/decision_review/nod_send_email_job_spec.rb
+++ b/spec/sidekiq/decision_review/nod_send_email_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DecisionReview::NodSendEmailJob, type: :job do
 
   let(:email_address) { Faker::Internet.email }
   let(:template_id) { Faker::Internet.uuid }
-  let(:customisation) { { 'full_name' => Faker::Name.name } }
+  let(:personalisation) { { 'full_name' => Faker::Name.name } }
   let(:line_num) { 5 }
 
   before do
@@ -24,9 +24,9 @@ RSpec.describe DecisionReview::NodSendEmailJob, type: :job do
   describe 'perform' do
     context 'with correct job parameters' do
       it 'sends email using VANotify service' do
-        expect(service).to receive(:send_email).with({ email_address:, template_id:, customisation: })
+        expect(service).to receive(:send_email).with({ email_address:, template_id:, personalisation: })
 
-        subject.perform_async(email_address, template_id, customisation, line_num)
+        subject.perform_async(email_address, template_id, personalisation, line_num)
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe DecisionReview::NodSendEmailJob, type: :job do
           expect(args[:params][:exception_message]).to eq error_message
         end
 
-        expect { job.perform(email_address, template_id, customisation, line_num) }.not_to raise_exception
+        expect { job.perform(email_address, template_id, personalisation, line_num) }.not_to raise_exception
       end
     end
   end


### PR DESCRIPTION
## Summary

This fixes an error with a parameter name in the `DecisionReview::NodSendEmailJob` added in #15795

## Related issue(s)

#15795

## Testing done

- [x] *New code is covered by unit tests*
Manually tested the changes

## What areas of the site does it impact?
* Same as #15795

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
