### PR TITLE
Adds debugging info to /v0/profile/contacts endpoint

### DIFF
--- a/app/swagger/swagger/schemas/contacts.rb
+++ b/app/swagger/swagger/schemas/contacts.rb
@@ -10,7 +10,7 @@ module Swagger::Schemas
       key :required, [:data]
       property :data, type: :array do
         items do
-          property :id, type: :string, example: 'dbbf9a58-41e5-40c0-bdb5-fc1407aa1f05'
+          property :id, type: :string
           property :type, type: :string
           property :attributes do
             key :$ref, :Contact
@@ -21,17 +21,17 @@ module Swagger::Schemas
 
     swagger_schema :Contact do
       key :required, %i[contact_type given_name family_name primary_phone]
-      property :contact_type, type: :string, enum: VAProfile::Models::AssociatedPerson::CONTACT_TYPES
-      property :given_name, type: %i[string null]
-      property :family_name, type: %i[string null]
-      property :relationship, type: %i[string null]
-      property :address_line1, type: %i[string null]
-      property :address_line2, type: %i[string null]
-      property :address_line3, type: %i[string null]
-      property :city, type: %i[string null]
-      property :state, type: %i[string null]
-      property :zip_code, type: %i[string null]
-      property :primary_phone, type: %i[string null]
+      property :contact_type, type: :string, enum: VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPES
+      property :given_name, type: %i[string]
+      property :family_name, type: %i[string]
+      property :relationship, type: %i[string]
+      property :address_line1, type: %i[string]
+      property :address_line2, type: %i[string]
+      property :address_line3, type: %i[string]
+      property :city, type: %i[string]
+      property :state, type: %i[string]
+      property :zip_code, type: %i[string]
+      property :primary_phone, type: %i[string]
     end
   end
 end

--- a/app/swagger/swagger/schemas/contacts.rb
+++ b/app/swagger/swagger/schemas/contacts.rb
@@ -24,18 +24,18 @@ module Swagger::Schemas
       property(
         :contact_type,
         type: :string,
-        enum: VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPES
+        enum: VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPE
       )
-      property :given_name, type: %i[string]
-      property :family_name, type: %i[string]
-      property :relationship, type: %i[string]
-      property :address_line1, type: %i[string]
-      property :address_line2, type: %i[string]
-      property :address_line3, type: %i[string]
-      property :city, type: %i[string]
-      property :state, type: %i[string]
-      property :zip_code, type: %i[string]
-      property :primary_phone, type: %i[string]
+      property :given_name, type: %i[string null]
+      property :family_name, type: %i[string null]
+      property :relationship, type: %i[string null]
+      property :address_line1, type: %i[string null]
+      property :address_line2, type: %i[string null]
+      property :address_line3, type: %i[string null]
+      property :city, type: %i[string null]
+      property :state, type: %i[string null]
+      property :zip_code, type: %i[string null]
+      property :primary_phone, type: %i[strin null]
     end
   end
 end

--- a/app/swagger/swagger/schemas/contacts.rb
+++ b/app/swagger/swagger/schemas/contacts.rb
@@ -21,7 +21,11 @@ module Swagger::Schemas
 
     swagger_schema :Contact do
       key :required, %i[contact_type given_name family_name primary_phone]
-      property :contact_type, type: :string, enum: VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPES
+      property(
+        :contact_type,
+        type: :string,
+        enum: VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPES
+      )
       property :given_name, type: %i[string]
       property :family_name, type: %i[string]
       property :relationship, type: %i[string]

--- a/app/swagger/swagger/schemas/contacts.rb
+++ b/app/swagger/swagger/schemas/contacts.rb
@@ -35,7 +35,7 @@ module Swagger::Schemas
       property :city, type: %i[string null]
       property :state, type: %i[string null]
       property :zip_code, type: %i[string null]
-      property :primary_phone, type: %i[strin null]
+      property :primary_phone, type: %i[string null]
     end
   end
 end

--- a/app/swagger/swagger/schemas/contacts.rb
+++ b/app/swagger/swagger/schemas/contacts.rb
@@ -24,7 +24,7 @@ module Swagger::Schemas
       property(
         :contact_type,
         type: :string,
-        enum: VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPE
+        enum: VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPES
       )
       property :given_name, type: %i[string null]
       property :family_name, type: %i[string null]

--- a/config/database.yml
+++ b/config/database.yml
@@ -39,7 +39,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  url: postgis://postgres:password@localhost:5432/vets_api_test
+  url: <%= Settings.test_database_url %><%= ENV['TEST_ENV_NUMBER'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -39,7 +39,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  url: <%= Settings.test_database_url %><%= ENV['TEST_ENV_NUMBER'] %>
+  url: postgis://postgres:password@localhost:5432/vets_api_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/lib/va_profile/models/associated_person.rb
+++ b/lib/va_profile/models/associated_person.rb
@@ -10,19 +10,27 @@ module VAProfile
       OTHER_EMERGENCY_CONTACT = 'Other emergency contact'
       PRIMARY_NEXT_OF_KIN = 'Primary Next of Kin'
       OTHER_NEXT_OF_KIN = 'Other Next of Kin'
+      DESIGNEE = 'Designee'
+      POWER_OF_ATTORNEY = 'Power of Attorney'
 
-      CONTACT_TYPES = [
+      PERSONAL_HEALTH_CARE_CONTACT_TYPES = [
         EMERGENCY_CONTACT,
         OTHER_EMERGENCY_CONTACT,
         PRIMARY_NEXT_OF_KIN,
         OTHER_NEXT_OF_KIN
       ].freeze
 
+      CONTACT_TYPES = [
+        *PERSONAL_HEALTH_CARE_CONTACT_TYPES,
+        DESIGNEE,
+        POWER_OF_ATTORNEY,
+      ].freeze
+
       attribute :contact_type, String
       attribute :given_name, Common::TitlecaseString
       attribute :middle_name, Common::TitlecaseString
       attribute :family_name, Common::TitlecaseString
-      attribute :relationship, Common::TitlecaseString
+      attribute :relationship, String
       attribute :address_line1, String
       attribute :address_line2, String
       attribute :address_line3, String

--- a/lib/va_profile/models/associated_person.rb
+++ b/lib/va_profile/models/associated_person.rb
@@ -23,7 +23,7 @@ module VAProfile
       CONTACT_TYPES = [
         *PERSONAL_HEALTH_CARE_CONTACT_TYPES,
         DESIGNEE,
-        POWER_OF_ATTORNEY,
+        POWER_OF_ATTORNEY
       ].freeze
 
       attribute :contact_type, String

--- a/lib/va_profile/profile/v3/health_benefit_bio_response.rb
+++ b/lib/va_profile/profile/v3/health_benefit_bio_response.rb
@@ -13,6 +13,7 @@ module VAProfile
         attribute :va_profile_tx_audit_id, String
 
         def initialize(response)
+          body = response.body
           contacts = body.dig('profile', 'health_benefit', 'associated_persons')
                          &.select { |p| valid_contact_types.include?(p['contact_type']) }
                          &.sort_by { |p| valid_contact_types.index(p['contact_type']) }
@@ -21,7 +22,7 @@ module VAProfile
           super(response.status, { contacts:, messages:, va_profile_tx_audit_id: })
         end
 
-        def metadata
+        def debug_data
           {
             status:,
             message:,
@@ -36,7 +37,10 @@ module VAProfile
         end
 
         def message
-          messages&.first&.to_h
+          m = messages&.first
+          return '' unless m
+
+          "#{m.code} #{m.key} #{m.text}"
         end
       end
     end

--- a/lib/va_profile/profile/v3/health_benefit_bio_response.rb
+++ b/lib/va_profile/profile/v3/health_benefit_bio_response.rb
@@ -8,33 +8,35 @@ module VAProfile
   module Profile
     module V3
       class HealthBenefitBioResponse < VAProfile::Response
-        attr_reader :body
-
         attribute :contacts, Array[VAProfile::Models::AssociatedPerson]
         attribute :messages, Array[VAProfile::Models::Message]
+        attribute :va_profile_tx_audit_id, String
 
         def initialize(response)
-          @body = response.body
           contacts = body.dig('profile', 'health_benefit', 'associated_persons')
                          &.select { |p| valid_contact_types.include?(p['contact_type']) }
                          &.sort_by { |p| valid_contact_types.index(p['contact_type']) }
           messages = body['messages']
-          super(response.status, { contacts:, messages: })
+          va_profile_tx_audit_id = response.response_headers['vaprofiletxauditid']
+          super(response.status, { contacts:, messages:, va_profile_tx_audit_id: })
         end
 
         def metadata
-          { status:, messages: }
+          {
+            status:,
+            message:,
+            va_profile_tx_audit_id:
+          }
         end
 
         private
 
         def valid_contact_types
-          [
-            VAProfile::Models::AssociatedPerson::EMERGENCY_CONTACT,
-            VAProfile::Models::AssociatedPerson::OTHER_EMERGENCY_CONTACT,
-            VAProfile::Models::AssociatedPerson::PRIMARY_NEXT_OF_KIN,
-            VAProfile::Models::AssociatedPerson::OTHER_NEXT_OF_KIN
-          ]
+          VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPES
+        end
+
+        def message
+          messages&.first&.to_h
         end
       end
     end

--- a/lib/va_profile/profile/v3/service.rb
+++ b/lib/va_profile/profile/v3/service.rb
@@ -26,8 +26,10 @@ module VAProfile
         def get_health_benefit_bio
           oid = MPI::Constants::VA_ROOT_OID
           path = "#{oid}/#{ERB::Util.url_encode(icn_with_aaid)}"
-          response = perform(:post, path, { bios: [{ bioPath: 'healthBenefit' }] })
-          VAProfile::Profile::V3::HealthBenefitBioResponse.new(response)
+          service_response = perform(:post, path, { bios: [{ bioPath: 'healthBenefit' }] })
+          response = VAProfile::Profile::V3::HealthBenefitBioResponse.new(service_response)
+          Sentry.set_extras(response.debug_data) unless response.ok?
+          response
         end
 
         def get_military_info

--- a/spec/controllers/v0/profile/contacts_controller_spec.rb
+++ b/spec/controllers/v0/profile/contacts_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe V0::Profile::ContactsController, type: :controller do
     end
 
     context 'feature disabled' do
-      it 'returns an unauthorized status code' do
+      it 'returns a not found status code' do
         Flipper.disable(:profile_contacts)
         sign_in_as user
         expect(subject).to have_http_status(:not_found)

--- a/spec/lib/va_profile/models/associated_person_spec.rb
+++ b/spec/lib/va_profile/models/associated_person_spec.rb
@@ -35,15 +35,12 @@ describe VAProfile::Models::AssociatedPerson do
     it 'titlecases family_name' do
       expect(subject.family_name).to eq('Williams')
     end
-
-    it 'titlecases relationship' do
-      expect(subject.relationship).to eq('Unrelated Friend')
-    end
   end
 
   context 'Virtus::Attribute, String type attributes' do
     %i[
       contact_type
+      relationship
       address_line1
       address_line2
       address_line3

--- a/spec/lib/va_profile/profile/v3/health_benefit_bio_response_spec.rb
+++ b/spec/lib/va_profile/profile/v3/health_benefit_bio_response_spec.rb
@@ -7,17 +7,22 @@ describe VAProfile::Profile::V3::HealthBenefitBioResponse do
   subject { described_class.new(response) }
 
   let(:response) do
-    double('Faraday::Response',
-           status: 200,
-           body: {
-             'profile' => {
-               'health_benefit' => {
-                 'associated_persons' => [{
-                   'contact_type' => contact_type
-                 }]
-               }
-             }
-           })
+    double(
+      'Faraday::Response',
+      status: 200,
+      body: {
+        'profile' => {
+          'health_benefit' => {
+            'associated_persons' => [{
+              'contact_type' => contact_type
+            }]
+          }
+        }
+      },
+      response_headers: {
+        'vaprofiletxauditid' => 'abc123'
+      }
+    )
   end
 
   describe 'Emergency contact' do

--- a/spec/lib/va_profile/profile/v3/service_spec.rb
+++ b/spec/lib/va_profile/profile/v3/service_spec.rb
@@ -55,6 +55,15 @@ describe VAProfile::Profile::V3::Service do
   describe '#get_health_benefit_bio' do
     let(:user) { build(:user, :loa3, idme_uuid:) }
 
+    let(:cassette_filename) { "spec/support/vcr_cassettes/#{cassette}.yml" }
+    let(:cassette_data) { YAML.load_file(cassette_filename) }
+    let(:va_profile_tx_audit_id) { cassette_data['http_interactions'][0]['response']['headers']['Vaprofiletxauditid'][0] }
+    let(:debug_data) { {
+      status:,
+      message:,
+      va_profile_tx_audit_id:
+    }}
+
     around do |ex|
       VCR.use_cassette(cassette) { ex.run }
     end
@@ -68,19 +77,21 @@ describe VAProfile::Profile::V3::Service do
         expect(response.status).to eq(200)
         expect(response.contacts.size).to eq(4)
         types = response.contacts.map(&:contact_type)
-        valid_contact_types = [
-          VAProfile::Models::AssociatedPerson::EMERGENCY_CONTACT,
-          VAProfile::Models::AssociatedPerson::OTHER_EMERGENCY_CONTACT,
-          VAProfile::Models::AssociatedPerson::PRIMARY_NEXT_OF_KIN,
-          VAProfile::Models::AssociatedPerson::OTHER_NEXT_OF_KIN
-        ]
+        valid_contact_types = VAProfile::Models::AssociatedPerson::PERSONAL_HEALTH_CARE_CONTACT_TYPES
         expect(types).to match_array(valid_contact_types)
+      end
+
+      it 'does not call Sentry.set_extras' do
+        expect(Sentry).not_to receive(:set_extras)
+        subject.get_health_benefit_bio
       end
     end
 
     context '404 response' do
       let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
       let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_404' }
+      let(:status) { 404 }
+      let(:message) { 'MVI201 MviNotFound The person with the identifier requested was not found in MVI.' }
 
       it 'includes messages received from the api' do
         response = subject.get_health_benefit_bio
@@ -88,17 +99,29 @@ describe VAProfile::Profile::V3::Service do
         expect(response.contacts.size).to eq(0)
         expect(response.messages.size).to eq(1)
       end
+
+      it 'calls Sentry.set_extras' do
+        expect(Sentry).to receive(:set_extras).once.with(debug_data)
+        subject.get_health_benefit_bio
+      end
     end
 
     context '500 response' do
       let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
       let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_500' }
+      let(:status) { 500 }
+      let(:message) { 'MVI203 MviResponseError MVI returned acknowledgement error code AE with error detail: More Than One Active Correlation Exists' }
 
       it 'includes messages recieved from the api' do
         response = subject.get_health_benefit_bio
         expect(response.status).to eq(500)
         expect(response.contacts.size).to eq(0)
         expect(response.messages.size).to eq(1)
+      end
+
+      it 'calls Sentry.set_extras' do
+        expect(Sentry).to receive(:set_extras).once.with(debug_data)
+        subject.get_health_benefit_bio
       end
     end
 

--- a/spec/lib/va_profile/profile/v3/service_spec.rb
+++ b/spec/lib/va_profile/profile/v3/service_spec.rb
@@ -115,7 +115,9 @@ describe VAProfile::Profile::V3::Service do
       let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_500' }
       let(:status) { 500 }
       let(:message) do
-        'MVI203 MviResponseError MVI returned acknowledgement error code AE with error detail: More Than One Active Correlation Exists'
+        result = 'MVI203 MviResponseError MVI returned acknowledgement error code '
+        result += 'AE with error detail: More Than One Active Correlation Exists'
+        result
       end
 
       it 'includes messages recieved from the api' do

--- a/spec/lib/va_profile/profile/v3/service_spec.rb
+++ b/spec/lib/va_profile/profile/v3/service_spec.rb
@@ -57,12 +57,16 @@ describe VAProfile::Profile::V3::Service do
 
     let(:cassette_filename) { "spec/support/vcr_cassettes/#{cassette}.yml" }
     let(:cassette_data) { YAML.load_file(cassette_filename) }
-    let(:va_profile_tx_audit_id) { cassette_data['http_interactions'][0]['response']['headers']['Vaprofiletxauditid'][0] }
-    let(:debug_data) { {
-      status:,
-      message:,
-      va_profile_tx_audit_id:
-    }}
+    let(:va_profile_tx_audit_id) do
+      cassette_data['http_interactions'][0]['response']['headers']['Vaprofiletxauditid'][0]
+    end
+    let(:debug_data) do
+      {
+        status:,
+        message:,
+        va_profile_tx_audit_id:
+      }
+    end
 
     around do |ex|
       VCR.use_cassette(cassette) { ex.run }
@@ -110,7 +114,9 @@ describe VAProfile::Profile::V3::Service do
       let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
       let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_500' }
       let(:status) { 500 }
-      let(:message) { 'MVI203 MviResponseError MVI returned acknowledgement error code AE with error detail: More Than One Active Correlation Exists' }
+      let(:message) do
+        'MVI203 MviResponseError MVI returned acknowledgement error code AE with error detail: More Than One Active Correlation Exists'
+      end
 
       it 'includes messages recieved from the api' do
         response = subject.get_health_benefit_bio

--- a/spec/requests/va_profile/contacts_request_spec.rb
+++ b/spec/requests/va_profile/contacts_request_spec.rb
@@ -11,38 +11,40 @@ RSpec.describe 'contacts' do
     VCR.use_cassette(cassette) { ex.run }
   end
 
-  describe 'GET /v0/profile/contacts -> 200' do
-    let(:idme_uuid) { 'dd681e7d6dea41ad8b80f8d39284ef29' }
-    let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_200' }
+  describe 'GET /v0/profile/contacts' do
+    context '200 response' do
+      let(:idme_uuid) { 'dd681e7d6dea41ad8b80f8d39284ef29' }
+      let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_200' }
 
-    it 'responds with contacts' do
-      sign_in_as(user)
-      get '/v0/profile/contacts'
-      expect(response).to have_http_status(:ok)
-      expect(response).to match_response_schema('contacts')
-      expect(resource['data'].size).to eq(4)
+      it 'responds with contacts' do
+        sign_in_as(user)
+        get '/v0/profile/contacts'
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_response_schema('contacts')
+        expect(resource['data'].size).to eq(4)
+      end
     end
-  end
 
-  describe 'GET /v0/profile/contacts -> 404' do
-    let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
-    let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_404' }
+    context '404 response' do
+      let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
+      let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_404' }
 
-    it 'responds with 404 status' do
-      sign_in_as(user)
-      get '/v0/profile/contacts'
-      expect(response).to have_http_status(:not_found)
+      it 'responds with 404 status' do
+        sign_in_as(user)
+        get '/v0/profile/contacts'
+        expect(response).to have_http_status(:not_found)
+      end
     end
-  end
 
-  describe 'GET /v0/profile/contacts -> 500' do
-    let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
-    let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_500' }
+    context '500 response' do
+      let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
+      let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_500' }
 
-    it 'responds with 500 status' do
-      sign_in_as(user)
-      get '/v0/profile/contacts'
-      expect(response).to have_http_status(:internal_server_error)
+      it 'responds with 500 status' do
+        sign_in_as(user)
+        get '/v0/profile/contacts'
+        expect(response).to have_http_status(:internal_server_error)
+      end
     end
   end
 end

--- a/spec/requests/va_profile/contacts_request_spec.rb
+++ b/spec/requests/va_profile/contacts_request_spec.rb
@@ -7,14 +7,17 @@ RSpec.describe 'contacts' do
   let(:user) { build(:user, :loa3, idme_uuid:) }
   let(:resource) { JSON.parse(response.body) }
 
+  around do |ex|
+    VCR.use_cassette(cassette) { ex.run }
+  end
+
   describe 'GET /v0/profile/contacts -> 200' do
     let(:idme_uuid) { 'dd681e7d6dea41ad8b80f8d39284ef29' }
+    let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_200' }
 
     it 'responds with contacts' do
       sign_in_as(user)
-      VCR.use_cassette('va_profile/profile/v3/health_benefit_bio_200') do
-        get '/v0/profile/contacts'
-      end
+      get '/v0/profile/contacts'
       expect(response).to have_http_status(:ok)
       expect(response).to match_response_schema('contacts')
       expect(resource['data'].size).to eq(4)
@@ -23,13 +26,23 @@ RSpec.describe 'contacts' do
 
   describe 'GET /v0/profile/contacts -> 404' do
     let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
+    let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_404' }
 
     it 'responds with 404 status' do
       sign_in_as(user)
-      VCR.use_cassette('va_profile/profile/v3/health_benefit_bio_404') do
-        get '/v0/profile/contacts'
-      end
+      get '/v0/profile/contacts'
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'GET /v0/profile/contacts -> 500' do
+    let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
+    let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_500' }
+
+    it 'responds with 500 status' do
+      sign_in_as(user)
+      get '/v0/profile/contacts'
+      expect(response).to have_http_status(:internal_server_error)
     end
   end
 end

--- a/spec/requests/va_profile/contacts_request_spec.rb
+++ b/spec/requests/va_profile/contacts_request_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe 'contacts' do
       end
     end
 
+    context '401 response' do
+      let(:idme_uuid) { 'dd681e7d6dea41ad8b80f8d39284ef29' }
+      let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_200' }
+
+      it 'responds with 401 status' do
+        get '/v0/profile/contacts'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '403 response' do
+      let(:user) { build(:user, :loa1) }
+      let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_200' }
+
+      it 'responds with 403 status' do
+        sign_in_as(user)
+        get '/v0/profile/contacts'
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
     context '404 response' do
       let(:idme_uuid) { '88f572d4-91af-46ef-a393-cba6c351e252' }
       let(:cassette) { 'va_profile/profile/v3/health_benefit_bio_404' }


### PR DESCRIPTION
## Summary

Prepare `profile_contacts` feature for canary release

- *This work is behind a feature toggle (flipper): YES* `profile_contacts`
- Adds call to `Sentry.set_extras` to include service response status code, primary error message, and audit id from source system when response is not ok
- Updates specs

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#79017

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*: Non 200 requests did not call `Sentry.set_extras`
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*: Sign in with a user w/o a record in ES, verify Sentry/Datadog picks up debug data
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios.*: See `spec/controllers/v0/profile/contacts_controller_spec.rb`
  - *What is the testing plan for rolling out the feature?* See ticket

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
