### PR TITLE
add UUID to 1010d JSON output

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -10,6 +10,7 @@ module SimpleFormsApi
 
     def initialize(data)
       @data = data
+      @uuid = SecureRandom.uuid
     end
 
     def metadata
@@ -21,12 +22,13 @@ module SimpleFormsApi
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
-        'ssn_or_tin' => @data.dig('veteran', 'ssn_or_tin')
+        'ssn_or_tin' => @data.dig('veteran', 'ssn_or_tin'),
+        'uuid' => @uuid
       }
     end
 
     def handle_attachments(file_path)
-      uuid = SecureRandom.uuid # Generate the UUID inline
+      uuid = @uuid # Generate the UUID as an instance variable
       file_path_uuid = file_path.gsub('vha_10_10d-tmp', "#{uuid}_vha_10_10d-tmp")
       File.rename(file_path, file_path_uuid)
       attachments = get_attachments


### PR DESCRIPTION
Summary: This PR adds the UUID to the Metadata JSON file that will be uploaded to the PEGA S3 bucket.
This fulfills the ticket 75508. See "related issue"

## Related issue(s)
https://app.zenhub.com/workspaces/ivc-forms-652da2d3f0ae4c0016bfb109/issues/gh/department-of-veterans-affairs/va.gov-team/75508




## Testing done

- [ x] *New code is covered by unit tests*
Verified that the JSON is in the s3 bucket



## What areas of the site does it impact?
It will affect 1010d and other IVC forms

## Acceptance criteria
UUID is in the JSON file
