### PR TITLE
name spaceing

### DIFF
--- a/modules/vye/app/controllers/vye/application_controller.rb
+++ b/modules/vye/app/controllers/vye/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Vye
-  class ApplicationController < ApplicationController
+  class ApplicationController < ::ApplicationController
   end
 end


### PR DESCRIPTION
added `::` to application controller for clarity