### PR TITLE
Update serializer coder syntax per 7.1 deprecation message

### DIFF
--- a/app/models/async_transaction/base.rb
+++ b/app/models/async_transaction/base.rb
@@ -14,7 +14,7 @@ module AsyncTransaction
       where('created_at < ?', DELETE_COMPLETED_AFTER.ago).where(status: COMPLETED)
     }
 
-    serialize :metadata, JsonMarshal::Marshaller
+    serialize :metadata, coder: JsonMarshal::Marshaller
 
     has_kms_key
     has_encrypted :metadata, key: :kms_key, **lockbox_options

--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -32,7 +32,7 @@ class InProgressForm < ApplicationRecord
   scope :not_submitted, -> { where.not("metadata -> 'submission' ->> 'status' = ?", 'applicationSubmitted') }
   scope :unsubmitted_fsr, -> { for_form('5655').not_submitted }
   attribute :user_uuid, CleanUUID.new
-  serialize :form_data, JsonMarshal::Marshaller
+  serialize :form_data, coder: JsonMarshal::Marshaller
   has_kms_key
   has_encrypted :form_data, key: :kms_key, **lockbox_options
   validates(:form_data, presence: true)

--- a/app/models/nod_notification.rb
+++ b/app/models/nod_notification.rb
@@ -3,7 +3,7 @@
 require 'json_marshal/marshaller'
 
 class NodNotification < ApplicationRecord
-  serialize :payload, JsonMarshal::Marshaller
+  serialize :payload, coder: JsonMarshal::Marshaller
 
   has_kms_key
   has_encrypted :payload, key: :kms_key, **lockbox_options

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -44,8 +44,8 @@ module AppealsApi
       nil
     end
 
-    serialize :auth_headers, JsonMarshal::Marshaller
-    serialize :form_data, JsonMarshal::Marshaller
+    serialize :auth_headers, coder: JsonMarshal::Marshaller
+    serialize :form_data, coder: JsonMarshal::Marshaller
     has_kms_key
     has_encrypted :auth_headers, :form_data, key: :kms_key, **lockbox_options
 

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -52,8 +52,8 @@ module AppealsApi
       nil
     end
 
-    serialize :auth_headers, JsonMarshal::Marshaller
-    serialize :form_data, JsonMarshal::Marshaller
+    serialize :auth_headers, coder: JsonMarshal::Marshaller
+    serialize :form_data, coder: JsonMarshal::Marshaller
     has_kms_key
     has_encrypted :auth_headers, :form_data, key: :kms_key, **lockbox_options
 

--- a/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
+++ b/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
@@ -36,8 +36,8 @@ module AppealsApi
     scope :v2, -> { where(api_version: 'V2') }
     scope :v0, -> { where(api_version: 'V0') }
 
-    serialize :auth_headers, JsonMarshal::Marshaller
-    serialize :form_data, JsonMarshal::Marshaller
+    serialize :auth_headers, coder: JsonMarshal::Marshaller
+    serialize :form_data, coder: JsonMarshal::Marshaller
     has_kms_key
     has_encrypted :auth_headers, :form_data, key: :kms_key, **lockbox_options
 

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -10,11 +10,11 @@ require 'claims_api/claim_logger'
 module ClaimsApi
   class AutoEstablishedClaim < ApplicationRecord
     include FileData
-    serialize :auth_headers, JsonMarshal::Marshaller
-    serialize :bgs_flash_responses, JsonMarshal::Marshaller
-    serialize :bgs_special_issue_responses, JsonMarshal::Marshaller
-    serialize :form_data, JsonMarshal::Marshaller
-    serialize :evss_response, JsonMarshal::Marshaller
+    serialize :auth_headers, coder: JsonMarshal::Marshaller
+    serialize :bgs_flash_responses, coder: JsonMarshal::Marshaller
+    serialize :bgs_special_issue_responses, coder: JsonMarshal::Marshaller
+    serialize :form_data, coder: JsonMarshal::Marshaller
+    serialize :evss_response, coder: JsonMarshal::Marshaller
     has_kms_key
     has_encrypted :auth_headers, :bgs_flash_responses, :bgs_special_issue_responses, :evss_response, :form_data,
                   key: :kms_key, **lockbox_options

--- a/modules/claims_api/app/models/claims_api/evidence_waiver_submission.rb
+++ b/modules/claims_api/app/models/claims_api/evidence_waiver_submission.rb
@@ -4,7 +4,7 @@ require 'json_marshal/marshaller'
 
 class ClaimsApi::EvidenceWaiverSubmission < ApplicationRecord
   validates :cid, presence: true
-  serialize :auth_headers, JsonMarshal::Marshaller
+  serialize :auth_headers, coder: JsonMarshal::Marshaller
 
   has_kms_key
   has_encrypted :auth_headers, key: :kms_key, **lockbox_options

--- a/modules/claims_api/app/models/claims_api/power_of_attorney.rb
+++ b/modules/claims_api/app/models/claims_api/power_of_attorney.rb
@@ -6,9 +6,9 @@ require 'common/file_helpers'
 module ClaimsApi
   class PowerOfAttorney < ApplicationRecord
     include FileData
-    serialize :auth_headers, JsonMarshal::Marshaller
-    serialize :form_data, JsonMarshal::Marshaller
-    serialize :source_data, JsonMarshal::Marshaller
+    serialize :auth_headers, coder: JsonMarshal::Marshaller
+    serialize :form_data, coder: JsonMarshal::Marshaller
+    serialize :source_data, coder: JsonMarshal::Marshaller
     has_kms_key
     has_encrypted :auth_headers, :form_data, :source_data, key: :kms_key, **lockbox_options
 

--- a/modules/claims_api/app/models/concerns/claims_api/file_data.rb
+++ b/modules/claims_api/app/models/concerns/claims_api/file_data.rb
@@ -8,7 +8,7 @@ module ClaimsApi
     extend ActiveSupport::Concern
 
     included do
-      serialize :file_data, JsonMarshal::Marshaller
+      serialize :file_data, coder: JsonMarshal::Marshaller
       has_kms_key
       has_encrypted :file_data, key: :kms_key, **lockbox_options
 

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
@@ -48,9 +48,9 @@ module CovidVaccine
         reg.form_data&.symbolize_keys!
       end
 
-      serialize :eligibility_info, JsonMarshal::Marshaller
-      serialize :form_data, JsonMarshal::Marshaller
-      serialize :raw_form_data, JsonMarshal::Marshaller
+      serialize :eligibility_info, coder: JsonMarshal::Marshaller
+      serialize :form_data, coder: JsonMarshal::Marshaller
+      serialize :raw_form_data, coder: JsonMarshal::Marshaller
       has_kms_key
       has_encrypted :eligibility_info, :form_data, :raw_form_data, key: :kms_key, **lockbox_options
     end

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
@@ -11,8 +11,8 @@ module CovidVaccine
         reg.form_data&.symbolize_keys!
       end
 
-      serialize :form_data, JsonMarshal::Marshaller
-      serialize :raw_form_data, JsonMarshal::Marshaller
+      serialize :form_data, coder: JsonMarshal::Marshaller
+      serialize :raw_form_data, coder: JsonMarshal::Marshaller
       has_kms_key
       has_encrypted :form_data, :raw_form_data, key: :kms_key, **lockbox_options
     end

--- a/modules/health_quest/app/models/health_quest/questionnaire_response.rb
+++ b/modules/health_quest/app/models/health_quest/questionnaire_response.rb
@@ -21,8 +21,8 @@ module HealthQuest
   class QuestionnaireResponse < ApplicationRecord
     attr_accessor :user
 
-    serialize :questionnaire_response_data, JsonMarshal::Marshaller
-    serialize :user_demographics_data, JsonMarshal::Marshaller
+    serialize :questionnaire_response_data, coder: JsonMarshal::Marshaller
+    serialize :user_demographics_data, coder: JsonMarshal::Marshaller
     has_kms_key
     has_encrypted :questionnaire_response_data, :user_demographics_data, key: :kms_key, **lockbox_options
 

--- a/modules/vye/app/models/vye/user_info.rb
+++ b/modules/vye/app/models/vye/user_info.rb
@@ -54,7 +54,7 @@ module Vye
 
     validates(*REQUIRED_ATTRIBUTES, presence: true)
 
-    serialize :dob, DobSerializer
+    serialize :dob, coder: DobSerializer
 
     before_validation :digest_ssn
 


### PR DESCRIPTION
## Summary

- Fixing the fallowing warning ahead of the bump to Rails 7.1:
  - `DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.`
  - Fix: `serialize :payload, JsonMarshal::Marshaller` -> `serialize :payload, coder: JsonMarshal::Marshaller`