### PR TITLE
added the BRD feature flag to features.yml

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1263,6 +1263,9 @@ features:
   disability_compensation_remove_pciu:
     actor_type: user
     description: If enabled, VA Profile is used to populate contact information- without PCIU calls (status quo)
+  disability_compensation_lighthouse_brd:
+    actor_type: user
+    description: If enabled uses the lighthouse Benefits Reference Data service
   virtual_agent_fetch_jwt_token:
     actor_type: user
     description: Enable the fetching of a JWT token to access MAP environment

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -1029,6 +1029,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
       end
 
       it 'supports getting separation_locations' do
+        Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_BRD)
         expect(subject).to validate(:get, '/v0/disability_compensation_form/separation_locations', 401)
         VCR.use_cassette('evss/reference_data/get_intake_sites_500') do
           expect(subject).to validate(:get, '/v0/disability_compensation_form/separation_locations', 502, headers)


### PR DESCRIPTION
This PR fixes the initial deploy of BRD migration, where the Flipper flag `disability_compensation_lighthouse_brd` was accidentally omitted from `features.yml` (making it inaccessible from the Flipper dashboard)


## Summary

- This work is behind a feature toggle (flipper): ~YES/NO~ this work is part of the feature toggle itself
- The `disability_compensation_lighthouse_brd` toggle was added to `features.yml`
- Disability Benefits Experience Team 1 (dBeX tReX 🦖)

## Related issue(s)

- [78798](https://app.zenhub.com/workspaces/disability-experience-63dbdb0a401c4400119d3a44/issues/gh/department-of-veterans-affairs/va.gov-team/78798)
- Original [PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15302/files)

## Testing done

- [x] *New code is covered by unit tests*
- Feature toggle now shows up in /flipper/features

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/92405130/4e62073f-c82a-4142-b67e-da229e402f47)


## What areas of the site does it impact?
526EZ application

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
