### PR TITLE
Added status tracking to our tracked item logging for DataDog

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -89,7 +89,8 @@ module V0
                             { message_type: 'lh.cst.evidence_requests',
                               claim_id:,
                               tracked_item_id: ti['id'],
-                              tracked_item_type: ti['displayName'] })
+                              tracked_item_type: ti['displayName'],
+                              tracked_item_status: ti['status'] })
       end
     end
   end

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -135,14 +135,16 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
                 { message_type: 'lh.cst.evidence_requests',
                   claim_id: '600383363',
                   tracked_item_id: 395_084,
-                  tracked_item_type: 'Request 1' })
+                  tracked_item_type: 'Request 1',
+                  tracked_item_status: 'NEEDED_FROM_YOU' })
         expect(Rails.logger)
           .to have_received(:info)
           .with('Evidence Request Types',
                 { message_type: 'lh.cst.evidence_requests',
                   claim_id: '600383363',
                   tracked_item_id: 394_443,
-                  tracked_item_type: 'Submit buddy statement(s)' })
+                  tracked_item_type: 'Submit buddy statement(s)',
+                  tracked_item_status: 'NEEDED_FROM_YOU' })
       end
     end
 

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/show/200_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/show/200_response.yml
@@ -222,7 +222,7 @@ http_interactions:
                               "requestedDate": "2023-03-16",
                               "suspenseDate": "2023-04-15",
                               "id": 395084,
-                              "status": "SUBMITTED_AWAITING_REVIEW",
+                              "status": "NEEDED_FROM_YOU",
                               "uploaded": true,
                               "uploadsAllowed": true
                            },
@@ -235,7 +235,7 @@ http_interactions:
                               "requestedDate": "2023-04-14",
                               "suspenseDate": null,
                               "id": 394443,
-                              "status": "INITIAL_REVIEW_COMPLETE",
+                              "status": "NEEDED_FROM_YOU",
                               "uploaded": true,
                               "uploadsAllowed": false
                            }


### PR DESCRIPTION
## Summary

- Added status tracking to `app/controllers/v0/benefits_claims_controller.rb`
- Updated `spec/support/vcr_cassettes/lighthouse/benefits_claims/show/200_response.yml` to contain `NEEDED_FROM_YOU` statuses in tracked items
- Updated `spec/controllers/v0/benefits_claims_controller_spec.rb`

## Related issue(s)

- [Update Evidence Request Logging](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78342)

## Testing done

- [x] *New code is covered by unit tests*
