### PR TITLE
Fix for requesting travel pay token, add specs

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -28,12 +28,11 @@ module TravelPay
       btsss_url = Settings.travel_pay.base_url
       api_key = Settings.travel_pay.subscription_key
 
-      connection(server_url: btsss_url).post('api/v1/Auth/access-token') do |req|
+      response = connection(server_url: btsss_url).post('api/v1/Auth/access-token') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
         req.body = { authJwt: vagov_token }
       end
-
       response.body['access_token']
     end
 

--- a/modules/travel_pay/spec/services/client_spec.rb
+++ b/modules/travel_pay/spec/services/client_spec.rb
@@ -34,6 +34,24 @@ describe TravelPay::Client do
     end
   end
 
+  context 'request_btsss_token' do
+    it 'returns btsss token from proper endpoint' do
+      @stubs.post("/api/v1/Auth/access-token") do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          '{"access_token": "fake_btsss_token"}'
+        ]
+      end
+
+      client = TravelPay::Client.new
+      token = client.request_btsss_token('fake_veis_token', 'fake_vagov_token')
+
+      expect(token).to eq('fake_btsss_token')
+      @stubs.verify_stubbed_calls
+    end
+  end
+
   context 'ping' do
     it 'receives response from ping endpoint' do
       @stubs.get('/api/v1/Sample/ping') do


### PR DESCRIPTION
The `request_btsss_token` method was found to be not working when implemented in `TravelPay::PingsController#authorized_ping`. This PR fixes that issue while adding specs.