### PR TITLE
[1115] poc: add logic to verify a PDF was properly stamped

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -1276,4 +1277,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.4.19
+   2.4.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,6 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,6 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -1277,4 +1276,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.4.9
+   2.4.19

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -26,7 +26,7 @@ module SimpleFormsApi
                   end
       stamp_text = SUBMISSION_TEXT + current_time
       desired_stamps = [[10, 10, stamp_text]]
-      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, auth_text, text_only: false) }
+      verified_stamp(desired_stamps, stamped_template_path, auth_text, text_only: false)
 
       stamp_submission_date(stamped_template_path, form.submission_date_config)
     end
@@ -34,7 +34,7 @@ module SimpleFormsApi
     def self.stamp107959f1(stamped_template_path, form)
       desired_stamps = [[26, 82.5, form.data['statement_of_truth_signature']]]
       append_to_stamp = false
-      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
+      verified_stamp(desired_stamps, stamped_template_path, append_to_stamp)
     end
 
     def self.stamp264555(stamped_template_path, form)
@@ -43,7 +43,7 @@ module SimpleFormsApi
       desired_stamps.append([73, 355, 'X']) unless form.data['previous_hi_application']['has_previous_hi_application']
       desired_stamps.append([73, 320, 'X']) unless form.data['living_situation']['is_in_care_facility']
       append_to_stamp = false
-      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
+      verified_stamp(desired_stamps, stamped_template_path, append_to_stamp)
     end
 
     def self.stamp214142(stamped_template_path, form)
@@ -234,12 +234,6 @@ module SimpleFormsApi
       end
     end
 
-    def self.verified_multistamp(stamped_template_path, signature_text, page_configuration)
-      raise StandardError, 'Provided signature was empty' unless signature_text
-
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
-    end
-
     def self.verify(template_path)
       orig_size = File.size(template_path)
       yield
@@ -248,6 +242,18 @@ module SimpleFormsApi
       raise StandardError, 'PDF stamping failed.' unless stamped_size > orig_size
     rescue
       raise StandardError, 'An error occurred while verifying stamp.'
+    end
+
+    def self.verified_stamp(desired_stamps, stamped_template_path, auth_text, **)
+      # raise StandardError, 'No stamps were provided' if desired_stamps.empty?
+
+      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, auth_text, **) }
+    end
+
+    def self.verified_multistamp(stamped_template_path, signature_text, page_configuration)
+      raise StandardError, 'Provided signature was empty' unless signature_text
+
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.default_page_configuration

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -244,10 +244,10 @@ module SimpleFormsApi
       raise StandardError, 'An error occurred while verifying stamp.'
     end
 
-    def self.verified_multistamp(stamped_template_path, signature_text, page_configuration)
-      raise StandardError, 'Provided signature was empty' unless signature_text
+    def self.verified_multistamp(stamped_template_path, stamp_text, page_configuration)
+      raise StandardError, 'Provided text to stamp was empty' unless stamp_text
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, stamp_text, page_configuration) }
     end
 
     def self.default_page_configuration

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -26,9 +26,7 @@ module SimpleFormsApi
                   end
       stamp_text = SUBMISSION_TEXT + current_time
       desired_stamps = [[10, 10, stamp_text]]
-      verified_stamp(stamped_template_path) do
-        stamp(desired_stamps, stamped_template_path, auth_text, text_only: false)
-      end
+      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, auth_text, text_only: false) }
 
       stamp_submission_date(stamped_template_path, form.submission_date_config)
     end
@@ -36,7 +34,7 @@ module SimpleFormsApi
     def self.stamp107959f1(stamped_template_path, form)
       desired_stamps = [[26, 82.5, form.data['statement_of_truth_signature']]]
       append_to_stamp = false
-      verified_stamp(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
+      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
     end
 
     def self.stamp264555(stamped_template_path, form)
@@ -45,7 +43,7 @@ module SimpleFormsApi
       desired_stamps.append([73, 355, 'X']) unless form.data['previous_hi_application']['has_previous_hi_application']
       desired_stamps.append([73, 320, 'X']) unless form.data['living_situation']['is_in_care_facility']
       append_to_stamp = false
-      verified_stamp(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
+      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
     end
 
     def self.stamp214142(stamped_template_path, form)
@@ -57,7 +55,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
 
       # This is a one-off case where we need to stamp a date on the first page of 21-4142 when resubmitting
       if form.data['in_progress_form_created_at']
@@ -76,7 +74,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, date_title, page_configuration, 12) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, date_title, page_configuration, 12) }
 
       page_configuration = [
         { type: :text, position: date_text_stamp_position },
@@ -84,7 +82,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, date_text, page_configuration, 12) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, date_text, page_configuration, 12) }
     end
 
     def self.stamp2110210(stamped_template_path, form)
@@ -96,7 +94,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp210845(stamped_template_path, form)
@@ -108,7 +106,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp21p0847(stamped_template_path, form)
@@ -119,7 +117,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp210972(stamped_template_path, form)
@@ -131,7 +129,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp210966(stamped_template_path, form)
@@ -142,7 +140,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp2010207(stamped_template_path, form)
@@ -164,7 +162,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp4010007_uuid(uuid)
@@ -175,7 +173,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, uuid, page_configuration, 7) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, uuid, page_configuration, 7) }
     end
 
     def self.multistamp(stamped_template_path, signature_text, page_configuration, font_size = 16)
@@ -232,13 +230,11 @@ module SimpleFormsApi
         page_configuration[config[:page_number]] = { type: :text, position: date_text_stamp_position }
 
         current_time = Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D')
-        verified_stamp(stamped_template_path) do
-          multistamp(stamped_template_path, current_time, page_configuration, 12)
-        end
+        verify(stamped_template_path) { multistamp(stamped_template_path, current_time, page_configuration, 12) }
       end
     end
 
-    def self.verified_stamp(template_path)
+    def self.verify(template_path)
       orig_size = File.size(template_path)
       yield
       stamped_size = File.size(template_path)

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -26,7 +26,7 @@ module SimpleFormsApi
                   end
       stamp_text = SUBMISSION_TEXT + current_time
       desired_stamps = [[10, 10, stamp_text]]
-      verified_stamp(desired_stamps, stamped_template_path, auth_text, text_only: false)
+      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, auth_text, text_only: false) }
 
       stamp_submission_date(stamped_template_path, form.submission_date_config)
     end
@@ -34,7 +34,7 @@ module SimpleFormsApi
     def self.stamp107959f1(stamped_template_path, form)
       desired_stamps = [[26, 82.5, form.data['statement_of_truth_signature']]]
       append_to_stamp = false
-      verified_stamp(desired_stamps, stamped_template_path, append_to_stamp)
+      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
     end
 
     def self.stamp264555(stamped_template_path, form)
@@ -43,7 +43,7 @@ module SimpleFormsApi
       desired_stamps.append([73, 355, 'X']) unless form.data['previous_hi_application']['has_previous_hi_application']
       desired_stamps.append([73, 320, 'X']) unless form.data['living_situation']['is_in_care_facility']
       append_to_stamp = false
-      verified_stamp(desired_stamps, stamped_template_path, append_to_stamp)
+      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
     end
 
     def self.stamp214142(stamped_template_path, form)
@@ -242,12 +242,6 @@ module SimpleFormsApi
       raise StandardError, 'PDF stamping failed.' unless stamped_size > orig_size
     rescue
       raise StandardError, 'An error occurred while verifying stamp.'
-    end
-
-    def self.verified_stamp(desired_stamps, stamped_template_path, auth_text, **)
-      # raise StandardError, 'No stamps were provided' if desired_stamps.empty?
-
-      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, auth_text, **) }
     end
 
     def self.verified_multistamp(stamped_template_path, signature_text, page_configuration)

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -55,7 +55,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      multistamp(stamped_template_path, signature_text, page_configuration)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
 
       # This is a one-off case where we need to stamp a date on the first page of 21-4142 when resubmitting
       if form.data['in_progress_form_created_at']
@@ -74,7 +74,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      multistamp(stamped_template_path, date_title, page_configuration, 12)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, date_title, page_configuration, 12) }
 
       page_configuration = [
         { type: :text, position: date_text_stamp_position },
@@ -82,7 +82,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      multistamp(stamped_template_path, date_text, page_configuration, 12)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, date_text, page_configuration, 12) }
     end
 
     def self.stamp2110210(stamped_template_path, form)
@@ -94,7 +94,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      multistamp(stamped_template_path, signature_text, page_configuration)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp210845(stamped_template_path, form)
@@ -106,7 +106,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      multistamp(stamped_template_path, signature_text, page_configuration)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp21p0847(stamped_template_path, form)
@@ -117,7 +117,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      multistamp(stamped_template_path, signature_text, page_configuration)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp210972(stamped_template_path, form)
@@ -129,7 +129,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      multistamp(stamped_template_path, signature_text, page_configuration)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp210966(stamped_template_path, form)
@@ -140,7 +140,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      multistamp(stamped_template_path, signature_text, page_configuration)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp2010207(stamped_template_path, form)
@@ -162,7 +162,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      multistamp(stamped_template_path, signature_text, page_configuration)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.stamp4010007_uuid(uuid)
@@ -173,7 +173,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      multistamp(stamped_template_path, uuid, page_configuration, 7)
+      verified_stamp(stamped_template_path) { multistamp(stamped_template_path, uuid, page_configuration, 7) }
     end
 
     def self.multistamp(stamped_template_path, signature_text, page_configuration, font_size = 16)
@@ -200,9 +200,8 @@ module SimpleFormsApi
     def self.stamp(desired_stamps, stamped_template_path, append_to_stamp, text_only: true)
       current_file_path = stamped_template_path
       desired_stamps.each do |x, y, text|
-        out_path = CentralMail::DatestampPdf.new(current_file_path, append_to_stamp:).run(text:, x:, y:, text_only:,
-                                                                                          size: 9)
-        current_file_path = out_path
+        datestamp_instance = CentralMail::DatestampPdf.new(current_file_path, append_to_stamp:)
+        current_file_path = datestamp_instance.run(text:, x:, y:, text_only:, size: 9)
       end
       File.rename(current_file_path, stamped_template_path)
     end
@@ -230,9 +229,21 @@ module SimpleFormsApi
         page_configuration = default_page_configuration
         page_configuration[config[:page_number]] = { type: :text, position: date_text_stamp_position }
 
-        multistamp(stamped_template_path, Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'), page_configuration,
-                   12)
+        current_time = Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D')
+        verified_stamp(stamped_template_path) do
+          multistamp(stamped_template_path, current_time, page_configuration, 12)
+        end
       end
+    end
+
+    def self.verified_stamp(template_path)
+      orig_size = File.size(template_path)
+      yield
+      stamped_size = File.size(template_path)
+
+      raise StandardError, 'PDF stamping failed.' unless stamped_size > orig_size
+    rescue
+      raise StandardError, 'An error occurred while verifying stamp.'
     end
 
     def self.default_page_configuration

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -43,7 +43,7 @@ module SimpleFormsApi
       desired_stamps.append([73, 355, 'X']) unless form.data['previous_hi_application']['has_previous_hi_application']
       desired_stamps.append([73, 320, 'X']) unless form.data['living_situation']['is_in_care_facility']
       append_to_stamp = false
-      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
+      stamp(desired_stamps, stamped_template_path, append_to_stamp)
     end
 
     def self.stamp214142(stamped_template_path, form)
@@ -239,15 +239,15 @@ module SimpleFormsApi
       yield
       stamped_size = File.size(template_path)
 
-      raise StandardError, 'PDF stamping failed.' unless stamped_size > orig_size
-    rescue
-      raise StandardError, 'An error occurred while verifying stamp.'
+      raise StandardError, 'The PDF remained unchanged upon stamping.' unless stamped_size > orig_size
+    rescue => e
+      raise StandardError, "An error occurred while verifying stamp: #{e}"
     end
 
-    def self.verified_multistamp(stamped_template_path, stamp_text, page_configuration)
-      raise StandardError, 'Provided text to stamp was empty' unless stamp_text
+    def self.verified_multistamp(stamped_template_path, stamp_text, page_configuration, *)
+      raise StandardError, 'The provided stamp content was empty.' if stamp_text.blank?
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, stamp_text, page_configuration) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, stamp_text, page_configuration, *) }
     end
 
     def self.default_page_configuration

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -26,7 +26,9 @@ module SimpleFormsApi
                   end
       stamp_text = SUBMISSION_TEXT + current_time
       desired_stamps = [[10, 10, stamp_text]]
-      stamp(desired_stamps, stamped_template_path, auth_text, text_only: false)
+      verified_stamp(stamped_template_path) do
+        stamp(desired_stamps, stamped_template_path, auth_text, text_only: false)
+      end
 
       stamp_submission_date(stamped_template_path, form.submission_date_config)
     end
@@ -34,7 +36,7 @@ module SimpleFormsApi
     def self.stamp107959f1(stamped_template_path, form)
       desired_stamps = [[26, 82.5, form.data['statement_of_truth_signature']]]
       append_to_stamp = false
-      stamp(desired_stamps, stamped_template_path, append_to_stamp)
+      verified_stamp(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
     end
 
     def self.stamp264555(stamped_template_path, form)
@@ -43,7 +45,7 @@ module SimpleFormsApi
       desired_stamps.append([73, 355, 'X']) unless form.data['previous_hi_application']['has_previous_hi_application']
       desired_stamps.append([73, 320, 'X']) unless form.data['living_situation']['is_in_care_facility']
       append_to_stamp = false
-      stamp(desired_stamps, stamped_template_path, append_to_stamp)
+      verified_stamp(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
     end
 
     def self.stamp214142(stamped_template_path, form)

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -55,7 +55,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verified_multistamp(stamped_template_path, signature_text, page_configuration)
 
       # This is a one-off case where we need to stamp a date on the first page of 21-4142 when resubmitting
       if form.data['in_progress_form_created_at']
@@ -74,7 +74,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, date_title, page_configuration, 12) }
+      verified_multistamp(stamped_template_path, date_title, page_configuration, 12)
 
       page_configuration = [
         { type: :text, position: date_text_stamp_position },
@@ -82,7 +82,7 @@ module SimpleFormsApi
         { type: :new_page }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, date_text, page_configuration, 12) }
+      verified_multistamp(stamped_template_path, date_text, page_configuration, 12)
     end
 
     def self.stamp2110210(stamped_template_path, form)
@@ -94,7 +94,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verified_multistamp(stamped_template_path, signature_text, page_configuration)
     end
 
     def self.stamp210845(stamped_template_path, form)
@@ -106,7 +106,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verified_multistamp(stamped_template_path, signature_text, page_configuration)
     end
 
     def self.stamp21p0847(stamped_template_path, form)
@@ -117,7 +117,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verified_multistamp(stamped_template_path, signature_text, page_configuration)
     end
 
     def self.stamp210972(stamped_template_path, form)
@@ -129,7 +129,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verified_multistamp(stamped_template_path, signature_text, page_configuration)
     end
 
     def self.stamp210966(stamped_template_path, form)
@@ -140,7 +140,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verified_multistamp(stamped_template_path, signature_text, page_configuration)
     end
 
     def self.stamp2010207(stamped_template_path, form)
@@ -162,7 +162,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
+      verified_multistamp(stamped_template_path, signature_text, page_configuration)
     end
 
     def self.stamp4010007_uuid(uuid)
@@ -173,7 +173,7 @@ module SimpleFormsApi
         { type: :text, position: desired_stamps[0] }
       ]
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, uuid, page_configuration, 7) }
+      verified_multistamp(stamped_template_path, uuid, page_configuration, 7)
     end
 
     def self.multistamp(stamped_template_path, signature_text, page_configuration, font_size = 16)
@@ -224,14 +224,20 @@ module SimpleFormsApi
         page_configuration = default_page_configuration
         page_configuration[config[:page_number]] = { type: :text, position: date_title_stamp_position }
 
-        multistamp(stamped_template_path, SUBMISSION_DATE_TITLE, page_configuration, 12)
+        verified_multistamp(stamped_template_path, SUBMISSION_DATE_TITLE, page_configuration, 12)
 
         page_configuration = default_page_configuration
         page_configuration[config[:page_number]] = { type: :text, position: date_text_stamp_position }
 
         current_time = Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D')
-        verify(stamped_template_path) { multistamp(stamped_template_path, current_time, page_configuration, 12) }
+        verified_multistamp(stamped_template_path, current_time, page_configuration, 12)
       end
+    end
+
+    def self.verified_multistamp(stamped_template_path, signature_text, page_configuration)
+      raise StandardError, 'Provided signature was empty' unless signature_text
+
+      verify(stamped_template_path) { multistamp(stamped_template_path, signature_text, page_configuration) }
     end
 
     def self.verify(template_path)

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21P_0847.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21P_0847.json
@@ -30,5 +30,6 @@
     "relationship_to_veteran": "other",
     "otherRelationship_to_veteran": "friend of a friend"
   },
-  "additional_information": "Lots of \"extra\" stuff here"
+  "additional_information": "Lots of \"extra\" stuff here",
+  "statement_of_truth_signature": "John Veteran"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21_0845.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21_0845.json
@@ -44,5 +44,6 @@
   "release_duration": "untilDate",
   "release_end_date": "2033-06-16",
   "security_question": "motherBirthplace",
-  "security_answer": "Las Vegas, NV"
+  "security_answer": "Las Vegas, NV",
+  "statement_of_truth_signature": "John Veteran"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21_10210.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21_10210.json
@@ -53,5 +53,6 @@
   },
   "witness_other_relationship_to_claimant": "Other text",
   "claimant_type": "non-veteran",
-  "claim_ownership": "third-party"
+  "claim_ownership": "third-party",
+  "statement_of_truth_signature": "John Veteran"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21_4142.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_21_4142.json
@@ -138,5 +138,6 @@
     "preparer_organization": "Top Org",
     "court_appointment_info": "Representing \"court stuff\" like...Representing court stuff like...Representing court stuff like...Representing court stuff like...Representing court stuff like...Representing court stuff like...",
     "relationship_to_veteran": "Veteran Service Officer"
-  }
+  },
+  "statement_of_truth_signature": "John Veteran"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_unhandled.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_with_dangerous_characters_unhandled.json
@@ -59,5 +59,6 @@
       "postal_code": "54890"
     }
   },
-  "remarks": "Lengthy \"remarks\" here \nabout what is needed\tand such"
+  "remarks": "Lengthy \"remarks\" here \nabout what is needed\tand such",
+  "statement_of_truth_signature": "John Veteran"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21_0845.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21_0845.json
@@ -36,5 +36,6 @@
   "release_duration": "untilDate",
   "release_end_date": "2033-06-16",
   "security_question": "motherBirthplace",
-  "security_answer": "Las Vegas, NV"
+  "security_answer": "Las Vegas, NV",
+  "statement_of_truth_signature": "John M Veteran"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21_10210-min.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21_10210-min.json
@@ -16,5 +16,6 @@
       "state": "CA",
       "postal_code": "12345"
   },
-  "veteran_phone": "555-555-5557"
+  "veteran_phone": "555-555-5557",
+  "statement_of_truth_signature": "Arthur C Preparer"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21_10210.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21_10210.json
@@ -53,5 +53,6 @@
   },
   "witness_other_relationship_to_claimant": "Other text",
   "claimant_type": "non-veteran",
-  "claim_ownership": "third-party"
+  "claim_ownership": "third-party",
+  "statement_of_truth_signature": "Joe Center Claimant"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21p_0847-min.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21p_0847-min.json
@@ -22,5 +22,6 @@
   "veteran_ssn": "999442222",
   "relationship_to_deceased_claimant": {
     "relationship_to_veteran": "spouse"
-  }
+  },
+  "statement_of_truth_signature": "Arthur C Preparer"
 }

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21p_0847.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21p_0847.json
@@ -30,5 +30,6 @@
     "relationship_to_veteran": "other",
     "otherRelationship_to_veteran": "friend of a friend"
   },
-  "additional_information": "Lots of extra stuff here"
+  "additional_information": "Lots of extra stuff here",
+  "statement_of_truth_signature": "Arthur C Preparer"
 }

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -5,18 +5,21 @@ require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::PdfFiller do
   def self.test_pdf_fill(form_number, test_payload = form_number)
-    it 'fills out a PDF from a templated JSON file' do
-      expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
+    form_name = form_number.split(Regexp.union(%w[vba_ vha_]))[1].gsub('_', '-')
+    context "when filling the pdf for form #{form_name} given template #{test_payload}" do
+      it 'fills out a PDF from a templated JSON file' do
+        expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
 
-      # remove the pdf if it already exists
-      FileUtils.rm_f(expected_pdf_path)
+        # remove the pdf if it already exists
+        FileUtils.rm_f(expected_pdf_path)
 
-      # fill the PDF
-      data = JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{test_payload}.json"))
-      form = "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-      filler = SimpleFormsApi::PdfFiller.new(form_number:, form:)
-      filler.generate
-      expect(File.exist?(expected_pdf_path)).to eq(true)
+        # fill the PDF
+        data = JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{test_payload}.json"))
+        form = "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
+        filler = SimpleFormsApi::PdfFiller.new(form_number:, form:)
+        filler.generate
+        expect(File.exist?(expected_pdf_path)).to eq(true)
+      end
     end
   end
 

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -28,8 +28,8 @@ describe SimpleFormsApi::PdfStamper do
     end
   end
 
-  describe '.verified_stamp' do
-    subject(:verified_stamp) { described_class.verified_stamp('template_path') { double } }
+  describe '.verify' do
+    subject(:verify) { described_class.verify('template_path') { double } }
 
     before { allow(File).to receive(:size).and_return(orig_size, stamped_size) }
 
@@ -40,7 +40,7 @@ describe SimpleFormsApi::PdfStamper do
         let(:stamped_size) { orig_size + 1 }
 
         it 'succeeds' do
-          expect { verified_stamp }.not_to raise_error
+          expect { verify }.not_to raise_error
         end
       end
 
@@ -48,7 +48,7 @@ describe SimpleFormsApi::PdfStamper do
         let(:stamped_size) { orig_size }
 
         it 'raises an error message' do
-          expect { verified_stamp }.to raise_error('An error occurred while verifying stamp.')
+          expect { verify }.to raise_error('An error occurred while verifying stamp.')
         end
       end
 
@@ -56,7 +56,7 @@ describe SimpleFormsApi::PdfStamper do
         let(:stamped_size) { orig_size - 1 }
 
         it 'raises an error message' do
-          expect { verified_stamp }.to raise_error('An error occurred while verifying stamp.')
+          expect { verify }.to raise_error('An error occurred while verifying stamp.')
         end
       end
     end

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -6,6 +6,7 @@ require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe SimpleFormsApi::PdfStamper do
   let(:data) { JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{test_payload}.json")) }
   let(:form) { "SimpleFormsApi::#{test_payload.titleize.gsub(' ', '')}".constantize.new(data) }
+  let(:path) { 'tmp/stuff.json' }
 
   describe 'form-specific stamp methods' do
     subject(:stamp) { described_class.send(stamp_method, generated_form_path, form) }
@@ -24,6 +25,74 @@ describe SimpleFormsApi::PdfStamper do
         it 'raises an error' do
           expect { stamp }.to raise_error(StandardError, 'An error occurred while verifying stamp.')
         end
+      end
+    end
+  end
+
+  describe '.stamp107959f1' do
+    subject(:stamp107959f1) { described_class.stamp107959f1(path, form) }
+
+    before do
+      allow(described_class).to receive(:stamp).and_return(true)
+      allow(File).to receive(:size).and_return(1, 2)
+    end
+
+    context 'when statement_of_truth_signature is provided' do
+      before { stamp107959f1 }
+
+      let(:test_payload) { 'vha_10_7959f_1' }
+      let(:signature) { form.data['statement_of_truth_signature'] }
+      let(:stamps) { [[26, 82.5, signature]] }
+
+      it 'calls stamp with correct desired_stamp' do
+        expect(described_class).to have_received(:stamp).with(stamps, path, false)
+      end
+    end
+  end
+
+  describe '.stamp264555' do
+    subject(:stamp264555) { described_class.stamp264555(path, form) }
+
+    before do
+      allow(described_class).to receive(:stamp).and_return(true)
+      allow(File).to receive(:size).and_return(1, 2)
+    end
+
+    context 'when it is called with legitimate parameters' do
+      before { stamp264555 }
+
+      let(:test_payload) { 'vba_26_4555' }
+      let(:stamps) { [] }
+
+      it 'calls stamp correctly' do
+        expect(described_class).to have_received(:stamp).with(stamps, path, false)
+      end
+    end
+  end
+
+  describe '.stamp210845' do
+    subject(:stamp210845) { described_class.stamp210845(path, form) }
+
+    before do
+      allow(described_class).to receive(:multistamp).and_return(true)
+      allow(File).to receive(:size).and_return(1, 2)
+    end
+
+    context 'when it is called with legitimate parameters' do
+      before { stamp210845 }
+
+      let(:test_payload) { 'vba_21_0845' }
+      let(:signature) { form.data['statement_of_truth_signature'] }
+      let(:page_config) do
+        [
+          { type: :new_page },
+          { type: :new_page },
+          { type: :text, position: [50, 240] }
+        ]
+      end
+
+      it 'calls multistamp correctly' do
+        expect(described_class).to have_received(:multistamp).with(path, signature, page_config)
       end
     end
   end
@@ -58,6 +127,22 @@ describe SimpleFormsApi::PdfStamper do
         it 'raises an error message' do
           expect { verify }.to raise_error('An error occurred while verifying stamp.')
         end
+      end
+    end
+  end
+
+  describe '.verified_multistamp' do
+    subject(:verified_multistamp) { described_class.verified_multistamp(path, signature_text, config) }
+
+    before { allow(described_class).to receive(:verify).and_return(true) }
+
+    context 'when signature_text is blank' do
+      let(:path) { nil }
+      let(:signature_text) { nil }
+      let(:config) { nil }
+
+      it 'raises an error' do
+        expect { verified_multistamp }.to raise_error('Provided signature was empty')
       end
     end
   end

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -4,22 +4,33 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::PdfStamper do
-  def self.test_pdf_stamp_error(stamp_method, test_payload)
-    it 'raises an error when generating stamped file' do
+  let(:data) { JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{test_payload}.json")) }
+  let(:form) { "SimpleFormsApi::#{test_payload.titleize.gsub(' ', '')}".constantize.new(data) }
+
+  describe 'pdf_stamping' do
+    subject(:stamp) { SimpleFormsApi::PdfStamper.send(stamp_method, generated_form_path, form) }
+
+    before do
       allow(Common::FileHelpers).to receive(:random_file_path).and_return('fake/stamp_path')
       allow(Common::FileHelpers).to receive(:delete_file_if_exists)
+    end
 
-      generated_form_path = 'fake/generated_form_path'
-      data = JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{test_payload}.json"))
-      form = "SimpleFormsApi::#{test_payload.titleize.gsub(' ', '')}".constantize.new(data)
+    context 'when generating stamped file' do
+      [
+        %w[stamp214142 vba_21_4142],
+        %w[stamp2110210 vba_21_10210],
+        %w[stamp21p0847 vba_21p_0847]
+      ].each do |stamp_method, test_payload|
+        context "when #{stamp_method} receives #{test_payload} payload" do
+          let(:test_payload) { test_payload }
+          let(:stamp_method) { stamp_method }
+          let(:generated_form_path) { 'fake/generated_form_path' }
 
-      expect do
-        SimpleFormsApi::PdfStamper.send(stamp_method, generated_form_path, form)
-      end.to raise_error(StandardError, 'An error occurred while verifying stamp.')
+          it 'raises an error' do
+            expect { stamp }.to raise_error(StandardError, 'An error occurred while verifying stamp.')
+          end
+        end
+      end
     end
   end
-
-  test_pdf_stamp_error 'stamp214142', 'vba_21_4142'
-  test_pdf_stamp_error 'stamp2110210', 'vba_21_10210'
-  test_pdf_stamp_error 'stamp21p0847', 'vba_21p_0847'
 end

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -23,7 +23,7 @@ describe SimpleFormsApi::PdfStamper do
         let(:generated_form_path) { 'fake/generated_form_path' }
 
         it 'raises an error' do
-          expect { stamp }.to raise_error(StandardError, 'An error occurred while verifying stamp.')
+          expect { stamp }.to raise_error(StandardError, /An error occurred while verifying stamp/)
         end
       end
     end
@@ -117,7 +117,9 @@ describe SimpleFormsApi::PdfStamper do
         let(:stamped_size) { orig_size }
 
         it 'raises an error message' do
-          expect { verify }.to raise_error('An error occurred while verifying stamp.')
+          expect { verify }.to raise_error(
+            'An error occurred while verifying stamp: The PDF remained unchanged upon stamping.'
+          )
         end
       end
 
@@ -125,7 +127,9 @@ describe SimpleFormsApi::PdfStamper do
         let(:stamped_size) { orig_size - 1 }
 
         it 'raises an error message' do
-          expect { verify }.to raise_error('An error occurred while verifying stamp.')
+          expect { verify }.to raise_error(
+            'An error occurred while verifying stamp: The PDF remained unchanged upon stamping.'
+          )
         end
       end
     end
@@ -142,7 +146,7 @@ describe SimpleFormsApi::PdfStamper do
       let(:config) { nil }
 
       it 'raises an error' do
-        expect { verified_multistamp }.to raise_error('Provided signature was empty')
+        expect { verified_multistamp }.to raise_error('The provided stamp content was empty.')
       end
     end
   end

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -8,7 +8,6 @@ describe SimpleFormsApi::PdfStamper do
     it 'raises an error when generating stamped file' do
       allow(Common::FileHelpers).to receive(:random_file_path).and_return('fake/stamp_path')
       allow(Common::FileHelpers).to receive(:delete_file_if_exists)
-      allow(Prawn::Document).to receive(:generate).and_raise('Error generating stamped file')
 
       generated_form_path = 'fake/generated_form_path'
       data = JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{test_payload}.json"))
@@ -16,9 +15,7 @@ describe SimpleFormsApi::PdfStamper do
 
       expect do
         SimpleFormsApi::PdfStamper.send(stamp_method, generated_form_path, form)
-      end.to raise_error(RuntimeError, 'Error generating stamped file')
-
-      expect(Common::FileHelpers).to have_received(:delete_file_if_exists).with('fake/stamp_path')
+      end.to raise_error(StandardError, 'An error occurred while verifying stamp.')
     end
   end
 

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -7,8 +7,8 @@ describe SimpleFormsApi::PdfStamper do
   let(:data) { JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{test_payload}.json")) }
   let(:form) { "SimpleFormsApi::#{test_payload.titleize.gsub(' ', '')}".constantize.new(data) }
 
-  describe 'pdf_stamping' do
-    subject(:stamp) { SimpleFormsApi::PdfStamper.send(stamp_method, generated_form_path, form) }
+  describe 'form-specific stamp methods' do
+    subject(:stamp) { described_class.send(stamp_method, generated_form_path, form) }
 
     before do
       allow(Common::FileHelpers).to receive(:random_file_path).and_return('fake/stamp_path')
@@ -16,13 +16,47 @@ describe SimpleFormsApi::PdfStamper do
     end
 
     %w[21-4142 21-10210 21p-0847].each do |form_number|
-      context "when generating a stamped form #{form_number}" do
+      context "when generating a stamped file for form #{form_number}" do
         let(:stamp_method) { "stamp#{form_number.gsub('-', '')}" }
         let(:test_payload) { "vba_#{form_number.gsub('-', '_')}" }
         let(:generated_form_path) { 'fake/generated_form_path' }
 
         it 'raises an error' do
           expect { stamp }.to raise_error(StandardError, 'An error occurred while verifying stamp.')
+        end
+      end
+    end
+  end
+
+  describe '.verified_stamp' do
+    subject(:verified_stamp) { described_class.verified_stamp('template_path') { double } }
+
+    before { allow(File).to receive(:size).and_return(orig_size, stamped_size) }
+
+    describe 'when verifying a stamp' do
+      let(:orig_size) { 10_000 }
+
+      context 'when the stamped file size is larger than the original' do
+        let(:stamped_size) { orig_size + 1 }
+
+        it 'succeeds' do
+          expect { verified_stamp }.not_to raise_error
+        end
+      end
+
+      context 'when the stamped file size is the same as the original' do
+        let(:stamped_size) { orig_size }
+
+        it 'raises an error message' do
+          expect { verified_stamp }.to raise_error('An error occurred while verifying stamp.')
+        end
+      end
+
+      context 'when the stamped file size is less than the original' do
+        let(:stamped_size) { orig_size - 1 }
+
+        it 'raises an error message' do
+          expect { verified_stamp }.to raise_error('An error occurred while verifying stamp.')
         end
       end
     end

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -15,20 +15,14 @@ describe SimpleFormsApi::PdfStamper do
       allow(Common::FileHelpers).to receive(:delete_file_if_exists)
     end
 
-    context 'when generating stamped file' do
-      [
-        %w[stamp214142 vba_21_4142],
-        %w[stamp2110210 vba_21_10210],
-        %w[stamp21p0847 vba_21p_0847]
-      ].each do |stamp_method, test_payload|
-        context "when #{stamp_method} receives #{test_payload} payload" do
-          let(:test_payload) { test_payload }
-          let(:stamp_method) { stamp_method }
-          let(:generated_form_path) { 'fake/generated_form_path' }
+    %w[21-4142 21-10210 21p-0847].each do |form_number|
+      context "when generating a stamped form #{form_number}" do
+        let(:stamp_method) { "stamp#{form_number.gsub('-', '')}" }
+        let(:test_payload) { "vba_#{form_number.gsub('-', '_')}" }
+        let(:generated_form_path) { 'fake/generated_form_path' }
 
-          it 'raises an error' do
-            expect { stamp }.to raise_error(StandardError, 'An error occurred while verifying stamp.')
-          end
+        it 'raises an error' do
+          expect { stamp }.to raise_error(StandardError, 'An error occurred while verifying stamp.')
         end
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Added a lambda method which verifies when a stamp has successfully been applied to a pdf
- Added test coverage surrounding new logic
- Updated existing test coverage for the pdf_stamper class to align with RSpec patterns

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
department-of-veterans-affairs/VA.gov-team-forms#1115

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

- PDF Stamping and Filling

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
