### PR TITLE
Add mhv-appointments to datadog service catalog

### DIFF
--- a/.github/scripts/validate-datadog-yaml/datadog-schema2.2.json
+++ b/.github/scripts/validate-datadog-yaml/datadog-schema2.2.json
@@ -1,0 +1,208 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://github.com/DataDog/schema/tree/main/service-catalog/v2.2/schema.json",
+	"title": "Service Definition Schema v2.2",
+	"description": "A service definition for providing additional service metadata and integrations v2.2",
+	"type": "object",
+	"properties": {
+		"schema-version": {
+			"description": "Schema version being used",
+			"examples": ["v2.2"],
+			"type": "string",
+			"default": "v2.2",
+			"enum": ["v2.2"]
+		},
+		"dd-service": {
+			"description": "Unique identifier of the service. Must be unique across all services, and is used to match with a service in Datadog",
+			"examples": ["my-service"],
+			"type": "string"
+		},
+		"team": {
+			"description": "Team that owns the service. It is used to locate a team defined in Datadog Teams if it exists",
+			"examples": ["my-team"],
+			"type": "string"
+		},
+		"application": {
+			"description": "Identifier for a group of related services serving a product feature, which the service is a part of",
+			"examples": ["my-app"],
+			"type": "string"
+		},
+		"description": {
+			"description": "A short description of the service",
+			"examples": ["My app description"],
+			"type": "string"
+		},
+		"tier": {
+			"description": "Importance of the service",
+			"examples": ["1", "High"],
+			"type": "string"
+		},
+		"lifecycle": {
+			"description": "The current life cycle phase of the service.",
+			"examples": ["sandbox", "staging", "production", "deprecated"],
+			"type": "string"
+		},
+		"type": {
+			"description": "The type of service",
+			"examples": ["web", "db", "cache", "function", "browser", "mobile", "custom"],
+			"type": "string",
+			"enum": ["web", "db", "cache", "function", "browser", "mobile", "custom"]
+		},
+		"languages": {
+			"description": "The service's programming language. See examples for a list of recognizable languages",
+			"examples": [["dotnet", "go", "java", "js", "php", "python", "ruby", "c++"]],
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"contacts": {
+			"description": "A list of contacts related to the services. ",
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/contact"
+			}
+		},
+		"links": {
+			"description": "A list of links related to the services. ",
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/link"
+			}
+		},
+		"tags": {
+			"description": "A set of custom tags",
+			"examples": [["my:tag"]],
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"integrations": {
+			"description": "Third party integrations that Datadog supports",
+			"type": "object",
+			"properties": {
+				"pagerduty": {
+					"description": "Pagerduty integration for the service",
+					"type": "object",
+					"properties": {
+						"service-url": {
+							"description": "Pagerduty Service URL",
+							"examples": ["https://my-org.pagerduty.com/service-directory/PMyService"],
+							"type": "string",
+							"pattern": "^(https?://)?[a-zA-Z\\d_\\-.]+\\.pagerduty\\.com/service-directory/(P[a-zA-Z\\d_\\-]+)/?$"
+						}
+					},
+					"required": ["service-url"],
+					"additionalProperties": false
+				},
+				"opsgenie": {
+					"description": "Opsgenie integration for the service",
+					"type": "object",
+					"properties": {
+						"service-url": {
+							"description": "Opsgenie Service URL",
+							"examples": ["https://www.opsgenie.com/service/123e4567-e89b-12d3-a456-426614174000"],
+							"type": "string",
+							"pattern": "^(https?://)?[a-zA-Z\\d_\\-.]+\\.opsgenie\\.com/service/([a-zA-Z\\d_\\-]+)/?$"
+						},
+						"region": {
+							"description": "Opsgenie Instance Region",
+							"type": "string",
+							"examples": ["US", "EU"],
+							"enum": ["US", "EU"]
+						}
+					},
+					"required": ["service-url"],
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"extensions": {
+			"description": "Custom extensions",
+			"type": "object",
+			"additionalProperties": true
+		},
+		"ci-pipeline-fingerprints": {
+			"description": "A set of CI pipeline fingerprints related to the service",
+			"examples": [["j88xdEy0J5lc", "eZ7LMljCk8vo"]],
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		}
+	},
+	"additionalProperties": false,
+	"required": ["schema-version", "dd-service"],
+	"$defs": {
+		"link": {
+			"additionalProperties": false,
+			"type": "object",
+			"properties": {
+				"name": {
+					"description": "Link name",
+					"examples": ["Runbook", "Dashboard"],
+					"type": "string"
+				},
+				"type": {
+					"description": "Link type. See examples for a list of recognizable types",
+					"examples": ["runbook", "doc", "repo", "dashboard", "other"],
+					"type": "string",
+					"default": "other"
+				},
+				"url": {
+					"description": "Link url",
+					"examples": ["https://my-runbook"],
+					"type": "string",
+					"format": "uri"
+				},
+				"provider": {
+					"description": "Link provider. See examples for a list of recognizable providers",
+					"examples": ["Github", "Confluence"],
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"type",
+				"url"
+			]
+		},
+		"contact": {
+			"additionalProperties": false,
+			"type": "object",
+			"properties": {
+				"name": {
+					"description": "Contact name",
+					"examples": ["Oncall Slack", "Team Email"],
+					"type": "string",
+					"minLength": 2
+				},
+				"type": {
+					"description": "Contact type. See examples for a list of recognizable types",
+					"examples": ["email", "slack", "microsoft-teams"],
+					"type": "string"
+				},
+				"contact": {
+					"description": "Contact value",
+					"examples": ["contact@datadoghq.com", "https://my-org.slack.com/archives/my-channel"],
+					"type": "string"
+				}
+			},
+			"if": {
+				"properties": {"type": {"const": "email"}}
+			},
+			"then": {
+				"properties": {"contact": {"format": "email"}}
+			},
+			"else": {
+				"properties": {"contact": {"format": "uri"}}
+			},
+			"required": [
+				"type",
+				"contact"
+			]
+		}
+	}
+}

--- a/.github/workflows/datadog_service_catalog_update.yml
+++ b/.github/workflows/datadog_service_catalog_update.yml
@@ -45,7 +45,7 @@ jobs:
           cmd: yq '.' ${{matrix.file}}
       - name: 'Update Service Catalog in DataDog'
         run: |
-          curl --location --request POST 'https://api.ddog-gov.com/api/v2/services/definitions?schema_version=v2.1' \
+          curl --location --request POST 'https://api.ddog-gov.com/api/v2/services/definitions?schema_version=v2.2' \
           --header 'Accept: application/json' \
           --header 'DD-API-KEY: ${{ secrets.DD_API_KEY }}' \
           --header 'DD-APPLICATION-KEY: ${{ secrets.DD_APP_KEY }}' \

--- a/.github/workflows/validate-datadog-changes.yml
+++ b/.github/workflows/validate-datadog-changes.yml
@@ -31,4 +31,4 @@ jobs:
         working-directory: ./.github/scripts/validate-datadog-yaml
         run: |
               files=("${{steps.get_filenames.outputs.changedFiles}}")
-              python validate_yaml.py -s datadog-schema2.1.json -F $files
+              python validate_yaml.py -s datadog-schema2.2.json -F $files

--- a/datadog-service-catalog/datadog-service-catalog.yml
+++ b/datadog-service-catalog/datadog-service-catalog.yml
@@ -353,6 +353,21 @@ contacts:
 integrations: {}
 ---
 schema-version: v2.1
+dd-service: mhv-appointments
+team: mhv-appointments
+application: health
+tier: '1'
+description: Veteran medical appointment scheduling service.
+lifecycle: production
+contacts:
+  - name: "#appointments-team"
+    type: slack
+    contact: https://dsva.slack.com/archives/CMNQT72LX
+type: web
+languages:
+  - ruby
+---
+schema-version: v2.1
 dd-service: mhv-messaging
 team: vfs-myhealth
 application: health

--- a/datadog-service-catalog/datadog-service-catalog.yml
+++ b/datadog-service-catalog/datadog-service-catalog.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: dependent-change
 team: benefits
 application: 686c/674
@@ -16,7 +16,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/vad-969-xqc/benefits---dependents-686674
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: mobile-application
 tier: '1'
 lifecycle: production
@@ -35,7 +35,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/pzz-7x2-4cs/mobile-api-dashboard
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: claim-status
 team: benefits
 application: claim status tool application
@@ -53,7 +53,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/uc8-jnr-zhm/benefits---claim-status-tool
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: gibill-application
 team: vfs-education
 tier: '1'
@@ -64,7 +64,7 @@ contacts:
     contact: https://dsva.slack.com/archives/CG6N59X40
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: healthcare-application
 team: 1010-health-apps
 application: health
@@ -81,7 +81,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/p5g-fys-epz/1010-health-apps
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: profile
 team: auth-experience-profile
 tier: '1'
@@ -92,7 +92,7 @@ contacts:
     contact: https://dsva.slack.com/archives/C909ZG2BB
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: education-forms
 team: vfs-education
 tier: '1'
@@ -103,7 +103,7 @@ contacts:
     contact: https://dsva.slack.com/archives/CG6N59X40
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: ask-va
 team: octo-engineers
 tier: '2'
@@ -114,7 +114,7 @@ contacts:
     contact: https://dsva.slack.com/archives/C05A2F6DEAE
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: evidence-upload
 team: benefits
 application: Notice of Disagreement, Supplemental Claims
@@ -133,7 +133,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/u78-itq-2yt
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: appeal-application
 team: benefits
 application: Supplemental Claims
@@ -151,7 +151,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/uc7-8ai-6c3/benefits---supplemental-claims
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: direct-deposit
 team: auth-experience-profile
 tier: '1'
@@ -167,7 +167,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/gra-npe-h52/authenticated-experience-cp-direct-deposit
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: avs
 team: After Visit Summary
 description: Displays after visit summaries to veterans.
@@ -177,7 +177,7 @@ contacts:
     contact: https://dsva.slack.com/archives/C04UBETRY8N
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: disability-application
 team: benefits
 application: disability benefits application
@@ -195,7 +195,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/form-526-disability-compensation
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: appeal-status
 team: benefits
 application: Appeal Status - part of Claim Status Tool
@@ -213,7 +213,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/cpt-6qy-rbc
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: homepage
 team: vfs-websites
 tier: '1'
@@ -226,7 +226,7 @@ tags:
   - homepage
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: caregiver-application
 team: 1010-health-apps
 tier: '1'
@@ -242,7 +242,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/p5g-fys-epz/1010-health-apps
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: feature-flag
 team: platform
 application: platform
@@ -258,7 +258,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/sbb-id5-kwh/feature-toggles-500-errors
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: financial-report
 team: vfs-debt
 tier: '1'
@@ -268,7 +268,7 @@ contacts:
     contact: https://dsva.slack.com/archives/CPE4AJ6Q0
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: search
 team: vfs-websites
 tier: '1'
@@ -278,7 +278,7 @@ contacts:
     contact: https://dsva.slack.com/archives/C011K1VSTC3
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: save-in-progress
 team: platform
 application: platform
@@ -289,7 +289,7 @@ contacts:
     contact: https://dsva.slack.com/archives/CBU0KDSB1
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: authentication
 team: platform-identity
 tier: '1'
@@ -303,7 +303,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/52g-hyg-wcj/vsp-identity-monitor-dashboard
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: mobile-app
 team: vfs-mobile
 tier: '1'
@@ -323,7 +323,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/pzz-7x2-4cs/mobile-api-dashboard
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: pension-application
 team: benefits
 application: Pension / form 21P-527EZ
@@ -341,7 +341,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/vk2-6zi-zzu/benefits---form-527-pension-benefits
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: education-enrollment-verification
 team: vfs-education
 tier: '1'
@@ -352,7 +352,7 @@ contacts:
     contact: https://dsva.slack.com/archives/CG6N59X40
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: mhv-appointments
 team: mhv-appointments
 application: health
@@ -367,7 +367,7 @@ type: web
 languages:
   - ruby
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: mhv-messaging
 team: vfs-myhealth
 application: health
@@ -384,7 +384,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/5r5-ra2-qga/mhv-secure-messaging
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: intent-to-file
 team: benefits
 application: disability-app
@@ -402,7 +402,7 @@ links:
     url: https://vagov.ddog-gov.com/dashboard/9c7-45v-3fx
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: mhv-medications
 team: vfs-myhealth
 application: health
@@ -413,7 +413,7 @@ contacts:
     contact: https://dsva.slack.com/archives/C04PRFEJQTY
 integrations: {}
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: find-a-form
 team: vfs-websites
 tier: '1'

--- a/datadog-service-catalog/debt-resolution.yml
+++ b/datadog-service-catalog/debt-resolution.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: v2.1
+schema-version: v2.2
 dd-service: debt-resolution
 team: vfs-debt
 tier: '1'


### PR DESCRIPTION
## Summary

This PR does 2 things:

- exports the [MHV appointments service catalog entry](https://vagov.ddog-gov.com/apm/services/mhv-appointments/operations/rack.request/resources?dependencyMap=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&env=eks-prod&fromUser=false&groupMapByOperation=null&hostGroup=&operationName=rack.request&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap95%29%2CtopN%3A%215%29%2Cversion%3A%211%29&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%29%2Cversion%3A%211%29&view=spans&start=1711634057535&end=1711637657535&paused=false) and updates it to tier 1 per OCTO review.
- updates the service catalog schema to version 2.2 to be able to represent all fields in the mhv appointments service catalog export