### PR TITLE
added more temp logging to debug in staging

### DIFF
--- a/app/controllers/v1/pension_ipf_callbacks_controller.rb
+++ b/app/controllers/v1/pension_ipf_callbacks_controller.rb
@@ -45,16 +45,20 @@ module V1
     def authenticate_user_with_token
       Rails.logger.info('pension-ipf-callbacks-69766 - Received request, authenticating')
       authenticate_with_http_token do |token|
+        # TODO: Temp logging for debugging Staging issue. Remove after testing
+        Rails.logger.info("pension-ipf-callbacks-69766 - Expecting #{bearer_token_secret}")
+        Rails.logger.info("pension-ipf-callbacks-69766 - Length: #{bearer_token_secret.length}")
+        Rails.logger.info("pension-ipf-callbacks-69766 - Received #{token}")
+        Rails.logger.info("pension-ipf-callbacks-69766 - Length: #{token.length}")
         return false if bearer_token_secret.nil?
 
+        Rails.logger.info("pension-ipf-callbacks-69766 - Is equal?: #{token == bearer_token_secret}")
         token == bearer_token_secret
       end
     end
 
     def authenticity_error
       Rails.logger.info('pension-ipf-callbacks-69766 - Failed to authenticate request')
-      # TODO: Temp logging for debugging Staging issue. Remove after testing
-      Rails.logger.info("pension-ipf-callbacks-69766 - Expected #{bearer_token_secret}")
       render json: { message: 'Invalid credentials' }, status: :unauthorized
     end
 


### PR DESCRIPTION
## Summary

- Added more temp logging for debugging bearer token auth issue in staging.
- Pension benefits team to own this change.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/16154

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
