### PR TITLE
MHV-56394 Add no-cache header to all FHIR search query requests

### DIFF
--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -89,11 +89,8 @@ module MedicalRecords
 
     def list_allergies
       bundle = fhir_search(FHIR::AllergyIntolerance,
-                           {
-                             search: { parameters: { patient: patient_fhir_id, 'clinical-status': 'active',
-                                                     'verification-status:not': 'entered-in-error' } },
-                             headers: { 'Cache-Control': 'no-cache' }
-                           })
+                           search: { parameters: { patient: patient_fhir_id, 'clinical-status': 'active',
+                                                   'verification-status:not': 'entered-in-error' } })
       sort_bundle(bundle, :recordedDate, :desc)
     end
 
@@ -103,10 +100,7 @@ module MedicalRecords
 
     def list_vaccines
       bundle = fhir_search(FHIR::Immunization,
-                           {
-                             search: { parameters: { patient: patient_fhir_id, 'status:not': 'entered-in-error' } },
-                             headers: { 'Cache-Control': 'no-cache' }
-                           })
+                           search: { parameters: { patient: patient_fhir_id, 'status:not': 'entered-in-error' } })
       sort_bundle(bundle, :occurrenceDateTime, :desc)
     end
 
@@ -118,21 +112,15 @@ module MedicalRecords
       # loinc_codes =
       #   "#{BLOOD_PRESSURE},#{BREATHING_RATE},#{HEART_RATE},#{HEIGHT},#{TEMPERATURE},#{WEIGHT},#{PULSE_OXIMETRY}"
       bundle = fhir_search(FHIR::Observation,
-                           {
-                             search: { parameters: { patient: patient_fhir_id, category: 'vital-signs',
-                                                     'status:not': 'entered-in-error' } },
-                             headers: { 'Cache-Control': 'no-cache' }
-                           })
+                           search: { parameters: { patient: patient_fhir_id, category: 'vital-signs',
+                                                   'status:not': 'entered-in-error' } })
       sort_bundle(bundle, :effectiveDateTime, :desc)
     end
 
     def list_conditions
       bundle = fhir_search(FHIR::Condition,
-                           {
-                             search: { parameters: { patient: patient_fhir_id,
-                                                     'verification-status:not': 'entered-in-error' } },
-                             headers: { 'Cache-Control': 'no-cache' }
-                           })
+                           search: { parameters: { patient: patient_fhir_id,
+                                                   'verification-status:not': 'entered-in-error' } })
       sort_bundle(bundle, :recordedDate, :desc)
     end
 
@@ -145,11 +133,8 @@ module MedicalRecords
     def list_clinical_notes
       loinc_codes = "#{PHYSICIAN_PROCEDURE_NOTE},#{DISCHARGE_SUMMARY},#{CONSULT_RESULT}"
       bundle = fhir_search(FHIR::DocumentReference,
-                           {
-                             search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
-                                                     'status:not': 'entered-in-error' } },
-                             headers: { 'Cache-Control': 'no-cache' }
-                           })
+                           search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
+                                                   'status:not': 'entered-in-error' } })
 
       # Sort the bundle of notes based on the date field appropriate to each note type.
       sort_bundle_with_criteria(bundle, :desc) do |resource|
@@ -174,10 +159,7 @@ module MedicalRecords
 
     def get_diagnostic_report(record_id)
       fhir_search(FHIR::DiagnosticReport,
-                  {
-                    search: { parameters: { _id: record_id, _include: '*', 'status:not': 'entered-in-error' } },
-                    headers: { 'Cache-Control': 'no-cache' }
-                  })
+                  search: { parameters: { _id: record_id, _include: '*', 'status:not': 'entered-in-error' } })
     end
 
     ##
@@ -234,11 +216,8 @@ module MedicalRecords
     #
     def list_labs_chemhem_diagnostic_report
       fhir_search(FHIR::DiagnosticReport,
-                  {
-                    search: { parameters: { patient: patient_fhir_id, category: 'LAB',
-                                            'status:not': 'entered-in-error' } },
-                    headers: { 'Cache-Control': 'no-cache' }
-                  })
+                  search: { parameters: { patient: patient_fhir_id, category: 'LAB',
+                                          'status:not': 'entered-in-error' } })
     end
 
     ##
@@ -250,11 +229,8 @@ module MedicalRecords
     def list_labs_other_diagnostic_report
       loinc_codes = "#{MICROBIOLOGY},#{PATHOLOGY}"
       fhir_search(FHIR::DiagnosticReport,
-                  {
-                    search: { parameters: { patient: patient_fhir_id, code: loinc_codes,
-                                            'status:not': 'entered-in-error' } },
-                    headers: { 'Cache-Control': 'no-cache' }
-                  })
+                  search: { parameters: { patient: patient_fhir_id, code: loinc_codes,
+                                          'status:not': 'entered-in-error' } })
     end
 
     ##
@@ -266,10 +242,8 @@ module MedicalRecords
     def list_labs_document_reference
       loinc_codes = "#{EKG},#{RADIOLOGY}"
       fhir_search(FHIR::DocumentReference,
-                  {
-                    search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
-                                            'status:not': 'entered-in-error' } }
-                  })
+                  search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
+                                          'status:not': 'entered-in-error' } })
     end
 
     ##
@@ -300,7 +274,11 @@ module MedicalRecords
     # @return [FHIR::ClientReply]
     #
     def fhir_search_query(fhir_model, params)
+      default_headers = { 'Cache-Control': 'no-cache' }
+      params[:headers] = default_headers.merge(params.fetch(:headers, {}))
+
       params[:search][:parameters].merge!(_count: DEFAULT_COUNT)
+
       result = fhir_client.search(fhir_model, params)
       handle_api_errors(result) if result.resource.nil?
       result

--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -118,15 +118,21 @@ module MedicalRecords
       # loinc_codes =
       #   "#{BLOOD_PRESSURE},#{BREATHING_RATE},#{HEART_RATE},#{HEIGHT},#{TEMPERATURE},#{WEIGHT},#{PULSE_OXIMETRY}"
       bundle = fhir_search(FHIR::Observation,
-                           search: { parameters: { patient: patient_fhir_id, category: 'vital-signs',
-                                                   'status:not': 'entered-in-error' } })
+                           {
+                             search: { parameters: { patient: patient_fhir_id, category: 'vital-signs',
+                                                     'status:not': 'entered-in-error' } },
+                             headers: { 'Cache-Control': 'no-cache' }
+                           })
       sort_bundle(bundle, :effectiveDateTime, :desc)
     end
 
     def list_conditions
       bundle = fhir_search(FHIR::Condition,
-                           search: { parameters: { patient: patient_fhir_id,
-                                                   'verification-status:not': 'entered-in-error' } })
+                           {
+                             search: { parameters: { patient: patient_fhir_id,
+                                                     'verification-status:not': 'entered-in-error' } },
+                             headers: { 'Cache-Control': 'no-cache' }
+                           })
       sort_bundle(bundle, :recordedDate, :desc)
     end
 
@@ -168,7 +174,10 @@ module MedicalRecords
 
     def get_diagnostic_report(record_id)
       fhir_search(FHIR::DiagnosticReport,
-                  search: { parameters: { _id: record_id, _include: '*', 'status:not': 'entered-in-error' } })
+                  {
+                    search: { parameters: { _id: record_id, _include: '*', 'status:not': 'entered-in-error' } },
+                    headers: { 'Cache-Control': 'no-cache' }
+                  })
     end
 
     ##
@@ -225,8 +234,11 @@ module MedicalRecords
     #
     def list_labs_chemhem_diagnostic_report
       fhir_search(FHIR::DiagnosticReport,
-                  search: { parameters: { patient: patient_fhir_id, category: 'LAB',
-                                          'status:not': 'entered-in-error' } })
+                  {
+                    search: { parameters: { patient: patient_fhir_id, category: 'LAB',
+                                            'status:not': 'entered-in-error' } },
+                    headers: { 'Cache-Control': 'no-cache' }
+                  })
     end
 
     ##
@@ -238,8 +250,11 @@ module MedicalRecords
     def list_labs_other_diagnostic_report
       loinc_codes = "#{MICROBIOLOGY},#{PATHOLOGY}"
       fhir_search(FHIR::DiagnosticReport,
-                  search: { parameters: { patient: patient_fhir_id, code: loinc_codes,
-                                          'status:not': 'entered-in-error' } })
+                  {
+                    search: { parameters: { patient: patient_fhir_id, code: loinc_codes,
+                                            'status:not': 'entered-in-error' } },
+                    headers: { 'Cache-Control': 'no-cache' }
+                  })
     end
 
     ##
@@ -251,8 +266,10 @@ module MedicalRecords
     def list_labs_document_reference
       loinc_codes = "#{EKG},#{RADIOLOGY}"
       fhir_search(FHIR::DocumentReference,
-                  search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
-                                          'status:not': 'entered-in-error' } })
+                  {
+                    search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
+                                            'status:not': 'entered-in-error' } }
+                  })
     end
 
     ##

--- a/spec/lib/medical_records/client_spec.rb
+++ b/spec/lib/medical_records/client_spec.rb
@@ -44,7 +44,7 @@ describe MedicalRecords::Client do
         client.get_patient_by_identifier(client.fhir_client, patient_id)
         expect(
           a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
-        ).to have_been_made.once
+        ).to have_been_made.at_least_once
       end
     end
 
@@ -81,6 +81,9 @@ describe MedicalRecords::Client do
   it 'gets a list of allergies', :vcr do
     VCR.use_cassette 'mr_client/get_a_list_of_allergies' do
       allergy_list = client.list_allergies
+      expect(
+        a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
+      ).to have_been_made.at_least_once
       expect(allergy_list).to be_a(FHIR::Bundle)
       expect(info_log_buffer.string).not_to include('2952')
       # Verify that the list is sorted reverse chronologically (with nil values to the end).
@@ -106,6 +109,9 @@ describe MedicalRecords::Client do
     VCR.use_cassette 'mr_client/get_a_list_of_vaccines' do
       vaccine_list = client.list_vaccines
       expect(vaccine_list).to be_a(FHIR::Bundle)
+      expect(
+        a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
+      ).to have_been_made.at_least_once
       # Verify that the list is sorted reverse chronologically (with nil values to the end).
       vaccine_list.entry.each_cons(2) do |prev, curr|
         prev_date = prev.resource.occurrenceDateTime
@@ -126,6 +132,9 @@ describe MedicalRecords::Client do
     VCR.use_cassette 'mr_client/get_a_list_of_vitals' do
       vitals_list = client.list_vitals
       expect(vitals_list).to be_a(FHIR::Bundle)
+      expect(
+        a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
+      ).to have_been_made.at_least_once
       # Verify that the list is sorted reverse chronologically (with nil values to the end).
       vitals_list.entry.each_cons(2) do |prev, curr|
         prev_date = prev.resource.effectiveDateTime
@@ -138,6 +147,9 @@ describe MedicalRecords::Client do
   it 'gets a list of health conditions', :vcr do
     VCR.use_cassette 'mr_client/get_a_list_of_health_conditions' do
       condition_list = client.list_conditions
+      expect(
+        a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
+      ).to have_been_made.at_least_once
       expect(condition_list).to be_a(FHIR::Bundle)
       # Verify that the list is sorted reverse chronologically (with nil values to the end).
       condition_list.entry.each_cons(2) do |prev, curr|
@@ -153,7 +165,7 @@ describe MedicalRecords::Client do
       note_list = client.list_clinical_notes
       expect(
         a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
-      ).to have_been_made.once
+      ).to have_been_made.at_least_once
       expect(note_list).to be_a(FHIR::Bundle)
       # Verify that the list is sorted reverse chronologically (with nil values to the end).
       note_list.entry.each_cons(2) do |prev, curr|


### PR DESCRIPTION
## Summary

- Abstracted out the "no-cache" header so it is automatically added to all FHIR search query requests.

## Related issue(s)

### [MHV-56394](https://jira.devops.va.gov/browse/MHV-56394) - Add no-cache header to vitals (and remaining domains) ###

> Make sure we add the appropriate "no-cache" header for all domains.

## Testing done

- Added additional testing to verify no-cache header is added.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
