### PR TITLE
Fix Faker Deprecation Warning

### DIFF
--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
     gender { %w[M F].sample }
     birth_date { Faker::Date.between(from: 80.years.ago, to: 30.years.ago).strftime('%Y%m%d') }
     deceased_date { nil }
-    ssn { Faker::IDNumber.valid.delete('-') }
+    ssn { Faker::IdNumber.valid.delete('-') }
     address { build(:mpi_profile_address) }
     home_phone { Faker::PhoneNumber.phone_number }
     person_types { ['PAT'] }

--- a/spec/support/form1010cg_helpers/build_claim_data_for.rb
+++ b/spec/support/form1010cg_helpers/build_claim_data_for.rb
@@ -31,7 +31,7 @@ module Form1010cgHelpers
 
     # Required property for :veteran
     if form_subject == :veteran
-      data['ssnOrTin'] = Faker::IDNumber.valid.remove('-')
+      data['ssnOrTin'] = Faker::IdNumber.valid.remove('-')
       data['plannedClinic'] = '568A4'
     end
 


### PR DESCRIPTION
## Summary

[faker](https://rubygems.org/gems/faker) v3.3.0 introduced a new warning: DEPRECATION WARNING: Faker::IDNumber is deprecated. Use Faker::IdNumber instead.

- Update Faker::IDNumber to Faker::IdNumber

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79372

## Testing done

- No new tests added
