### PR TITLE
Track the benefit types selected by users for 21-0966

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -90,6 +90,7 @@ module SimpleFormsApi
         intent_service = SimpleFormsApi::IntentToFile.new(icn, params)
         existing_intents = intent_service.existing_intents
         confirmation_number, expiration_date = intent_service.submit
+        form.track_user_identity(confirmation_number)
 
         render json: {
           confirmation_number:,

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -67,7 +67,9 @@ module SimpleFormsApi
     def track_user_identity(confirmation_number)
       identity = data['preparer_identification']
       StatsD.increment("#{STATS_KEY}.#{identity}")
+      benefit_types = data['benefit_selection'].map { |benefit_type, is_selected| benefit_type if is_selected }.compact.join(', ')
       Rails.logger.info('Simple forms api - 21-0966 submission user identity', identity:, confirmation_number:)
+      Rails.logger.info('Simple forms api - 21-0966 submission benefit types', benefit_types:, confirmation_number:)
     end
 
     private


### PR DESCRIPTION
## Summary
This PR adds some extra tracking for DataDog, for Simple Forms form 21-0966. In addition to tracking the user identity, we also want to track which types of benefits the user selected.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1019
