### PR TITLE
Serparate user profile  3 db up

### DIFF
--- a/db/migrate/20240318190236_add_user_profile_id_to_tables.vye.rb
+++ b/db/migrate/20240318190236_add_user_profile_id_to_tables.vye.rb
@@ -1,0 +1,7 @@
+# This migration comes from vye (originally 20240316034337)
+class AddUserProfileIdToTables < ActiveRecord::Migration[7.1]
+  def change
+    add_column :vye_user_infos, :user_profile_id, :integer
+    add_column :vye_pending_documents, :user_profile_id, :integer
+  end
+end

--- a/db/migrate/20240318190237_fix_address_names.vye.rb
+++ b/db/migrate/20240318190237_fix_address_names.vye.rb
@@ -1,0 +1,14 @@
+# This migration comes from vye (originally 20240318162206)
+class FixAddressNames < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_columns(
+        :vye_address_changes,
+        :address_line5_ciphertext,
+        :address_line6_ciphertext
+      )
+    end
+
+    add_column :vye_address_changes, :address5_ciphertext, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_15_033526) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -1275,9 +1275,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_15_033526) do
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "address_line5_ciphertext"
-    t.text "address_line6_ciphertext"
     t.string "origin"
+    t.text "address5_ciphertext"
     t.index ["user_info_id"], name: "index_vye_address_changes_on_user_info_id"
   end
 
@@ -1329,6 +1328,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_15_033526) do
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_profile_id"
     t.index ["ssn_digest"], name: "index_vye_pending_documents_on_ssn_digest"
   end
 
@@ -1359,6 +1359,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_15_033526) do
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_profile_id"
     t.index ["icn"], name: "index_vye_user_infos_on_icn"
     t.index ["ssn_digest"], name: "index_vye_user_infos_on_ssn_digest"
   end

--- a/modules/vye/db/migrate/20240316034337_add_user_profile_id_to_tables.rb
+++ b/modules/vye/db/migrate/20240316034337_add_user_profile_id_to_tables.rb
@@ -1,0 +1,6 @@
+class AddUserProfileIdToTables < ActiveRecord::Migration[7.1]
+  def change
+    add_column :vye_user_infos, :user_profile_id, :integer
+    add_column :vye_pending_documents, :user_profile_id, :integer
+  end
+end

--- a/modules/vye/db/migrate/20240318162206_fix_address_names.rb
+++ b/modules/vye/db/migrate/20240318162206_fix_address_names.rb
@@ -1,0 +1,13 @@
+class FixAddressNames < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_columns(
+        :vye_address_changes,
+        :address_line5_ciphertext,
+        :address_line6_ciphertext
+      )
+    end
+
+    add_column :vye_address_changes, :address5_ciphertext, :text
+  end
+end


### PR DESCRIPTION
https://jira.devops.va.gov/browse/VYE-253
https://jira.devops.va.gov/browse/VYE-254

As:

VYE Backend Developer

I need:

To separate data  from transient date.

So that: 

 Data that's not transient does not get purged.

Considerations:

No considerations

Acceptance Criteria: 

 Data that's not transient does not get purged.

Have to be moved out in separate tables

ICN
SSN 
Claim number 

Testing Considerations:

Not a new feature, so there's no test component

Other Considerations: 

No other considerations

As:

VYE Backend Developer

I need:

 To separate address data from BDN

So that: 

 It could be added to the addresses array in user profile

Considerations:

No considerations

Acceptance Criteria: 

So front end can see all the addresses
Will only show the last address to populate from

Testing Considerations:

No testing considerations

Other Considerations: 

No other considerations