### PR TITLE
Fix `AppealsAPI` Sidekiq Job Descriptions

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -19,9 +19,9 @@ PERIODIC_JOBS = lambda { |mgr|
   mgr.register('45 0 * * *', 'AppealsApi::NoticeOfDisagreementCleanUpWeekOldPii')
   # Remove PII of NoticeOfDisagreements that have 1) reached one of the 'completed' statuses and 2) are a week old
   mgr.register('45 0 * * *', 'AppealsApi::SupplementalClaimCleanUpPii')
-  # Ensures that appeal evidence received "late" (after the appeal has reached "success") is submitted to Central Mail
-  mgr.register('30 * * * *', 'AppealsApi::EvidenceSubmissionBackup')
   # Remove PII of SupplementalClaims that have 1) reached one of the 'completed' statuses and 2) are a week old
+  mgr.register('30 * * * *', 'AppealsApi::EvidenceSubmissionBackup')
+  # Ensures that appeal evidence received "late" (after the appeal has reached "success") is submitted to Central Mail
   mgr.register('0 23 * * 1-5', 'AppealsApi::DecisionReviewReportDaily')
   # Daily report of appeals submissions
   mgr.register('0 23 * * 1-5', 'AppealsApi::DailyErrorReport')


### PR DESCRIPTION
## Summary
At some point, the descriptions of two unrelated Appeals API jobs got swapped, so the comments were no longer associated with the correct job. This PR resolves that issue.

My team (Lighthouse Team Banana Peels) maintains the `appeals_api` module.

## Related issue(s)
No issue/ticket. Just something noticed while scanning code today and thought to fix.

## Testing done
Not needed, since this change only affects code comments.

## Screenshots
None

## What areas of the site does it impact?
This PR affects the `appeals_api` jobs only, and is not a functional change, just a change to comments.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution – N/A
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected – N/A
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested.
