### PR TITLE
76818: Change config for NodEmailLoaderJob to use a hash

### DIFF
--- a/app/sidekiq/decision_review/nod_email_loader_job.rb
+++ b/app/sidekiq/decision_review/nod_email_loader_job.rb
@@ -15,7 +15,7 @@ module DecisionReview
       user_uuid: nil
     }.freeze
 
-    def perform(file_name, template_id, s3_config = Settings.decision_review.s3)
+    def perform(file_name, template_id, s3_config)
       csv_file = get_csv(file_name, s3_config)
 
       line_num = 1
@@ -36,9 +36,9 @@ module DecisionReview
 
     # returns StringIO
     def get_csv(file_name, s3_config)
-      credentials = Aws::Credentials.new(s3_config.aws_access_key_id, s3_config.aws_secret_access_key)
-      s3 = Aws::S3::Client.new(region: s3_config.region, credentials:)
-      s3.get_object(bucket: s3_config.bucket, key: file_name).body
+      credentials = Aws::Credentials.new(s3_config[:aws_access_key_id], s3_config[:aws_secret_access_key])
+      s3 = Aws::S3::Client.new(region: s3_config[:region], credentials:)
+      s3.get_object(bucket: s3_config[:bucket], key: file_name).body
     rescue => e
       raise "Error fetching #{file_name}: #{e}"
     end


### PR DESCRIPTION
## Summary
Params for Sidekiq job need to be passed in as a hash instead of an object. This is owned by the Decision Reviews team.

## Related issue(s)
#15795 

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
  - Old behavior used a default S3 configuration so this issue did not occur until a separate S3 config was passed in
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  - Manually tested

## What areas of the site does it impact?
* None aside from Sidekiq job queues

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
