### PR TITLE
78647 no call set_echeckin_started for OH travel claims

### DIFF
--- a/modules/check_in/app/controllers/check_in/v2/patient_check_ins_controller.rb
+++ b/modules/check_in/app/controllers/check_in/v2/patient_check_ins_controller.rb
@@ -14,18 +14,18 @@ module CheckIn
           render json: check_in_session.unauthorized_message, status: :unauthorized and return
         end
 
-        patient_check_in_data = ::V2::Lorota::Service.build(check_in: check_in_session).check_in_data
+        check_in_data = ::V2::Lorota::Service.build(check_in: check_in_session).check_in_data
 
         if Flipper.enabled?('check_in_experience_45_minute_reminder')
-          if start_check_in_called?(patient_check_in_data)
-            params[:set_e_checkin_started_called] = true
-          else
+          if call_set_echeckin_started?(check_in_data)
             ::V2::Chip::Service.build(check_in: check_in_session).set_echeckin_started
             params[:set_e_checkin_started_called] = false
+          else
+            params[:set_e_checkin_started_called] = true
           end
         end
 
-        render json: patient_check_in_data
+        render json: check_in_data
       end
 
       def create
@@ -57,8 +57,10 @@ module CheckIn
         params[:handoff]&.downcase == 'true'
       end
 
-      def start_check_in_called?(patient_check_in_data)
-        patient_check_in_data.dig(:payload, :setECheckinStartedCalled)
+      def call_set_echeckin_started?(check_in_data)
+        return false if 'oh'.casecmp?(params[:facilityType])
+
+        !check_in_data.dig(:payload, :setECheckinStartedCalled)
       end
     end
   end

--- a/modules/check_in/spec/request/v2/patient_check_ins_request_spec.rb
+++ b/modules/check_in/spec/request/v2/patient_check_ins_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'V2::PatientCheckIns', type: :request do
       end
     end
 
-    context 'when the session is authorized with DOB' do
+    context 'when the session is authorized' do
       let(:next_of_kin1) do
         {
           'name' => 'Joe',
@@ -194,6 +194,65 @@ RSpec.describe 'V2::PatientCheckIns', type: :request do
           allow(Flipper).to receive(:enabled?).with('check_in_experience_45_minute_reminder').and_return(true)
         end
 
+        context 'for OH sites' do
+          let(:appointment) do
+            {
+              'appointmentIEN' => '4822366',
+              'clinicCreditStopCodeName' => '',
+              'clinicFriendlyName' => 'Endoscopy',
+              'clinicIen' => '32216049',
+              'clinicLocation' => '',
+              'clinicName' => 'Endoscopy',
+              'clinicPhoneNumber' => '909-825-7084',
+              'clinicStopCodeName' => 'Mental Health, Primary Care',
+              'doctorName' => 'Dr. Jones',
+              'edipi' => '1000000105',
+              'facility' => 'Jerry L. Pettis Memorial Veterans Hospital',
+              'facilityAddress' => {
+                'city' => 'Loma Linda',
+                'state' => 'CA',
+                'street1' => '',
+                'street2' => '',
+                'street3' => '',
+                'zip' => '92357-1000'
+              },
+              'icn' => '1013220078V743173',
+              'kind' => 'clinic',
+              'startTime' => '2024-02-14T22:10:00.000+00:00',
+              'stationNo' => '530',
+              'status' => 'Confirmed',
+              'timezone' => 'America/Los_Angeles'
+            }
+          end
+          let(:resp) do
+            {
+              'id' => id,
+              'payload' => {
+                'address' => '1166 6th Avenue 22, New York, NY 23423 US',
+                'demographics' => {},
+                'appointments' => [appointment],
+                'patientDemographicsStatus' => {},
+                'setECheckinStartedCalled' => nil
+              }
+            }
+          end
+
+          it 'does not call set_echeckin_started' do
+            VCR.use_cassette 'check_in/lorota/token/token_200' do
+              post '/check_in/v2/sessions', **session_params
+              expect(response.status).to eq(200)
+            end
+
+            VCR.use_cassette('check_in/lorota/data/data_oracle_health_200', match_requests_on: [:host]) do
+              VCR.use_cassette 'check_in/chip/token/token_200' do
+                get "/check_in/v2/patient_check_ins/#{id}?facilityType=oh"
+              end
+            end
+            expect(response.status).to eq(200)
+            expect(JSON.parse(response.body)).to eq(resp)
+          end
+        end
+
         context 'when set_echeckin_started call succeeds' do
           it 'calls set_echeckin_started and returns valid response' do
             VCR.use_cassette 'check_in/lorota/token/token_200' do
@@ -272,7 +331,7 @@ RSpec.describe 'V2::PatientCheckIns', type: :request do
   describe 'POST `create`' do
     let(:post_params) { { patient_check_ins: { uuid: id, appointment_ien: '123-abc' } } }
 
-    context 'when session is authorized with DOB' do
+    context 'when session is authorized' do
       let(:session_params) do
         {
           params: {

--- a/spec/support/vcr_cassettes/check_in/lorota/data/data_oracle_health_200.yml
+++ b/spec/support/vcr_cassettes/check_in/lorota/data/data_oracle_health_200.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com/dev/data
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+        - Server
+      Date:
+      - Mon, 29 Jun 2020 15:46:52 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "5bcd636c-d4d3-4349-9058-03b2f6b38ced",
+          "scope": "read.full",
+          "payload": {
+            "address": "1166 6th Avenue 22, New York, NY 23423 US",
+            "appointments": [
+              {
+                "appointmentIEN": "4822366",
+                "clinicCreditStopCodeName": "",
+                "clinicFriendlyName": "Endoscopy",
+                "clinicIen": "32216049",
+                "clinicLocation": "",
+                "clinicName": "Endoscopy",
+                "clinicPhoneNumber": "909-825-7084",
+                "clinicStopCodeName": "Mental Health, Primary Care",
+                "doctorName": "Dr. Jones",
+                "edipi": "1000000105",
+                "facility": "Jerry L. Pettis Memorial Veterans Hospital",
+                "facilityAddress": {
+                  "city": "Loma Linda",
+                  "state": "CA",
+                  "street1": "",
+                  "street2": "",
+                  "street3": "",
+                  "zip": "92357-1000"
+                },
+                "icn": "1013220078V743173",
+                "kind": "clinic",
+                "startTime": "2024-02-14T22:10:00.000+00:00",
+                "stationNo": "530",
+                "status": "Confirmed",
+                "timezone": "America/Los_Angeles"
+              }
+            ],
+            "patientCellPhone": "+15555555555",
+            "type": "OH"
+          }
+        }
+  recorded_at: Thu, 19 Nov 2020 16:45:03 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Summary
This PR adds the logic to check if the incoming 'data' request is for OH sites (for travel claims) and doesn't call  CHIP `set_echeckin_started` in that case. For OH sites, currently there's no check_in functionaliy.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78647

## Testing done

- [x] *New code is covered by unit tests*
- [x] local testing

## What areas of the site does it impact?
* check_in experience

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution

