### PR TITLE
79628 remove travel claims increase timeout flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -156,10 +156,6 @@ features:
     actor_type: user
     description: Uses the refactored code for Travel Claim Redis client to fetch attributes
     enable_in_development: true
-  check_in_experience_travel_claim_increase_timeout:
-    actor_type: user
-    description: Increases the timeout for BTSSS submit claim request to 120 seconds
-    enable_in_development: true
   claim_letters_access:
     actor_type: user
     description: Enables users to access the claim letters page

--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -58,7 +58,7 @@ module TravelClaim
     #
     def submit_claim(token:, patient_icn:, appointment_date:)
       connection(server_url: claims_url).post("/#{claims_base_path}/api/ClaimIngest/submitclaim") do |req|
-        req.options.timeout = 120 if Flipper.enabled?(:check_in_experience_travel_claim_increase_timeout)
+        req.options.timeout = 120
         req.headers = claims_default_header.merge('Authorization' => "Bearer #{token}")
         req.body = claims_data.merge({ ClaimantID: patient_icn, Appointment:
           { AppointmentDateTime: appointment_date } }).to_json

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -10,7 +10,6 @@ describe TravelClaim::Client do
 
   before do
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
-    allow(Flipper).to receive(:enabled?).with(:check_in_experience_travel_claim_increase_timeout).and_return(true)
   end
 
   describe '.build' do

--- a/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
+++ b/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
@@ -179,7 +179,6 @@ describe CheckIn::TravelClaimSubmissionWorker, type: :worker do
   before do
     allow(TravelClaim::RedisClient).to receive(:build).and_return(redis_client)
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
-    allow(Flipper).to receive(:enabled?).with(:check_in_experience_travel_claim_increase_timeout).and_return(true)
 
     allow(redis_client).to receive(:patient_cell_phone).and_return(patient_cell_phone)
     allow(redis_client).to receive(:token).and_return(redis_token)


### PR DESCRIPTION
## Summary
This PR removes the feature flag that was used to add the the code to increase the Faraday timeout to 120 seconds for travel claims API client. The code has been running correctly in production for a while, and this feature flag is no longer necessary.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/79628

## Testing done

- [x] rspecs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
