### PR TITLE
Remove reference to va_online_scheduling_required_schedulable_param feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1090,10 +1090,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for proof of concept to help Veteran contact a facility when the type of care is not available
-  va_online_scheduling_required_schedulable_param:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle that requires the inclusion of a new 'schedulable' boolean param for fetching facilities
   va_online_scheduling_after_visit_summary:
     actor_type: user
     enable_in_development: true

--- a/modules/vaos/app/controllers/vaos/v2/facilities_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/facilities_controller.rb
@@ -44,12 +44,9 @@ module VAOS
       end
 
       def schedulable
-        if Flipper.enabled?('va_online_scheduling_required_schedulable_param')
-          # with this flag on, we will always want to return 'true' for this param per github issue #59503
-          params[:schedulable] = true
-        else
-          params[:schedulable]
-        end
+        # We will always want to return 'true' for this param per github issue #59503
+        # and PR vets-api#13087
+        params[:schedulable] = true
       end
     end
   end

--- a/modules/vaos/spec/request/v2/facilities_request_spec.rb
+++ b/modules/vaos/spec/request/v2/facilities_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'facilities', type: :request do
 
   before do
     Flipper.enable('va_online_scheduling')
-    Flipper.enable('va_online_scheduling_required_schedulable_param')
     sign_in_as(user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
   end


### PR DESCRIPTION
## Summary

This PR removes the obsolete feature flag `va_online_scheduling_required_schedulable_param` and its references in this repo. This flag is currently enabled in [staging](https://staging-api.va.gov/v0/feature_toggles?cookie_id) and [production](https://api.va.gov/v0/feature_toggles).

For testing disable the following feature flags and confirm scheduling appointments are working as expected. Refer to [this checklist](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59503#issuecomment-1626071303) for a full list of scenarios.

## Related issue(s)

- Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/63682. 

## Testing done

- [x] New code is covered by existing unit tests
- Prior to this change, `schedulable` is forced to `true` only if the feature flag is enabled. Now the feature flag is removed, this parameter is always set to `true`.
- Regression tests for the current behavior is tested without setting the `va_online_scheduling_required_schedulable_param` flag to be true
## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature


