### PR TITLE
API-33857: Fix Failing `VAForms` Spec

### DIFF
--- a/modules/va_forms/spec/requests/v0/forms_request_spec.rb
+++ b/modules/va_forms/spec/requests/v0/forms_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'VA Forms', type: :request do
 
   let!(:form) do
     create(:va_form)
-    create(:va_form, form_name: '527', row_id: '4157', last_sha256_change: Date.new(2024, 3, 15))
+    create(:va_form, form_name: '527', row_id: '4157')
     create(:deleted_va_form)
     create(:va_form,
            form_name: '21-2001',
@@ -85,7 +85,7 @@ RSpec.describe 'VA Forms', type: :request do
     it 'returns the date of the last sha256 change' do
       get "#{base_url}?query=527"
       last_sha256_change = JSON.parse(response.body)['data'][0]['attributes']['last_sha256_change']
-      expect(last_sha256_change).to eql('2024-03-15')
+      expect(last_sha256_change).to eql(form.last_sha256_change.strftime('%Y-%m-%d'))
     end
   end
 

--- a/modules/va_forms/spec/requests/v0/forms_request_spec.rb
+++ b/modules/va_forms/spec/requests/v0/forms_request_spec.rb
@@ -9,16 +9,7 @@ RSpec.describe 'VA Forms', type: :request do
     create(:va_form)
     create(:va_form, form_name: '527', row_id: '4157')
     create(:deleted_va_form)
-    create(:va_form,
-           form_name: '21-2001',
-           row_id: '4158',
-           change_history: {
-             'versions' =>
-               [{ 'sha256' => 'a8ba72e148e15e4e03476bb7fbbdbc4facd43ceb52d10eb2f605a8aa8b4bad6a',
-                  'revision_on' => '2024-01-08' },
-                { 'sha256' => '68b6d817881be1a1c8f323a9073a343b81d1c5a6e03067f27fe595db77645c22',
-                  'revision_on' => '2024-03-15' }]
-           })
+    create(:va_form, form_name: '21-2001', row_id: '4158')
   end
   let(:base_url) { '/services/va_forms/v0/forms' }
   let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }


### PR DESCRIPTION
## Summary
A spec was added in #15968 but was failing due to a mistake that I made while writing the spec. The `last_sha256_change` field is modified when the record is saved (`before_save` callback), so I shouldn't have used a static date in the assertion.

My team (Lighthouse Team Banana Peels) maintains the `va_forms` module.

## Related issue(s)
[API-33857](https://jira.devops.va.gov/browse/API-33857)

## Testing done
Spec is now passing consistently.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `va_forms` module only.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
