### PR TITLE
78335 Update Appointment data serializer

### DIFF
--- a/modules/check_in/app/serializers/check_in/v2/appointment_data_serializer.rb
+++ b/modules/check_in/app/serializers/check_in/v2/appointment_data_serializer.rb
@@ -14,7 +14,34 @@ module CheckIn
             appt.except!(:patientDFN)
           end
 
-        raw_demographics = object.payload[:demographics]
+        demographics = prepare_demographics(object.payload[:demographics])
+
+        raw_confirmation = object.payload[:patientDemographicsStatus]
+        demographics_confirmation = if raw_confirmation.nil?
+                                      {}
+                                    else
+                                      {
+                                        demographicsNeedsUpdate: raw_confirmation[:demographicsNeedsUpdate],
+                                        demographicsConfirmedAt: raw_confirmation[:demographicsConfirmedAt],
+                                        nextOfKinNeedsUpdate: raw_confirmation[:nextOfKinNeedsUpdate],
+                                        nextOfKinConfirmedAt: raw_confirmation[:nextOfKinConfirmedAt],
+                                        emergencyContactNeedsUpdate: raw_confirmation[:emergencyContactNeedsUpdate],
+                                        emergencyContactConfirmedAt: raw_confirmation[:emergencyContactConfirmedAt]
+                                      }
+                                    end
+
+        {
+          address: object.payload[:address],
+          demographics:,
+          appointments:,
+          patientDemographicsStatus: demographics_confirmation,
+          setECheckinStartedCalled: object.payload[:setECheckinStartedCalled]
+        }
+      end
+
+      def self.prepare_demographics(raw_demographics)
+        return {} if raw_demographics.nil?
+
         demographics = {
           mailingAddress: address_helper(raw_demographics[:mailingAddress]),
           homeAddress: address_helper(raw_demographics[:homeAddress]),
@@ -24,41 +51,21 @@ module CheckIn
           emailAddress: raw_demographics[:emailAddress]
         }
 
-        raw_next_of_kin = object.payload.dig(:demographics, :nextOfKin1)
-        next_of_kin1 = {
-          name: raw_next_of_kin[:name],
-          relationship: raw_next_of_kin[:relationship],
-          phone: raw_next_of_kin[:phone],
-          workPhone: raw_next_of_kin[:workPhone],
-          address: address_helper(raw_next_of_kin[:address])
-        }
-        demographics.merge!(nextOfKin1: next_of_kin1)
+        demographics.merge!(nextOfKin1: prepare_contact(raw_demographics[:nextOfKin1])) if raw_demographics[:nextOfKin1]
+        if raw_demographics[:emergencyContact]
+          demographics.merge!(emergencyContact: prepare_contact(raw_demographics[:emergencyContact]))
+        end
 
-        raw_emergency_contact = object.payload.dig(:demographics, :emergencyContact)
-        emergency_contact = {
-          name: raw_emergency_contact[:name],
-          relationship: raw_emergency_contact[:relationship],
-          phone: raw_emergency_contact[:phone],
-          workPhone: raw_emergency_contact[:workPhone],
-          address: address_helper(raw_emergency_contact[:address])
-        }
-        demographics.merge!(emergencyContact: emergency_contact)
+        demographics
+      end
 
-        raw_confirmation = object.payload[:patientDemographicsStatus]
-        demographics_confirmation = {
-          demographicsNeedsUpdate: raw_confirmation[:demographicsNeedsUpdate],
-          demographicsConfirmedAt: raw_confirmation[:demographicsConfirmedAt],
-          nextOfKinNeedsUpdate: raw_confirmation[:nextOfKinNeedsUpdate],
-          nextOfKinConfirmedAt: raw_confirmation[:nextOfKinConfirmedAt],
-          emergencyContactNeedsUpdate: raw_confirmation[:emergencyContactNeedsUpdate],
-          emergencyContactConfirmedAt: raw_confirmation[:emergencyContactConfirmedAt]
-        }
-        set_e_check_in_started_called = object.payload[:setECheckinStartedCalled]
+      def self.prepare_contact(raw_contact)
         {
-          demographics:,
-          appointments:,
-          patientDemographicsStatus: demographics_confirmation,
-          setECheckinStartedCalled: set_e_check_in_started_called
+          name: raw_contact[:name],
+          relationship: raw_contact[:relationship],
+          phone: raw_contact[:phone],
+          workPhone: raw_contact[:workPhone],
+          address: address_helper(raw_contact[:address])
         }
       end
 

--- a/modules/check_in/app/services/travel_claim/service.rb
+++ b/modules/check_in/app/services/travel_claim/service.rb
@@ -58,7 +58,7 @@ module TravelClaim
     #
     # @see TravelClaim::Client#submit_claim
     #
-    # @return [Response] claimNumber
+    # @return [Hash] response hash
     def submit_claim
       resp = if token.present?
                client.submit_claim(token:, patient_icn:, appointment_date:)

--- a/modules/check_in/spec/request/v2/patient_check_ins_request_spec.rb
+++ b/modules/check_in/spec/request/v2/patient_check_ins_request_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe 'V2::PatientCheckIns', type: :request do
         {
           'id' => id,
           'payload' => {
+            'address' => nil,
             'demographics' => demographics,
             'appointments' => [appointment1],
             'patientDemographicsStatus' => patient_demographic_status,

--- a/modules/check_in/spec/request/v2/pre_check_ins_request_spec.rb
+++ b/modules/check_in/spec/request/v2/pre_check_ins_request_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe 'V2::PreCheckInsController', type: :request do
         {
           'id' => id,
           'payload' => {
+            'address' => nil,
             'demographics' => demographics,
             'appointments' => [appointment1],
             'patientDemographicsStatus' => patient_demographic_status,

--- a/modules/check_in/spec/serializers/check_in/v2/appointment_data_serializer_spec.rb
+++ b/modules/check_in/spec/serializers/check_in/v2/appointment_data_serializer_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe CheckIn::V2::AppointmentDataSerializer do
           type: :appointment_data,
           attributes: {
             payload: {
+              address: nil,
               demographics: {
                 mailingAddress: {
                   street1: '123 Turtle Trail',
@@ -279,6 +280,49 @@ RSpec.describe CheckIn::V2::AppointmentDataSerializer do
       appt_serializer = CheckIn::V2::AppointmentDataSerializer.new(appt_struct)
 
       expect(appt_serializer.serializable_hash).to eq(serialized_hash_response)
+    end
+
+    context 'when demographics and demographics status are nil' do
+      let(:appointment_data) do
+        {
+          id: 'd602d9eb-9a31-484f-9637-13ab0b507e0d',
+          payload: {
+            appointments: [
+              {
+                appointmentIEN: '460'
+              }
+            ]
+          }
+        }
+      end
+      let(:serialized_hash_response) do
+        {
+          data: {
+            id: 'd602d9eb-9a31-484f-9637-13ab0b507e0d',
+            type: :appointment_data,
+            attributes: {
+              payload: {
+                address: nil,
+                demographics: {},
+                appointments: [
+                  {
+                    appointmentIEN: '460'
+                  }
+                ],
+                patientDemographicsStatus: {},
+                setECheckinStartedCalled: nil
+              }
+            }
+          }
+        }
+      end
+
+      it 'return empty hash' do
+        appt_struct = OpenStruct.new(appointment_data)
+        appt_serializer = CheckIn::V2::AppointmentDataSerializer.new(appt_struct)
+
+        expect(appt_serializer.serializable_hash).to eq(serialized_hash_response)
+      end
     end
   end
 end

--- a/modules/check_in/spec/services/v2/lorota/service_spec.rb
+++ b/modules/check_in/spec/services/v2/lorota/service_spec.rb
@@ -159,6 +159,7 @@ describe V2::Lorota::Service do
   let(:approved_response) do
     {
       payload: {
+        address: nil,
         demographics: {
           mailingAddress: {
             street1: '123 Turtle Trail',


### PR DESCRIPTION
## Summary
This PR updates the appointment data serializer to handle Oracle Health data. Specifically, it handles the address fields in a separate location, and null values for demographics, demographics status.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/78335

## Testing done
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
- check in experience

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.

