### PR TITLE
Remove Job Cancellation Code from `VBADocuments::UploadProcessor`

### DIFF
--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -135,7 +135,6 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request, retry: 3 do
         @md = JSON.parse(valid_metadata)
         @upload_submission = VBADocuments::UploadSubmission.new
         @upload_submission.update(status: 'uploaded')
-        allow_any_instance_of(VBADocuments::UploadProcessor).to receive(:cancelled?).and_return(false)
         allow_any_instance_of(Tempfile).to receive(:size).and_return(1) # must be > 0 or submission will error w/DOC107
         allow(VBADocuments::MultipartParser).to receive(:parse) {
           { 'metadata' => @md.to_json, 'content' => valid_doc }

--- a/modules/vba_documents/spec/request/v2/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v2/uploads_request_spec.rb
@@ -202,7 +202,6 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request, retry: 3 do
         @md = JSON.parse(valid_metadata)
         @upload_submission = VBADocuments::UploadSubmission.new
         @upload_submission.update(status: 'uploaded')
-        allow_any_instance_of(VBADocuments::UploadProcessor).to receive(:cancelled?).and_return(false)
         allow_any_instance_of(Tempfile).to receive(:size).and_return(1) # must be > 0 or submission will error w/DOC107
         allow(VBADocuments::MultipartParser).to receive(:parse) {
           { 'metadata' => @md.to_json, 'content' => valid_doc }

--- a/modules/vba_documents/spec/sidekiq/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/upload_processor_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
   end
 
   before do
-    allow_any_instance_of(described_class).to receive(:cancelled?).and_return(false)
     allow_any_instance_of(Tempfile).to receive(:size).and_return(1) # must be > 0 or submission will error w/DOC107
     objstore = instance_double(VBADocuments::ObjectStore)
     version = instance_double(Aws::S3::ObjectVersion)


### PR DESCRIPTION
## Summary
A production issue began on March 25, 2024 where Benefits Intake API submissions were not being processed out of "uploaded" status. The issue is ongoing, and we suspect that it is caused by the job cancellation code, which is not in regular use. The job is currently succeeding quickly, but short-circuiting any of the real processing code, so it is not behaving as expected. No code changes were made this past week, so we suspect it may be related to the Redis upgrade. The job cancellation code calls Redis under the hood.

My team (Lighthouse Team Banana Peels) maintains the `vba_documents` module.

## Related issue(s)
None, as this was discovered as a production issue.

## Testing done
Ensured that all Benefits Intake endpoints still return their expected response after removing the job cancellation code, and that records can be processed locally.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `vba_documents` module only.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
