### PR TITLE
updated rx client to remove cache busting

### DIFF
--- a/lib/rx/client.rb
+++ b/lib/rx/client.rb
@@ -123,10 +123,7 @@ module Rx
     # @return [Faraday::Env]
     #
     def post_refill_rxs(ids)
-      if (result = perform(:post, 'prescription/rxrefill', ids, token_headers))
-        Common::Collection.bust([cache_key('getactiverx'), cache_key('gethistoryrx')])
-      end
-      result
+      perform(:post, 'prescription/rxrefill', ids, token_headers)
     end
 
     ##
@@ -136,10 +133,7 @@ module Rx
     # @return [Faraday::Env]
     #
     def post_refill_rx(id)
-      if (result = perform(:post, "prescription/rxrefill/#{id}", nil, token_headers))
-        Common::Collection.bust([cache_key('getactiverx'), cache_key('gethistoryrx')])
-      end
-      result
+      perform(:post, "prescription/rxrefill/#{id}", nil, token_headers)
     end
 
     ##


### PR DESCRIPTION
## Summary

We were seeing an error when calling this with nil keys:
`Common::Collection.bust([cache_key('getactiverx'), cache_key('gethistoryrx')])`

More investigation is needed but for the time being this works.

## Related issue(s)

No ticket related, investigating urgent issue

## Testing done

- Tested locally

## Screenshots
None

## What areas of the site does it impact?
MHV/mobile medications apps

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
