### PR TITLE
API-34921 remove itf ids from alerts

### DIFF
--- a/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
+++ b/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
@@ -57,11 +57,15 @@ module ClaimsApi
         return '' if errored_submissions.count.zero?
 
         errored_submission_message = ''.dup
-        errored_submission_message << "*#{submission_type} Errors* \nTotal: #{errored_submissions.count} \n```"
-        errored_submissions.each do |submission_id|
-          errored_submission_message << "#{submission_id} \n"
+        if submission_type == 'Intent to File'
+          errored_submission_message << "*#{submission_type} Errors* \nTotal: #{errored_submissions.count} \n\n"
+        else
+          errored_submission_message << "*#{submission_type} Errors* \nTotal: #{errored_submissions.count} \n```"
+          errored_submissions.each do |submission_id|
+            errored_submission_message << "#{submission_id} \n"
+          end
+          errored_submission_message << "```  \n\n"
         end
-        errored_submission_message << "```  \n\n"
         errored_submission_message
       end
     end

--- a/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
+++ b/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
@@ -21,13 +21,17 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
                          "\nThe following submissions have encountered errors in *#{environment}*. \n\n*Disability " \
                          "Compensation Errors* \nTotal: 2 \n```123456 \n789101112 \n```  \n\n*Power of " \
                          "Attorney Errors* \nTotal: 2 \n```1314151617 \n181920212223 \n```  \n\n*Intent to " \
-                         "File Errors* \nTotal: 1 \n```24252627 \n```  \n\n*Evidence Waiver Errors* \nTotal: 2 " \
+                         "File Errors* \nTotal: 1 \n\n*Evidence Waiver Errors* \nTotal: 2 " \
                          "\n```32333435 \n36373839 \n```  \n\n"
 
       expect(message).to include("#{claims.count} \n")
+      expect(message).to include("123456 \n789101112 \n")
       expect(message).to include("#{poa.count} \n")
+      expect(message).to include("1314151617 \n181920212223 \n")
       expect(message).to include("#{itf.count} \n")
+      expect(message).not_to include("24252627 \n")
       expect(message).to include("#{ews.count} \n")
+      expect(message).to include("32333435 \n36373839 \n")
 
       expect(message).to eq(expected_message)
     end


### PR DESCRIPTION
## Summary
* Show ITF errored count but not the array of Ids

## Related issue(s)
[API-34921](https://jira.devops.va.gov/browse/API-34921)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* It showed the whole array of IDs
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:* Yes, but it previously was so nothing new there.
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

#### Testing notes
* A sample of the test message can be seen below in the "screenshots" (This will be run in Production so the ENV values would say production, but to test it was run in development locally obviously)
* If you really want to trigger the message and send a test you will need to force the job to get queued.
    * Keep in mind it will also depend on what you have in your dev DB.
    * You will first need to set the `audit_enabled` settings value to `true` in your local or test yml file
    * Then you will need to queue up the job somehow
         * One way to do this is just put it as the first line in a controller method you then hit
         * Make sure to include the file `require 'claims_api/report_hourly_unsuccessful_submissions'`
         * Adding `ClaimsApi::ReportHourlyUnsuccessfulSubmissions.perform_async` should be all that is needed to trigger it to queue up
         * I would recommend stopping sidekiq first so you can see it actually queued up.
         
## Screenshots
<img width="560" alt="Screenshot 2024-03-19 at 3 41 35 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/129893414/36322e1e-eb2e-408c-b51f-62949d82caa8">

## What areas of the site does it impact?
	modified:   modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
	modified:   modules/claims_api/spec/services/failed_submissions_messenger_spec.rb

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
