### PR TITLE
78148 Delete InProgressForm after submitting 5655

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/financial_status_report_service.rb
+++ b/modules/debts_api/lib/debts_api/v0/financial_status_report_service.rb
@@ -73,6 +73,7 @@ module DebtsApi
       Rails.logger.info('Submitting Combined FSR')
       create_vba_fsr(fsr_builder)
       create_vha_fsr(fsr_builder)
+      fsr_builder.destroy_related_form
       user_form = fsr_builder.user_form.form_data
 
       {

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_builder.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_builder.rb
@@ -104,5 +104,9 @@ module DebtsApi
       form = DebtsApi::V0::VbaFsrForm.new(params)
       form.form_data.nil? ? nil : form
     end
+
+    def destroy_related_form
+      InProgressForm.form_for_user('5655', @user)&.destroy!
+    end
   end
 end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_builder_spec.rb
@@ -214,4 +214,28 @@ RSpec.describe DebtsApi::V0::FsrFormBuilder, type: :service do
       end
     end
   end
+
+  describe '#destroy_related_form' do
+    let(:combined_form_data) { get_fixture_absolute('modules/debts_api/spec/fixtures/fsr_forms/combined_fsr_form') }
+    let(:user) { build(:user, :loa3) }
+    let(:user_data) { build(:user_profile_attributes) }
+    let(:in_progress_form) { create(:in_progress_5655_form, user_uuid: user.uuid) }
+
+    context 'when IPF has already been deleted' do
+      it 'does not throw an error' do
+        expect(InProgressForm.all.length).to eq(0)
+        described_class.new(combined_form_data, '123', user).destroy_related_form
+        expect(InProgressForm.all.length).to eq(0)
+      end
+    end
+
+    context 'when IPF is present' do
+      it 'deletes related In Progress Form' do
+        in_progress_form
+        expect(InProgressForm.all.length).to eq(1)
+        described_class.new(combined_form_data, '123', user).destroy_related_form
+        expect(InProgressForm.all.length).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
After submitting a 5655 submission we want to delete the related InProgressForm. This will prevent repeat submissions of the same FSR.

## Related issue(s)
[78148](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/78148)
[72987](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/72987)

## Testing done
Specs added

## What areas of the site does it impact?
FSR submission, Debt Portal

## Acceptance criteria
After all 5655 submissions for a combined FSR have been created the related InProgressForm is deleted.
