### PR TITLE
[79732] Updating login.gov verified SSOe calls to use 'exact' authn context instead of 'min'

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -231,8 +231,7 @@ module V1
         url_service.login_url(
           'logingov',
           [IAL::LOGIN_GOV_IAL2, AAL::LOGIN_GOV_AAL2],
-          AuthnContext::LOGIN_GOV,
-          AuthnContext::MINIMUM
+          AuthnContext::LOGIN_GOV
         )
       when 'logingov_signup'
         url_service.logingov_signup_url([IAL::LOGIN_GOV_IAL1, AAL::LOGIN_GOV_AAL2])


### PR DESCRIPTION
## Summary

- This PR updates the SSOe login.gov verified authentication call to use the `exact` authn context instead of `min`. This is necessary because a regression was previously introduced when SSOe IAM interface with login.gov transitioned to using OIDC login.gov flow, and the way certain authn patterns work was changed.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79732

## Testing done



## What areas of the site does it impact?
SSOe Authentication

## Acceptance criteria

- [ ] Ensure login.gov verified authentication for SSOe works as expected