### PR TITLE
Change absolute pathing (wrong) to relative pathing

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -11,7 +11,7 @@ module TravelPay
       auth_url = Settings.travel_pay.veis.auth_url
       tenant_id = Settings.travel_pay.veis.tenant_id
 
-      connection(server_url: auth_url).post("/#{tenant_id}/oauth2/token") do |req|
+      connection(server_url: auth_url).post("#{tenant_id}/oauth2/token") do |req|
         req.headers[:content_type] = 'application/x-www-form-urlencoded'
         req.body = URI.encode_www_form(veis_params)
       end
@@ -26,7 +26,7 @@ module TravelPay
       btsss_url = Settings.travel_pay.base_url
       api_key = Settings.travel_pay.subscription_key
 
-      connection(server_url: btsss_url).post('/api/v1/Auth/access-token') do |req|
+      connection(server_url: btsss_url).post('api/v1/Auth/access-token') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
         req.body = { authJwt: vagov_token }
@@ -42,7 +42,7 @@ module TravelPay
       btsss_url = Settings.travel_pay.base_url
       api_key = Settings.travel_pay.subscription_key
 
-      connection(server_url: btsss_url).get('/api/v1/Sample/ping') do |req|
+      connection(server_url: btsss_url).get('api/v1/Sample/ping') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
       end


### PR DESCRIPTION
Faraday truncates the `server_url` to just the domain if you provide a `/` in your path. This is the reason we were getting 404s from the BTSSS API. 

So:

```ruby
# Incorrectly hits: https://httpbin.org/1/2
connection(server_url: 'https://httpbin.org/links').get('/1/2')

# Correctly hits: https://httpbin.org/links/1/2
# Note this missing leading forward slash in the get method
connection(server_url: 'https://httpbin.org/links').get('1/2')
```