### PR TITLE
Representative user auth flow

### DIFF
--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -32,9 +32,10 @@ module SentryControllerLogging
   def tags_context
     { controller_name: }.tap do |tags|
       if current_user.present?
-        tags[:sign_in_method] = current_user.identity.sign_in[:service_name]
+        sign_in = current_user.respond_to?(:identity) ? current_user.identity.sign_in : current_user.sign_in
+        tags[:sign_in_method] = sign_in[:service_name]
         # account_type is filtered by sentry, becasue in other contexts it refers to a bank account type
-        tags[:sign_in_acct_type] = current_user.identity.sign_in[:account_type]
+        tags[:sign_in_acct_type] = sign_in[:account_type]
       else
         tags[:sign_in_method] = 'not-signed-in'
       end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -10,6 +10,9 @@ development: &defaults
   user_b_store:
     namespace: users_b
     each_ttl: 1800
+  representative_user_store:
+    namespace: representative_users
+    each_ttl: 1800
   user_identity_store:
     namespace: user_identities
     each_ttl: 1800

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -78,6 +78,7 @@ sign_in:
   mockdata_sync_api_key: ~
   vaweb_client_id: vaweb
   vamobile_client_id: vamobile
+  arp_client_id: arp
 
 terms_of_use:
   current_version: v1

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -112,3 +112,15 @@ chatbot.update!(
   access_token_duration: SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
   certificates: [File.read('spec/fixtures/sign_in/sample_service_account.crt')]
 )
+
+# Create config for accredited_representative_portal
+arp = SignIn::ClientConfig.find_or_initialize_by(client_id: 'arp')
+arp.update!(authentication: SignIn::Constants::Auth::COOKIE,
+            anti_csrf: true,
+            pkce: true,
+            description: 'Accredited Representative Portal',
+            redirect_uri: 'http://localhost:3001/auth/login/callback',
+            access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
+            access_token_attributes: %w[first_name last_name email],
+            refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES,
+            logout_redirect_uri: 'http://localhost:3001/representatives')

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
@@ -1,29 +1,24 @@
 # frozen_string_literal: true
 
 module AccreditedRepresentativePortal
-  class ApplicationController < ::ApplicationController
+  class ApplicationController < SignIn::ApplicationController
+    include SignIn::AudienceValidator
+    include Authenticable
     # TODO: Add ARP to Datadog Service Catalog #77004
     #   https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/77004
     # It will be the dd-service property for your application here:
     #   https://github.com/department-of-veterans-affairs/vets-api/tree/master/datadog-service-catalog
     service_tag 'accredited-representative-portal'
+    validates_access_token_audience Settings.sign_in.arp_client_id
 
     before_action :verify_feature_enabled!
-
-    # TODO: Integrate SignIn Service to ARP Engine #76157
-    #   https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/76157
-    skip_before_action :authenticate
 
     private
 
     def verify_feature_enabled!
       return if Flipper.enabled?(:accredited_representative_portal_api)
 
-      routing_error
-    end
-
-    def current_user
-      nil
+      raise Common::Exceptions::RoutingError, params[:path]
     end
   end
 end

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module V0
+    class RepresentativeUsersController < ApplicationController
+      def show
+        render json: @current_user
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/authenticable.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/authenticable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module Authenticable
+    extend ActiveSupport::Concern
+
+    included do
+      prepend SignIn::Authentication
+    end
+
+    private
+
+    def load_user_object
+      RepresentativeUserLoader.new(access_token:, request_ip: request.remote_ip).perform
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/representative_user.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/representative_user.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class RepresentativeUser < Common::RedisStore
+    redis_store REDIS_CONFIG[:representative_user_store][:namespace]
+    redis_ttl REDIS_CONFIG[:representative_user_store][:each_ttl]
+    redis_key :uuid
+
+    attribute :uuid
+    attribute :email
+    attribute :first_name
+    attribute :last_name
+    attribute :icn
+    alias_attribute :mhv_icn, :icn
+    attribute :idme_uuid
+    attribute :logingov_uuid
+    attribute :fingerprint
+    attribute :last_signed_in
+    attribute :authn_context
+    attribute :loa
+    attribute :sign_in
+
+    validates :uuid, :email, :first_name, :last_name, :icn, presence: true
+  end
+end

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_creator.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_creator.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class RepresentativeUserCreator
+    attr_reader :state_payload,
+                :idme_uuid,
+                :logingov_uuid,
+                :authn_context,
+                :current_ial,
+                :max_ial,
+                :credential_email,
+                :multifactor,
+                :verified_icn,
+                :edipi,
+                :mhv_correlation_id,
+                :request_ip,
+                :first_name,
+                :last_name
+
+    def initialize(user_attributes:, state_payload:, verified_icn:, request_ip:)
+      @state_payload = state_payload
+      @idme_uuid = user_attributes[:idme_uuid]
+      @logingov_uuid = user_attributes[:logingov_uuid]
+      @authn_context = user_attributes[:authn_context]
+      @current_ial = user_attributes[:current_ial]
+      @max_ial = user_attributes[:max_ial]
+      @credential_email = user_attributes[:csp_email]
+      @multifactor = user_attributes[:multifactor]
+      @edipi = user_attributes[:edipi]
+      @mhv_correlation_id = user_attributes[:mhv_correlation_id]
+      @verified_icn = verified_icn
+      @request_ip = request_ip
+      @first_name = user_attributes[:first_name]
+      @last_name = user_attributes[:last_name]
+    end
+
+    def perform
+      create_authenticated_user
+      create_credential_email
+      create_user_acceptable_verified_credential
+      create_code_container
+      user_code_map
+    end
+
+    private
+
+    def create_authenticated_user
+      user
+    end
+
+    def create_credential_email
+      Login::UserCredentialEmailUpdater.new(credential_email:,
+                                            user_verification:).perform
+    end
+
+    def create_user_acceptable_verified_credential
+      Login::UserAcceptableVerifiedCredentialUpdater.new(user_account: user_verification.user_account).perform
+    end
+
+    def create_code_container
+      SignIn::CodeContainer.new(code: login_code,
+                                client_id: state_payload.client_id,
+                                code_challenge: state_payload.code_challenge,
+                                user_verification_id: user_verification.id,
+                                credential_email:,
+                                user_attributes: access_token_attributes).save!
+    end
+
+    def user_verifier_object
+      @user_verifier_object ||= OpenStruct.new({ idme_uuid:,
+                                                 logingov_uuid:,
+                                                 sign_in:,
+                                                 edipi:,
+                                                 mhv_correlation_id:,
+                                                 icn: verified_icn })
+    end
+
+    def user_code_map
+      @user_code_map ||= SignIn::UserCodeMap.new(login_code:,
+                                                 type: state_payload.type,
+                                                 client_state: state_payload.client_state,
+                                                 client_config:,
+                                                 terms_code: nil)
+    end
+
+    def user_verification
+      @user_verification ||= Login::UserVerifier.new(user_verifier_object).perform
+    end
+
+    def sign_in
+      @sign_in ||= {
+        service_name: state_payload.type,
+        auth_broker: SignIn::Constants::Auth::BROKER_CODE,
+        client_id: state_payload.client_id
+      }
+    end
+
+    def loa
+      @loa ||= { current: ial_to_loa(current_ial), highest: ial_to_loa(max_ial) }
+    end
+
+    def ial_to_loa(ial)
+      ial == SignIn::Constants::Auth::IAL_TWO ? SignIn::Constants::Auth::LOA_THREE : SignIn::Constants::Auth::LOA_ONE
+    end
+
+    def user_uuid
+      @user_uuid ||= user_verification.backing_credential_identifier
+    end
+
+    def access_token_attributes
+      { first_name:,
+        last_name:,
+        email: credential_email }.compact
+    end
+
+    def client_config
+      @client_config ||= SignIn::ClientConfig.find_by!(client_id: state_payload.client_id)
+    end
+
+    def login_code
+      @login_code ||= SecureRandom.uuid
+    end
+
+    def user
+      @user ||= begin
+        user = RepresentativeUser.new
+        user.uuid = user_uuid
+        user.icn = verified_icn
+        user.email = credential_email
+        user.idme_uuid = idme_uuid
+        user.logingov_uuid = logingov_uuid
+        user.first_name = first_name
+        user.last_name = last_name
+        user.fingerprint = request_ip
+        user.last_signed_in = Time.zone.now
+        user.authn_context = authn_context
+        user.loa = loa
+        user.sign_in = sign_in
+        user.save
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class RepresentativeUserLoader
+    attr_reader :access_token, :request_ip
+
+    def initialize(access_token:, request_ip:)
+      @access_token = access_token
+      @request_ip = request_ip
+    end
+
+    def perform
+      find_valid_user || reload_user
+    end
+
+    private
+
+    def find_valid_user
+      RepresentativeUser.find(access_token.user_uuid)
+    end
+
+    def reload_user
+      validate_account_and_session
+      current_user
+    end
+
+    def validate_account_and_session
+      raise SignIn::Errors::SessionNotFoundError.new message: 'Invalid Session Handle' unless session
+    end
+
+    def loa
+      current_loa = user_is_verified? ? SignIn::Constants::Auth::LOA_THREE : SignIn::Constants::Auth::LOA_ONE
+      { current: current_loa, highest: SignIn::Constants::Auth::LOA_THREE }
+    end
+
+    def sign_in
+      { service_name: user_verification.credential_type,
+        client_id: session.client_id,
+        auth_broker: SignIn::Constants::Auth::BROKER_CODE }
+    end
+
+    def authn_context
+      case user_verification.credential_type
+      when  SignIn::Constants::Auth::IDME
+        user_is_verified? ?  SignIn::Constants::Auth::IDME_LOA3 : SignIn::Constants::Auth::IDME_LOA1
+      when  SignIn::Constants::Auth::DSLOGON
+        user_is_verified? ?  SignIn::Constants::Auth::IDME_DSLOGON_LOA3 : SignIn::Constants::Auth::IDME_DSLOGON_LOA1
+      when  SignIn::Constants::Auth::MHV
+        user_is_verified? ?  SignIn::Constants::Auth::IDME_MHV_LOA3 : SignIn::Constants::Auth::IDME_MHV_LOA1
+      when  SignIn::Constants::Auth::LOGINGOV
+        user_is_verified? ?  SignIn::Constants::Auth::LOGIN_GOV_IAL2 : SignIn::Constants::Auth::LOGIN_GOV_IAL1
+      end
+    end
+
+    def user_is_verified?
+      session.user_account.verified?
+    end
+
+    def session
+      @session ||= SignIn::OAuthSession.find_by(handle: access_token.session_handle)
+    end
+
+    def user_verification
+      @user_verification ||= session.user_verification
+    end
+
+    def current_user
+      return @current_user if @current_user.present?
+
+      user = RepresentativeUser.new
+      user.uuid = access_token.user_uuid
+      user.icn = session.user_account.icn
+      user.email = session.credential_email
+      user.first_name = session.user_attributes_hash['first_name']
+      user.last_name = session.user_attributes_hash['last_name']
+      user.fingerprint = request_ip
+      user.authn_context = authn_context
+      user.loa = loa
+      user.logingov_uuid = user_verification.logingov_uuid
+      user.idme_uuid = user_verification.idme_uuid || user_verification.backing_idme_uuid
+      user.last_signed_in = session.created_at
+      user.sign_in = sign_in
+      user.save
+
+      @current_user = user
+    end
+  end
+end

--- a/modules/accredited_representative_portal/config/routes.rb
+++ b/modules/accredited_representative_portal/config/routes.rb
@@ -7,5 +7,7 @@ AccreditedRepresentativePortal::Engine.routes.draw do
         post :accept
       end
     end
+
+    get 'user', to: 'representative_users#show'
   end
 end

--- a/modules/accredited_representative_portal/spec/controllers/concerns/accredited_representative_portal/authenticable_spec.rb
+++ b/modules/accredited_representative_portal/spec/controllers/concerns/accredited_representative_portal/authenticable_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../support/authentication'
+
+RSpec.describe AccreditedRepresentativePortal::Authenticable do
+  controller(AccreditedRepresentativePortal::ApplicationController) do
+    def index
+      head :ok
+    end
+  end
+
+  let(:representative_user) { create(:representative_user) }
+
+  before do
+    login_as(representative_user)
+  end
+
+  it 'loads the current rep user from the overridden load_user_object method' do
+    expect(AccreditedRepresentativePortal::RepresentativeUserLoader).to receive(:new).and_call_original
+
+    get :index
+    expect(controller.instance_variable_get(:@current_user)).to be_a(AccreditedRepresentativePortal::RepresentativeUser)
+  end
+end

--- a/modules/accredited_representative_portal/spec/factories/representative_user.rb
+++ b/modules/accredited_representative_portal/spec/factories/representative_user.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :representative_user, class: 'AccreditedRepresentativePortal::RepresentativeUser' do
+    uuid { SecureRandom.uuid }
+    email { Faker::Internet.email }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    icn { '123498767V234859' }
+    idme_uuid { SecureRandom.uuid }
+    logingov_uuid { SecureRandom.uuid }
+    fingerprint { Faker::Internet.ip_v4_address }
+    last_signed_in { Time.zone.now }
+    authn_context { LOA::IDME_LOA3_VETS }
+    loa { { current: LOA::THREE, highest: LOA::THREE } }
+    sign_in {
+      { service_name: SignIn::Constants::Auth::IDME, client_id: SecureRandom.uuid,
+        auth_broker: SignIn::Constants::Auth::BROKER_CODE }
+    }
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/representative_user_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/representative_user_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::RepresentativeUser, type: :model do
+  describe 'validations' do
+    context 'valid'
+    context 'when all required attributes are present' do
+      let(:representative_user) { build(:representative_user) }
+
+      it 'is valid' do
+        expect(representative_user).to be_valid
+      end
+    end
+  end
+
+  context 'invalid' do
+    let(:expected_error_message) { "can't be blank" }
+
+    context 'when uuid is missing' do
+      let(:representative_user) { build(:representative_user, uuid: nil) }
+
+      it 'is invalid' do
+        expect(representative_user).not_to be_valid
+        expect(representative_user.errors[:uuid]).to include(expected_error_message)
+      end
+    end
+
+    context 'when email is missing' do
+      let(:representative_user) { build(:representative_user, email: nil) }
+
+      it 'is invalid' do
+        expect(representative_user).not_to be_valid
+        expect(representative_user.errors[:email]).to include(expected_error_message)
+      end
+    end
+
+    context 'when first name is missing' do
+      let(:representative_user) { build(:representative_user, first_name: nil) }
+
+      it 'is invalid' do
+        expect(representative_user).not_to be_valid
+        expect(representative_user.errors[:first_name]).to include(expected_error_message)
+      end
+    end
+
+    context 'when last name is missing' do
+      let(:representative_user) { build(:representative_user, last_name: nil) }
+
+      it 'is invalid' do
+        expect(representative_user).not_to be_valid
+        expect(representative_user.errors[:last_name]).to include(expected_error_message)
+      end
+    end
+
+    context 'when icn is missing' do
+      let(:representative_user) { build(:representative_user, icn: nil) }
+
+      it 'is invalid' do
+        expect(representative_user).not_to be_valid
+        expect(representative_user.errors[:icn]).to include(expected_error_message)
+      end
+    end
+  end
+
+  describe 'alias attributes' do
+    let(:icn_value) { SecureRandom.hex(10) }
+    let(:representative_user) { build(:representative_user, icn: icn_value) }
+
+    it 'aliases icn to mhv_icn' do
+      expect(representative_user.mhv_icn).to eq(icn_value)
+    end
+  end
+
+  describe 'Redis interactions' do
+    let!(:representative_user) { create(:representative_user) }
+
+    before { representative_user.save! }
+
+    it 'saves and retrieves the model from Redis' do
+      retrieved = AccreditedRepresentativePortal::RepresentativeUser.find(representative_user.uuid)
+      expect(retrieved).to be_a(AccreditedRepresentativePortal::RepresentativeUser)
+      expect(retrieved.uuid).to eq(representative_user.uuid)
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/application_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/application_spec.rb
@@ -9,38 +9,74 @@ RSpec.describe AccreditedRepresentativePortal::ApplicationController, type: :req
       response
     end
 
-    before(:context) do
+    let(:arp_client_id) { 'arp' }
+    let(:invalid_client_id) { 'invalid' }
+
+    let(:valid_access_token) { create(:access_token, audience: [arp_client_id]) }
+    let(:invalid_access_token) { create(:access_token, audience: [invalid_client_id]) }
+    let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: valid_access_token).perform }
+
+    before do
       AccreditedRepresentativePortal::Engine.routes.draw do
         get 'arbitrary', to: 'arbitrary#arbitrary'
       end
     end
 
-    after(:context) do
+    after do
       # We could have set up our test such that we can unset
       # `ArbitraryController` as a const during cleanup. But we'll just leave it
       # around and avoid the extra metaprogramming.
       Rails.application.reload_routes!
     end
 
-    describe 'when the accredited_representative_portal_api feature toggle' do
+    context 'when authenticated' do
       before do
-        expect(Flipper).to(
-          receive(:enabled?)
-            .with(:accredited_representative_portal_api)
-            .and_return(enabled)
-        )
+        cookies[SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME] = access_token_cookie
       end
 
-      describe 'is enabled' do
-        let(:enabled) { true }
+      context 'with a valid audience' do
+        it 'allows access' do
+          expect(subject).to have_http_status(:ok)
+        end
 
-        it { is_expected.to have_http_status(:ok) }
+        context 'when the representatives_portal_api feature toggle' do
+          before do
+            allow(Flipper).to receive(:enabled?).with(:accredited_representative_portal_api).and_return(enabled)
+          end
+
+          context 'is enabled' do
+            let(:enabled) { true }
+
+            it { is_expected.to have_http_status(:ok) }
+          end
+
+          context 'is disabled' do
+            let(:enabled) { false }
+
+            it { is_expected.to have_http_status(:not_found) }
+          end
+        end
       end
 
-      describe 'is disabled' do
-        let(:enabled) { false }
+      context 'with an invalid audience' do
+        let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: invalid_access_token).perform }
+        let(:expected_log_message) { '[SignIn::AudienceValidator] Invalid audience' }
+        let(:expected_log_payload) do
+          { invalid_audience: invalid_access_token.audience, valid_audience: valid_access_token.audience }
+        end
+        let(:expected_response_body) do
+          { errors: 'Invalid audience' }.to_json
+        end
 
-        it { is_expected.to have_http_status(:not_found) }
+        before do
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'denies access' do
+          expect(subject).to have_http_status(:unauthorized)
+          expect(subject.body).to eq(expected_response_body)
+          expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
+        end
       end
     end
   end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_controller_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_controller_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../../support/authentication'
 
 RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsController, type: :request do
+  let(:representative_user) { create(:representative_user) }
+
   before do
-    Flipper.enable(:representatives_portal_api)
+    login_as(representative_user)
+    allow(Flipper).to receive(:enabled?).with(:accredited_representative_portal_api).and_return(true)
   end
 
   describe 'POST /accept' do

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_user_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_user_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../support/authentication'
+
+RSpec.describe '/accredited_representative_portal/v0/representative_user', type: :request do
+  describe '#show' do
+    context 'when authenticated' do
+      let(:arp_client_id) { 'arp' }
+      let(:current_representative_user) { create(:representative_user) }
+
+      before do
+        login_as(current_representative_user)
+      end
+
+      it 'responds with the current_user' do
+        get '/accredited_representative_portal/v0/user'
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['uuid']).to eq(current_representative_user.uuid)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'responds with unauthorized' do
+        get '/accredited_representative_portal/v0/user'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/routing/accredited_representative_portal/v0/representative_user_routing_spec.rb
+++ b/modules/accredited_representative_portal/spec/routing/accredited_representative_portal/v0/representative_user_routing_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeUsersController, type: :routing do
+  describe 'routing' do
+    it 'routes to #show' do
+      expect(get: '/accredited_representative_portal/v0/user').to route_to(
+        'accredited_representative_portal/v0/representative_users#show', format: :json
+      )
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/representative_user_creator_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/representative_user_creator_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'timecop'
+
+RSpec.describe AccreditedRepresentativePortal::RepresentativeUserCreator do
+  describe '#perform' do
+    subject(:representative_user_creator) do
+      described_class.new(user_attributes:, state_payload:, verified_icn:, request_ip:)
+    end
+
+    let(:user_attributes) do
+      {
+        logingov_uuid:,
+        loa:,
+        csp_email:,
+        current_ial:,
+        max_ial:,
+        multifactor:,
+        authn_context:,
+        first_name:,
+        last_name:
+      }
+    end
+
+    let(:state_payload) do
+      create(:state_payload,
+             client_state:,
+             client_id:,
+             code_challenge:,
+             type:)
+    end
+
+    let(:logingov_uuid) { SecureRandom.hex }
+    let(:authn_context) { service_name }
+    let(:csp_email) { 'some-csp-email' }
+    let(:first_name) { 'Jane' }
+    let(:last_name) { 'Doe' }
+    let(:request_ip) { '127.0.0.1' }
+    let(:loa) { { current: SignIn::Constants::Auth::LOA_THREE, highest: SignIn::Constants::Auth::LOA_THREE } }
+    let(:current_ial) { SignIn::Constants::Auth::IAL_TWO }
+    let(:max_ial) { SignIn::Constants::Auth::IAL_TWO }
+    let(:multifactor) { true }
+    let(:service_name) { SignIn::Constants::Auth::LOGINGOV }
+    let(:verified_icn) { 'verified-icn' }
+    let!(:user_verification) { create(:logingov_user_verification, logingov_uuid:) }
+    let(:user_uuid) { user_verification.backing_credential_identifier }
+    let(:login_code) { 'some-login-code' }
+    let(:expected_last_signed_in) { '2023-1-1' }
+    let(:client_state) { SecureRandom.alphanumeric(SignIn::Constants::Auth::CLIENT_STATE_MINIMUM_LENGTH) }
+    let(:client_config) { create(:client_config) }
+    let(:client_id) { client_config.client_id }
+    let(:code_challenge) { 'some-code-challenge' }
+    let(:type) { SignIn::Constants::Auth::LOGINGOV }
+    let(:sign_in) do
+      {
+        service_name:,
+        auth_broker: SignIn::Constants::Auth::BROKER_CODE,
+        client_id:
+      }
+    end
+
+    before do
+      allow(SecureRandom).to receive(:uuid).and_return(login_code)
+      Timecop.freeze(expected_last_signed_in)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it 'creates a RepresentativeUser with expected attributes' do
+      representative_user_creator.perform
+
+      representative_user = AccreditedRepresentativePortal::RepresentativeUser.find(user_uuid)
+      expect(representative_user).to be_a(AccreditedRepresentativePortal::RepresentativeUser)
+      expect(representative_user.uuid).to eq(user_uuid)
+      expect(representative_user.icn).to eq(verified_icn)
+      expect(representative_user.email).to eq(csp_email)
+      expect(representative_user.idme_uuid).to eq(nil)
+      expect(representative_user.logingov_uuid).to eq(logingov_uuid)
+      expect(representative_user.first_name).to eq(first_name)
+      expect(representative_user.last_name).to eq(last_name)
+      expect(representative_user.fingerprint).to eq(request_ip)
+      expect(representative_user.last_signed_in).to eq(expected_last_signed_in)
+      expect(representative_user.authn_context).to eq(authn_context)
+      expect(representative_user.loa).to eq(loa)
+      expect(representative_user.sign_in).to eq(sign_in)
+    end
+
+    it 'sets terms code to nil' do
+      user_code_map = representative_user_creator.perform
+
+      expect(user_code_map.terms_code).to be_nil
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/representative_user_loader_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/representative_user_loader_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::RepresentativeUserLoader do
+  describe '#perform' do
+    subject(:representative_user_loader) { described_class.new(access_token:, request_ip:) }
+
+    let(:access_token) { create(:access_token, user_uuid: user.uuid, session_handle:) }
+    let!(:user) { create(:representative_user, uuid: user_uuid, icn: user_icn, loa: user_loa) }
+    let(:user_uuid) { user_account.id }
+    let(:user_account) { create(:user_account) }
+    let(:user_verification) { create(:idme_user_verification, user_account:) }
+    let(:user_loa) { { current: SignIn::Constants::Auth::LOA_THREE, highest: SignIn::Constants::Auth::LOA_THREE } }
+    let(:user_icn) { user_account.icn }
+    let(:session) { create(:oauth_session, user_account:, user_verification:) }
+    let(:session_handle) { session.handle }
+    let(:request_ip) { '123.456.78.90' }
+
+    shared_examples 'reloaded user' do
+      context 'and associated session cannot be found' do
+        let(:session) { nil }
+        let(:session_handle) { 'some-not-found-session-handle' }
+        let(:expected_error) { SignIn::Errors::SessionNotFoundError }
+        let(:expected_error_message) { 'Invalid Session Handle' }
+
+        it 'raises a session not found error' do
+          expect { representative_user_loader.perform }.to raise_error(expected_error, expected_error_message)
+        end
+      end
+
+      context 'and associated session exists' do
+        let(:session) do
+          create(:oauth_session, client_id:, user_account:, user_verification:)
+        end
+        let(:edipi) { 'some-mpi-edipi' }
+        let(:idme_uuid) { user_verification.idme_uuid }
+        let(:email) { session.credential_email }
+        let(:authn_context) { SignIn::Constants::Auth::IDME_LOA3 }
+        let(:service_name) { user_verification.credential_type }
+        let(:multifactor) { true }
+        let(:client_config) { create(:client_config) }
+        let(:client_id) { client_config.client_id }
+        let(:auth_broker) { SignIn::Constants::Auth::BROKER_CODE }
+        let(:sign_in) do
+          { service_name:,
+            auth_broker:,
+            client_id: }
+        end
+
+        it 'reloads user object with expected attributes' do
+          reloaded_user = representative_user_loader.perform
+
+          expect(reloaded_user).to be_a(AccreditedRepresentativePortal::RepresentativeUser)
+          expect(reloaded_user.uuid).to eq(user_uuid)
+          expect(reloaded_user.email).to eq(email)
+          expect(reloaded_user.first_name).to eq(session.user_attributes_hash['first_name'])
+          expect(reloaded_user.last_name).to eq(session.user_attributes_hash['last_name'])
+          expect(reloaded_user.icn).to eq(user_icn)
+          expect(reloaded_user.idme_uuid).to eq(idme_uuid)
+          expect(reloaded_user.logingov_uuid).to eq(nil)
+          expect(reloaded_user.fingerprint).to eq(request_ip)
+          expect(reloaded_user.last_signed_in).to eq(session.created_at)
+          expect(reloaded_user.authn_context).to eq(authn_context)
+          expect(reloaded_user.loa).to eq(user_loa)
+          expect(reloaded_user.sign_in).to eq(sign_in)
+        end
+      end
+    end
+
+    context 'when user record already exists in redis' do
+      let(:user_uuid) { user_account.id }
+
+      context 'and user identity record exists in redis' do
+        it 'returns existing user redis record' do
+          expect(representative_user_loader.perform.uuid).to eq(user_uuid)
+        end
+      end
+    end
+
+    context 'when user record no longer exists in redis' do
+      before do
+        user.destroy
+      end
+
+      it_behaves_like 'reloaded user'
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/support/authentication.rb
+++ b/modules/accredited_representative_portal/spec/support/authentication.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Authentication
+  def login_as(representative_user, options = {})
+    access_token = options[:access_token] || create(:access_token, user_uuid: representative_user.uuid,
+                                                                   audience: ['arp'])
+    cookies[SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME] =
+      SignIn::AccessTokenJwtEncoder.new(access_token:).perform
+  end
+end
+
+RSpec.configure do |config|
+  config.include Authentication
+end


### PR DESCRIPTION
## Summary
- Add auth flow for a representative user
- create a basic RepresentativeUser model
- Create RepresentativeUser creator and loader
- add access_token audience validation to arp controllers to only accept arp sessions

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#78007 
- department-of-veterans-affairs/va.gov-team#78002

## Testing
- Seed `vets-api` database - `rails db:seed`
- Start `vets-api` - `rails s`
- Start `vets-website` - `yarn watch`
- Authenticate  through USiP - [http://localhost:3001/sign-in/?application=arp&oauth=true](http://localhost:3001/sign-in/?application=arp&oauth=true)
- Hit the `rep_user` endpoint - [http://localhost:3000/accredited_representative_portal/v0/user](http://localhost:3000/accredited_representative_portal/v0/rep_user)
    - You should see JSON of the the `rep_user` you are signed in with
- Try to hit a `vets-api` route - [http://localhost:3000/v0/user](http://localhost:3000/v0/user)
   - You should be blocked and get an error: `{"errors":"Invalid audience"}` 

## What areas of the site does it impact?
Authentication, representative portal authentication

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
