### PR TITLE
remove acl line

### DIFF
--- a/lib/simple_forms_api_submission/s3.rb
+++ b/lib/simple_forms_api_submission/s3.rb
@@ -23,7 +23,7 @@ module SimpleFormsApiSubmission
                             bucket: Settings.ivc_forms.s3.bucket,
                             key:,
                             body: File.read(file),
-                            metadata:,
+                            metadata:
                           })
         { success: true }
       rescue => e

--- a/lib/simple_forms_api_submission/s3.rb
+++ b/lib/simple_forms_api_submission/s3.rb
@@ -24,7 +24,6 @@ module SimpleFormsApiSubmission
                             key:,
                             body: File.read(file),
                             metadata:,
-                            acl: 'public-read'
                           })
         { success: true }
       rescue => e


### PR DESCRIPTION
## Summary

Currently, submitting a form 1010d on staging errors because the S3 bucket doesn't support ACLs, and we're sending an ACL property.

This PR removes the ACL line from s3 config so we can push to bucket that doesn't support ACLs

- This work is behind a feature toggle (flipper): NA, not on prod yet

## Testing done

- [ ] *New code is covered by unit tests*
- Previously, form 1010d submitting on staging would get a 500
- To verify changes are working as intended, used the S3 credentials locally and was able to submit a form to the S3 bucket in question

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
