### PR TITLE
78436 station type issue

### DIFF
--- a/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_controller.rb
+++ b/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_controller.rb
@@ -147,6 +147,8 @@ module DebtsApi
             :debt_type,
             :deduction_code,
             :p_h_amt_due,
+            :p_h_dfn_number,
+            :p_h_cerner_patient_id,
             :resolution_comment,
             :resolution_option,
             { station: [:facilit_y_num] }

--- a/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
+++ b/modules/debts_api/lib/debts_api/v0/vha_fsr_form.rb
@@ -83,7 +83,7 @@ module DebtsApi
     def station_adjustments(form)
       stations = []
       @copays.each do |copay|
-        stations << 'vista' if copay['pHDfnNumber'].instance_of?(Integer) && (copay['pHDfnNumber']).positive?
+        stations << 'vista' if copay['pHDfnNumber'].to_i.positive?
         if copay['pHCernerPatientId'].instance_of?(String) && copay['pHCernerPatientId'].strip.length.positive?
           stations << 'cerner'
         end


### PR DESCRIPTION
## Summary
The FSR service has logic that depends on controller params that up till now were not explicitly permitted.

## Related issue(s)
[78436](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/78436)
[67409](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/67409)

## Testing done
Specs green

## What areas of the site does it impact?
FSR submission

## Acceptance criteria
For FSR controller, `p_h_dfn_number` and `p_h_cerner_patient_id` should both be permitted params under `selected_debts_and_copays` field.