### PR TITLE
[DR-74493] fix pdf validation config in prod

### DIFF
--- a/lib/decision_review/utilities/pdf_validation/configuration.rb
+++ b/lib/decision_review/utilities/pdf_validation/configuration.rb
@@ -23,7 +23,8 @@ module DecisionReview
       def self.base_request_headers
         # Can use regular Decision Reviews API key in lower environments
         return super unless Rails.env.production?
-        # Since we're using the `uploads/validate_document` endpoint under Benefits Intake API, 
+
+        # Since we're using the `uploads/validate_document` endpoint under Benefits Intake API,
         # we need to use their API key. This is pulled from BenefitsIntakeService::Configuration
         api_key = Settings.benefits_intake_service.api_key || Settings.form526_backup.api_key
         super.merge('apiKey' => api_key)

--- a/lib/decision_review/utilities/pdf_validation/configuration.rb
+++ b/lib/decision_review/utilities/pdf_validation/configuration.rb
@@ -4,7 +4,7 @@ module DecisionReview
   module PdfValidation
     class Configuration < DecisionReview::Configuration
       ##
-      # @return [String] Base path for decision review URLs.
+      # @return [String] Base path for PDF validation URL.
       #
       def base_path
         Settings.decision_review.pdf_validation.url
@@ -15,6 +15,18 @@ module DecisionReview
       #
       def service_name
         'DecisionReview::PDFValidation'
+      end
+
+      ##
+      # @return [Hash] The basic headers required for any decision review API call.
+      #
+      def self.base_request_headers
+        # Can use regular Decision Reviews API key in lower environments
+        return super unless Rails.env.production?
+        # Since we're using the `uploads/validate_document` endpoint under Benefits Intake API, 
+        # we need to use their API key. This is pulled from BenefitsIntakeService::Configuration
+        api_key = Settings.benefits_intake_service.api_key || Settings.form526_backup.api_key
+        super.merge('apiKey' => api_key)
       end
 
       ##


### PR DESCRIPTION

## Summary
This feature is controlled by a backend setting that is enabled in staging but not prod (yet): `Settings.decision_review.pdf_validation.enabled`

This fixes the configuration used in the [proxy service](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/decision_review/utilities/pdf_validation/service.rb) that was previously built but never fully switched on (see more details [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/74493#issuecomment-2012637042)) — we are now ready to use it, so I've been trying to fix the configurations to make sure it all works as expected. 

I recently learned that we are able to use the Decision Reviews API key in dev and staging as originally designed (through this service's [configuration inheriting the DR configuration](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/decision_review/utilities/pdf_validation/configuration.rb#L5)) —  but it didn't work in production when I tried making some test calls using the DR prod API key. The test calls _did_ work when I used prod's Benefits Intake API key, so I've added a conditional to use the proper API key in production

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/74493

## Testing done
- Tested that dev still works as it previously did, will also check in staging
- Checked that `Settings.benefits_intake_service.api_key || Settings.form526_backup.api_key` returns the proper API key in production. Will check in production that API call using service works before enabling the feature

## What areas of the site does it impact?
Appeals Backend (on a feature that is not enabled in production yet)

## Acceptance criteria

- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

