### PR TITLE
Slight refactor to add UUID to user identity tracking for simple_forms_api

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -109,6 +109,7 @@ module SimpleFormsApi
           status, error_message = handle_ivc_uploads(form_id, metadata, ivc_file_paths)
         else
           status, confirmation_number = upload_pdf_to_benefits_intake(file_path, metadata)
+          form.track_user_identity(confirmation_number)
 
           SimpleFormsApi::PdfStamper.stamp4010007_uuid(confirmation_number) if form_id == 'vba_40_10007'
 
@@ -157,7 +158,6 @@ module SimpleFormsApi
       def get_file_paths_and_metadata(parsed_form_data)
         form_id = get_form_id
         form = "SimpleFormsApi::#{form_id.titleize.gsub(' ', '')}".constantize.new(parsed_form_data)
-        form.track_user_identity
         filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, form:)
 
         file_path = if @current_user

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -103,7 +103,7 @@ module SimpleFormsApi
       def submit_form_to_central_mail
         form_id = get_form_id
         parsed_form_data = JSON.parse(params.to_json)
-        file_path, ivc_file_paths, metadata = get_file_paths_and_metadata(parsed_form_data)
+        file_path, ivc_file_paths, metadata, form = get_file_paths_and_metadata(parsed_form_data)
 
         if IVC_FORM_NUMBER_MAP.value?(form_id)
           status, error_message = handle_ivc_uploads(form_id, metadata, ivc_file_paths)
@@ -175,7 +175,7 @@ module SimpleFormsApi
             [file_path]
           end
 
-        [file_path, maybe_add_file_paths, metadata]
+        [file_path, maybe_add_file_paths, metadata, form]
       end
 
       def get_upload_location_and_uuid(lighthouse_service)

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -40,6 +40,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -54,7 +54,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -39,7 +39,7 @@ module SimpleFormsApi
       }
     end
 
-    def (confirmation_number); end
+    def track_user_identity(confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -39,7 +39,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity; end
+    def (confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -63,7 +63,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -31,6 +31,6 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -38,10 +38,10 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity
+    def track_user_identity(confirmation_number)
       identity = "#{data['claimant_type']} #{data['claim_ownership']}"
       StatsD.increment("#{STATS_KEY}.#{identity}")
-      Rails.logger.info('Simple forms api - 21-10210 submission user identity', identity:)
+      Rails.logger.info('Simple forms api - 21-10210 submission user identity', identity:, confirmation_number:)
     end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -37,10 +37,10 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity
+    def track_user_identity(confirmation_number)
       identity = data.dig('preparer_identification', 'relationship_to_veteran')
       StatsD.increment("#{STATS_KEY}.#{identity}")
-      Rails.logger.info('Simple forms api - 21-4142 submission user identity', identity:)
+      Rails.logger.info('Simple forms api - 21-4142 submission user identity', identity:, confirmation_number:)
     end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -35,7 +35,7 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -46,7 +46,7 @@ module SimpleFormsApi
       { should_stamp_date?: false }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -39,7 +39,7 @@ module SimpleFormsApi
       { should_stamp_date?: false }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
@@ -48,7 +48,7 @@ module SimpleFormsApi
       value.to_s # Convert nil to an empty string
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
 
     def submission_date_config
       { should_stamp_date?: false }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -46,7 +46,7 @@ module SimpleFormsApi
       { should_stamp_date?: false }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_7959f_1.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_7959f_1.rb
@@ -26,6 +26,6 @@ module SimpleFormsApi
       { should_stamp_date?: false }
     end
 
-    def track_user_identity; end
+    def track_user_identity(confirmation_number); end
   end
 end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -5,23 +5,23 @@ require 'simple_forms_api_submission/metadata_validator'
 
 RSpec.describe 'Forms uploader', type: :request do
   non_ivc_forms = [
-    # 'vba_26_4555.json',
-    # 'vba_21_4142.json',
-    # 'vba_21_10210.json',
-    # 'vba_21p_0847.json',
-    # 'vba_21_0972.json',
-    # 'vba_21_0845.json',
-    # 'vba_40_0247.json',
-    # 'vba_21_0966.json',
-    # 'vba_20_10206.json',
-    # 'vba_40_10007.json',
-    # 'vba_20_10207-veteran.json',
+    'vba_26_4555.json',
+    'vba_21_4142.json',
+    'vba_21_10210.json',
+    'vba_21p_0847.json',
+    'vba_21_0972.json',
+    'vba_21_0845.json',
+    'vba_40_0247.json',
+    'vba_21_0966.json',
+    'vba_20_10206.json',
+    'vba_40_10007.json',
+    'vba_20_10207-veteran.json',
     'vba_20_10207-non-veteran.json'
   ]
 
   ivc_forms = [
-    # 'vha_10_10d.json',
-    # 'vha_10_7959f_1.json'
+    'vha_10_10d.json',
+    'vha_10_7959f_1.json'
   ]
 
   describe '#submit' do

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -5,23 +5,23 @@ require 'simple_forms_api_submission/metadata_validator'
 
 RSpec.describe 'Forms uploader', type: :request do
   non_ivc_forms = [
-    'vba_26_4555.json',
-    'vba_21_4142.json',
-    'vba_21_10210.json',
-    'vba_21p_0847.json',
-    'vba_21_0972.json',
-    'vba_21_0845.json',
-    'vba_40_0247.json',
-    'vba_21_0966.json',
-    'vba_20_10206.json',
-    'vba_40_10007.json',
-    'vba_20_10207-veteran.json',
+    # 'vba_26_4555.json',
+    # 'vba_21_4142.json',
+    # 'vba_21_10210.json',
+    # 'vba_21p_0847.json',
+    # 'vba_21_0972.json',
+    # 'vba_21_0845.json',
+    # 'vba_40_0247.json',
+    # 'vba_21_0966.json',
+    # 'vba_20_10206.json',
+    # 'vba_40_10007.json',
+    # 'vba_20_10207-veteran.json',
     'vba_20_10207-non-veteran.json'
   ]
 
   ivc_forms = [
-    'vha_10_10d.json',
-    'vha_10_7959f_1.json'
+    # 'vha_10_10d.json',
+    # 'vha_10_7959f_1.json'
   ]
 
   describe '#submit' do


### PR DESCRIPTION
## Summary
This PR moves where we track user identity so that we can add the `confirmation_code` to DataDog as well. This way we can keep track of particular user types with their actual form submissions.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/77983