### PR TITLE
Track users for remaining three forms

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -3,6 +3,7 @@
 module SimpleFormsApi
   class VBA2010206
     include Virtus.model(nullify_blank: true)
+    STATS_KEY = 'api.simple_forms_api.20_10206'
 
     attribute :data
 
@@ -40,6 +41,10 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity(confirmation_number); end
+    def track_user_identity(confirmation_number)
+      identity = data['preparer_type']
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('Simple forms api - 20-10206 submission user identity', identity:, confirmation_number:)
+    end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -3,6 +3,7 @@
 module SimpleFormsApi
   class VBA210966
     include Virtus.model(nullify_blank: true)
+    STATS_KEY = 'api.simple_forms_api.21_0966'
 
     attribute :data
 
@@ -63,7 +64,11 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity(confirmation_number); end
+    def track_user_identity(confirmation_number)
+      identity = data['preparer_identification']
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('Simple forms api - 21-0966 submission user identity', identity:, confirmation_number:)
+    end
 
     private
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -3,6 +3,7 @@
 module SimpleFormsApi
   class VBA210972
     include Virtus.model(nullify_blank: true)
+    STATS_KEY = 'api.simple_forms_api.21_0972'
 
     attribute :data
 
@@ -31,6 +32,10 @@ module SimpleFormsApi
       }
     end
 
-    def track_user_identity(confirmation_number); end
+    def track_user_identity(confirmation_number)
+      identity = data['claimant_identification']
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('Simple forms api - 21-0972 submission user identity', identity:, confirmation_number:)
+    end
   end
 end


### PR DESCRIPTION
## Summary
This PR tracks users for the remaining three simple forms:
- 20-10206
- 21-0972
- 21-0966

Until now I've been handling these one at a time but I figured the pattern was clear and small enough that I could just knock the rest out with one PR.

## Related issue(s)
- [20-10206](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1111)
- [21-0972](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1112)
- [21-0966](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1113)
