### PR TITLE
Specify lgy_sahsha in grant manager headers and endpoint

### DIFF
--- a/lib/lgy/service.rb
+++ b/lib/lgy/service.rb
@@ -182,7 +182,9 @@ module LGY
 
     def sahsha_request_headers
       {
-        Authorization: "api-key { \"appId\":\"#{Settings.lgy_sahsha.app_id}\", \"apiKey\": \"#{Settings.lgy_sahsha.api_key}\"}"
+        Authorization: "api-key { \"appId\":\"#{Settings.lgy_sahsha.app_id}\", \"apiKey\": \"#{
+          Settings.lgy_sahsha.api_key
+        }\"}"
       }
     end
 

--- a/lib/lgy/service.rb
+++ b/lib/lgy/service.rb
@@ -167,7 +167,7 @@ module LGY
           :post,
           "#{grant_manager_end_point}/application/createGrantApplication",
           payload.to_json,
-          request_headers
+          sahsha_request_headers
         )
       end
     rescue Common::Client::Errors::ClientError => e
@@ -177,6 +177,12 @@ module LGY
     def request_headers
       {
         Authorization: "api-key { \"appId\":\"#{Settings.lgy.app_id}\", \"apiKey\": \"#{Settings.lgy.api_key}\"}"
+      }
+    end
+
+    def sahsha_request_headers
+      {
+        Authorization: "api-key { \"appId\":\"#{Settings.lgy_sahsha.app_id}\", \"apiKey\": \"#{Settings.lgy_sahsha.api_key}\"}"
       }
     end
 
@@ -193,7 +199,7 @@ module LGY
     end
 
     def grant_manager_end_point
-      "#{Settings.lgy.base_url}/grant-manager/api/grants"
+      "#{Settings.lgy_sahsha.base_url}/grant-manager/api/grants"
     end
   end
 end


### PR DESCRIPTION
## Summary
This PR more properly distinguishes between `lgy` and `lgy_sahsha`, which should have two different app ids and api keys.
