### PR TITLE
VAOS Revert Cancellation Exclusions at Lovell Clinics

### DIFF
--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -940,25 +940,4 @@ describe VAOS::V2::AppointmentsService do
       end
     end
   end
-
-  describe 'lovell_appointment?' do
-    it 'returns false when the appointment is nil' do
-      expect(subject.send(:lovell_appointment?, nil)).to eq(false)
-    end
-
-    it 'returns false when the appointment location id is missing' do
-      appointment = { id: '123456' }
-      expect(subject.send(:lovell_appointment?, appointment)).to eq(false)
-    end
-
-    it 'returns true if the appointment is a Lovell appointment' do
-      appointment = { location_id: '556', id: '123456' }
-      expect(subject.send(:lovell_appointment?, appointment)).to eq(true)
-    end
-
-    it 'returns false if the appointment is not a Lovell appointment' do
-      appointment = { location_id: '983', id: '123456' }
-      expect(subject.send(:lovell_appointment?, appointment)).to eq(false)
-    end
-  end
 end


### PR DESCRIPTION

## Summary

Removes, no longer required, code that prevents cancellation of Lovell site appointments. This is a revert of commit (0f0412d)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/78780

## Testing done

Removed tests that covered deleted code. Ensured existing tests still pass.

