### PR TITLE
Improve EP Merge logging and claim status compatibility

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -15,7 +15,14 @@ module Form526ClaimFastTrackingConcern
 
   EP_MERGE_BASE_CODES = %w[010 110 020 030 040].freeze
   EP_MERGE_SPECIAL_ISSUE = 'EMP'
-  OPEN_STATUSES = ['CLAIM RECEIVED', 'UNDER REVIEW', 'GATHERING OF EVIDENCE', 'REVIEW OF EVIDENCE'].freeze
+  OPEN_STATUSES = [
+    'CLAIM RECEIVED',
+    'UNDER REVIEW',
+    'GATHERING OF EVIDENCE',
+    'REVIEW OF EVIDENCE',
+    'CLAIM_RECEIVED',
+    'INITIAL_REVIEW'
+  ].freeze
 
   def send_rrd_alert_email(subject, message, error = nil, to = Settings.rrd.alerts.recipients)
     RrdAlertMailer.build(self, subject, message, error, to).deliver_now
@@ -116,14 +123,17 @@ module Form526ClaimFastTrackingConcern
     pending_eps = open_claims.select do |claim|
       EP_MERGE_BASE_CODES.include?(claim['base_end_product_code']) && OPEN_STATUSES.include?(claim['status'])
     end
-    StatsD.distribution("#{EP_MERGE_STATSD_KEY_PREFIX}.pending_ep_count", pending_eps.count)
+    Rails.logger.info('EP Merge total open EPs', id:, count: pending_eps.count)
     return unless pending_eps.count == 1
 
     date = Date.strptime(pending_eps.first['date'], '%m/%d/%Y')
     days_ago = (Time.zone.today - date).round
-    StatsD.distribution("#{EP_MERGE_STATSD_KEY_PREFIX}.pending_ep_age", days_ago)
-
-    if Flipper.enabled?(:disability_526_ep_merge_api, User.find(user_uuid))
+    feature_enabled = Flipper.enabled?(:disability_526_ep_merge_api, User.find(user_uuid))
+    Rails.logger.info(
+      'EP Merge open EP eligibility',
+      { id:, feature_enabled:, pending_ep_age: days_ago, pending_ep_status: pending_eps.first['status'] }
+    )
+    if feature_enabled
       save_metadata(ep_merge_pending_claim_id: pending_eps.first['id'])
       add_ep_merge_special_issue!
     end


### PR DESCRIPTION
## Summary
*This work is behind a feature toggle (flipper): YES* (`disability_526_ep_merge_api`)
This PR improves two aspects of EP400 Merging:
- Add Lighthouse-compatible open claim statuses that are equivalent to the existing EVSS ones
- Switch from StatsD to Rails.logger for more precise data visibility on DataDog

I am part of the Claims Fast-Tracking crew's Employee Experience team. We work closely with the Disability Experience team which owns this code.

## Related issue(s)
- [Slack conversation](https://dsva.slack.com/archives/C01BVF2A3V0/p1712081164187339) about Lighthouse claim statuses
- Previous work in #14144 to tweak StatsD data format

## Testing done

- [ ] *New code is covered by unit tests*
- Old behavior: data logged to `StatsD.distribution`
- New behavior: data logged to `Rails.logger.info`

## What areas of the site does it impact?
* No impact on users

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)