### PR TITLE
79457 handle ICN for OH data

### DIFF
--- a/modules/check_in/app/serializers/check_in/v2/appointment_data_serializer.rb
+++ b/modules/check_in/app/serializers/check_in/v2/appointment_data_serializer.rb
@@ -11,7 +11,7 @@ module CheckIn
       attribute :payload do |object|
         appointments =
           object.payload[:appointments].map do |appt|
-            appt.except!(:patientDFN)
+            appt.except!(:patientDFN, :icn, :edipi)
           end
 
         demographics = prepare_demographics(object.payload[:demographics])
@@ -70,6 +70,8 @@ module CheckIn
       end
 
       def self.address_helper(address)
+        return {} if address.nil?
+
         {
           street1: address[:street1],
           street2: address[:street2],

--- a/modules/check_in/app/serializers/check_in/v2/appointment_identifiers_serializer.rb
+++ b/modules/check_in/app/serializers/check_in/v2/appointment_identifiers_serializer.rb
@@ -21,7 +21,7 @@ module CheckIn
       end
 
       attribute :icn do |object|
-        object.payload.dig(:demographics, :icn)
+        object.payload.dig(:demographics, :icn) || object.payload[:appointments].first[:icn]
       end
 
       attribute :mobilePhone do |object|

--- a/modules/check_in/spec/request/v2/patient_check_ins_request_spec.rb
+++ b/modules/check_in/spec/request/v2/patient_check_ins_request_spec.rb
@@ -206,7 +206,6 @@ RSpec.describe 'V2::PatientCheckIns', type: :request do
               'clinicPhoneNumber' => '909-825-7084',
               'clinicStopCodeName' => 'Mental Health, Primary Care',
               'doctorName' => 'Dr. Jones',
-              'edipi' => '1000000105',
               'facility' => 'Jerry L. Pettis Memorial Veterans Hospital',
               'facilityAddress' => {
                 'city' => 'Loma Linda',
@@ -216,7 +215,6 @@ RSpec.describe 'V2::PatientCheckIns', type: :request do
                 'street3' => '',
                 'zip' => '92357-1000'
               },
-              'icn' => '1013220078V743173',
               'kind' => 'clinic',
               'startTime' => '2024-02-14T22:10:00.000+00:00',
               'stationNo' => '530',

--- a/modules/check_in/spec/serializers/check_in/v2/appointment_data_serializer_spec.rb
+++ b/modules/check_in/spec/serializers/check_in/v2/appointment_data_serializer_spec.rb
@@ -324,5 +324,98 @@ RSpec.describe CheckIn::V2::AppointmentDataSerializer do
         expect(appt_serializer.serializable_hash).to eq(serialized_hash_response)
       end
     end
+
+    context 'for OH data' do
+      let(:appointment_data_oh) do
+        {
+          id: 'd602d9eb-9a31-484f-9637-13ab0b507e0d',
+          scope: 'read.full',
+          payload: {
+            address: '1166 6th Avenue 22, New York, NY 23423 US',
+            appointments: [
+              {
+                appointmentIEN: '4822366',
+                clinicCreditStopCodeName: '',
+                clinicFriendlyName: 'Endoscopy',
+                clinicIen: '32216049',
+                clinicLocation: '',
+                clinicName: 'Endoscopy',
+                clinicPhoneNumber: '909-825-7084',
+                clinicStopCodeName: 'Mental Health, Primary Care',
+                doctorName: 'Dr. Jones',
+                edipi: '1000000105',
+                facility: 'Jerry L. Pettis Memorial Veterans Hospital',
+                facilityAddress: {
+                  city: 'Loma Linda',
+                  state: 'CA',
+                  street1: '',
+                  street2: '',
+                  street3: '',
+                  zip: '92357-1000'
+                },
+                icn: '1013220078V743173',
+                kind: 'clinic',
+                startTime: '2024-02-14T22:10:00.000+00:00',
+                stationNo: '530',
+                status: 'Confirmed',
+                timezone: 'America/Los_Angeles'
+              }
+            ],
+            patientCellPhone: '4445556666',
+            facilityType: 'OH'
+          }
+        }
+      end
+      let(:serialized_hash_response) do
+        {
+          data: {
+            id: 'd602d9eb-9a31-484f-9637-13ab0b507e0d',
+            type: :appointment_data,
+            attributes: {
+              payload: {
+                address: '1166 6th Avenue 22, New York, NY 23423 US',
+                demographics: {},
+                appointments: [
+                  {
+                    appointmentIEN: '4822366',
+                    clinicCreditStopCodeName: '',
+                    clinicFriendlyName: 'Endoscopy',
+                    clinicIen: '32216049',
+                    clinicLocation: '',
+                    clinicName: 'Endoscopy',
+                    clinicPhoneNumber: '909-825-7084',
+                    clinicStopCodeName: 'Mental Health, Primary Care',
+                    doctorName: 'Dr. Jones',
+                    facility: 'Jerry L. Pettis Memorial Veterans Hospital',
+                    facilityAddress: {
+                      city: 'Loma Linda',
+                      state: 'CA',
+                      street1: '',
+                      street2: '',
+                      street3: '',
+                      zip: '92357-1000'
+                    },
+                    kind: 'clinic',
+                    startTime: '2024-02-14T22:10:00.000+00:00',
+                    stationNo: '530',
+                    status: 'Confirmed',
+                    timezone: 'America/Los_Angeles'
+                  }
+                ],
+                patientDemographicsStatus: {},
+                setECheckinStartedCalled: nil
+              }
+            }
+          }
+        }
+      end
+
+      it 'returns a serialized hash' do
+        appt_struct = OpenStruct.new(appointment_data_oh)
+        appt_serializer = CheckIn::V2::AppointmentDataSerializer.new(appt_struct)
+
+        expect(appt_serializer.serializable_hash).to eq(serialized_hash_response)
+      end
+    end
   end
 end

--- a/modules/check_in/spec/serializers/check_in/v2/appointment_identifiers_serializer_spec.rb
+++ b/modules/check_in/spec/serializers/check_in/v2/appointment_identifiers_serializer_spec.rb
@@ -75,6 +75,47 @@ RSpec.describe CheckIn::V2::AppointmentIdentifiersSerializer do
     }
   end
 
+  let(:appointment_data_oh) do
+    {
+      id: 'd602d9eb-9a31-484f-9637-13ab0b507e0d',
+      scope: 'read.full',
+      payload: {
+        address: '1166 6th Avenue 22, New York, NY 23423 US',
+        appointments: [
+          {
+            appointmentIEN: '4822366',
+            clinicCreditStopCodeName: '',
+            clinicFriendlyName: 'Endoscopy',
+            clinicIen: '32216049',
+            clinicLocation: '',
+            clinicName: 'Endoscopy',
+            clinicPhoneNumber: '909-825-7084',
+            clinicStopCodeName: 'Mental Health, Primary Care',
+            doctorName: 'Dr. Jones',
+            edipi: '1000000105',
+            facility: 'Jerry L. Pettis Memorial Veterans Hospital',
+            facilityAddress: {
+              city: 'Loma Linda',
+              state: 'CA',
+              street1: '',
+              street2: '',
+              street3: '',
+              zip: '92357-1000'
+            },
+            icn: '1013220078V743173',
+            kind: 'clinic',
+            startTime: '2024-02-14T22:10:00.000+00:00',
+            stationNo: '530',
+            status: 'Confirmed',
+            timezone: 'America/Los_Angeles'
+          }
+        ],
+        patientCellPhone: '4445556666',
+        facilityType: 'OH'
+      }
+    }
+  end
+
   describe '#serializable_hash' do
     context 'when icn does not exist' do
       let(:serialized_hash_response) do
@@ -346,6 +387,34 @@ RSpec.describe CheckIn::V2::AppointmentIdentifiersSerializer do
 
       it 'returns a serialized hash with edipi and facility type' do
         appt_struct = OpenStruct.new(appointment_data_edipi)
+        appt_serializer = CheckIn::V2::AppointmentIdentifiersSerializer.new(appt_struct)
+
+        expect(appt_serializer.serializable_hash).to eq(serialized_hash_response)
+      end
+    end
+
+    context 'for OH data' do
+      let(:serialized_hash_response) do
+        {
+          data: {
+            id: 'd602d9eb-9a31-484f-9637-13ab0b507e0d',
+            type: :appointment_identifier,
+            attributes: {
+              patientDFN: nil,
+              stationNo: '530',
+              appointmentIEN: '4822366',
+              icn: '1013220078V743173',
+              mobilePhone: nil,
+              patientCellPhone: '4445556666',
+              facilityType: 'OH',
+              edipi: '1000000105'
+            }
+          }
+        }
+      end
+
+      it 'returns serialized identifier data' do
+        appt_struct = OpenStruct.new(appointment_data_oh)
         appt_serializer = CheckIn::V2::AppointmentIdentifiersSerializer.new(appt_struct)
 
         expect(appt_serializer.serializable_hash).to eq(serialized_hash_response)


### PR DESCRIPTION
## Summary
Add serialization for ICN for Oracle Health data, since it's not in demographics object, but in appointments object.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79457

## Testing done

- [x] rspecs
- [x] local testing

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
