### PR TITLE
Create `Inquiries#create_reply` endpoint

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -46,6 +46,11 @@ module AskVAApi
         render json: serializer.serializable_hash, status: :ok
       end
 
+      def create_reply
+        response = Correspondences::Creator.new(message: params[:reply], inquiry_id: params[:id], service: nil).call
+        render json: response.to_json, status: :ok
+      end
+
       private
 
       def inquiry_params

--- a/modules/ask_va_api/app/lib/ask_va_api/correspondences/creator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/correspondences/creator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module AskVAApi
+  module Correspondences
+    class CorrespondencesCreatorError < StandardError; end
+
+    class Creator
+      attr_reader :message, :inquiry_id, :service
+
+      def initialize(message:, inquiry_id:, service:)
+        @message = message
+        @inquiry_id = inquiry_id
+        @service = service || default_service
+      end
+
+      def call
+        payload = { Reply: message }
+        post_data(payload:)
+      rescue => e
+        ErrorHandler.handle_service_error(e)
+      end
+
+      private
+
+      def default_service
+        Crm::Service.new(icn: nil)
+      end
+
+      def post_data(payload: {})
+        endpoint = "inquiries/#{inquiry_id}/reply/new"
+
+        response = service.call(endpoint:, payload:)
+        handle_response_data(response)
+      end
+
+      def handle_response_data(response)
+        if response[:Data].nil?
+          raise CorrespondencesCreatorError, response[:Message]
+        else
+          response[:Data]
+        end
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/config/routes.rb
+++ b/modules/ask_va_api/config/routes.rb
@@ -10,10 +10,11 @@ AskVAApi::Engine.routes.draw do
     get '/inquiries/:id', to: 'inquiries#show'
     get '/inquiries/:id/status', to: 'inquiries#status'
     get '/download_attachment', to: 'inquiries#download_attachment'
+    get '/profile', to: 'inquiries#profile'
     post '/inquiries/auth', to: 'inquiries#create'
     post '/inquiries', to: 'inquiries#unauth_create'
     post '/upload_attachment', to: 'inquiries#upload_attachment'
-    get '/profile', to: 'inquiries#profile'
+    post '/inquiries/:id/reply/new', to: 'inquiries#create_reply'
 
     # static_data
     get '/categories', to: 'static_data#categories'

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/correspondences/creator_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/correspondences/creator_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AskVAApi
+  module Correspondences
+    RSpec.describe Creator do
+      subject(:creator) { described_class.new(message:, inquiry_id: '123', service: nil) }
+
+      let(:message) { 'this is a corespondence message' }
+
+      describe '#call' do
+        context 'when successful' do
+          before do
+            allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('Token')
+            allow_any_instance_of(Crm::Service).to receive(:call).and_return({ Data: { Id: '456' } })
+          end
+
+          it 'response with a correspondence ID' do
+            expect(creator.call).to eq({ Id: '456' })
+          end
+        end
+
+        context 'when not successful' do
+          before do
+            allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('Token')
+            allow_any_instance_of(Crm::Service).to receive(:call).and_return({ Data: nil, Message: 'Error has occur' })
+          end
+
+          it 'raise CorrespondenceCreatorError' do
+            expect { creator.call }.to raise_error(ErrorHandler::ServiceError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/spec/requests/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/v0/inquiries_spec.rb
@@ -337,4 +337,18 @@ RSpec.describe AskVAApi::V0::InquiriesController, type: :request do
                                                         'attributes' => { 'status' => 'Reopened' } })
     end
   end
+
+  describe 'POST #create_reply' do
+    let(:payload) { { 'reply' => 'this is my reply' } }
+
+    before do
+      allow_any_instance_of(Crm::Service).to receive(:call).and_return({ Data: { Id: '123' } })
+      sign_in(authorized_user)
+      post '/ask_va_api/v0/inquiries/123/reply/new', params: payload
+    end
+
+    it 'returns status 200' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

1. **Service Class Addition:** Implemented `Correspondences::Creator` to handle the creation of replies, ensuring that business logic is encapsulated and reusable.

2. **Controller Action:** Added `Inquiries#create_reply` action, which utilizes the `Correspondences::Creator` to create a reply tied to a specific inquiry.

3. **Routing:** Extended `routes.rb` to include a new route `/inquiries/:id/reply/new`, facilitating the creation of new replies through a RESTful interface.

This update streamlines the process of replying to inquiries, making our interaction with users more efficient and organized.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/526

## Testing done

- [x] *New code is covered by unit tests*
## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature