### PR TITLE
Removed unused Yellow Ribbon feature toggles

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1322,12 +1322,6 @@ features:
     description: >-
       Master toggle for the VYE (Verify Your Enrollment) project.
       If enabled, requests will be allowed to reach the controllers, otherwise a 400 (Bad Request) will be returned.
-  yellow_ribbon_degree_filter:
-    actor_type: user
-    description: Enable the degree type filter for the Find a Yellow Ribbon school search
-  yellow_ribbon_search_enhancement:
-    actor_type: user
-    description: Enable changes to Find a Yellow Ribbon school search functionality
   travel_pay_power_switch:
     actor_type: user
     description: >-


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This work is behind a feature toggle (flipper): NO
- Removed two unused flipper toggles
- Not a bug
- Team IIR, we are the current owners

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/465
https://github.com/department-of-veterans-affairs/va-iir/issues/242

## Testing done

- [ ] New code is covered by unit tests
- Prior to this change, two unused feature toggles appeared in flipper
- To verify, navigate to `http://localhost:3000/flipper/features` and confirm that these two toggles do not appear
- Testing consisted of a code search to confirm that these toggles are unused

## Screenshots
None

## What areas of the site does it impact?
This only affects flipper

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None
