### PR TITLE
API-33857: Remove `versions` Table Previously Used by the `paper_trail` Gem

### DIFF
--- a/db/migrate/20240315210805_drop_versions.rb
+++ b/db/migrate/20240315210805_drop_versions.rb
@@ -1,0 +1,7 @@
+class DropVersions < ActiveRecord::Migration[7.1]
+  # This table was previously used to store version history for the `VAForms::Form` model
+  # The `paper_trail` gem has since been removed, and all data has been migrated to the `va_forms_forms` table
+  def change
+    drop_table :versions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1160,17 +1160,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.index ["status"], name: "index_vba_documents_upload_submissions_on_status"
   end
 
-  create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
-    t.bigint "item_id", null: false
-    t.string "event", null: false
-    t.string "whodunnit"
-    t.text "object"
-    t.datetime "created_at"
-    t.text "object_changes"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
-  end
-
   create_table "veteran_device_records", force: :cascade do |t|
     t.bigint "device_id", null: false
     t.boolean "active", default: true, null: false


### PR DESCRIPTION
## Summary
Given that the `paper_trail` gem was removed in #15969, we can now safely remove the `versions` table that the gem previously used to store version history for the `VAForms::Form` model.

I confirmed on all `vets-api` environments that the table is only storing version history for the `VAForms::Form` model (see below). All data previously stored in this table has been migrated to the `va_forms_forms` table. My team (Lighthouse Team Banana Peels) maintains the `va_forms` module.

<img width="483" alt="Screenshot 2024-03-15 at 5 10 07 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/11942904/fc21fc57-8a02-412e-8581-ac87925c9e28">

## Related issue(s)
[API-33857](https://jira.devops.va.gov/browse/API-33857)

## Testing done
After running the migration, I ran the app locally and tested the forms `index` and `show` endpoints against my local dataset.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `va_forms` module only. 

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution – N/A
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.