### PR TITLE
78436 coerce pHDfnNumber to integer

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -83,7 +83,7 @@ module DebtsApi
     def station_adjustments(form)
       stations = []
       @copays.each do |copay|
-        stations << 'vista' if copay['pHDfnNumber'].instance_of?(Integer) && (copay['pHDfnNumber']).positive?
+        stations << 'vista' if copay['pHDfnNumber'].to_i.positive?
         if copay['pHCernerPatientId'].instance_of?(String) && copay['pHCernerPatientId'].strip.length.positive?
           stations << 'cerner'
         end


### PR DESCRIPTION
## Summary
We should not be assuming that the value of pHDfnNumber is an integer. Coerce to integer and then behave accordingly.

## Related issue(s)
[78436](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/78436)
[67409](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/67409)

## Testing done
Specs green

## What areas of the site does it impact?
FSR submission

## Acceptance criteria
VHA FSR submission behave as expected even if the value of pHDfnNumber is a string.
