### PR TITLE
API-35187: Remove Performance Benchmark Code from `VBADocuments::UploadProcessor`

### DIFF
--- a/modules/vba_documents/app/sidekiq/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/sidekiq/vba_documents/upload_processor.rb
@@ -14,32 +14,27 @@ module VBADocuments
     include VBADocuments::UploadValidations
 
     STATSD_DUPLICATE_UUID_KEY = 'api.vba.document_upload.duplicate_uuid'
-    STATSD_TIMING = 'api.vba.document_upload_perf_timing'
 
     # Ensure that multiple jobs for the same GUID aren't spawned,
     # to avoid race condition when parsing the multipart file
     sidekiq_options unique_for: 30.days
 
     def perform(guid, caller_data, retries = 0)
+      # @retries variable used via the CentralMail::Utilities which is included via VBADocuments::UploadValidations
+      @retries = retries
+      @cause = caller_data.nil? ? { caller: 'unknown' } : caller_data['caller']
       response = nil
-      brt = Benchmark.realtime do
-        # @retries variable used via the CentralMail::Utilities which is included via VBADocuments::UploadValidations
-        @retries = retries
-        @cause = caller_data.nil? ? { caller: 'unknown' } : caller_data['caller']
-        response = nil
-        VBADocuments::UploadSubmission.with_advisory_lock(guid) do
-          @upload = VBADocuments::UploadSubmission.where(status: 'uploaded').find_by(guid:)
-          if @upload
-            tracking_hash = { 'job' => 'VBADocuments::UploadProcessor' }.merge(@upload.as_json)
-            Rails.logger.info('VBADocuments: Start Processing.', tracking_hash)
-            response = download_and_process
-            tracking_hash = { 'job' => 'VBADocuments::UploadProcessor' }.merge(@upload.reload.as_json)
-            Rails.logger.info('VBADocuments: Stop Processing.', tracking_hash)
-          end
+
+      VBADocuments::UploadSubmission.with_advisory_lock(guid) do
+        @upload = VBADocuments::UploadSubmission.where(status: 'uploaded').find_by(guid:)
+        if @upload
+          tracking_hash = { 'job' => 'VBADocuments::UploadProcessor' }.merge(@upload.as_json)
+          Rails.logger.info('VBADocuments: Start Processing.', tracking_hash)
+          response = download_and_process
+          tracking_hash = { 'job' => 'VBADocuments::UploadProcessor' }.merge(@upload.reload.as_json)
+          Rails.logger.info('VBADocuments: Stop Processing.', tracking_hash)
         end
       end
-      StatsD.increment(STATSD_TIMING, tags: ["jid: #{jid}", "guid: #{@upload&.guid}", 'step: perform_complete',
-                                             "time: #{brt.round(5)}}"])
 
       response&.success? ? true : false
     end
@@ -48,54 +43,31 @@ module VBADocuments
 
     # rubocop:disable Metrics/MethodLength
     def download_and_process
-      tempfile, timestamp = nil
-      brt = Benchmark.realtime do
-        tempfile, timestamp = VBADocuments::PayloadManager.download_raw_file(@upload.guid)
-      end
-      StatsD.increment(STATSD_TIMING, tags: ["jid: #{jid}", "guid: #{@upload.guid}", 'step: download_raw_file',
-                                             "raw_file_size: #{tempfile.size}", "time: #{brt.round(5)}}"])
-
+      tempfile, timestamp = VBADocuments::PayloadManager.download_raw_file(@upload.guid)
       response = nil
+
       begin
-        parts, inspector = nil
-        brt = Benchmark.realtime do
-          @upload.update(metadata: @upload.metadata.merge(original_file_metadata(tempfile)))
+        @upload.update(metadata: @upload.metadata.merge(original_file_metadata(tempfile)))
 
-          validate_payload_size(tempfile)
+        validate_payload_size(tempfile)
 
-          parts = VBADocuments::MultipartParser.parse(tempfile.path)
-          inspector = VBADocuments::PDFInspector.new(pdf: parts)
-          @upload.update(uploaded_pdf: inspector.pdf_data)
-        end
-        StatsD.increment(STATSD_TIMING, tags: ["jid: #{jid}", "guid: #{@upload.guid}", 'step: parse_parts',
-                                               "time: #{brt.round(5)}}"])
+        parts = VBADocuments::MultipartParser.parse(tempfile.path)
+        inspector = VBADocuments::PDFInspector.new(pdf: parts)
+        @upload.update(uploaded_pdf: inspector.pdf_data)
 
-        metadata = nil
-        brt = Benchmark.realtime do
-          # Validations
-          validate_parts(@upload, parts)
-          validate_metadata(parts[META_PART_NAME], @upload.consumer_id, @upload.guid,
-                            submission_version: @upload.metadata['version'].to_i)
-          metadata = perfect_metadata(@upload, parts, timestamp)
+        # Validations
+        validate_parts(@upload, parts)
+        validate_metadata(parts[META_PART_NAME], @upload.consumer_id, @upload.guid,
+                          submission_version: @upload.metadata['version'].to_i)
+        metadata = perfect_metadata(@upload, parts, timestamp)
 
-          pdf_validator_options = VBADocuments::DocumentRequestValidator.pdf_validator_options
-          validate_documents(parts, pdf_validator_options)
-        end
-        StatsD.increment(STATSD_TIMING, tags: ["jid: #{jid}", "guid: #{@upload.guid}", 'step: validate',
-                                               "time: #{brt.round(5)}}"])
+        pdf_validator_options = VBADocuments::DocumentRequestValidator.pdf_validator_options
+        validate_documents(parts, pdf_validator_options)
 
-        brt = Benchmark.realtime do
-          response = submit(metadata, parts)
-        end
-        StatsD.increment(STATSD_TIMING, tags: ["jid: #{jid}", "guid: #{@upload.guid}", 'step: cm_upload',
-                                               "time: #{brt.round(5)}}"])
+        response = submit(metadata, parts)
 
-        brt = Benchmark.realtime do
-          process_response(response)
-          log_submission(@upload, metadata)
-        end
-        StatsD.increment(STATSD_TIMING, tags: ["jid: #{jid}", "guid: #{@upload.guid}", 'step: process_resp',
-                                               "time: #{brt.round(5)}}"])
+        process_response(response)
+        log_submission(@upload, metadata)
       rescue Common::Exceptions::GatewayTimeout => e
         handle_gateway_timeout(e)
       rescue VBADocuments::UploadError => e


### PR DESCRIPTION
## Summary
This PR removes some performance benchmarking code that was added to the `VBADocuments::UploadProcessor` job last year in order to capture timing metrics on each step of the job. These metrics were used to determine the areas for performance improvement. The code was only intended to be put in place temporarily. This PR removes it to reduce the chances of a production error from the code and to improve readability of the job.

My team (Lighthouse Team Banana Peels) maintains the `vba_documents` module.

## Related issue(s)
[API-35187](https://jira.devops.va.gov/browse/API-35187)

## Testing done
The `VBADocuments::UploadProcessor` job was run locally to confirm that behavior of the job did not change. In addition, all unit tests are still passing.

## Screenshots
None

## What areas of the site does it impact?
The PR impacts the `vba_documents` module only, and specifically the `VBADocuments::UploadProcessor` job.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
