### PR TITLE
Add logging back to lighthouse service exception class

### DIFF
--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -86,11 +86,19 @@ module Lighthouse
         .transform_keys(&:to_sym)
     end
 
-    # sends errors to sentry!
+    # log errors
     def self.send_error_logs(error, service_name, lighthouse_client_id, url)
-      base_key_string = "#{lighthouse_client_id} #{url} Lighthouse Error"
+      # Faraday error may contain request data
+      error.response.delete(:request)
+
       Rails.logger.error(
-        base_key_string
+        service_name,
+        {
+          url:,
+          lighthouse_client_id:,
+          status: error.response[:status],
+          body: error.response[:body]
+        }
       )
 
       extra_context = Sentry.set_extras(


### PR DESCRIPTION
## Summary
Due to a Faraday update in Dec 2023, the Faraday error response object contains request data by default. The `Lighthouse::ServiceException` class was logging the full response, so sensitive data from the request was being sent to Datadog.

The initial action taken was to remove some of the logging from `Lighthouse::ServiceException`.  This PR restores the logging and addresses this issue.  A ticket is set to be opened to apply additional enhancements/refactorings to this class.

Additionally, [PR #16105](https://github.com/department-of-veterans-affairs/vets-api/pull/16105) sets an option within the Faraday middleware to remove the request. 

## Related issue(s)
[This postmortem](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Postmortems/2024/2024-03-22%20-%20Profile%20-%20CnP%20DD%20Logging%20Issue.md) provides more details about the issue.