### PR TITLE
API-33857: Add Rake Task for Migrating `VAForms::Form` Version Data

### DIFF
--- a/modules/va_forms/lib/tasks/migrate_form_change_history_from_paper_trail.rake
+++ b/modules/va_forms/lib/tasks/migrate_form_change_history_from_paper_trail.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :va_forms do
+  task migrate_form_change_history_from_paper_trail: :environment do
+    VAForms::Form.all.each do |form|
+      form_versions = form.versions.order(created_at: :asc)
+
+      if form_versions.present?
+        form.last_sha256_change = form_versions.last&.created_at
+        form.change_history = {}
+        form.change_history['versions'] = form_versions.map do |v|
+          if v.changeset.present?
+            {
+              sha256: v.changeset['sha256']&.last,
+              revision_on: v.created_at&.strftime('%Y-%m-%d')
+            }
+          end
+        end
+        form.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds a single-use rake task to the `VAForms` module that migrates our form version data from the separate `versions` table (used by the `paper_trail` gem) to the `va_forms_forms` table. The columns that will be populated in the `va_forms_forms` table by the rake task are `last_sha256_change` and `change_history`. 

This data migration is to prepare for the removal of the `paper_trail` gem and the associated `versions` table. However, no data is removed in this PR, and our Forms API endpoints will continue to pull data from the `versions` table for the time-being.

My team (Lighthouse Team Banana Peels) maintains the `VAForms` module, and this rake task will be removed once the migration has successfully completed.

## Related issue(s)
[API-33857](https://jira.devops.va.gov/browse/API-33857)

## Testing done
Ran the migration against my local database's form data to confirm that it ran successfully and that the `last_sha256_change` and `change_history` contents were correct. Our production code does not use this data just yet. This PR is only to populate/migrate the data.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `VAForms` module only.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution – N/A
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
