### PR TITLE
change workflow name to specify preview env

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,8 +1,8 @@
-name: build-and-publish
-run-name: Build And Publish
+name: build-and-publish-preview-environment
+run-name: Build And Publish Preview Environment
 on: [push]
 jobs:
-  build-and-publish:
+  build-and-publish-preview-environment:
     runs-on: ubuntu-latest
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,8 +1,8 @@
-name: build-and-publish-preview-environment
+name: Build And Publish Preview Environment
 run-name: Build And Publish Preview Environment
 on: [push]
 jobs:
-  build-and-publish-preview-environment:
+  build-and-publish:
     runs-on: ubuntu-latest
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}


### PR DESCRIPTION
## Summary

A failing `build-and-publish` workflow can look alarming (see screenshot). Some users think this is related to code being deployed to production. Rename to specify preview environments.

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/d94efe32-3ee3-4817-ad93-a48823a2e5bc)

## What areas of the site does it impact?
CI run.

