### PR TITLE
Move travel pay ping endpoint to new controller

### DIFF
--- a/modules/travel_pay/app/controllers/travel_pay/claims_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/claims_controller.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module TravelPay
-  class ClaimsController < ApplicationController
-    def index; end
-  end
-end

--- a/modules/travel_pay/app/controllers/travel_pay/claims_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/claims_controller.rb
@@ -2,21 +2,6 @@
 
 module TravelPay
   class ClaimsController < ApplicationController
-    ##
-    # For now, index is integrated with PING endpoint until
-    # upstream API is more complete.
-    def index
-      veis_response = client.request_veis_token
-
-      veis_token = veis_response.body['access_token']
-
-      btsss_ping_response = client.ping(veis_token)
-
-      render json: { data: "Received ping from upstream server with status #{btsss_ping_response.status}." }
-    end
-
-    def client
-      TravelPay::Client.new
-    end
+    def index; end
   end
 end

--- a/modules/travel_pay/app/controllers/travel_pay/pings_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/pings_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module TravelPay
+  class PingsController < ApplicationController
+    def ping
+      veis_response = client.request_veis_token
+
+      veis_token = veis_response.body['access_token']
+
+      btsss_ping_response = client.ping(veis_token)
+
+      render json: { data: "Received ping from upstream server with status #{btsss_ping_response.status}." }
+    end
+
+    def client
+      TravelPay::Client.new
+    end
+  end
+end

--- a/modules/travel_pay/config/routes.rb
+++ b/modules/travel_pay/config/routes.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 TravelPay::Engine.routes.draw do
-  resources :claims
   get '/pings/ping', to: 'pings#ping'
 end

--- a/modules/travel_pay/config/routes.rb
+++ b/modules/travel_pay/config/routes.rb
@@ -2,4 +2,5 @@
 
 TravelPay::Engine.routes.draw do
   resources :claims
+  get '/pings/ping', to: 'pings#ping'
 end

--- a/modules/travel_pay/spec/controllers/pings_controller_spec.rb
+++ b/modules/travel_pay/spec/controllers/pings_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe TravelPay::ClaimsController, type: :request do
+RSpec.describe TravelPay::PingsController, type: :request do
   let(:user) { build(:user) }
   let(:client) { instance_double(TravelPay::Client) }
 
@@ -18,7 +18,7 @@ RSpec.describe TravelPay::ClaimsController, type: :request do
     Flipper.disable :travel_pay_power_switch
   end
 
-  describe '#index' do
+  describe '#ping' do
     context 'the feature switch is enabled' do
       before do
         Flipper.enable :travel_pay_power_switch
@@ -26,14 +26,14 @@ RSpec.describe TravelPay::ClaimsController, type: :request do
 
       it 'requests a token and sends a ping to BTSSS' do
         expect(client).to receive(:ping)
-        get '/travel_pay/claims'
+        get '/travel_pay/pings/ping'
         expect(response.body).to include('ping')
       end
     end
 
     context 'the feature switch is disabled' do
       it 'raises the proper error' do
-        get '/travel_pay/claims'
+        get '/travel_pay/pings/ping'
         expect(response).to have_http_status(:service_unavailable)
         expect(response.body).to include('This feature has been temporarily disabled')
       end


### PR DESCRIPTION
Creates new `TravelPay::PingsController` and moves ping functionality out of `claims/index` (which will be needed later) into the new controller.