### PR TITLE
[DR-65545] Log KPIs for Supplemental Claims (contestable issues)

### DIFF
--- a/lib/decision_review_v1/appeals/supplemental_claim_services.rb
+++ b/lib/decision_review_v1/appeals/supplemental_claim_services.rb
@@ -82,7 +82,17 @@ module DecisionReviewV1
         with_monitoring_and_error_handling do
           path = "contestable_issues/supplemental_claims?benefit_type=#{benefit_type}"
           headers = get_contestable_issues_headers(user)
-          response = perform :get, path, nil, headers
+          common_log_params = { key: :get_contestable_issues, form_id: '995', user_uuid: user.uuid,
+                                upstream_system: 'Lighthouse' }
+          begin
+            response = perform :get, path, nil, headers
+            log_formatted(**common_log_params.merge(is_success: true, status_code: response.status, body: '[Redacted]'))
+          rescue => e
+            # We can freely log Lighthouse's error responses because they do not include PII or PHI.
+            # See https://developer.va.gov/explore/api/decision-reviews/docs?version=v1.
+            log_formatted(**common_log_params.merge(is_success: false, response_error: e))
+            raise e
+          end
           raise_schema_error_unless_200_status response.status
           validate_against_schema(
             json: response.body,

--- a/lib/decision_review_v1/appeals/supplemental_claim_services.rb
+++ b/lib/decision_review_v1/appeals/supplemental_claim_services.rb
@@ -6,6 +6,7 @@ require 'decision_review_v1/utilities/constants'
 
 module DecisionReviewV1
   module Appeals
+    # rubocop:disable Metrics/ModuleLength
     module SupplementalClaimServices
       include DecisionReviewV1::Appeals::Helpers
 
@@ -202,5 +203,6 @@ module DecisionReviewV1
         CentralMail::Service.new.upload(processor.request_body)
       end
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/spec/requests/v1/supplemental_claims/contestable_issues_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims/contestable_issues_controller_request_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe V1::SupplementalClaims::ContestableIssuesController do
 
     it 'fetches issues that the Veteran could contest via a supplemental claim' do
       VCR.use_cassette('decision_review/SC-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with({
+                                                      message: 'Get contestable issues success!',
+                                                      user_uuid: user.uuid,
+                                                      action: 'Get contestable issues',
+                                                      form_id: '995',
+                                                      upstream_system: 'Lighthouse',
+                                                      downstream_system: nil,
+                                                      is_success: true,
+                                                      http: {
+                                                        status_code: 200,
+                                                        body: '[Redacted]'
+                                                      }
+                                                    })
         subject
         expect(response).to be_successful
         expect(JSON.parse(response.body)['data']).to be_an Array
@@ -27,6 +41,20 @@ RSpec.describe V1::SupplementalClaims::ContestableIssuesController do
     it 'adds to the PersonalInformationLog when an exception is thrown' do
       VCR.use_cassette('decision_review/SC-GET-CONTESTABLE-ISSUES-RESPONSE-404_V1') do
         expect(personal_information_logs.count).to be 0
+        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error).with({
+                                                       message: 'Get contestable issues failure!',
+                                                       user_uuid: user.uuid,
+                                                       action: 'Get contestable issues',
+                                                       form_id: '995',
+                                                       upstream_system: 'Lighthouse',
+                                                       downstream_system: nil,
+                                                       is_success: false,
+                                                       http: {
+                                                         status_code: 404,
+                                                         body: anything
+                                                       }
+                                                     })
         subject
         expect(personal_information_logs.count).to be 1
         pil = personal_information_logs.first


### PR DESCRIPTION
## Summary

Follow-up to #16176 to make things a little easier to review. This covers adding logging to SC contestable issues

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/65545

## Testing done

- [x] *New code is covered by unit tests*
- [x] Tested that API call works locally.
- Will do a test on staging to check that uploads/form submission both work and logs are showing up in DataDog as expected

## What areas of the site does it impact?
The Supplemental Claims form 

## Acceptance criteria
 - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
 - [x] No error nor warning in the console.
 - [x] Events are being sent to the appropriate logging solution
 - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
 - [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
