### PR TITLE
Replaced PCIU::VALID_EMAIL_REGEX with VaProfile::VALID_EMAIL_REGEX

### DIFF
--- a/app/models/messaging_preference.rb
+++ b/app/models/messaging_preference.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/models/base'
-require 'evss/pciu/email_address'
+require 'va_profile/models/email'
 
 # Secure Messaging Notification Preference Model
 class MessagingPreference < Common::Base
@@ -25,7 +25,7 @@ class MessagingPreference < Common::Base
   validates(
     :email_address,
     presence: true,
-    format: { with: EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX },
+    format: { with: VAProfile::Models::Email::VALID_EMAIL_REGEX },
     length: { maximum: 255, minimum: 6 }
   )
 

--- a/app/models/prescription_preference.rb
+++ b/app/models/prescription_preference.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/models/base'
-require 'evss/pciu/email_address'
-
+require 'va_profile/models/email'
 ##
 # Models Prescription notification preference
 #
@@ -21,7 +20,7 @@ class PrescriptionPreference < Common::Base
   validates(
     :email_address,
     presence: true,
-    format: { with: EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX },
+    format: { with: VAProfile::Models::Email::VALID_EMAIL_REGEX },
     length: { maximum: 255, minimum: 6 }
   )
 

--- a/app/swagger/swagger/schemas/vet360/email.rb
+++ b/app/swagger/swagger/schemas/vet360/email.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'evss/pciu/email_address'
+require 'va_profile/models/email'
 
 module Swagger
   module Schemas
@@ -15,7 +15,7 @@ module Swagger
                    example: 'john@example.com',
                    minLength: 6,
                    maxLength: 255,
-                   pattern: EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX.inspect
+                   pattern: VAProfile::Models::Email::VALID_EMAIL_REGEX.inspect
         end
 
         swagger_schema :PutVet360Email do
@@ -26,7 +26,7 @@ module Swagger
                    example: 'john@example.com',
                    minLength: 6,
                    maxLength: 255,
-                   pattern: EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX.inspect
+                   pattern: VAProfile::Models::Email::VALID_EMAIL_REGEX.inspect
         end
       end
     end

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -6,6 +6,7 @@ require 'evss/pciu/email_address_response'
 require 'evss/pciu/phone_number_response'
 require 'evss/pciu/request_body'
 require 'evss/service'
+require 'evss/pciu/email_address'
 
 module EVSS
   module PCIU

--- a/lib/va_profile/models/email.rb
+++ b/lib/va_profile/models/email.rb
@@ -2,7 +2,6 @@
 
 require_relative 'base'
 require 'common/models/attribute_types/iso8601_time'
-require 'evss/pciu/email_address'
 require 'va_profile/concerns/defaultable'
 require 'va_profile/concerns/expirable'
 
@@ -11,6 +10,7 @@ module VAProfile
     class Email < Base
       include VAProfile::Concerns::Defaultable
       include VAProfile::Concerns::Expirable
+      VALID_EMAIL_REGEX = /.+@.+\..+/i
 
       attribute :created_at, Common::ISO8601Time
       attribute :email_address, String
@@ -26,7 +26,7 @@ module VAProfile
       validates(
         :email_address,
         presence: true,
-        format: { with: EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX },
+        format: { with: VALID_EMAIL_REGEX },
         length: { maximum: 255, minimum: 6 }
       )
 

--- a/spec/lib/va_profile/models/email_spec.rb
+++ b/spec/lib/va_profile/models/email_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'va_profile/models/email'
+
+describe VAProfile::Models::Email do
+  it 'has valid factory' do
+    expect(build(:email)).to be_valid
+  end
+
+  it 'requires an email', :aggregate_failures do
+    expect(build(:email, email_address: '')).not_to be_valid
+    expect(build(:email, email_address: nil)).not_to be_valid
+  end
+
+  it 'is a validly formatted email', :aggregate_failures do
+    # Valid email formats
+    expect(build(:email, email_address: 'john@gmail.com')).to be_valid
+    expect(build(:email, email_address: '12john34@gmail.com')).to be_valid
+    expect(build(:email, email_address: 'john+tom@gmail.com')).to be_valid
+    expect(build(:email, email_address: 'j@example.com')).to be_valid
+    expect(build(:email, email_address: 'jack@anything.io')).to be_valid
+    expect(build(:email, email_address: 'jack@anything.org')).to be_valid
+    expect(build(:email, email_address: 'jack@anything.net')).to be_valid
+    expect(build(:email, email_address: 'jack@anything.whatever')).to be_valid
+
+    # Invalid email formats
+    expect(build(:email, email_address: 'johngmail.com')).not_to be_valid
+    expect(build(:email, email_address: 'john#gmail.com')).not_to be_valid
+    expect(build(:email, email_address: 'john@gmail')).not_to be_valid
+    expect(build(:email, email_address: '@example.com')).not_to be_valid
+  end
+end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

PCIU service will be deprecated soon. Currently, these 4 files are using the EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX.
-  PrescriptionPreference
-  MessagingPreference
-  Vets360 Email
-  VAProfile: Email

VaProfile has replaced PCIU. The `EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX` has been replaced with `VAProfile::Models::Email::VALID_EMAIL_REGEX`.

EVSS::PCIU::EmailAddress files will be removed after this has been merged.


## Related issue(s)

- department-of-veterans-affairs/va.gov-team/issues/76165
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] Validated  VAProfile::Models::Email::VALID_EMAIL_REGEX in the rails console
```
irb(main):003> require 'va_profile/models/email'
=> true
irb(main):004> VAProfile::Models::Email::VALID_EMAIL_REGEX
=> /.+@.+\..+/i
irb(main):005> require 'evss/pciu/email_address'
=> true
irb(main):006> EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX
=> /.+@.+\..+/i
```