### PR TITLE
Do not retry the BenefitsIntakeStatusJob

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -4,6 +4,9 @@ require 'benefits_intake_service/service'
 
 class BenefitsIntakeStatusJob
   include Sidekiq::Job
+
+  sidekiq_options retry: false
+  
   STATS_KEY = 'api.benefits_intake.submission_status'
   MAX_BATCH_SIZE = 1000
 

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -6,7 +6,7 @@ class BenefitsIntakeStatusJob
   include Sidekiq::Job
 
   sidekiq_options retry: false
-  
+
   STATS_KEY = 'api.benefits_intake.submission_status'
   MAX_BATCH_SIZE = 1000
 


### PR DESCRIPTION
## Summary
This PR configures Sidekiq to _not_ retry the `BenefitsIntakeStatusJob`. It's ok not to retry this one because it runs daily and doesn't affect operations; it's purely for status reporting. If we miss a day, it's not a big deal. If it fails once, it'd probably fail every retry.