### PR TITLE
78786: Add additional file support for 10-7959f-2; Update some 10-10d…

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -55,7 +55,7 @@ module SimpleFormsApi
       end
 
       def submit_supporting_documents
-        if %w[40-0247 20-10207 10-10D 40-10007].include?(params[:form_id])
+        if %w[40-0247 20-10207 10-10D 40-10007 10-7959F-2].include?(params[:form_id])
           attachment = PersistentAttachments::MilitaryRecords.new(form_id: params[:form_id])
           attachment.file = params['file']
           raise Common::Exceptions::ValidationErrors, attachment unless attachment.valid?
@@ -171,7 +171,7 @@ module SimpleFormsApi
 
         maybe_add_file_paths =
           case form_id
-          when 'vba_40_0247', 'vba_20_10207', 'vha_10_10d', 'vba_40_10007'
+          when 'vba_40_0247', 'vba_20_10207', 'vha_10_10d', 'vba_40_10007', 'vha_10_7959f_2'
             form.handle_attachments(file_path)
           else
             [file_path]

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_7959f_2.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_7959f_2.rb
@@ -8,18 +8,40 @@ module SimpleFormsApi
 
     def initialize(data)
       @data = data
+      @uuid = SecureRandom.uuid
     end
 
     def metadata
       {
         'veteranFirstName' => @data.dig('veteran', 'full_name', 'first'),
+        'veteranMiddleName' => @data.dig('veteran', 'full_name', 'middle'),
         'veteranLastName' => @data.dig('veteran', 'full_name', 'last'),
         'fileNumber' => @data.dig('veteran', 'va_claim_number').presence || @data.dig('veteran', 'ssn'),
         'zipCode' => @data.dig('veteran', 'mailing_address', 'postal_code') || '00000',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
-        'businessLine' => 'CMP'
+        'businessLine' => 'CMP',
+        'uuid' => @uuid
       }
+    end
+
+    def handle_attachments(file_path)
+      uuid = @uuid # Generate the UUID as an instance variable
+      file_path_uuid = file_path.gsub('vha_10_7959f_2-tmp', "#{uuid}_vha_10_7959f_2-tmp")
+      File.rename(file_path, file_path_uuid)
+      attachments = get_attachments
+      file_paths = [file_path_uuid]
+
+      if attachments.count.positive?
+        attachments.each_with_index do |attachment, index|
+          new_file_name = "#{uuid}_vha_10_7959f_2-tmp#{index + 1}.pdf"
+          new_file_path = File.join(File.dirname(attachment), new_file_name)
+          File.rename(attachment, new_file_path)
+          file_paths << new_file_path
+        end
+      end
+
+      file_paths
     end
 
     def submission_date_config
@@ -27,5 +49,22 @@ module SimpleFormsApi
     end
 
     def track_user_identity(confirmation_number); end
+
+    private
+
+    def get_attachments
+      attachments = []
+
+      # TODO: We need to look into generatings individual PDFs for each
+      # attachment based on what PEGA needs
+      supporting_documents = @data['supporting_docs']
+      if supporting_documents
+        confirmation_codes = []
+        supporting_documents&.map { |doc| confirmation_codes << doc['confirmation_code'] }
+        PersistentAttachment.where(guid: confirmation_codes).map { |attachment| attachments << attachment.to_pdf }
+      end
+
+      attachments
+    end
   end
 end

--- a/modules/simple_forms_api/spec/models/vha_10_10d_spec.rb
+++ b/modules/simple_forms_api/spec/models/vha_10_10d_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# spec/models/simple_forms_api/vha1010d_spec.rb
-
 require 'rails_helper'
 
 folder_path = 'modules/simple_forms_api/spec/fixtures/test_file/'
@@ -16,7 +14,7 @@ RSpec.describe SimpleFormsApi::VHA1010d do
         'va_claim_number' => '123456789',
         'address' => { 'postal_code' => '12345' }
       },
-      'form_number' => 'VHA1010d',
+      'form_number' => '10-10D',
       'veteran_supporting_documents' => [
         { 'confirmation_code' => 'abc123' },
         { 'confirmation_code' => 'def456' }
@@ -35,7 +33,7 @@ RSpec.describe SimpleFormsApi::VHA1010d do
         'fileNumber' => '123456789',
         'zipCode' => '12345',
         'source' => 'VA Platform Digital Forms',
-        'docType' => 'VHA1010d',
+        'docType' => '10-10D',
         'businessLine' => 'CMP'
       )
     end

--- a/modules/simple_forms_api/spec/models/vha_10_7959f_2_spec.rb
+++ b/modules/simple_forms_api/spec/models/vha_10_7959f_2_spec.rb
@@ -39,22 +39,4 @@ RSpec.describe SimpleFormsApi::VHA107959f2 do
       )
     end
   end
-
-  describe '#handle_attachments' do
-    it 'calls CombinePDF.new' do
-      # Stub the CombinePDF.new method to return a double that does not perform any actions
-      allow(CombinePDF).to receive(:new).and_return(double('combined_pdf', save: nil))
-      combined_pdf = CombinePDF.new
-      p combined_pdf # Output to console using `p` for inspection
-
-      # Stub the file operation
-      allow(File).to receive(:exist?).with(file_path).and_return(true)
-      allow(File).to receive(:open).with(file_path, 'rb')
-      # Call the method under test
-      vha107959f2.handle_attachments(file_path)
-
-      # Verify that CombinePDF.new was called
-      expect(CombinePDF).to have_received(:new)
-    end
-  end
 end

--- a/modules/simple_forms_api/spec/models/vha_10_7959f_2_spec.rb
+++ b/modules/simple_forms_api/spec/models/vha_10_7959f_2_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+folder_path = 'modules/simple_forms_api/spec/fixtures/test_file/'
+file_name = 'test_file.pdf'
+file_path = File.join(folder_path, file_name)
+
+RSpec.describe SimpleFormsApi::VHA107959f2 do
+  let(:data) do
+    {
+      'veteran' => {
+        'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
+        'va_claim_number' => '123456789',
+        'mailing_address' => { 'postal_code' => '12345' }
+      },
+      'form_number' => '10-7959F-2',
+      'veteran_supporting_documents' => [
+        { 'confirmation_code' => 'abc123' },
+        { 'confirmation_code' => 'def456' }
+      ]
+    }
+  end
+  let(:vha107959f2) { described_class.new(data) }
+
+  describe '#metadata' do
+    it 'returns metadata for the form' do
+      metadata = vha107959f2.metadata
+
+      expect(metadata).to include(
+        'veteranFirstName' => 'John',
+        'veteranMiddleName' => 'P',
+        'veteranLastName' => 'Doe',
+        'fileNumber' => '123456789',
+        'zipCode' => '12345',
+        'source' => 'VA Platform Digital Forms',
+        'docType' => '10-7959F-2',
+        'businessLine' => 'CMP'
+      )
+    end
+  end
+
+  describe '#handle_attachments' do
+    it 'calls CombinePDF.new' do
+      # Stub the CombinePDF.new method to return a double that does not perform any actions
+      allow(CombinePDF).to receive(:new).and_return(double('combined_pdf', save: nil))
+      combined_pdf = CombinePDF.new
+      p combined_pdf # Output to console using `p` for inspection
+
+      # Stub the file operation
+      allow(File).to receive(:exist?).with(file_path).and_return(true)
+      allow(File).to receive(:open).with(file_path, 'rb')
+      # Call the method under test
+      vha107959f2.handle_attachments(file_path)
+
+      # Verify that CombinePDF.new was called
+      expect(CombinePDF).to have_received(:new)
+    end
+  end
+end

--- a/modules/simple_forms_api/spec/models/vha_10_7959f_2_spec.rb
+++ b/modules/simple_forms_api/spec/models/vha_10_7959f_2_spec.rb
@@ -2,10 +2,6 @@
 
 require 'rails_helper'
 
-folder_path = 'modules/simple_forms_api/spec/fixtures/test_file/'
-file_name = 'test_file.pdf'
-file_path = File.join(folder_path, file_name)
-
 RSpec.describe SimpleFormsApi::VHA107959f2 do
   let(:data) do
     {


### PR DESCRIPTION
## Summary
Added additional file attachment handling to 10-7959F-2.

- Most of it can be copied over from 10-10D
- Added model spec
- Renamed 10-10D to match nomenclature of file

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78786

## Testing done
- Unit test
