### PR TITLE
Fix BGS breakers matching

### DIFF
--- a/modules/claims_api/lib/bgs_service/local_bgs.rb
+++ b/modules/claims_api/lib/bgs_service/local_bgs.rb
@@ -33,8 +33,11 @@ module ClaimsApi
       url = Settings.bgs.url
       path = URI.parse(url).path
       host = URI.parse(url).host
+      port = URI.parse(url).port
       matcher = proc do |request_env|
-        request_env.url.host == host && request_env.url.path =~ /^#{path}/
+        request_env.url.host == host &&
+          request_env.url.port == port &&
+          request_env.url.path =~ /^#{path}/
       end
 
       Breakers::Service.new(


### PR DESCRIPTION
## Summary
- Match the BGS URI matching to be more specific for BGS

## Related issue(s)
- no issue created

## Testing done
- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
Requests to BGS (specifically using LocalBGS)

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
