### PR TITLE
Add logic to direct deposit control info

### DIFF
--- a/lib/lighthouse/direct_deposit/control_information.rb
+++ b/lib/lighthouse/direct_deposit/control_information.rb
@@ -5,18 +5,57 @@ module Lighthouse
     class ControlInformation
       include ActiveModel::Model
 
-      attr_accessor :can_update_direct_deposit,
-                    :is_corp_available,
-                    :is_corp_rec_found,
-                    :has_no_bdn_payments,
-                    :has_identity,
-                    :has_index,
-                    :is_competent,
-                    :has_mailing_address,
-                    :has_no_fiduciary_assigned,
-                    :is_not_deceased,
-                    :has_payment_address,
-                    :is_edu_claim_available
+      ACTIONS = [:can_update_direct_deposit].freeze
+      USAGES = %i[is_corp_available is_edu_claim_available].freeze
+      RESTRICTIONS = %i[
+        is_corp_rec_found
+        has_no_bdn_payments
+        has_identity
+        has_index
+        is_competent
+        has_mailing_address
+        has_no_fiduciary_assigned
+        is_not_deceased
+        has_payment_address
+      ].freeze
+
+      attr_accessor(*(ACTIONS + USAGES + RESTRICTIONS))
+      attr_reader :errors
+
+      alias :comp_and_pen? is_corp_available
+      alias :edu_benefits? is_edu_claim_available
+
+      def account_updatable?
+        @can_update_direct_deposit && restrictions.size.zero?
+      end
+
+      def benefit_type?
+        comp_and_pen? || edu_benefits?
+      end
+
+      def restrictions
+        RESTRICTIONS.reject { |name| send(name) }
+      end
+
+      def clear_restrictions
+        @can_update_direct_deposit = true
+        RESTRICTIONS.each { |name| send("#{name}=", true) }
+      end
+
+      def valid?
+        @errors = []
+
+        error = 'Has restrictions. Account should not be updatable.'
+        errors << error if @can_update_direct_deposit && restrictions.any?
+
+        error = 'Has no restrictions. Account should be updatable.'
+        errors << error if !@can_update_direct_deposit && restrictions.empty?
+
+        error = 'Missing benefit type. Must be either CnP or EDU benefits.'
+        errors << error unless benefit_type?
+
+        errors.size.zero?
+      end
     end
   end
 end

--- a/spec/lib/lighthouse/direct_deposit/control_information_spec.rb
+++ b/spec/lib/lighthouse/direct_deposit/control_information_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'lighthouse/direct_deposit/control_information'
+
+RSpec.describe Lighthouse::DirectDeposit::ControlInformation do
+  let(:info) { described_class.new }
+
+  before do
+    info.clear_restrictions
+  end
+
+  context 'when no restrictions' do
+    it 'is updateable' do
+      expect(info.account_updatable?).to be(true)
+      expect(info.restrictions).to be_empty
+    end
+  end
+
+  context 'when there is a restriction' do
+    it 'is not updateable' do
+      Lighthouse::DirectDeposit::ControlInformation::RESTRICTIONS.each do |name|
+        info.clear_restrictions
+        info.send("#{name}=", false)
+
+        expect(info.account_updatable?).to be(false)
+        expect(info.restrictions).not_to be_empty
+      end
+    end
+  end
+
+  context 'when is_corp_available is true' do
+    it 'is for comp and pen' do
+      info.is_corp_available = true
+      expect(info.comp_and_pen?).to be(true)
+    end
+  end
+
+  context 'when is_edu_claim_available is true' do
+    it 'is for edu benefits' do
+      info.is_edu_claim_available = true
+      expect(info.edu_benefits?).to be(true)
+    end
+  end
+
+  context 'has no benefit type' do
+    it 'is invalid' do
+      expect(info.valid?).to be(false)
+      expect(info.errors).to eq(['Missing benefit type. Must be either CnP or EDU benefits.'])
+    end
+  end
+
+  context 'has restrictions' do
+    it 'account should not be updatable' do
+      info.is_edu_claim_available = true
+      info.has_identity = false
+
+      expect(info.valid?).to be(false)
+      expect(info.errors).to eq(['Has restrictions. Account should not be updatable.'])
+    end
+  end
+
+  context 'has no restrictions' do
+    it 'account should be updatable' do
+      info.is_corp_available = true
+      info.can_update_direct_deposit = false
+
+      expect(info.valid?).to be(false)
+      expect(info.errors).to eq(['Has no restrictions. Account should be updatable.'])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add logic to direct deposit control information class.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/79248

## Testing done
`spec/lib/lighthouse/direct_deposit/control_information_spec.rb`