### PR TITLE
Update direct deposit error codes and add additional route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,6 +299,7 @@ Rails.application.routes.draw do
       resource :military_occupations, only: :show
 
       # Lighthouse
+      resource :direct_deposits, only: %i[show update]
       namespace :direct_deposits do
         resource :disability_compensations, only: %i[show update]
       end

--- a/lib/lighthouse/direct_deposit/error_parser.rb
+++ b/lib/lighthouse/direct_deposit/error_parser.rb
@@ -44,29 +44,35 @@ module Lighthouse
       end
 
       def self.parse_code(detail) # rubocop:disable Metrics/MethodLength
-        return 'cnp.payment.api.rate.limit.exceeded' if detail.include? 'API rate limit exceeded'
-        return 'cnp.payment.api.gateway.timeout' if detail.include? 'Did not receive a timely response'
-        return 'cnp.payment.invalid.authentication.creds' if detail.include? 'Invalid authentication credentials'
-        return 'cnp.payment.invalid.token' if detail.include? 'Invalid token'
-        return 'cnp.payment.invalid.scopes' if detail.include? 'scopes are not configured'
-        return 'cnp.payment.icn.not.found' if detail.include? 'No data found for ICN'
-        return 'cnp.payment.icn.invalid' if detail.include? 'getDirectDeposit.icn size'
-        return 'cnp.payment.account.number.invalid' if detail.include? 'payment.accountNumber.invalid'
-        return 'cnp.payment.account.type.invalid' if detail.include? 'payment.accountType.invalid'
-        return 'cnp.payment.account.number.fraud' if detail.include? 'Flashes on record'
-        return 'cnp.payment.routing.number.invalid.checksum' if detail.include? 'accountRoutingNumber.invalidCheckSum'
-        return 'cnp.payment.routing.number.invalid' if detail.include? 'payment.accountRoutingNumber.invalid'
-        return 'cnp.payment.routing.number.fraud' if detail.include? 'Routing number related to potential fraud'
-        return 'cnp.payment.restriction.indicators.present' if detail.include? 'restriction.indicators.present'
-        return 'cnp.payment.day.phone.number.invalid' if detail.include? 'Day phone number is invalid'
-        return 'cnp.payment.day.area.number.invalid' if detail.include? 'Day area number is invalid'
-        return 'cnp.payment.night.phone.number.invalid' if detail.include? 'Night phone number is invalid'
-        return 'cnp.payment.night.area.number.invalid' if detail.include? 'Night area number is invalid'
-        return 'cnp.payment.mailing.address.invalid' if detail.include? 'field not entered for mailing address update'
-        return 'cnp.payment.potential.fraud' if detail.include? 'GUIE50041'
-        return 'cnp.payment.unspecified.error' if detail.include? 'GUIE50022'
+        return "#{prefix}.api.rate.limit.exceeded" if detail.include? 'API rate limit exceeded'
+        return "#{prefix}.api.gateway.timeout" if detail.include? 'Did not receive a timely response'
+        return "#{prefix}.invalid.authentication.creds" if detail.include? 'Invalid authentication credentials'
+        return "#{prefix}.invalid.token" if detail.include? 'Invalid token'
+        return "#{prefix}.invalid.scopes" if detail.include? 'scopes are not configured'
+        return "#{prefix}.icn.not.found" if detail.include? 'No data found for ICN'
+        return "#{prefix}.icn.invalid" if detail.include? 'getDirectDeposit.icn size'
+        return "#{prefix}.account.number.invalid" if detail.include? 'payment.accountNumber.invalid'
+        return "#{prefix}.account.type.invalid" if detail.include? 'payment.accountType.invalid'
+        return "#{prefix}.account.number.fraud" if detail.include? 'Flashes on record'
+        return "#{prefix}.routing.number.invalid.checksum" if detail.include? 'accountRoutingNumber.invalidCheckSum'
+        return "#{prefix}.routing.number.invalid" if detail.include? 'payment.accountRoutingNumber.invalid'
+        return "#{prefix}.routing.number.fraud" if detail.include? 'Routing number related to potential fraud'
+        return "#{prefix}.restriction.indicators.present" if detail.include? 'restriction.indicators.present'
+        return "#{prefix}.day.phone.number.invalid" if detail.include? 'Day phone number is invalid'
+        return "#{prefix}.day.area.number.invalid" if detail.include? 'Day area number is invalid'
+        return "#{prefix}.night.phone.number.invalid" if detail.include? 'Night phone number is invalid'
+        return "#{prefix}.night.area.number.invalid" if detail.include? 'Night area number is invalid'
+        return "#{prefix}.mailing.address.invalid" if detail.include? 'field not entered for mailing address update'
+        return "#{prefix}.potential.fraud" if detail.include? 'GUIE50041'
+        return "#{prefix}.unspecified.error" if detail.include? 'GUIE50022'
 
-        'cnp.payment.generic.error'
+        "#{prefix}.generic.error"
+      end
+
+      def self.prefix
+        return 'direct.deposit' if Flipper.enabled?(:profile_show_direct_deposit_single_form)
+
+        'cnp.payment'
       end
 
       def self.data_source

--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
     sign_in_as(user)
     token = 'abcdefghijklmnop'
     allow_any_instance_of(DirectDeposit::Configuration).to receive(:access_token).and_return(token)
+    Flipper.disable(:profile_show_direct_deposit_single_form)
   end
 
   describe '#show' do
@@ -402,6 +403,60 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
         expect(e['code']).to eq('cnp.payment.potential.fraud')
         expect(e['source']).to eq('Lighthouse Direct Deposit')
       end
+    end
+  end
+
+  describe '#update feature flag' do
+    let(:params) do
+      {
+        routing_number: '031000503',
+        account_number: '12345678'
+      }
+    end
+
+    context 'when feature flag is on' do
+      before do
+        Flipper.enable(:profile_show_direct_deposit_single_form)
+      end
+
+      it 'error code is prefixed with direct.deposit' do
+        VCR.use_cassette('lighthouse/direct_deposit/update/400_invalid_account_type') do
+          put(:update, params:)
+        end
+
+        json = JSON.parse(response.body)
+        e = json['errors'].first
+
+        expect(e['code']).to eq('direct.deposit.account.type.invalid')
+      end
+    end
+
+    context 'when feature flag is off' do
+      it 'error code is prefixed with cnp.payment' do
+        VCR.use_cassette('lighthouse/direct_deposit/update/400_invalid_account_type') do
+          put(:update, params:)
+        end
+
+        json = JSON.parse(response.body)
+        e = json['errors'].first
+
+        expect(e['code']).to eq('cnp.payment.account.type.invalid')
+      end
+    end
+  end
+
+  describe '#show alternate route' do
+    it 'returns direct deposit info' do
+      VCR.use_cassette('lighthouse/direct_deposit/show/200_valid') do
+        get(:show, params: { use_route: 'v0/profile/direct_deposits' })
+      end
+
+      json = JSON.parse(response.body)
+      payment_account = json['data']['attributes']['payment_account']
+      control_info = json['data']['attributes']['control_information']
+
+      expect(payment_account).not_to be_nil
+      expect(control_info).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary
Two direct deposit changes:
- Add additional route `v0/profile/direct_deposits`.
- When `profile_show_direct_deposit_single_form` is on, set prefix on error codes to `direct.deposit` instead of `cnp.payment`.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/79767

## Testing done
Specs added to `disability_compensations_controller_spec.rb` to test:
- Additional route
- Feature flag for error code prefixes
