### PR TITLE
ClamAV in Containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ node_modules
 # Ignore public folder (used for local document uploads)
 public
 
+# Ignore any files within clamav_tmp
+
+clamav_tmp/*
+!/clamav_tmp/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'bootsnap', require: false
 gem 'breakers'
 gem 'carrierwave'
 gem 'carrierwave-aws'
-gem 'clam_scan'
+gem 'clamav-client', require: 'clamav/client'
 gem 'combine_pdf'
 gem 'config'
 gem 'connect_vbms', git: 'https://github.com/department-of-veterans-affairs/connect_vbms.git', branch: 'master', require: 'vbms'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    clam_scan (0.0.2)
+    clamav-client (3.2.0)
     cliver (0.3.2)
     coderay (1.1.3)
     coercible (1.0.0)
@@ -581,8 +581,13 @@ GEM
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     libdatadog (5.0.0.1.0)
+    libdatadog (5.0.0.1.0-aarch64-linux)
     libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-arm64-darwin)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
@@ -1039,8 +1044,9 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin-22
   java
-  ruby
   x64-mingw32
   x86-mingw32
   x86-mswin32
@@ -1074,7 +1080,7 @@ DEPENDENCIES
   carrierwave-aws
   check_in!
   claims_api!
-  clam_scan
+  clamav-client
   combine_pdf
   config
   connect_vbms!

--- a/app/uploaders/uploader_virus_scan.rb
+++ b/app/uploaders/uploader_virus_scan.rb
@@ -16,13 +16,14 @@ module UploaderVirusScan
   def validate_virus_free(file)
     return unless Rails.env.production?
 
-    temp_file_path = Common::FileHelpers.generate_temp_file(file.read)
+    temp_file_path = Common::FileHelpers.generate_clamav_temp_file(file.read)
     result = Common::VirusScan.scan(temp_file_path)
     File.delete(temp_file_path)
 
-    unless result.safe?
+    # Common::VirusScan result will return true or false
+    unless result # unless safe
       file.delete
-      raise VirusFoundError, result.body
+      raise VirusFoundError, "Virus Found + #{temp_file_path}"
     end
   end
 end

--- a/bin/fake_clamdscan
+++ b/bin/fake_clamdscan
@@ -1,5 +1,0 @@
-#!/bin/bash
-# frozen_string_literal: true
-
-echo 'Fake scanning file with fake_clamdscan script'
-exit 0

--- a/config/clamd.conf
+++ b/config/clamd.conf
@@ -1,5 +1,7 @@
 Foreground yes
-DatabaseDirectory /srv/vets-api/clamav/database
-LocalSocket /srv/vets-api/clamav/clamd.ctl
 TCPSocket 3310
 TCPAddr 127.0.0.1
+
+LogSyslog yes
+LogVerbose yes
+ExtendedDetectionInfo yes

--- a/config/freshclam.conf
+++ b/config/freshclam.conf
@@ -3,5 +3,5 @@ PidFile /srv/vets-api/clamav/freshclam.pid
 Checks 8
 DatabaseDirectory /srv/vets-api/clamav/database
 PrivateMirror dsva-vetsgov-utility-clamav.s3-us-gov-west-1.amazonaws.com
-NotifyClamd  /srv/vets-api/src/config/clamd.conf
+NotifyClamd  /app/config/clamd.conf
 ReceiveTimeout 600

--- a/config/initializers/clamav.rb
+++ b/config/initializers/clamav.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+if Rails.env.development?
+  ENV["CLAMD_TCP_HOST"] = Settings.clamav.host || 'clamav'
+  ENV["CLAMD_TCP_PORT"] = Settings.clamav.port || '3310'
+end

--- a/config/initializers/clamscan.rb
+++ b/config/initializers/clamscan.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-ClamScan.configure do |clam_config|
-  clam_config.client_location = Settings.binaries.clamdscan
-end

--- a/config/settings.local.yml.example
+++ b/config/settings.local.yml.example
@@ -6,11 +6,11 @@
   # The relative path to department-of-veterans-affairs/vets-api-mockdata
   # cache_dir: ../vets-api-mockdata
 
-# binaries:
-  # For NATIVE and DOCKER installation
+# clamav:
   # A "virus scanner" that always returns success for development purposes
-  # NOTE: You may need to specify a full path instead of a relative path
-  # clamdscan: ./bin/fake_clamdscan
+  # mock: true
+  # host: '0.0.0.0'
+  # port: '33100'
 
 # NOTE: This file is excluded by railsconfig in the test env.
 # Use config/settings/test.local.yml instead.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,6 +93,9 @@ binaries:
   pdftk: pdftk
   clamdscan: /usr/bin/clamdscan
 
+clamav:
+  mock: false
+
 db_encryption_key: f01ff8ebd1a2b053ad697ae1f0d86adb
 
 database_url: postgis:///vets-api

--- a/docker-compose-clamav.yml
+++ b/docker-compose-clamav.yml
@@ -1,0 +1,10 @@
+version: '3.4'
+services:
+  clamav:
+    volumes:
+     - shared-vol:/vets-api
+    image: clamav/clamav
+    ports:
+      - 33100:3310
+volumes:
+ shared-vol:

--- a/docker-compose-deps.yml
+++ b/docker-compose-deps.yml
@@ -13,4 +13,11 @@ services:
       - ./data:/var/lib/postgresql/data:cached
     ports:
       - "54320:5432"
-
+  clamav:
+    volumes:
+     - shared-vol:/vets-api
+    image: clamav/clamav
+    ports:
+      - 33100:3310
+volumes:
+ shared-vol:

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -1,55 +1,61 @@
-version: '3.4'
+version: '3.8'
+
+x-app: &common
+  build:
+    args:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
+    context: .
+  environment:
+    BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
+    "Settings.database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
+    "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
+    "Settings.redis.app_data.url": "redis://redis:6379"
+    "Settings.redis.sidekiq.url": "redis://redis:6379"
+    "Settings.redis.rails_cache.url": "redis://redis:6379"
+  image: vets-api:${DOCKER_IMAGE:-latest}
+  volumes:
+    - "../vets-api-mockdata:/cache"
+    - .:/app:cached
+    - shared-vol:/tmp
+  working_dir: /app
+  depends_on:
+    - clamav
+    - postgres
+    - redis
+  links:
+    - clamav
+    - postgres
+    - redis
+
 services:
+  clamav:
+    image: clamav/clamav
+    ports:
+      - 33100:3310
+    volumes:
+     - shared-vol:/vets-api
   redis:
     image: redis:5.0-alpine
-    restart: unless-stopped
+    ports:
+      - 63790:6379
   postgres:
-    image: mdillon/postgis:11-alpine
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
-    volumes:
-      - db-data:/var/lib/postgresql/data:cached
+      PGDATA: /tmp
+    image: postgis/postgis:14-3.3-alpine
     ports:
-      - "54320:5432"
-    restart: unless-stopped
-  vets-api:
-    build:
-      context: .
-      target: development
-      args:
-        sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
-        userid: "${VETS_API_USER_ID}"
-    command: >
-      bash -c "bundle exec rake db:migrate || bundle exec rake db:setup db:migrate
-      && touch tmp/caching-dev.txt && foreman start -m all=1,clamd=0,freshclam=0"
-    image: "vets-api:${DOCKER_IMAGE:-latest}"
+      - 54320:5432
     volumes:
-      - .:/srv/vets-api/src:cached
-      - dev_bundle:/usr/local/bundle
-      - ../.secret:/srv/vets-api/secret:cached
-      - ../.pki:/srv/vets-api/pki:cached
+      - ./data:/var/lib/postgresql/data:cached
+  web:
+    <<: *common
     ports:
-      - "3000:3000"
-    environment:
-      "Settings.database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
-      "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}?pool=4"
-      "Settings.redis.app_data.url": "redis://redis:6379"
-      "Settings.redis.sidekiq.url": "redis://redis:6379"
-      "Settings.redis.rails_cache.url": "redis://redis:6379"
-      "Settings.binaries.clamdscan": "clamscan" # Not running a separate process within the container for clamdscan, so we use clamscan which requires no daemon
-      POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
-      POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
-      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
-      PUMA_THREADS: "${PUMA_THREADS:-4}"
-    depends_on:
-      - postgres
-      - redis
-    links:
-      - postgres
-      - redis
-    restart: unless-stopped
+      - 3000:3000
+  worker:
+    <<: *common
+    command: bundle exec sidekiq -q critical,4 -q tasker,3 -q default,2 -q low,1
+
 volumes:
-  db-data:
-  dev_bundle:
+ shared-vol:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -38,3 +38,4 @@ services:
       - postgres
 volumes:
   test_bundle:
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,49 +1,61 @@
-version: '3.4'
+version: '3.8'
+
+x-app: &common
+  build:
+    args:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
+    context: .
+  environment:
+    BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
+    "Settings.database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
+    "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
+    "Settings.redis.app_data.url": "redis://redis:6379"
+    "Settings.redis.sidekiq.url": "redis://redis:6379"
+    "Settings.redis.rails_cache.url": "redis://redis:6379"
+  image: vets-api:${DOCKER_IMAGE:-latest}
+  volumes:
+    - "../vets-api-mockdata:/cache"
+    - .:/app:cached
+    - shared-vol:/tmp
+  working_dir: /app
+  depends_on:
+    - clamav
+    - postgres
+    - redis
+  links:
+    - clamav
+    - postgres
+    - redis
+
 services:
+  clamav:
+    image: clamav/clamav
+    ports:
+      - 33100:3310
+    volumes:
+     - shared-vol:/vets-api
   redis:
     image: redis:5.0-alpine
     ports:
-      - "63790:6379"
+      - 63790:6379
   postgres:
-    image: mdillon/postgis:11-alpine
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+      PGDATA: /tmp
+    image: postgis/postgis:14-3.3-alpine
+    ports:
+      - 54320:5432
     volumes:
       - ./data:/var/lib/postgresql/data:cached
+  web:
+    <<: *common
     ports:
-      - "54320:5432"
-  vets-api:
-    build:
-      context: .
-      target: development
-      args:
-        sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
-        userid: "${VETS_API_USER_ID}"
-    image: "vets-api:${DOCKER_IMAGE:-latest}"
-    volumes:
-      - .:/srv/vets-api/src:cached
-      - "../vets-api-mockdata:/cache"
-      - dev_bundle:/usr/local/bundle
-    ports:
-      - "3000:3000"
-    environment:
-      "Settings.database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
-      "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
-      "Settings.redis.app_data.url": "redis://redis:6379"
-      "Settings.redis.sidekiq.url": "redis://redis:6379"
-      "Settings.binaries.clamdscan": "clamscan" # Not running a separate process within the container for clamdscan, so we use clamscan which requires no daemon
-      POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
-      POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
-      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
-    depends_on:
-      - postgres
-      - redis
-    links:
-      - postgres
-      - redis
+      - 3000:3000
+  worker:
+    <<: *common
+    command: bundle exec sidekiq -q critical,4 -q tasker,3 -q default,2 -q low,1
 
 volumes:
-  db-data:
-  dev_bundle:
+ shared-vol:

--- a/lib/clamav/commands/patch_scan_command.rb
+++ b/lib/clamav/commands/patch_scan_command.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+## Monkey Patch for the clamav SCAN COMMAND
+## file path needs to be vets-api/ because of shared volumes
+
+# clamav-client - ClamAV client
+# Copyright (C) 2014 Franck Verrot <franck@verrot.fr>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'clamav/commands/command'
+
+module ClamAV
+  module Commands
+    class PatchScanCommand < Command
+      def initialize(path, path_finder = Util)
+        @path = path
+        @path_finder = path_finder
+      end
+
+      def call(conn)
+        @path_finder.path_to_files(@path).map { |file| scan_file(conn, file) }
+      end
+
+      def scan_file(conn, file)
+        stripped_filename = file.gsub(%r{^clamav_tmp/}, '') # need to send the file
+        get_status_from_response(conn.send_request("SCAN /vets-api/#{stripped_filename}"))
+      end
+    end
+  end
+end

--- a/lib/clamav/patch_client.rb
+++ b/lib/clamav/patch_client.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# clamav-client - ClamAV client
+# Copyright (C) 2014 Franck Verrot <franck@verrot.fr>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'clamav/connection'
+require 'clamav/commands/ping_command'
+require 'clamav/commands/quit_command'
+require 'clamav/commands/scan_command'
+require 'clamav/commands/instream_command'
+require 'clamav/util'
+require 'clamav/wrappers/new_line_wrapper'
+require 'clamav/wrappers/null_termination_wrapper'
+require_relative 'commands/patch_scan_command'
+
+module ClamAV
+  class PatchClient
+    def initialize(connection = default_connection)
+      @connection = connection
+      connection.establish_connection
+    end
+
+    def execute(command)
+      command.call(@connection)
+    end
+
+    def default_connection
+      ClamAV::Connection.new(
+        socket: resolve_default_socket,
+        wrapper: ::ClamAV::Wrappers::NewLineWrapper.new
+      )
+    end
+
+    def resolve_default_socket
+      unix_socket, tcp_host, tcp_port = ENV.values_at('CLAMD_UNIX_SOCKET', 'CLAMD_TCP_HOST', 'CLAMD_TCP_PORT')
+      if tcp_host && tcp_port
+        ::TCPSocket.new(tcp_host, tcp_port)
+      else
+        ::UNIXSocket.new(unix_socket || '/var/run/clamav/clamd.ctl')
+      end
+    end
+
+    def ping
+      execute Commands::PingCommand.new
+    end
+
+    def safe?(target)
+      return instream(target).virus_name.nil? if target.is_a?(StringIO)
+
+      scan(target).all? { |file| file.virus_name.nil? }
+    end
+
+    private
+
+    def instream(io)
+      execute Commands::InstreamCommand.new(io)
+    end
+
+    def scan(file_path)
+      execute Commands::PatchScanCommand.new(file_path)
+    end
+  end
+end

--- a/lib/common/file_helpers.rb
+++ b/lib/common/file_helpers.rb
@@ -22,5 +22,22 @@ module Common
 
       file_path
     end
+
+    def generate_clamav_temp_file(file_body, file_name = nil)
+      file_name = SecureRandom.hex if file_name.nil?
+      clamav_directory = Rails.root.join('clamav_tmp')
+      unless Dir.exist?(clamav_directory)
+        # Create the directory if it doesn't exist
+        Dir.mkdir(clamav_directory)
+      end
+
+      file_path = "clamav_tmp/#{file_name}"
+
+      File.open(file_path, 'wb') do |file|
+        file.write(file_body)
+      end
+
+      file_path
+    end
   end
 end

--- a/lib/common/virus_scan.rb
+++ b/lib/common/virus_scan.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'clamav/commands/patch_scan_command'
+require 'clamav/patch_client'
+
 module Common
   module VirusScan
     module_function
@@ -8,10 +11,15 @@ module Common
       # `clamd` runs within service group, needs group read
       File.chmod(0o640, file_path)
 
-      # NOTE: If using custom_args, no other arguments can be passed to
-      # ClamScan::Client.scan. All other arguments will be ignored
-      args = ['-c', Rails.root.join('config', 'clamd.conf').to_s, file_path]
-      ClamScan::Client.scan(custom_args: args)
+      if mock_enabled?
+        true
+      else
+        ClamAV::PatchClient.new.safe?(file_path) # patch to call our class
+      end
+    end
+
+    def mock_enabled?
+      Settings.clamav.mock
     end
   end
 end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -110,6 +110,8 @@ RSpec.describe 'Forms uploader', type: :request do
         sign_in
         allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
         allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
+        allow(Common::VirusScan).to receive(:scan).and_return(true)
+        allow_any_instance_of(Common::VirusScan).to receive(:scan).and_return(true)
       end
 
       describe 'request with intent to file' do

--- a/spec/lib/shrine/plugins/validate_virus_free_spec.rb
+++ b/spec/lib/shrine/plugins/validate_virus_free_spec.rb
@@ -29,31 +29,23 @@ describe Shrine::Plugins::ValidateVirusFree do
 
     context 'with errors' do
       before do
-        allow(ClamScan.configuration).to receive(:client_location).and_return('found')
+        allow(Common::VirusScan).to receive(:scan).and_return(false)
       end
 
       context 'while in development' do
         it 'logs an error message if clamd is not running' do
           expect(Rails.env).to receive(:development?).and_return(true)
           expect(Rails.logger).to receive(:error).with(/PLEASE START CLAMD/)
-          allow(ClamScan::Client).to receive(:scan)
-            .and_return(instance_double('ClamScan::Response',
-                                        safe?: false,
-                                        body: 'ERROR: Could not lookup : nodename nor servname provided, or not known'))
-
-          result = instance.validate_virus_free
+          result = instance.validate_virus_free(message: 'nodename nor servname provided')
           expect(result).to be(true)
         end
       end
 
       context 'with the default error message' do
         it 'adds an error if clam scan returns not safe' do
-          allow(ClamScan::Client).to receive(:scan)
-            .and_return(instance_double('ClamScan::Response', safe?: false, body: nil))
-
           result = instance.validate_virus_free
           expect(result).to be(false)
-          expect(instance.errors).to eq(['virus or malware detected'])
+          expect(instance.errors).to include(match(/Virus Found/))
         end
       end
 
@@ -61,9 +53,6 @@ describe Shrine::Plugins::ValidateVirusFree do
         let(:message) { 'oh noes!' }
 
         it 'adds an error with a custom error message if clam scan returns not safe' do
-          allow(ClamScan::Client).to receive(:scan)
-            .and_return(instance_double('ClamScan::Response', safe?: false))
-
           result = instance.validate_virus_free(message:)
           expect(result).to be(false)
           expect(instance.errors).to eq(['oh noes!'])
@@ -71,21 +60,18 @@ describe Shrine::Plugins::ValidateVirusFree do
       end
     end
 
-    it 'does not add an error if clam scan returns safe' do
-      allow(ClamScan::Client).to receive(:scan)
-        .and_return(instance_double('ClamScan::Response', safe?: true))
+    context 'it returns safe' do
+      before do
+        allow(Common::VirusScan).to receive(:scan).and_return(true)
+      end
 
-      expect(instance).not_to receive(:add_error_msg)
-      result = instance.validate_virus_free
-      expect(result).to be(true)
-    end
+      it 'does not add an error if clam scan returns safe' do
+        allow_any_instance_of(ClamAV::PatchClient).to receive(:safe?).and_return(true)
 
-    it 'changes group permissions of the uploaded file' do
-      allow(ClamScan::Client).to receive(:scan)
-        .and_return(instance_double('ClamScan::Response', safe?: true))
-
-      expect(File).to receive(:chmod).with(0o640, 'foo/bar.jpg').and_return(1)
-      instance.validate_virus_free
+        expect(instance).not_to receive(:add_error_msg)
+        result = instance.validate_virus_free
+        expect(result).to be(true)
+      end
     end
   end
 end

--- a/spec/models/persistent_attachments/dependency_claim_spec.rb
+++ b/spec/models/persistent_attachments/dependency_claim_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe PersistentAttachments::DependencyClaim, uploader_helpers: true do
   let(:file) { Rails.root.join('spec', 'fixtures', 'files', 'marriage-certificate.pdf') }
   let(:instance) { described_class.new(form_id: '686C-674') }
 
+  before do
+    allow(Common::VirusScan).to receive(:scan).and_return(true)
+  end
+
   it 'sets a guid on initialize' do
     expect(instance.guid).to be_a(String)
   end
 
   it 'allows adding a file' do
-    allow(ClamScan::Client).to receive(:scan)
-      .and_return(instance_double('ClamScan::Response', safe?: true))
+    allow_any_instance_of(ClamAV::PatchClient).to receive(:safe?).and_return(true)
     instance.file = file.open
     expect(instance.valid?).to be(true)
     expect(instance.file.shrine_class).to be(ClaimDocumentation::Uploader)

--- a/spec/models/persistent_attachments/lgy_claim_spec.rb
+++ b/spec/models/persistent_attachments/lgy_claim_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe PersistentAttachments::LgyClaim, uploader_helpers: true do
   let(:file) { Rails.root.join('spec', 'fixtures', 'files', 'marriage-certificate.pdf') }
   let(:instance) { described_class.new(form_id: '28-1880') }
 
+  before do
+    allow(Common::VirusScan).to receive(:scan).and_return(true)
+  end
+
   it 'sets a guid on initialize' do
     expect(instance.guid).to be_a(String)
   end
 
   it 'allows adding a file' do
-    allow(ClamScan::Client).to receive(:scan)
-      .and_return(instance_double('ClamScan::Response', safe?: true))
+    allow_any_instance_of(ClamAV::PatchClient).to receive(:safe?).and_return(true)
     instance.file = file.open
     expect(instance.valid?).to be(true)
     expect(instance.file.shrine_class).to be(ClaimDocumentation::Uploader)

--- a/spec/models/persistent_attachments/pension_burial_spec.rb
+++ b/spec/models/persistent_attachments/pension_burial_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe PersistentAttachments::PensionBurial, uploader_helpers: true do
   let(:file) { Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf') }
   let(:instance) { described_class.new(form_id: 'T-123') }
 
+  before do
+    allow(Common::VirusScan).to receive(:scan).and_return(true)
+  end
+
   it 'sets a guid on initialize' do
     expect(instance.guid).to be_a(String)
   end
 
   it 'allows adding a file' do
-    allow(ClamScan::Client).to receive(:scan)
-      .and_return(instance_double('ClamScan::Response', safe?: true))
+    allow_any_instance_of(ClamAV::PatchClient).to receive(:safe?).and_return(true)
     instance.file = file.open
     expect(instance.valid?).to be(true)
     expect(instance.file.shrine_class).to be(ClaimDocumentation::Uploader)

--- a/spec/requests/claim_documents_spec.rb
+++ b/spec/requests/claim_documents_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'Claim Document Attachment', type: :request do
   before do
     allow(Rails.logger).to receive(:info)
     allow(Rails.logger).to receive(:error)
-    allow(ClamScan::Client).to receive(:scan)
-      .and_return(instance_double('ClamScan::Response', safe?: true))
+    allow(Common::VirusScan).to receive(:scan).and_return(true)
+    allow_any_instance_of(Common::VirusScan).to receive(:scan).and_return(true)
   end
 
   context 'with a valid file' do

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -39,7 +39,6 @@ class SimpleCovHelper
 
   def self.add_filters
     add_filter 'app/controllers/concerns/accountable.rb'
-    add_filter 'config/initializers/clamscan.rb'
     add_filter 'lib/apps/configuration.rb'
     add_filter 'lib/apps/responses/response.rb'
     add_filter 'lib/config_helper.rb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,6 @@ unless ENV['NOCOVERAGE']
     add_filter 'app/controllers/concerns/accountable.rb'
     add_filter 'app/models/in_progress_disability_compensation_form.rb'
     add_filter 'app/serializers/appeal_serializer.rb'
-    add_filter 'config/initializers/clamscan.rb'
     add_filter 'lib/apps/configuration.rb'
     add_filter 'lib/apps/responses/response.rb'
     add_filter 'lib/config_helper.rb'

--- a/spec/support/uploader_helpers.rb
+++ b/spec/support/uploader_helpers.rb
@@ -7,14 +7,8 @@ module UploaderHelpers
 
   module ClassMethods
     def stub_virus_scan
-      let(:result) do
-        {
-          safe?: true
-        }
-      end
-
       before do
-        allow(Common::VirusScan).to receive(:scan).and_return(OpenStruct.new(result))
+        allow(Common::VirusScan).to receive(:scan).and_return(true)
       end
     end
   end

--- a/spec/uploaders/uploader_virus_scan_spec.rb
+++ b/spec/uploaders/uploader_virus_scan_spec.rb
@@ -24,19 +24,15 @@ describe UploaderVirusScan, uploader_helpers: true do
     end
 
     context 'with a virus' do
-      let(:result) do
-        {
-          safe?: false,
-          body: 'virus found'
-        }
-      end
+      let(:result) { false }
 
       it 'raises an error' do
+        allow(Common::VirusScan).to receive(:scan).and_return(false)
         expect(Rails.env).to receive(:production?).and_return(true)
         expect(file).to receive(:delete)
 
         expect { store_image }.to raise_error(
-          UploaderVirusScan::VirusFoundError, 'virus found'
+          UploaderVirusScan::VirusFoundError
         )
       end
     end


### PR DESCRIPTION
## Summary

- replace `clam_scan` with `clamav-client`
- remove clamav binaries & packages
- allow developers to mock clamav via `settings.local.yml`
- most files are 1:1 copies of k8s branch
- review instances should use clamav container

## Related issue(s)

- []()

## Testing done

- Manual local testing for mocking ClamAV
- Manual local testing for not-mocking ClamAV
- Manual testing for ClamAV on Review Instances

## Acceptance criteria

- [ ]  Developers can use ClamAV with native, docker, & hybrid setup
- [ ] Developers can mock ClamAV
- [ ]  ClamAV works in Review Instances