### PR TITLE
Changed the way we used the json middleware to accommodate the faraday update

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -12,7 +12,7 @@ module TravelPay
       tenant_id = Settings.travel_pay.veis.tenant_id
 
       connection(server_url: auth_url).post("/#{tenant_id}/oauth2/token") do |req|
-        req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        req.headers[:content_type] = 'application/x-www-form-urlencoded'
         req.body = URI.encode_www_form(veis_params)
       end
     end
@@ -71,7 +71,7 @@ module TravelPay
         conn.use :breakers
         conn.response :raise_error, error_prefix: service_name
         conn.response :betamocks if use_fakes?
-        conn.response :json, { content_type: /\bjson/ }
+        conn.response :json
 
         conn.adapter Faraday.default_adapter
       end


### PR DESCRIPTION
It appears that in an updated version of Faraday, the json middleware only accepts 0 or 1 parameters. I was used to being able to specify a pattern to match for the content type, but this throws an ArgumentError exception if used in the previous way.