### PR TITLE
78648 do not call refresh_appts for OH claims

### DIFF
--- a/modules/check_in/app/controllers/check_in/v2/patient_check_ins_controller.rb
+++ b/modules/check_in/app/controllers/check_in/v2/patient_check_ins_controller.rb
@@ -7,7 +7,8 @@ module CheckIn
       after_action :after_logger, only: %i[show create]
 
       def show
-        check_in_session = CheckIn::V2::Session.build(data: { uuid: params[:id], handoff: handoff? },
+        check_in_session = CheckIn::V2::Session.build(data: { uuid: params[:id], handoff: handoff?,
+                                                              facility_type: params[:facilityType] },
                                                       jwt: low_auth_token)
 
         unless check_in_session.authorized?

--- a/modules/check_in/app/models/check_in/v2/session.rb
+++ b/modules/check_in/app/models/check_in/v2/session.rb
@@ -25,7 +25,7 @@ module CheckIn
       DOB_REGEX = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/
       LAST_NAME_REGEX = /^.{1,600}$/
 
-      attr_reader :uuid, :dob, :last_name, :settings, :jwt, :check_in_type, :handoff
+      attr_reader :uuid, :dob, :last_name, :settings, :jwt, :check_in_type, :handoff, :facility_type
 
       def_delegators :settings, :redis_session_prefix
 
@@ -46,6 +46,7 @@ module CheckIn
         @last_name = opts.dig(:data, :last_name)
         @check_in_type = opts.dig(:data, :check_in_type)
         @handoff = opts.dig(:data, :handoff)
+        @facility_type = opts.dig(:data, :facility_type)
       end
 
       #

--- a/modules/check_in/app/services/v2/lorota/service.rb
+++ b/modules/check_in/app/services/v2/lorota/service.rb
@@ -87,7 +87,7 @@ module V2
 
         raw_data =
           if token.present?
-            chip_service.refresh_appointments if appointment_identifiers.present?
+            chip_service.refresh_appointments if refresh_appointments?
 
             lorota_client.data(token:)
           end
@@ -101,14 +101,15 @@ module V2
         patient_check_in.approved
       end
 
-      def appointment_identifiers
-        Rails.cache.read(
+      private
+
+      def refresh_appointments?
+        appointment_identifiers = Rails.cache.read(
           "check_in_lorota_v2_appointment_identifiers_#{check_in.uuid}",
           namespace: 'check-in-lorota-v2-cache'
         )
+        appointment_identifiers.present? && !'oh'.casecmp?(check_in.facility_type)
       end
-
-      private
 
       def error_message_handler(e)
         case Oj.load(e.original_body).fetch('error').strip.downcase

--- a/modules/check_in/spec/models/check_in/v2/session_spec.rb
+++ b/modules/check_in/spec/models/check_in/v2/session_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe CheckIn::V2::Session do
     it 'responds to handoff' do
       expect(subject.build({}).respond_to?(:handoff)).to be(true)
     end
+
+    it 'responds to facility_type' do
+      expect(subject.build({}).respond_to?(:facility_type)).to be(true)
+    end
   end
 
   describe '#valid?' do

--- a/modules/check_in/spec/services/v2/lorota/service_spec.rb
+++ b/modules/check_in/spec/services/v2/lorota/service_spec.rb
@@ -680,6 +680,10 @@ describe V2::Lorota::Service do
         .and_return(Faraday::Response.new(response_body: appointment_data.to_json, status: 200))
     end
 
+    it 'returns approved data' do
+      expect(subject.build(check_in: valid_check_in).check_in_data).to eq(approved_response)
+    end
+
     context 'when check_in_type is preCheckIn' do
       let(:opts) { { data: { check_in_type: 'preCheckIn' } } }
       let(:pre_check_in) { CheckIn::V2::Session.build(opts) }
@@ -702,8 +706,30 @@ describe V2::Lorota::Service do
       end
     end
 
-    it 'returns approved data' do
-      expect(subject.build(check_in: valid_check_in).check_in_data).to eq(approved_response)
+    context 'when appt identifiers are not present' do
+      it 'does not call refresh_appts' do
+        expect_any_instance_of(::V2::Chip::Service).not_to receive(:refresh_appointments)
+
+        expect(subject.build(check_in: valid_check_in).check_in_data).to eq(approved_response)
+      end
+    end
+
+    context 'when appt identifiers are present and facility type is OH' do
+      let(:valid_check_in_oh) { CheckIn::V2::Session.build(opts.deep_merge!({ data: { facility_type: 'oh' } })) }
+
+      before do
+        Rails.cache.write(
+          "check_in_lorota_v2_appointment_identifiers_#{id}",
+          '123',
+          namespace: 'check-in-lorota-v2-cache'
+        )
+      end
+
+      it 'does not call refresh_appts' do
+        expect_any_instance_of(::V2::Chip::Service).not_to receive(:refresh_appointments)
+
+        expect(subject.build(check_in: valid_check_in_oh).check_in_data).to eq(approved_response)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

For OH sites, there's no concept of "check in" currently, and so there's no concept of refresh appointments and those calls will fail if made. This PR checks the incoming parameter for facility_type = OH, and doesn't call CHIP's refresh_appointments for that case.

- *This work is behind a feature toggle (flipper): NO*

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78648

## Testing done

- [x] rspecs
- [x] local testing

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

