### PR TITLE
Enable mocking for demographics service

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -859,3 +859,11 @@
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/signup\/v1\/patients\/([V0-9]*)\/provisioning\/cerner'
+
+# VA Profile / Vet360
+- :name: "VA Profile"
+  :base_uri: <%= "#{URI(Settings.vet360.url).host}:#{URI(Settings.vet360.url).port}" %>
+  :endpoints:
+    - :method: :get
+      :path: "/demographics/demographics/v1/*/*"
+      :file_path: "vet360/demographics/default"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -247,7 +247,7 @@ vet360:
     cache_enabled: false
     enabled: true
     timeout: 30
-    mock: false
+    mock: true
   military_personnel:
     cache_enabled: false
     enabled: true

--- a/lib/va_profile/configuration.rb
+++ b/lib/va_profile/configuration.rb
@@ -16,9 +16,9 @@ module VAProfile
         faraday.use      :breakers
         faraday.use      Faraday::Response::RaiseError
 
-        faraday.response :betamocks if mock_enabled?
         faraday.response :snakecase, symbolize: false
         faraday.response :json, content_type: /\bjson/ # ensures only json content types parsed
+        faraday.response :betamocks if mock_enabled?
         faraday.adapter Faraday.default_adapter
       end
     end


### PR DESCRIPTION
## Summary

This PR enables betamocks for the demographics service. This is needed so we can properly test some new [changes](https://github.com/department-of-veterans-affairs/vets-api/pull/15831) to the `Users::Profile` service that introduces demographic data.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/78572

## Testing done

* Fetch and checkout the `demographics` branch for the vets-api-mockdata repo.
* Enable betamocks locally.
* Start vets-api and vets-website.
* Login as a user.
* Get the access token jwt from the `vagov_access_token` cookie
* Get the request IP from the request headers in the network tab
* In the Rails console, execute:
```ruby
access_token_jwt = "<access token jwt from cookie>"
access_token = SignIn::AccessTokenJwtDecoder.new(access_token_jwt: access_token_jwt).perform
request_ip = "<request ip from headers>"
user = SignIn::UserLoader.new(access_token:, request_ip:).perform
```
* Now that you have a user loaded in the console, you can make a call with the demographics service to get mocked data in the response.
```ruby
require 'va_profile/demographics/service'
VAProfile::Demographics::Service.new(user).get_demographics
```
* The return value should be a `DemographicResponse` with the gender identity and preferred name values from the mocked data.

## Screenshots
Not relevant.

## What areas of the site does it impact?
Anything that uses demographics service, though this doesn't actually update any production code paths.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None.
