### PR TITLE
Fix for implementing travel pay client number header

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -32,7 +32,7 @@ module TravelPay
       response = connection(server_url: btsss_url).post('api/v1/Auth/access-token') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
-        req.headers['BTSSS-API-Client-Number'] = client_number
+        req.headers['BTSSS-API-Client-Number'] = client_number.to_s
         req.body = { authJwt: vagov_token }
       end
       response.body['access_token']


### PR DESCRIPTION
Found issue while working on https://github.com/department-of-veterans-affairs/va.gov-team/issues/73503 - looks like the `BTSSS-API-Client-Number` header is an `integer` that needs to be converted to a `string`. Sending this request without converting the header to a `string` caused some Faraday errors.