### PR TITLE
VAOS Revert Remove Lovell Sites from Appointment Scheduling.

### DIFF
--- a/modules/vaos/spec/services/v2/mobile_facility_service_spec.rb
+++ b/modules/vaos/spec/services/v2/mobile_facility_service_spec.rb
@@ -452,32 +452,6 @@ describe VAOS::V2::MobileFacilityService do
     end
   end
 
-  describe '#remove_lovell_sites' do
-    context 'when facilities are blank' do
-      let(:facilities) { [] }
-
-      it 'returns an empty array' do
-        expect(subject.send(:remove_lovell_sites, facilities)).to eq([])
-      end
-    end
-
-    context 'when facilities are not blank' do
-      let(:facilities) { [{ id: '556' }, { id: '983' }, { id: '556GA' }] }
-
-      it 'returns an array without facilities starting with 556' do
-        expect(subject.send(:remove_lovell_sites, facilities)).to eq([{ id: '983' }])
-      end
-    end
-
-    context 'when facilities are all Lovell' do
-      let(:facilities) { [{ id: '556' }, { id: '556GA' }] }
-
-      it 'returns an empty array' do
-        expect(subject.send(:remove_lovell_sites, facilities)).to eq([])
-      end
-    end
-  end
-
   describe '#page_params' do
     context 'when per_page is positive' do
       context 'when per_page is positive' do


### PR DESCRIPTION
## Summary
Lovell sites no longer need to be excluded from appointment scheduling after the cutover to Oracle Health. The code that excluded Lovell sites has been removed.

This reverts commit 5ab933aa1a7c8a8b9e3dc4cd920a7a52e52a233b.


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/78777

## Testing done

- [X] Removed testing covering removed coded; ensured remaining test still works.

