### PR TITLE
Adds arg for poa_updater. Adds ternary for form to retrieve poa code.

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/poa_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_updater.rb
@@ -4,7 +4,7 @@ require 'bgs'
 
 module ClaimsApi
   class PoaUpdater < ClaimsApi::ServiceBase
-    def perform(power_of_attorney_id) # rubocop:disable Metrics/MethodLength
+    def perform(power_of_attorney_id, form_number) # rubocop:disable Metrics/MethodLength
       poa_form = ClaimsApi::PowerOfAttorney.find(power_of_attorney_id)
       service = BGS::Services.new(
         external_uid: poa_form.external_uid,
@@ -27,8 +27,7 @@ module ClaimsApi
         poa_form.vbms_error_message = nil if poa_form.vbms_error_message.present?
 
         ClaimsApi::Logger.log('poa', poa_id: poa_form.id, detail: 'BIRLS Success')
-
-        ClaimsApi::PoaVBMSUpdater.perform_async(poa_form.id) if enable_vbms_access?(poa_form:)
+        ClaimsApi::PoaVBMSUpdater.perform_async(poa_form.id, form_number) if enable_vbms_access?(poa_form:)
       else
         poa_form.status = ClaimsApi::PowerOfAttorney::ERRORED
         poa_form.vbms_error_message = "BGS Error: update_birls_record failed with code #{response[:return_code]}"

--- a/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
@@ -4,8 +4,9 @@ require 'bgs'
 
 module ClaimsApi
   class PoaVBMSUpdater < ClaimsApi::ServiceBase
-    def perform(power_of_attorney_id) # rubocop:disable Metrics/MethodLength
+    def perform(power_of_attorney_id, form = 2122) # rubocop:disable Metrics/MethodLength
       poa_form = ClaimsApi::PowerOfAttorney.find(power_of_attorney_id)
+      rep_or_org = form.to_s == '2122A' ? 'representative' : 'serviceOrganization'
       service = BGS::Services.new(
         external_uid: poa_form.external_uid,
         external_key: poa_form.external_key
@@ -15,13 +16,12 @@ module ClaimsApi
         'poa_vbms_updater',
         poa_id: power_of_attorney_id,
         detail: 'Updating Access',
-        poa_code: poa_form.form_data.dig('serviceOrganization', 'poaCode')
+        poa_code: poa_form.form_data.dig(rep_or_org, 'poaCode')
       )
-
       # allow_poa_c_add reports 'No Data' if sent lowercase
       response = service.corporate_update.update_poa_access(
         participant_id: poa_form.auth_headers['va_eauth_pid'],
-        poa_code: poa_form.form_data.dig('serviceOrganization', 'poaCode'),
+        poa_code: poa_form.form_data.dig(rep_or_org, 'poaCode'),
         allow_poa_access: 'y',
         allow_poa_c_add: allow_address_change?(poa_form, power_of_attorney_id) ? 'Y' : 'N'
       )


### PR DESCRIPTION
## Summary

- Adds arg for poa_updater. 
- Adds ternary for form to retrieve poa code.

## Related issue(s)

- [API-34931](https://jira.devops.va.gov/browse/API-34931)

## Testing done

- Tested with Postman: 2122 & 2122A submit, new.perform, checked the poa codes in the [poa_vbms_updater](https://github.com/department-of-veterans-affairs/vets-api/blob/API-34931-vbms-access-error/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb#L19)


## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/poa_updater.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature