### PR TITLE
Handle transliteration errors separately from other errors in Simple Forms

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -51,8 +51,10 @@ module SimpleFormsApi
           submit_form_to_central_mail
         end
       rescue Prawn::Errors::IncompatibleStringEncoding
+        byebug
         raise
       rescue => e
+        byebug
         raise Exceptions::ScrubbedUploadsSubmitError.new(params), e
       end
 

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -50,6 +50,8 @@ module SimpleFormsApi
         else
           submit_form_to_central_mail
         end
+      rescue Prawn::Errors::IncompatibleStringEncoding
+        raise
       rescue => e
         raise Exceptions::ScrubbedUploadsSubmitError.new(params), e
       end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -51,10 +51,8 @@ module SimpleFormsApi
           submit_form_to_central_mail
         end
       rescue Prawn::Errors::IncompatibleStringEncoding
-        byebug
         raise
       rescue => e
-        byebug
         raise Exceptions::ScrubbedUploadsSubmitError.new(params), e
       end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -240,6 +240,8 @@ module SimpleFormsApi
       stamped_size = File.size(template_path)
 
       raise StandardError, 'The PDF remained unchanged upon stamping.' unless stamped_size > orig_size
+    rescue Prawn::Errors::IncompatibleStringEncoding
+      raise
     rescue => e
       raise StandardError, "An error occurred while verifying stamp: #{e}"
     end

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_with_accented_chars_21_0966.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_with_accented_chars_21_0966.json
@@ -1,0 +1,49 @@
+{
+  "form_number": "21-0966",
+  "third_party_preparer_full_name": {
+    "first": "Preparer",
+    "middle": "V.",
+    "last": "Party, III"
+  },
+  "third_party_preparer_role": "other",
+  "other_third_party_preparer_role": "Secret agent",
+  "preparer_identification": "THIRD_PARTY_SURVIVING_DEPENDENT",
+  "surviving_dependent_full_name": {
+    "first": "I",
+    "middle": "Will",
+    "last": "Survive"
+  },
+  "surviving_dependent_date_of_birth": "1995-06-24",
+  "surviving_dependent_phone": "1234567890",
+  "surviving_dependent_international_phone": "2345678901",
+  "surviving_dependent_email": "survivor@dependent.com",
+  "surviving_dependent_mailing_address": {
+    "street": "123 Fake St.",
+    "street2": "Apt. 2",
+    "city": "Fakesville",
+    "country": "USA",
+    "state": "GA",
+    "postal_code": "12345"
+  },
+  "surviving_dependent_id": {
+    "ssn": "554565676",
+    "va_file_number": "12345678"
+  },
+  "veteran_full_name": {
+    "first": "Châu",
+    "middle": "m",
+    "last": "Nguyễn"
+  },
+  "veteran_date_of_birth": "1990-03-12",
+  "veteran_id": {
+    "ssn": "246813579"
+  },
+  "relationship_to_veteran": {
+    "relationship_to_veteran": "other"
+  },
+  "benefit_selection": {
+    "survivor": true
+  },
+  "statement_of_truth_signature": "José m Ramírez",
+  "statement_of_truth_certified": true
+}

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_with_non_latin_chars_21_0966.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_with_non_latin_chars_21_0966.json
@@ -1,0 +1,49 @@
+{
+  "form_number": "21-0966",
+  "third_party_preparer_full_name": {
+    "first": "Preparer",
+    "middle": "V.",
+    "last": "Party, III"
+  },
+  "third_party_preparer_role": "other",
+  "other_third_party_preparer_role": "Secret agent",
+  "preparer_identification": "THIRD_PARTY_SURVIVING_DEPENDENT",
+  "surviving_dependent_full_name": {
+    "first": "I",
+    "middle": "Will",
+    "last": "Survive"
+  },
+  "surviving_dependent_date_of_birth": "1995-06-24",
+  "surviving_dependent_phone": "1234567890",
+  "surviving_dependent_international_phone": "2345678901",
+  "surviving_dependent_email": "survivor@dependent.com",
+  "surviving_dependent_mailing_address": {
+    "street": "123 Fake St.",
+    "street2": "Apt. 2",
+    "city": "Fakesville",
+    "country": "USA",
+    "state": "GA",
+    "postal_code": "12345"
+  },
+  "surviving_dependent_id": {
+    "ssn": "554565676",
+    "va_file_number": "12345678"
+  },
+  "veteran_full_name": {
+    "first": "Châu",
+    "middle": "m",
+    "last": "Nguyễn"
+  },
+  "veteran_date_of_birth": "1990-03-12",
+  "veteran_id": {
+    "ssn": "246813579"
+  },
+  "relationship_to_veteran": {
+    "relationship_to_veteran": "other"
+  },
+  "benefit_selection": {
+    "survivor": true
+  },
+  "statement_of_truth_signature": "Châu m Nguyễn",
+  "statement_of_truth_certified": true
+}

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -347,14 +347,15 @@ RSpec.describe 'Forms uploader', type: :request do
 
     describe 'transliterating fields' do
       context 'transliteration fails' do
-        it 'raises a Prawn error' do
+        it 'responds with an error' do
           fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
                                          'form_with_non_latin_chars_21_0966.json')
           data = JSON.parse(fixture_path.read)
 
-          expect do
-            post '/simple_forms_api/v1/simple_forms', params: data
-          end.to raise_error Prawn::Errors::IncompatibleStringEncoding
+          post '/simple_forms_api/v1/simple_forms', params: data
+
+          expect(response).to have_http_status(:error)
+          expect(response.body).to include('not compatible with the Windows-1252 character set')
         end
       end
     end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -344,6 +344,20 @@ RSpec.describe 'Forms uploader', type: :request do
         end
       end
     end
+
+    describe 'transliterating fields' do
+      context 'transliteration fails' do
+        it 'raises a Prawn error' do
+          fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
+                                         'form_with_non_latin_chars_21_0966.json')
+          data = JSON.parse(fixture_path.read)
+
+          expect do
+            post '/simple_forms_api/v1/simple_forms', params: data
+          end.to raise_error Prawn::Errors::IncompatibleStringEncoding
+        end
+      end
+    end
   end
 
   describe '#submit_supporting_documents' do

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -346,6 +346,22 @@ RSpec.describe 'Forms uploader', type: :request do
     end
 
     describe 'transliterating fields' do
+      context 'transliteration succeeds' do
+        it 'responds with ok' do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
+                                             'form_with_accented_chars_21_0966.json')
+              data = JSON.parse(fixture_path.read)
+
+              post '/simple_forms_api/v1/simple_forms', params: data
+
+              expect(response).to have_http_status(:ok)
+            end
+          end
+        end
+      end
+
       context 'transliteration fails' do
         it 'responds with an error' do
           fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',


### PR DESCRIPTION
## Summary
This PR makes the simple forms controller specify if an error arises because of untransliteratable characters.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/864

## Testing done

New test written but it's mysteriously failing.

## Screenshots
Instead of the scrubbed error, this is what we send to the FE:
<img width="1090" alt="Screenshot 2024-04-03 at 10 16 12 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/5c4b3f75-fdc6-4981-a3b9-b42a8a07494f">
