### PR TITLE
Update vets_json_schema to new master version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,10 +73,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 78e9931f1b99663304f72c42fdd9f61ab328f4b1
+  revision: 7892dc348677325cc57712ff4a12d6a78f024315
   branch: master
   specs:
-    vets_json_schema (21.5.4)
+    vets_json_schema (21.5.5)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
- Which team do you work for, does your team own the maintenance of this component? 10-10 Health Enrollment team

## Related issue(s)


## Summary

- *This work is behind a feature toggle (flipper):* NO
- Updates the `vets_json_schema` version to the latest master revision via `bundle update vets_json_schema`
- 10-10 Health Enrollment Team

## Related issue(s)

- [Ticket #78506](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78506)

## Testing done

- confirmed that the version and revision are updated in Gemfile.lock

## Requested Feedback

- I've left out the `bundle update`'s removal of the `sidekiq` gems and their `einhorn` dependency, per the README's instructions.