### PR TITLE
Update Dangerfile to allow db/seeds changes with app code changes

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -191,11 +191,11 @@ module VSPDanger
   end
 
   class MigrationIsolator
+    DB_PATHS = ['db/migrate/', 'db/schema.rb'].freeze
+    SEEDS_PATHS = ['db/seeds/', 'db/seeds.rb'].freeze
+
     def run
-      if files.any? { |file| file.include? 'db/' } && !files.all? { |file| file.include? 'db/' }
-        # one of the changed files was in 'db/' but not all of them
-        return Result.error(error_message)
-      end
+      return Result.error(error_message) if db_files.any? && app_files.any?
 
       Result.success('All set.')
     end
@@ -204,7 +204,7 @@ module VSPDanger
 
     def error_message
       <<~EMSG
-        Modified files in `db/` should be the only files checked into this PR.
+        Modified files in `db/migrate` or `db/schema.rb` changes should be the only files checked into this PR.
 
         <details>
           <summary>File Summary</summary>
@@ -227,11 +227,15 @@ module VSPDanger
     end
 
     def app_files
-      files - db_files
+      files - db_files - seed_files
     end
 
     def db_files
-      files.select { |file| file.include? 'db/' }
+      files.select { |file| DB_PATHS.any? { |db_path| file.include?(db_path) } }
+    end
+
+    def seed_files
+      files.select { |file| SEEDS_PATHS.any? { |seed_path| file.include?(seed_path) } }
     end
 
     def files


### PR DESCRIPTION
## Summary

- Update Dangerfile to allow `db/seeds` changes with app code changes. Seeds rely on app code so they are normally updated with other app changes. Plus, seeds are only used in development. 

## Testing done
- Danger still successfully catches when edits are made to `db/schema.rb` or `db/migrate/` and app code
<img width="822" alt="Screenshot 2024-03-19 at 9 06 32 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10853209/cfe3a63e-c3d5-4a96-9c1f-0006d2b37631">

- Tested app code changes and `db/seeds` change and no Danger error was generated

## What areas of the site does it impact?
Danger check

