### PR TITLE
Updating version of REDIS to 6.2 in the docker compose files.

### DIFF
--- a/docker-compose-deps.yml
+++ b/docker-compose-deps.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   redis:
-    image: redis:5.0-alpine
+    image: redis:6.2-alpine
     ports:
       - "63790:6379"
   postgres:

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   redis:
-    image: redis:5.0-alpine
+    image: redis:6.2-alpine
     restart: unless-stopped
   postgres:
     image: mdillon/postgis:11-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   redis:
-    image: redis:5.0-alpine
+    image: redis:6.2-alpine
     ports:
       - "63790:6379"
   postgres:

--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -4,7 +4,7 @@ Vets API requires:
 
 - Ruby 3.2.3
 - PostgreSQL 15.x (including PostGIS 3)
-- Redis 5.0.x
+- Redis 6.2.x
 
   The most up-to-date versions of each key dependency will be specified in the `docker-compose.yml` [file](https://github.com/department-of-veterans-affairs/vets-api/blob/master/docker-compose.yml) and the `Dockerfile`.
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This work is behind a feature toggle (flipper): NO
- Updated the version of the REDIS docker instance from 5.0 to 6.2
- Bug is that, current `make up` fails due to version mismatch
- Update REDIS docker instance
- VES, we do not maintain
- No flipper

## Related issue(s)

- https://dsva.slack.com/archives/CBU0KDSB1/p1711464627165309
- *Link to epic if not included in ticket*

## Testing done

- [ ] No new code introduced
- vets-api failed to start due to REDIS version mismatch
- Run `make up`
  - I believe this is primarily a local environment change

## Acceptance criteria

- [x] vets-api now starts up in the docker container using the `make up` command

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
