### PR TITLE
Pension 76858 Removed gender from prefill json data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -661,6 +661,7 @@ config/form_profile_mappings/20-0995.yml @department-of-veterans-affairs/Benefit
 config/form_profile_mappings/20-0996.yml @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/21-526EZ.yml @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/21-686C.yml @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+config/form_profile_mappings/21P-527EZ.yml @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/21P-530.yml @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/22-0993.yml @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/22-0994.yml @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/form_profile_mappings/21P-527EZ.yml
+++ b/config/form_profile_mappings/21P-527EZ.yml
@@ -1,5 +1,4 @@
 veteran_full_name: [identity_information, full_name]
-gender: [identity_information, gender]
 veteran_date_of_birth: [identity_information, date_of_birth]
 veteran_social_security_number: [identity_information, ssn]
 veteranAddress: [contact_information, address]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -659,7 +659,6 @@ RSpec.describe FormProfile, type: :model do
         'country' => user.address[:country],
         'postal_code' => user.address[:postal_code][0..4]
       },
-      'gender' => user.gender,
       'veteranSocialSecurityNumber' => user.ssn,
       'veteranDateOfBirth' => user.birth_date
     }


### PR DESCRIPTION
## Summary

remove 'gender' from prefill json data

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/76858
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/866

## Testing done

viewing the network response in browser devtools, 'gender' was present in the return json data from in_progress_forms controller when beginning an application.
removed the mapping of the attribute for pensions 527ez prefill
beginning a new pension application, prefill data no longer has 'gender' attribute

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-api/assets/5315216/740cdd50-82c7-4e62-8805-9dd6d765f25c)


## What areas of the site does it impact?

Pensions

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
