### PR TITLE
Removed pciu service requirement Mobile/v0 controllers

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/emails_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/emails_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'common/exceptions/validation_errors'
-require 'evss/pciu/service'
 
 module Mobile
   module V0

--- a/modules/mobile/app/controllers/mobile/v0/phones_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/phones_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'common/exceptions/validation_errors'
-require 'evss/pciu/service'
 
 module Mobile
   module V0


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Removed `evss/pciu/service` references in Mobile/v0 controllers. PCIU service will be depreciated soon. Mobile controllers use the `Mobile::V0::Profile::SyncUpdateService` instead of the PCIU service. VAProfile::Models build mobile records:


```
modules/mobile/app/services/mobile/v0/profile/sync_update_service.rb
...
...
        def build_record(type, params)
          "VAProfile::Models::#{type.capitalize}"
            .constantize
            .new(params)
            .set_defaults(@user)
        end

```
## Related issue(s)
- department-of-veterans-affairs/va.gov-team#76174
