### PR TITLE
Rollback/disabled demographics api call from user endpoint

### DIFF
--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -55,7 +55,8 @@ module Users
       scaffold.prefills_available = prefills_available
       scaffold.services = services
       scaffold.session = session_data
-      scaffold.demographics = demographics_data
+      # Temporarily disabled call to demographcis to investigate possible bad IDs - cfelix 3/19/2024
+      # scaffold.demographics = demographics_data
     end
 
     def account


### PR DESCRIPTION
## Summary
Rollback the use of the demographics VA Profile API from the user endpoint until we can investigate why we are getting unknown user IDs in the Demographics requests. This rollback was done by checking out all the affected files from the PR from before [this change](https://github.com/department-of-veterans-affairs/vets-api/pull/15831).

## Related issue(s)
https://app.zenhub.com/workspaces/mhv-on-vagov-landing-page-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/74398

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
- Users endpoint

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
