### PR TITLE
replace global variable with new redis instance

### DIFF
--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -2,7 +2,8 @@
 
 # config/coverband.rb NOT in the initializers
 Coverband.configure do |config|
-  config.store = Coverband::Adapters::RedisStore.new($redis)
+  # Do not use the $redis global variable
+  config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: Settings.redis.app_data.url))
   config.logger = Rails.logger
 
   # config options false, true. (defaults to false)


### PR DESCRIPTION
## Summary

- Fix redis instantiation in coverband config file. 
- Don't use global $redis variable for coverband config file

## Related issue(s)

- None

## Testing done

- Manual testing

## Acceptance criteria

- [X]  Coverband correctly loads at `/coverband`
