### PR TITLE
Update Employee Experience Max CFI API Feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -351,9 +351,9 @@ features:
     actor_type: user
     description: enables displaying a short education blurb alongside rated disabilities already at maximum rating.
     enable_in_development: true
-  disability_526_maximum_rating_api:
+  disability_526_maximum_rating_api_all_conditions:
     actor_type: user
-    description: enables sending disability diagnostic codes to VRO Max CFI API to get the corresponding maximum ratings.
+    description: enables calls to VRO Max CFI API for all conditions, otherwise only calls for select conditions are made
     enable_in_development: false
   disability_526_ep_merge_api:
     actor_type: user

--- a/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
+++ b/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
@@ -14,49 +14,54 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
     end
     let(:disabilities_data) do
       [
-        { name: 'Hypertension', diagnostic_code: 7101, rating_percentage: 20 },
         { name: 'Tinnitus', diagnostic_code: 6260, rating_percentage: 10 },
+        { name: 'Hypertension', diagnostic_code: 7101, rating_percentage: 20 },
         { name: 'Vertigo', diagnostic_code: 6204, rating_percentage: 30 }
       ]
     end
 
-    context 'with disability_526_maximum_rating_api disabled' do
-      before { Flipper.disable(:disability_526_maximum_rating_api) }
+    context 'with disability_526_maximum_rating_api_all_conditions disabled' do
+      before { Flipper.disable(:disability_526_maximum_rating_api_all_conditions) }
 
-      it 'mutates just the tinnitus disability with hardcoded max rating' do
-        subject
-        max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
-        expect(max_ratings).to eq([nil, 10, nil])
+      it 'mutates just the tinnitus disability max rating from VRO' do
+        VCR.use_cassette('virtual_regional_office/max_ratings') do
+          subject
+          max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
+          expect(max_ratings).to eq([10, nil, nil])
+        end
       end
     end
 
-    context 'with disability_526_maximum_rating_api enabled' do
-      before { Flipper.enable(:disability_526_maximum_rating_api) }
-      after { Flipper.disable(:disability_526_maximum_rating_api) }
+    context 'with disability_526_maximum_rating_api_all_conditions enabled' do
+      before { Flipper.enable(:disability_526_maximum_rating_api_all_conditions) }
+      after { Flipper.disable(:disability_526_maximum_rating_api_all_conditions) }
 
-      context 'when a disabilities response contains rating for a disability' do
-        it 'mutates just the rated disability with a max rating' do
-          VCR.use_cassette('virtual_regional_office/max_ratings') do
+      context 'when a disabilities response does not contains rating any disability' do
+        it 'mutates none of the disabilities with a max rating' do
+          VCR.use_cassette('virtual_regional_office/max_ratings_none') do
             subject
             max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
-            expect(max_ratings).to eq([nil, 10, nil])
+            expect(max_ratings).to eq([nil, nil, nil])
           end
         end
       end
 
-      context 'when a disabilities response does not contains rating any disability' do
-        let(:disabilities_data) do
-          [
-            { name: 'Hypertension', diagnostic_code: 7101, rating_percentage: 20 },
-            { name: 'Vertigo', diagnostic_code: 6204, rating_percentage: 30 }
-          ]
-        end
-
-        it 'mutates none of the disabilities with a max rating' do
+      context 'when a disabilities response contains rating for a single disability' do
+        it 'mutates just the rated disability with a max rating' do
           VCR.use_cassette('virtual_regional_office/max_ratings') do
             subject
             max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
-            expect(max_ratings).to eq([nil, nil])
+            expect(max_ratings).to eq([10, nil, nil])
+          end
+        end
+      end
+
+      context 'when a disabilities response contains rating for a multiple disabilities' do
+        it 'mutates just the rated disabilities with a max rating' do
+          VCR.use_cassette('virtual_regional_office/max_ratings_multiple') do
+            subject
+            max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
+            expect(max_ratings).to eq([10, 60, nil])
           end
         end
       end
@@ -66,11 +71,9 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
           let(:rated_disabilities) { nil }
 
           it 'mutates only the valid disability with a max rating' do
-            VCR.use_cassette('virtual_regional_office/max_ratings') do
-              subject
-              max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
-              expect(max_ratings).to eq([])
-            end
+            subject
+            max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
+            expect(max_ratings).to eq([])
           end
         end
 

--- a/spec/support/vcr_cassettes/virtual_regional_office/max_ratings_multiple.yml
+++ b/spec/support/vcr_cassettes/virtual_regional_office/max_ratings_multiple.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:8120/employee-experience/max-ratings
     body:
       encoding: UTF-8
-      string: '{"diagnostic_codes":[6260]}'
+      string: '{"diagnostic_codes":[6260,7101,6204]}'
     headers:
       Accept:
       - application/json
@@ -32,6 +32,6 @@ http_interactions:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"ratings":[{"diagnostic_code":6260,"max_rating":10.0}]}'
+      string: '{"ratings":[{"diagnostic_code":7101, "max_rating": 60.0},{"diagnostic_code":6260,"max_rating":10.0}]}'
   recorded_at: Thu, 10 Aug 2023 19:52:24 GMT
 recorded_with: VCR 6.2.0

--- a/spec/support/vcr_cassettes/virtual_regional_office/max_ratings_none.yml
+++ b/spec/support/vcr_cassettes/virtual_regional_office/max_ratings_none.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:8120/employee-experience/max-ratings
     body:
       encoding: UTF-8
-      string: '{"diagnostic_codes":[6260]}'
+      string: '{"diagnostic_codes":[6260,7101,6204]}'
     headers:
       Accept:
       - application/json
@@ -32,6 +32,6 @@ http_interactions:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"ratings":[{"diagnostic_code":6260,"max_rating":10.0}]}'
+      string: '{"ratings":[]}'
   recorded_at: Thu, 10 Aug 2023 19:52:24 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary
- This work is behind a feature toggle (flipper): **YES**
- Removes the previous feature toggle that enabled/disabled use of the VRO client to make requests to the Max-CFI API. Adds in a new feature toggle that enables sending requests for all conditions. If disabled, only requests for select disabilities are made to obtain the max rating from the Max-CFI API. Employee Experience is expanding max rating notices for all diagnostic codes, and want all requests to be made through that client for all conditions. This new feature toggle is to only show the unchanged max rating for tinnitus until the downstream API is ready for other diagnostic codes.
- I am part of the Claims Fast-Tracking crew's Employee Experience team. We work closely with the Disability Experience team which owns this code.
- Flipper criteria:
  - **enabled**: Requests to get the max ratings are made to the VRO Max-CFI API for all disabilities
  - **disabled**: Requests to get the max ratings are made to the VRO Max-CFI API for only select disabilities (currently only tinnitus)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/abd-vro/issues/2804

## Testing done

- New code is covered by unit tests
- Old behavior: feature toggle `disability_526_maximum_rating_api` was used to enable requests to VRO Max-CFI API to get max ratings, otherwise a hardcoded max rating for tinnitus was used. 
- New behavior: All requests are made through VRO Max-CFI API to get max ratings. The new feature toggle `disability_526_maximum_rating_api_all_conditions` is used to enable requests to get max ratings for all diagnostic codes, otherwise requests are made to get max rating for tinnitus only.
- Testing plan: EE team plans to do E2E testing of the entire Max CFI flow, in VA.gov Staging / VBMS UAT.

## What areas of the site does it impact?
No behavior change

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.

