### PR TITLE
add statsD and key for datadog tracing 1010d

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_10d.rb
@@ -5,6 +5,7 @@ require 'securerandom'
 module SimpleFormsApi
   class VHA1010d
     include Virtus.model(nullify_blank: true)
+    STATS_KEY = 'api.simple_forms_api.1010d'
 
     attribute :data
 
@@ -50,7 +51,11 @@ module SimpleFormsApi
       { should_stamp_date?: false }
     end
 
-    def track_user_identity(confirmation_number); end
+    def track_user_identity(confirmation_number)
+      identity = "#{data['claimant_type']} #{data['claim_ownership']}"
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('Simple forms api - 1010d submission user identity', identity:, confirmation_number:)
+    end
 
     private
 


### PR DESCRIPTION
## Summary

This PR is to add 1010d metrics tracking in datadog.

## Related issue(s)

Other forms like vba_21_10210 has the same metrics added

## Testing done

- [ x] *New code is covered by unit tests*
Unit testing completed. 

## What areas of the site does it impact?
It only affects datadog monitoring

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


