### PR TITLE
VAOS Removed Clinic Stop Code Filtering Feature Toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1020,10 +1020,6 @@ features:
     actor_type: user
     description: Allows veterans to cancel VA appointments
     enable_in_development: true
-  va_online_scheduling_clinic_filtering:
-    actor_type: user
-    description: Allows clinic selection filtering by stop codes
-    enable_in_development: true
   va_online_scheduling_community_care:
     actor_type: user
     description: Allows veterans to submit requests for Community Care appointments

--- a/modules/vaos/app/services/vaos/v2/systems_service.rb
+++ b/modules/vaos/app/services/vaos/v2/systems_service.rb
@@ -3,8 +3,6 @@
 module VAOS
   module V2
     class SystemsService < VAOS::SessionService
-      STOP_CODE_FILTERS = :va_online_scheduling_clinic_filtering
-
       def get_facility_clinics(location_id:,
                                clinical_service: nil,
                                clinic_ids: nil,
@@ -21,11 +19,9 @@ module VAOS
             'pageNumber' => page_number
           }.compact
 
-          #  'clinicalService' is used to retrieve clinics for appointment scheduling,
+          #  'clinicalService' is used when retrieving clinics for appointment scheduling,
           #  triggering stop code filtering to avoid displaying unavailable clinics.
-          if url_params['clinicalService'].present? && Flipper.enabled?(STOP_CODE_FILTERS, user)
-            url_params.merge!('enableStopCodeFilter' => true)
-          end
+          url_params.merge!('enableStopCodeFilter' => true) if url_params['clinicalService'].present?
 
           response = perform(:get, url, url_params, headers)
           response.body[:data].map { |clinic| OpenStruct.new(clinic) }


### PR DESCRIPTION
## Summary

Implementation and testing of VAOS clinic stop code filtering has been completed and it has been in place for over a month. The feature toggle and associated code is no longer needed.

This PR removes the **va_online_scheduling_clinic_filtering** feature toggle and associated Vets API code.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/78770


## Testing done

- [X] Ensured current RSpec tests still work.

