### PR TITLE
database changes to separate user_profile from user_info and address …

### DIFF
--- a/db/migrate/20240315033525_create_vye_user_profiles.vye.rb
+++ b/db/migrate/20240315033525_create_vye_user_profiles.vye.rb
@@ -1,0 +1,16 @@
+# This migration comes from vye (originally 20240229184515)
+class CreateVyeUserProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :vye_user_profiles do |t|
+      t.binary :ssn_digest, limit: 16.bytes
+      t.binary :file_number_digest, limit: 16.bytes
+      t.string :icn
+
+      t.timestamps
+    end
+
+    add_index :vye_user_profiles, :ssn_digest, unique: true
+    add_index :vye_user_profiles, :file_number_digest, unique: true
+    add_index :vye_user_profiles, :icn, unique: true
+  end
+end

--- a/db/migrate/20240315033526_add_address_details_to_vye_address_changes.vye.rb
+++ b/db/migrate/20240315033526_add_address_details_to_vye_address_changes.vye.rb
@@ -1,0 +1,8 @@
+# This migration comes from vye (originally 20240305040113)
+class AddAddressDetailsToVyeAddressChanges < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vye_address_changes, :address_line5_ciphertext, :text
+    add_column :vye_address_changes, :address_line6_ciphertext, :text
+    add_column :vye_address_changes, :origin, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_13_235317) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_15_033526) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -1275,6 +1275,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_13_235317) do
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "address_line5_ciphertext"
+    t.text "address_line6_ciphertext"
+    t.string "origin"
     t.index ["user_info_id"], name: "index_vye_address_changes_on_user_info_id"
   end
 
@@ -1358,6 +1361,17 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_13_235317) do
     t.datetime "updated_at", null: false
     t.index ["icn"], name: "index_vye_user_infos_on_icn"
     t.index ["ssn_digest"], name: "index_vye_user_infos_on_ssn_digest"
+  end
+
+  create_table "vye_user_profiles", force: :cascade do |t|
+    t.binary "ssn_digest"
+    t.binary "file_number_digest"
+    t.string "icn"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["file_number_digest"], name: "index_vye_user_profiles_on_file_number_digest", unique: true
+    t.index ["icn"], name: "index_vye_user_profiles_on_icn", unique: true
+    t.index ["ssn_digest"], name: "index_vye_user_profiles_on_ssn_digest", unique: true
   end
 
   create_table "vye_verifications", force: :cascade do |t|

--- a/modules/vye/db/migrate/20240229184515_create_vye_user_profiles.rb
+++ b/modules/vye/db/migrate/20240229184515_create_vye_user_profiles.rb
@@ -1,0 +1,15 @@
+class CreateVyeUserProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :vye_user_profiles do |t|
+      t.binary :ssn_digest, limit: 16.bytes
+      t.binary :file_number_digest, limit: 16.bytes
+      t.string :icn
+
+      t.timestamps
+    end
+
+    add_index :vye_user_profiles, :ssn_digest, unique: true
+    add_index :vye_user_profiles, :file_number_digest, unique: true
+    add_index :vye_user_profiles, :icn, unique: true
+  end
+end

--- a/modules/vye/db/migrate/20240305040113_add_address_details_to_vye_address_changes.rb
+++ b/modules/vye/db/migrate/20240305040113_add_address_details_to_vye_address_changes.rb
@@ -1,0 +1,7 @@
+class AddAddressDetailsToVyeAddressChanges < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vye_address_changes, :address_line5_ciphertext, :text
+    add_column :vye_address_changes, :address_line6_ciphertext, :text
+    add_column :vye_address_changes, :origin, :string
+  end
+end


### PR DESCRIPTION
https://jira.devops.va.gov/browse/VYE-253
https://jira.devops.va.gov/browse/VYE-254

As:

VYE Backend Developer

I need:

To separate data  from transient date.

So that: 

 Data that's not transient does not get purged.

Considerations:

No considerations

Acceptance Criteria: 

 Data that's not transient does not get purged.

Have to be moved out in separate tables

ICN
SSN 
Claim number 

Testing Considerations:

Not a new feature, so there's no test component

Other Considerations: 

No other considerations

As:

VYE Backend Developer

I need:

 To separate address data from BDN

So that: 

 It could be added to the addresses array in user profile

Considerations:

No considerations

Acceptance Criteria: 

So front end can see all the addresses
Will only show the last address to populate from

Testing Considerations:

No testing considerations

Other Considerations: 

No other considerations