### PR TITLE
[CST] Removing feature toggles that are no longer used

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -166,10 +166,6 @@ features:
     actor_type: user
     description: Enables users to access the claim letters page
     enable_in_development: true
-  cst_use_lighthouse:
-    actor_type: user
-    description: When enabled, claims status tool uses the Lighthouse API instead of EVSS
-    enable_in_development: true
   cst_use_lighthouse_5103:
     actor_type: user
     description: When enabled, claims status tool uses the Lighthouse API for the 5103 endpoint
@@ -189,10 +185,6 @@ features:
   cst_include_ddl_5103_letters:
     actor_type: user
     description: When enabled, the Download Decision Letters feature includes 5103 letters
-    enable_in_development: true
-  cst_use_new_claim_cards:
-    actor_type: user
-    description: When enabled, claims status tool uses the new claim card designs
     enable_in_development: true
   cst_use_claim_details_v2:
     actor_type: user


### PR DESCRIPTION
## Summary
Removing the `cst_use_lighthouse` and `cst_use_new_claim_cards` feature toggles from `features.yml` because they are no longer being used in vets-website

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/77311

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
