### PR TITLE
72987 Add ipf_data_ciphertext column to form5655_submissions

### DIFF
--- a/db/migrate/20240319141429_add_ipf_data_to_form5655_submission.rb
+++ b/db/migrate/20240319141429_add_ipf_data_to_form5655_submission.rb
@@ -1,0 +1,5 @@
+class AddIpfDataToForm5655Submission < ActiveRecord::Migration[7.1]
+  def change
+    add_column :form5655_submissions, :ipf_data_ciphertext, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -523,7 +523,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.datetime "updated_at", null: false
     t.datetime "flagged_value_updated_at"
     t.index ["ip_address", "representative_id", "flag_type", "flagged_value_updated_at"], name: "index_unique_constraint_fields", unique: true
-    t.index ["ip_address", "representative_id", "flag_type"], name: "index_unique_flagged_veteran_representative", unique: true
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -885,7 +884,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.string "uploaded_forms", array: true
+    t.string "uploaded_forms", default: [], array: true
     t.datetime "itf_datetime"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,13 +22,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "account_login_stats", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "idme_at", precision: nil
-    t.datetime "myhealthevet_at", precision: nil
-    t.datetime "dslogon_at", precision: nil
+    t.datetime "idme_at"
+    t.datetime "myhealthevet_at"
+    t.datetime "dslogon_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "current_verification"
-    t.datetime "logingov_at", precision: nil
+    t.datetime "logingov_at"
     t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
     t.index ["current_verification"], name: "index_account_login_stats_on_current_verification"
     t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
@@ -42,8 +42,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "idme_uuid"
     t.string "icn"
     t.string "edipi"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "sec_id"
     t.string "logingov_uuid"
     t.index ["icn"], name: "index_accounts_on_icn"
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -119,8 +119,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "appeals_api_higher_level_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status", default: "pending", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "code"
     t.string "detail"
     t.string "source"
@@ -157,7 +157,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "to"
     t.string "statusable_type"
     t.string "statusable_id"
-    t.datetime "status_update_time", precision: nil
+    t.datetime "status_update_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code"
@@ -191,8 +191,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status"
     t.string "transaction_id"
     t.string "transaction_status"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -220,8 +220,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.jsonb "feedback"
     t.jsonb "access"
     t.string "fingerprint"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.boolean "mobile"
     t.string "active_status"
@@ -242,8 +242,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "claims_api_auto_established_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.integer "evss_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "md5"
     t.string "source"
     t.string "flashes", default: [], array: true
@@ -296,8 +296,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status"
     t.string "current_poa"
     t.string "md5"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "vbms_new_document_version_ref_id"
     t.string "vbms_document_series_ref_id"
     t.string "vbms_error_message"
@@ -314,8 +314,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "auto_established_claim_id"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -350,8 +350,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "email_confirmation_id"
     t.string "enrollment_id"
     t.string "batch_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "raw_form_data_ciphertext"
     t.text "eligibility_info_ciphertext"
     t.text "form_data_ciphertext"
@@ -365,8 +365,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
     t.string "sid"
     t.uuid "account_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "expanded", default: false, null: false
     t.boolean "sequestered", default: false, null: false
     t.string "email_confirmation_id"
@@ -414,8 +414,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "code", null: false
     t.string "medical_term", null: false
     t.string "lay_term"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["code"], name: "index_disability_contentions_on_code", unique: true
     t.index ["lay_term"], name: "index_disability_contentions_on_lay_term", opclass: :gin_trgm_ops, using: :gin
     t.index ["medical_term"], name: "index_disability_contentions_on_medical_term", opclass: :gin_trgm_ops, using: :gin
@@ -426,19 +426,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "unit"
     t.geography "polygon", limit: {:srid=>4326, :type=>"st_polygon", :geographic=>true}, null: false
     t.string "vha_facility_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "min"
     t.integer "max"
-    t.datetime "vssc_extract_date", precision: nil, default: "2001-01-01 00:00:00"
+    t.datetime "vssc_extract_date", default: "2001-01-01 00:00:00"
     t.index ["polygon"], name: "index_drivetime_bands_on_polygon", using: :gist
   end
 
   create_table "education_benefits_claims", id: :serial, force: :cascade do |t|
-    t.datetime "submitted_at", precision: nil
-    t.datetime "processed_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "submitted_at"
+    t.datetime "processed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "regional_processing_office", null: false
     t.string "form_type", default: "1990"
     t.integer "saved_claim_id", null: false
@@ -451,8 +451,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "education_benefits_submissions", id: :serial, force: :cascade do |t|
     t.string "region", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "chapter33", default: false, null: false
     t.boolean "chapter30", default: false, null: false
     t.boolean "chapter1606", default: false, null: false
@@ -478,8 +478,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.datetime "updated_at", null: false
     t.boolean "poa"
     t.integer "remaining_entitlement"
-    t.datetime "denial_email_sent_at", precision: nil
-    t.datetime "confirmation_email_sent_at", precision: nil
+    t.datetime "denial_email_sent_at"
+    t.datetime "confirmation_email_sent_at"
     t.text "auth_headers_json_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -491,8 +491,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "evss_claims", id: :serial, force: :cascade do |t|
     t.integer "evss_id", null: false
     t.json "data", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "user_uuid", null: false
     t.json "list_data", default: {}, null: false
     t.boolean "requested_decision", default: false, null: false
@@ -509,8 +509,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "gate_name"
     t.string "value"
     t.string "user"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feature_name"], name: "index_feature_toggle_events_on_feature_name"
   end
 
@@ -528,8 +528,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
@@ -537,14 +537,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "feature_key", null: false
     t.string "key", null: false
     t.text "value"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
     t.string "carma_case_id", limit: 18, null: false
-    t.datetime "accepted_at", precision: nil, null: false
+    t.datetime "accepted_at", null: false
     t.json "metadata"
     t.json "attachments"
     t.datetime "created_at", null: false
@@ -571,7 +571,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status", null: false
     t.string "error_class"
     t.string "error_message"
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "updated_at", null: false
     t.jsonb "bgjob_errors", default: {}
     t.index ["bgjob_errors"], name: "index_form526_job_statuses_on_bgjob_errors", using: :gin
     t.index ["form526_submission_id"], name: "index_form526_job_statuses_on_form526_submission_id"
@@ -583,8 +583,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "saved_claim_id", null: false
     t.integer "submitted_claim_id"
     t.boolean "workflow_complete", default: false, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "multiple_birls", comment: "*After* a SubmitForm526 Job fails, a lookup is done to see if the veteran has multiple BIRLS IDs. This field gets set to true if that is the case. If the initial submit job succeeds, this field will remain false whether or not the veteran has multiple BIRLS IDs --so this field cannot technically be used to sum all Form526 veterans that have multiple BIRLS. This field /can/ give us an idea of how often having multiple BIRLS IDs is a problem."
     t.text "auth_headers_json_ciphertext"
     t.text "form_json_ciphertext"
@@ -616,8 +616,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "form_attachments", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "guid", null: false
     t.string "type", null: false
     t.text "file_data_ciphertext"
@@ -659,9 +659,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "edipi", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.datetime "dob", precision: nil, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "dob", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "ssn_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["edipi"], name: "index_gibs_not_found_users_on_edipi"
@@ -683,15 +683,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "msa", null: false
     t.string "msa_name"
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
 
   create_table "health_care_applications", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "state", default: "pending", null: false
     t.string "form_submission_id_string"
     t.string "timestamp"
@@ -713,18 +713,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "id_card_announcement_subscriptions", id: :serial, force: :cascade do |t|
     t.string "email", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_id_card_announcement_subscriptions_on_email", unique: true
   end
 
   create_table "in_progress_forms", id: :serial, force: :cascade do |t|
     t.string "user_uuid", null: false
     t.string "form_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.json "metadata"
-    t.datetime "expires_at", precision: nil
+    t.datetime "expires_at"
     t.text "form_data_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -742,19 +742,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|
     t.string "edipi", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["edipi"], name: "index_invalid_letter_address_edipis_on_edipi"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
     t.string "pagerduty_id"
     t.string "external_service"
-    t.datetime "start_time", precision: nil
-    t.datetime "end_time", precision: nil
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.string "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["end_time"], name: "index_maintenance_windows_on_end_time"
     t.index ["pagerduty_id"], name: "index_maintenance_windows_on_pagerduty_id"
     t.index ["start_time"], name: "index_maintenance_windows_on_start_time"
@@ -789,8 +789,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.uuid "handle", null: false
     t.uuid "user_account_id", null: false
     t.string "hashed_refresh_token", null: false
-    t.datetime "refresh_expiration", precision: nil, null: false
-    t.datetime "refresh_creation", precision: nil, null: false
+    t.datetime "refresh_expiration", null: false
+    t.datetime "refresh_creation", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_verification_id", null: false
@@ -826,10 +826,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.uuid "guid"
     t.string "type"
     t.string "form_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "saved_claim_id"
-    t.datetime "completed_at", precision: nil
+    t.datetime "completed_at"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["guid"], name: "index_persistent_attachments_on_guid", unique: true
@@ -840,8 +840,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "personal_information_logs", id: :serial, force: :cascade do |t|
     t.jsonb "data", null: false
     t.string "error_class", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_personal_information_logs_on_created_at"
     t.index ["error_class"], name: "index_personal_information_logs_on_error_class"
   end
@@ -853,7 +853,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.bigint "query_hash"
     t.float "total_time"
     t.bigint "calls"
-    t.datetime "captured_at", precision: nil
+    t.datetime "captured_at"
     t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
   end
 
@@ -862,7 +862,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "schema"
     t.text "relation"
     t.bigint "size"
-    t.datetime "captured_at", precision: nil
+    t.datetime "captured_at"
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
@@ -871,22 +871,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "application_uuid"
     t.string "return_description", null: false
     t.integer "return_code"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["application_uuid"], name: "index_preneed_submissions_on_application_uuid", unique: true
     t.index ["tracking_number"], name: "index_preneed_submissions_on_tracking_number", unique: true
   end
 
   create_table "saved_claims", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "form_id"
     t.uuid "guid", null: false
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
     t.string "uploaded_forms", array: true
-    t.datetime "itf_datetime", precision: nil
+    t.datetime "itf_datetime"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
@@ -919,7 +919,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "rpo"
     t.integer "number_of_submissions"
     t.string "filename"
-    t.datetime "successful_at", precision: nil
+    t.datetime "successful_at"
     t.integer "retry_attempt", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -932,8 +932,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "description", null: false
     t.integer "state_id", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -953,7 +953,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "add_ninety_day_hospital_copay"
     t.integer "outpatient_basic_care_copay"
     t.integer "outpatient_specialty_copay"
-    t.datetime "threshold_effective_date", precision: nil
+    t.datetime "threshold_effective_date"
     t.integer "aid_and_attendance_threshold"
     t.integer "outpatient_preventive_copay"
     t.integer "medication_copay"
@@ -964,8 +964,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "inpatient_per_diem"
     t.string "description"
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -976,8 +976,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "fips_code", null: false
     t.integer "country_id", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -989,8 +989,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.integer "state_id", null: false
     t.integer "county_number", null: false
     t.integer "version", null: false
-    t.datetime "created", precision: nil, null: false
-    t.datetime "updated", precision: nil
+    t.datetime "created", null: false
+    t.datetime "updated"
     t.string "created_by"
     t.string "updated_by"
   end
@@ -1006,8 +1006,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
 
   create_table "test_user_dashboard_tud_account_availability_logs", force: :cascade do |t|
     t.string "account_uuid"
-    t.datetime "checkout_time", precision: nil
-    t.datetime "checkin_time", precision: nil
+    t.datetime "checkout_time"
+    t.datetime "checkin_time"
     t.boolean "has_checkin_error"
     t.boolean "is_manual_checkin"
     t.datetime "created_at", null: false
@@ -1021,12 +1021,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "middle_name"
     t.string "last_name"
     t.string "gender"
-    t.datetime "birth_date", precision: nil
+    t.datetime "birth_date"
     t.integer "ssn"
     t.string "phone"
     t.string "email"
     t.string "password"
-    t.datetime "checkout_time", precision: nil
+    t.datetime "checkout_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "services"
@@ -1039,8 +1039,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "user_acceptable_verified_credentials", force: :cascade do |t|
-    t.datetime "acceptable_verified_credential_at", precision: nil
-    t.datetime "idme_verified_credential_at", precision: nil
+    t.datetime "acceptable_verified_credential_at"
+    t.datetime "idme_verified_credential_at"
     t.uuid "user_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1071,7 +1071,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "logingov_uuid"
     t.string "mhv_uuid"
     t.string "dslogon_uuid"
-    t.datetime "verified_at", precision: nil
+    t.datetime "verified_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "backing_idme_uuid"
@@ -1093,15 +1093,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.date "last_revision_on"
     t.integer "pages"
     t.string "sha256"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "valid_pdf", default: false
     t.text "form_usage"
     t.text "form_tool_intro"
     t.string "form_tool_url"
     t.string "form_type"
     t.string "language"
-    t.datetime "deleted_at", precision: nil
+    t.datetime "deleted_at"
     t.string "related_forms", array: true
     t.jsonb "benefit_categories"
     t.string "form_details_url"
@@ -1148,8 +1148,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "s3_deleted"
     t.string "consumer_name"
     t.uuid "consumer_id"
@@ -1168,7 +1168,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at", precision: nil
+    t.datetime "created_at"
     t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
@@ -1188,8 +1188,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "name"
     t.string "phone"
     t.string "state", limit: 2
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "address_type"
     t.string "city"
     t.string "country_code_iso3"
@@ -1219,8 +1219,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "last_name"
     t.string "email"
     t.string "phone"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "poa_codes", default: [], array: true
     t.string "user_types", default: [], array: true
     t.text "ssn_ciphertext"
@@ -1254,8 +1254,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   create_table "vic_submissions", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "state", default: "pending", null: false
     t.uuid "guid", null: false
     t.json "response"
@@ -1285,10 +1285,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   create_table "vye_awards", force: :cascade do |t|
     t.integer "user_info_id"
     t.string "cur_award_ind"
-    t.datetime "award_begin_date", precision: nil
-    t.datetime "award_end_date", precision: nil
+    t.datetime "award_begin_date"
+    t.datetime "award_end_date"
     t.integer "training_time"
-    t.datetime "payment_date", precision: nil
+    t.datetime "payment_date"
     t.decimal "monthly_rate"
     t.string "begin_rsn"
     t.string "end_rsn"
@@ -1325,7 +1325,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "ssn_ciphertext"
     t.string "claim_no_ciphertext"
     t.string "doc_type"
-    t.datetime "queue_date", precision: nil
+    t.datetime "queue_date"
     t.string "rpo"
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
@@ -1351,9 +1351,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.text "stub_nm_ciphertext"
     t.string "mr_status"
     t.string "rem_ent"
-    t.datetime "cert_issue_date", precision: nil
-    t.datetime "del_date", precision: nil
-    t.datetime "date_last_certified", precision: nil
+    t.datetime "cert_issue_date"
+    t.datetime "del_date"
+    t.datetime "date_last_certified"
     t.integer "rpo_code"
     t.string "fac_code"
     t.decimal "payment_amt"
@@ -1383,8 +1383,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.string "change_flag"
     t.integer "rpo_code"
     t.boolean "rpo_flag"
-    t.datetime "act_begin", precision: nil
-    t.datetime "act_end", precision: nil
+    t.datetime "act_begin"
+    t.datetime "act_end"
     t.string "source_ind"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -22,13 +22,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
 
   create_table "account_login_stats", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "idme_at"
-    t.datetime "myhealthevet_at"
-    t.datetime "dslogon_at"
+    t.datetime "idme_at", precision: nil
+    t.datetime "myhealthevet_at", precision: nil
+    t.datetime "dslogon_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "current_verification"
-    t.datetime "logingov_at"
+    t.datetime "logingov_at", precision: nil
     t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
     t.index ["current_verification"], name: "index_account_login_stats_on_current_verification"
     t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
@@ -42,8 +42,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "idme_uuid"
     t.string "icn"
     t.string "edipi"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "sec_id"
     t.string "logingov_uuid"
     t.index ["icn"], name: "index_accounts_on_icn"
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -119,8 +119,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
 
   create_table "appeals_api_higher_level_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status", default: "pending", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "code"
     t.string "detail"
     t.string "source"
@@ -157,7 +157,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "to"
     t.string "statusable_type"
     t.string "statusable_id"
-    t.datetime "status_update_time"
+    t.datetime "status_update_time", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code"
@@ -191,8 +191,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "status"
     t.string "transaction_id"
     t.string "transaction_status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "metadata_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -220,8 +220,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.jsonb "feedback"
     t.jsonb "access"
     t.string "fingerprint"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.boolean "mobile"
     t.string "active_status"
@@ -242,8 +242,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   create_table "claims_api_auto_established_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.integer "evss_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "md5"
     t.string "source"
     t.string "flashes", default: [], array: true
@@ -296,8 +296,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "status"
     t.string "current_poa"
     t.string "md5"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "vbms_new_document_version_ref_id"
     t.string "vbms_document_series_ref_id"
     t.string "vbms_error_message"
@@ -314,8 +314,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "auto_established_claim_id"
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
@@ -350,8 +350,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "email_confirmation_id"
     t.string "enrollment_id"
     t.string "batch_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "raw_form_data_ciphertext"
     t.text "eligibility_info_ciphertext"
     t.text "form_data_ciphertext"
@@ -365,8 +365,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
     t.string "sid"
     t.uuid "account_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "expanded", default: false, null: false
     t.boolean "sequestered", default: false, null: false
     t.string "email_confirmation_id"
@@ -414,8 +414,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "code", null: false
     t.string "medical_term", null: false
     t.string "lay_term"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["code"], name: "index_disability_contentions_on_code", unique: true
     t.index ["lay_term"], name: "index_disability_contentions_on_lay_term", opclass: :gin_trgm_ops, using: :gin
     t.index ["medical_term"], name: "index_disability_contentions_on_medical_term", opclass: :gin_trgm_ops, using: :gin
@@ -426,19 +426,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "unit"
     t.geography "polygon", limit: {:srid=>4326, :type=>"st_polygon", :geographic=>true}, null: false
     t.string "vha_facility_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "min"
     t.integer "max"
-    t.datetime "vssc_extract_date", default: "2001-01-01 00:00:00"
+    t.datetime "vssc_extract_date", precision: nil, default: "2001-01-01 00:00:00"
     t.index ["polygon"], name: "index_drivetime_bands_on_polygon", using: :gist
   end
 
   create_table "education_benefits_claims", id: :serial, force: :cascade do |t|
-    t.datetime "submitted_at"
-    t.datetime "processed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "submitted_at", precision: nil
+    t.datetime "processed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "regional_processing_office", null: false
     t.string "form_type", default: "1990"
     t.integer "saved_claim_id", null: false
@@ -451,8 +451,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
 
   create_table "education_benefits_submissions", id: :serial, force: :cascade do |t|
     t.string "region", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "chapter33", default: false, null: false
     t.boolean "chapter30", default: false, null: false
     t.boolean "chapter1606", default: false, null: false
@@ -478,8 +478,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.datetime "updated_at", null: false
     t.boolean "poa"
     t.integer "remaining_entitlement"
-    t.datetime "denial_email_sent_at"
-    t.datetime "confirmation_email_sent_at"
+    t.datetime "denial_email_sent_at", precision: nil
+    t.datetime "confirmation_email_sent_at", precision: nil
     t.text "auth_headers_json_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -491,8 +491,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   create_table "evss_claims", id: :serial, force: :cascade do |t|
     t.integer "evss_id", null: false
     t.json "data", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "user_uuid", null: false
     t.json "list_data", default: {}, null: false
     t.boolean "requested_decision", default: false, null: false
@@ -509,8 +509,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "gate_name"
     t.string "value"
     t.string "user"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["feature_name"], name: "index_feature_toggle_events_on_feature_name"
   end
 
@@ -523,12 +523,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.datetime "updated_at", null: false
     t.datetime "flagged_value_updated_at"
     t.index ["ip_address", "representative_id", "flag_type", "flagged_value_updated_at"], name: "index_unique_constraint_fields", unique: true
+    t.index ["ip_address", "representative_id", "flag_type"], name: "index_unique_flagged_veteran_representative", unique: true
   end
 
   create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
@@ -536,14 +537,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "feature_key", null: false
     t.string "key", null: false
     t.text "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "form1010cg_submissions", force: :cascade do |t|
     t.string "carma_case_id", limit: 18, null: false
-    t.datetime "accepted_at", null: false
+    t.datetime "accepted_at", precision: nil, null: false
     t.json "metadata"
     t.json "attachments"
     t.datetime "created_at", null: false
@@ -570,7 +571,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "status", null: false
     t.string "error_class"
     t.string "error_message"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.jsonb "bgjob_errors", default: {}
     t.index ["bgjob_errors"], name: "index_form526_job_statuses_on_bgjob_errors", using: :gin
     t.index ["form526_submission_id"], name: "index_form526_job_statuses_on_form526_submission_id"
@@ -582,8 +583,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "saved_claim_id", null: false
     t.integer "submitted_claim_id"
     t.boolean "workflow_complete", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "multiple_birls", comment: "*After* a SubmitForm526 Job fails, a lookup is done to see if the veteran has multiple BIRLS IDs. This field gets set to true if that is the case. If the initial submit job succeeds, this field will remain false whether or not the veteran has multiple BIRLS IDs --so this field cannot technically be used to sum all Form526 veterans that have multiple BIRLS. This field /can/ give us an idea of how often having multiple BIRLS IDs is a problem."
     t.text "auth_headers_json_ciphertext"
     t.text "form_json_ciphertext"
@@ -609,13 +610,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.jsonb "public_metadata"
     t.integer "state", default: 0
     t.string "error_message"
+    t.text "ipf_data_ciphertext"
     t.index ["user_account_id"], name: "index_form5655_submissions_on_user_account_id"
     t.index ["user_uuid"], name: "index_form5655_submissions_on_user_uuid"
   end
 
   create_table "form_attachments", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "guid", null: false
     t.string "type", null: false
     t.text "file_data_ciphertext"
@@ -657,9 +659,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "edipi", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.datetime "dob", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "dob", precision: nil, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "ssn_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["edipi"], name: "index_gibs_not_found_users_on_edipi"
@@ -681,15 +683,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "msa", null: false
     t.string "msa_name"
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
 
   create_table "health_care_applications", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "pending", null: false
     t.string "form_submission_id_string"
     t.string "timestamp"
@@ -711,18 +713,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
 
   create_table "id_card_announcement_subscriptions", id: :serial, force: :cascade do |t|
     t.string "email", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_id_card_announcement_subscriptions_on_email", unique: true
   end
 
   create_table "in_progress_forms", id: :serial, force: :cascade do |t|
     t.string "user_uuid", null: false
     t.string "form_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.json "metadata"
-    t.datetime "expires_at"
+    t.datetime "expires_at", precision: nil
     t.text "form_data_ciphertext"
     t.text "encrypted_kms_key"
     t.uuid "user_account_id"
@@ -740,19 +742,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|
     t.string "edipi", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["edipi"], name: "index_invalid_letter_address_edipis_on_edipi"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
     t.string "pagerduty_id"
     t.string "external_service"
-    t.datetime "start_time"
-    t.datetime "end_time"
+    t.datetime "start_time", precision: nil
+    t.datetime "end_time", precision: nil
     t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["end_time"], name: "index_maintenance_windows_on_end_time"
     t.index ["pagerduty_id"], name: "index_maintenance_windows_on_pagerduty_id"
     t.index ["start_time"], name: "index_maintenance_windows_on_start_time"
@@ -787,8 +789,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.uuid "handle", null: false
     t.uuid "user_account_id", null: false
     t.string "hashed_refresh_token", null: false
-    t.datetime "refresh_expiration", null: false
-    t.datetime "refresh_creation", null: false
+    t.datetime "refresh_expiration", precision: nil, null: false
+    t.datetime "refresh_creation", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_verification_id", null: false
@@ -824,10 +826,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.uuid "guid"
     t.string "type"
     t.string "form_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "saved_claim_id"
-    t.datetime "completed_at"
+    t.datetime "completed_at", precision: nil
     t.text "file_data_ciphertext"
     t.text "encrypted_kms_key"
     t.index ["guid"], name: "index_persistent_attachments_on_guid", unique: true
@@ -838,8 +840,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   create_table "personal_information_logs", id: :serial, force: :cascade do |t|
     t.jsonb "data", null: false
     t.string "error_class", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["created_at"], name: "index_personal_information_logs_on_created_at"
     t.index ["error_class"], name: "index_personal_information_logs_on_error_class"
   end
@@ -851,7 +853,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.bigint "query_hash"
     t.float "total_time"
     t.bigint "calls"
-    t.datetime "captured_at"
+    t.datetime "captured_at", precision: nil
     t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
   end
 
@@ -860,7 +862,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.text "schema"
     t.text "relation"
     t.bigint "size"
-    t.datetime "captured_at"
+    t.datetime "captured_at", precision: nil
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
@@ -869,22 +871,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "application_uuid"
     t.string "return_description", null: false
     t.integer "return_code"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["application_uuid"], name: "index_preneed_submissions_on_application_uuid", unique: true
     t.index ["tracking_number"], name: "index_preneed_submissions_on_tracking_number", unique: true
   end
 
   create_table "saved_claims", id: :serial, force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "form_id"
     t.uuid "guid", null: false
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.string "uploaded_forms", default: [], array: true
-    t.datetime "itf_datetime"
+    t.string "uploaded_forms", array: true
+    t.datetime "itf_datetime", precision: nil
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
@@ -917,7 +919,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "rpo"
     t.integer "number_of_submissions"
     t.string "filename"
-    t.datetime "successful_at"
+    t.datetime "successful_at", precision: nil
     t.integer "retry_attempt", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -930,8 +932,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "description", null: false
     t.integer "state_id", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -951,7 +953,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "add_ninety_day_hospital_copay"
     t.integer "outpatient_basic_care_copay"
     t.integer "outpatient_specialty_copay"
-    t.datetime "threshold_effective_date"
+    t.datetime "threshold_effective_date", precision: nil
     t.integer "aid_and_attendance_threshold"
     t.integer "outpatient_preventive_copay"
     t.integer "medication_copay"
@@ -962,8 +964,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "inpatient_per_diem"
     t.string "description"
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -974,8 +976,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "fips_code", null: false
     t.integer "country_id", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -987,8 +989,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.integer "state_id", null: false
     t.integer "county_number", null: false
     t.integer "version", null: false
-    t.datetime "created", null: false
-    t.datetime "updated"
+    t.datetime "created", precision: nil, null: false
+    t.datetime "updated", precision: nil
     t.string "created_by"
     t.string "updated_by"
   end
@@ -1004,8 +1006,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
 
   create_table "test_user_dashboard_tud_account_availability_logs", force: :cascade do |t|
     t.string "account_uuid"
-    t.datetime "checkout_time"
-    t.datetime "checkin_time"
+    t.datetime "checkout_time", precision: nil
+    t.datetime "checkin_time", precision: nil
     t.boolean "has_checkin_error"
     t.boolean "is_manual_checkin"
     t.datetime "created_at", null: false
@@ -1019,12 +1021,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "middle_name"
     t.string "last_name"
     t.string "gender"
-    t.datetime "birth_date"
+    t.datetime "birth_date", precision: nil
     t.integer "ssn"
     t.string "phone"
     t.string "email"
     t.string "password"
-    t.datetime "checkout_time"
+    t.datetime "checkout_time", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "services"
@@ -1037,8 +1039,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   end
 
   create_table "user_acceptable_verified_credentials", force: :cascade do |t|
-    t.datetime "acceptable_verified_credential_at"
-    t.datetime "idme_verified_credential_at"
+    t.datetime "acceptable_verified_credential_at", precision: nil
+    t.datetime "idme_verified_credential_at", precision: nil
     t.uuid "user_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1069,7 +1071,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "logingov_uuid"
     t.string "mhv_uuid"
     t.string "dslogon_uuid"
-    t.datetime "verified_at"
+    t.datetime "verified_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "backing_idme_uuid"
@@ -1091,15 +1093,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.date "last_revision_on"
     t.integer "pages"
     t.string "sha256"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "valid_pdf", default: false
     t.text "form_usage"
     t.text "form_tool_intro"
     t.string "form_tool_url"
     t.string "form_type"
     t.string "language"
-    t.datetime "deleted_at"
+    t.datetime "deleted_at", precision: nil
     t.string "related_forms", array: true
     t.jsonb "benefit_categories"
     t.string "form_details_url"
@@ -1146,8 +1148,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "s3_deleted"
     t.string "consumer_name"
     t.uuid "consumer_id"
@@ -1166,7 +1168,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
@@ -1186,8 +1188,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "name"
     t.string "phone"
     t.string "state", limit: 2
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "address_type"
     t.string "city"
     t.string "country_code_iso3"
@@ -1217,8 +1219,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "last_name"
     t.string "email"
     t.string "phone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "poa_codes", default: [], array: true
     t.string "user_types", default: [], array: true
     t.text "ssn_ciphertext"
@@ -1252,8 +1254,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   end
 
   create_table "vic_submissions", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "pending", null: false
     t.uuid "guid", null: false
     t.json "response"
@@ -1283,10 +1285,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
   create_table "vye_awards", force: :cascade do |t|
     t.integer "user_info_id"
     t.string "cur_award_ind"
-    t.datetime "award_begin_date"
-    t.datetime "award_end_date"
+    t.datetime "award_begin_date", precision: nil
+    t.datetime "award_end_date", precision: nil
     t.integer "training_time"
-    t.datetime "payment_date"
+    t.datetime "payment_date", precision: nil
     t.decimal "monthly_rate"
     t.string "begin_rsn"
     t.string "end_rsn"
@@ -1323,7 +1325,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.text "ssn_ciphertext"
     t.string "claim_no_ciphertext"
     t.string "doc_type"
-    t.datetime "queue_date"
+    t.datetime "queue_date", precision: nil
     t.string "rpo"
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
@@ -1349,9 +1351,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.text "stub_nm_ciphertext"
     t.string "mr_status"
     t.string "rem_ent"
-    t.datetime "cert_issue_date"
-    t.datetime "del_date"
-    t.datetime "date_last_certified"
+    t.datetime "cert_issue_date", precision: nil
+    t.datetime "del_date", precision: nil
+    t.datetime "date_last_certified", precision: nil
     t.integer "rpo_code"
     t.string "fac_code"
     t.decimal "payment_amt"
@@ -1381,8 +1383,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190237) do
     t.string "change_flag"
     t.integer "rpo_code"
     t.boolean "rpo_flag"
-    t.datetime "act_begin"
-    t.datetime "act_end"
+    t.datetime "act_begin", precision: nil
+    t.datetime "act_end", precision: nil
     t.string "source_ind"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## Summary
In the future we want to be able to rehydrate an InProgressForm from a 5655 submission. To facilitate this feature we need to persist ipf data inside the submission itself.

## Related issue(s)
[72987](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/72987)
[78148](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/78148)

## Testing done
Specs green

## What areas of the site does it impact?
The form5655_submissions table

## Acceptance criteria
ipf_data_ciphertext column is added to the form5655_submissions table