### PR TITLE
Limit middle name to 40 characters on 26-4555

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -101,7 +101,7 @@ module SimpleFormsApi
         vaFileNumber: data.dig('veteran', 'va_file_number'),
         fullName: {
           first: full_name['first'],
-          middle: full_name['middle'],
+          middle: full_name['middle']&.[](0..39),
           last: full_name['last'],
           suffix: full_name['suffix']
         },

--- a/modules/simple_forms_api/spec/models/vba_26_4555_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_26_4555_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'SimpleFormsApi::VBA264555' do
+  describe 'veteran middle name' do
+    it 'limits the length to 40 characters' do
+      middle_name = 'Wolfeschlegelsteinhausenbergerdorffwelchevoralternwarengewissenhaftschaferswessenschafe
+      warenwohlgepflegeundsorgfaltigkeitbeschutzenvonangreifendurchihrraubgierigfeindewelchevoralternzwolftausend
+      jahresvorandieerscheinenvanderersteerdemenschderraumschiffgebrauchlichtalsseinursprungvonkraftgestartsein
+      langefahrthinzwischensternartigraumaufdersuchenachdiesternwelchegehabtbewohnbarplanetenkreisedrehensichund
+      wohinderneurassevonverstandigmenschlichkeitkonntefortpflanzenundsicherfreuenanlebenslanglichfreudeundruhemit
+      nichteinfurchtvorangreifenvonandererintelligentgeschopfsvonhinzwischensternartigraum'
+      shortened_name = 'Wolfeschlegelsteinhausenbergerdorffwelch'
+
+      form = SimpleFormsApi::VBA264555.new(
+        {
+          'veteran' => {
+            'full_name' => {
+              'middle' => middle_name
+            }
+          }
+        }
+      )
+
+      expect(shortened_name.length).to eq 40
+      expect(form.as_payload[:veteran][:fullName][:middle]).to eq shortened_name
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR limits the middle name to 40 characters when we pass the form data along to SAHSHA for 26-4555, per their request.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1106

## Testing done

New test written for this.
