### PR TITLE
Track users for 21P-0847

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -3,6 +3,7 @@
 module SimpleFormsApi
   class VBA21p0847
     include Virtus.model(nullify_blank: true)
+    STATS_KEY = 'api.simple_forms_api.21p_0847'
 
     attribute :data
 
@@ -35,7 +36,12 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity(confirmation_number); end
+    def track_user_identity(confirmation_number)
+      identity = form.data.dig('relationship_to_deceased_claimant', 'other_relationship_to_veteran') ||
+                 form.data.dig('relationship_to_deceased_claimant', 'relationship_to_veteran')
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('Simple forms api - 21P-0847 submission user identity', identity:, confirmation_number:)
+    end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -37,8 +37,8 @@ module SimpleFormsApi
     end
 
     def track_user_identity(confirmation_number)
-      identity = form.data.dig('relationship_to_deceased_claimant', 'other_relationship_to_veteran') ||
-                 form.data.dig('relationship_to_deceased_claimant', 'relationship_to_veteran')
+      identity = data.dig('relationship_to_deceased_claimant', 'other_relationship_to_veteran') ||
+                 data.dig('relationship_to_deceased_claimant', 'relationship_to_veteran')
       StatsD.increment("#{STATS_KEY}.#{identity}")
       Rails.logger.info('Simple forms api - 21P-0847 submission user identity', identity:, confirmation_number:)
     end


### PR DESCRIPTION
## Summary
This PR tracks users who fill out the 21P-0847 so that we can see what type of user filled out the form in DataDog.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1110