### PR TITLE
VAOS Added Safe Navigation When Checking Location Value

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -263,7 +263,9 @@ module VAOS
       def merge_facilities(appointments)
         appointments.each do |appt|
           appt[:location] = get_facility_memoized(appt[:location_id]) unless appt[:location_id].nil?
-          log_appt_id_location_name(appt) if cerner?(appt) && appt[:location].values.any? { |v| v.include?('COL OR 1') }
+          log_appt_id_location_name(appt) if cerner?(appt) && appt[:location]&.values&.any? do |v|
+                                               v.include?('COL OR 1')
+                                             end
         end
       end
 

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -263,9 +263,9 @@ module VAOS
       def merge_facilities(appointments)
         appointments.each do |appt|
           appt[:location] = get_facility_memoized(appt[:location_id]) unless appt[:location_id].nil?
-          log_appt_id_location_name(appt) if cerner?(appt) && appt[:location]&.values&.any? do |v|
-                                               v.include?('COL OR 1')
-                                             end
+          if cerner?(appt) && appt[:location]&.values&.any? { |v| v.include?('COL OR 1') }
+            log_appt_id_location_name(appt)
+          end
         end
       end
 

--- a/modules/vaos/spec/controllers/v2/appointments_controller_spec.rb
+++ b/modules/vaos/spec/controllers/v2/appointments_controller_spec.rb
@@ -89,4 +89,15 @@ RSpec.describe VAOS::V2::AppointmentsController, type: :request do
       end
     end
   end
+
+  describe '#merge_facilities' do
+    context 'with a cerner facility and location with no values' do
+      it 'does not log and does not throw an error' do
+        allow_any_instance_of(VAOS::V2::AppointmentsController).to receive(:get_facility_memoized).and_return(nil)
+        appointments = [{ identifier: [{ system: 'https://cerner/system' }], location_id: '123' }]
+        expect(Rails.logger).not_to receive(:info)
+        subject.send(:merge_facilities, appointments)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This fixes the `NoMethodError: undefined method `any?' for nil:NilClass` errors seen in Staging when logging Cerner information. It adds safe navigation to the **VAOS::V2::Appointments#merge_facilities** method.

## Related issue(s)

- [PR-16164](https://github.com/department-of-veterans-affairs/vets-api/pull/16164)

## Testing done

- Added RSpec test for the error condition

