### PR TITLE
Dbx 77011/add polling for backup submitted 526s

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -611,6 +611,7 @@ app/sidekiq/feature_cleaner_job.rb @department-of-veterans-affairs/va-api-engine
 app/sidekiq/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form1095 @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_confirmation_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/form526_status_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_failed_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/gi_bill_feedback_submission_job.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1251,6 +1252,7 @@ spec/sidekiq/facilities @department-of-veterans-affairs/vfs-facilities-frontend 
 spec/sidekiq/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form1095 @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form526_confirmation_email_job_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/form526_status_polling_job_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form5655/ @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/gi_bill_feedback_submission_job_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -53,7 +53,7 @@ class Form526Submission < ApplicationRecord
     # - a successfully delivered submission has failed 3rd party validations on backup path
     # - requires remediation
     event :reject_from_backup do
-      transitions to: :failed_backup_delivery
+      transitions to: :rejected_by_backup
     end
 
     # - Submission has entered a manual remediation flow, e.g. failsafe, paper submission
@@ -128,6 +128,11 @@ class Form526Submission < ApplicationRecord
   belongs_to :user_account, dependent: nil, optional: true
 
   validates(:auth_headers_json, presence: true)
+
+  scope :pending_backup_submissions, lambda {
+    where(aasm_state: 'delivered_to_backup')
+      .where.not(backup_submitted_claim_id: nil)
+  }
 
   def log_status_change
     log_hash = {

--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'benefits_intake_service/service'
+
+class Form526StatusPollingJob
+  include Sidekiq::Job
+  sidekiq_options retry: false
+
+  STATS_KEY = 'api.benefits_intake.submission_status'
+  MAX_BATCH_SIZE = 1000
+  attr_reader :max_batch_size
+
+  def initialize(max_batch_size: MAX_BATCH_SIZE)
+    @max_batch_size = max_batch_size
+    @total_handled = 0
+  end
+
+  def perform
+    Rails.logger.info('Beginning Form 526 Intake Status polling', total_submissions: submissions.count)
+    submissions.each_slice(max_batch_size) do |batch|
+      batch_ids = batch.pluck(:backup_submitted_claim_id).flatten
+      response = api_to_poll.get_bulk_status_of_uploads(batch_ids)
+      handle_response(response)
+    end
+    Rails.logger.info('Form 526 Intake Status polling complete', total_handled: @total_handled)
+  rescue => e
+    Rails.logger.error('Error processing 526 Intake Status batch', class: self.class.name, message: e.message)
+  end
+
+  private
+
+  def api_to_poll
+    @api_to_poll ||= BenefitsIntakeService::Service.new
+  end
+
+  def submissions
+    @submissions ||= Form526Submission.pending_backup_submissions
+  end
+
+  def handle_response(response)
+    response.body['data']&.each do |submission|
+      status = submission.dig('attributes', 'status')
+      submission_guid = submission['id']
+
+      if %w[error expired].include? status
+        log_result('failure')
+        handle_failure(submission_guid)
+      elsif %w[vbms success].include? status
+        log_result('success')
+        handle_success(submission_guid)
+      else
+        Rails.logger.warn(
+          'Unknown status returned from Benefits Intake API for 526 submission',
+          status:,
+          submission_id: submission.id
+        )
+      end
+      @total_handled += 1
+    end
+  end
+
+  def handle_failure(submission_guid)
+    form_submission = submissions.find_by(backup_submitted_claim_id: submission_guid)
+    form_submission.reject_from_backup!
+  end
+
+  def handle_success(submission_guid)
+    form_submission = submissions.find_by(backup_submitted_claim_id: submission_guid)
+    form_submission.finalize_success!
+  end
+
+  def log_result(result)
+    StatsD.increment("#{STATS_KEY}.526.#{result}")
+    StatsD.increment("#{STATS_KEY}.all_forms.#{result}")
+  end
+end

--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -39,6 +39,8 @@ PERIODIC_JOBS = lambda { |mgr|
   mgr.register('0 0 * * *', 'Crm::TopicsDataJob')
   # Update static data cache
   mgr.register('0 0 * * *', 'BenefitsIntakeStatusJob')
+  # Update static data cache for form 526
+  mgr.register('0 3 * * *', 'Form526StatusPollingJob')
   # Updates status of FormSubmissions per call to Lighthouse Benefits Intake API
 
   # mgr.register('0 0 * * *', 'VRE::CreateCh31SubmissionsReportJob')

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -17,6 +17,13 @@ FactoryBot.define do
     end
   end
 
+  trait :backup_path do
+    lighthouse_format_guid = "#{SecureRandom.hex(8)}-#{SecureRandom.hex(4)}-" \
+                             "#{SecureRandom.hex(4)}-#{SecureRandom.hex(4)}-" \
+                             "#{SecureRandom.hex(12)}"
+    backup_submitted_claim_id { lighthouse_format_guid }
+  end
+
   trait :with_everything do
     form_json do
       File.read("#{submissions_path}/with_everything.json")

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -23,6 +23,46 @@ RSpec.describe Form526Submission do
     File.read('spec/support/disability_compensation_form/submissions/only_526.json')
   end
 
+  describe 'scopes' do
+    describe 'pending_backup_submissions' do
+      let!(:new_submission) { create(:form526_submission, aasm_state: 'unprocessed') }
+      let!(:failed_primary_submission) do
+        create(:form526_submission, aasm_state: 'failed_primary_delivery')
+      end
+      let!(:rejected_primary_submission) do
+        create(:form526_submission, aasm_state: 'rejected_by_primary')
+      end
+      let!(:complete_primary_submission) do
+        create(:form526_submission, aasm_state: 'delivered_to_primary')
+      end
+      let!(:failed_backup_submission) do
+        create(:form526_submission, aasm_state: 'failed_backup_delivery')
+      end
+      let!(:rejected_backup_submission) do
+        create(:form526_submission, aasm_state: 'rejected_by_backup')
+      end
+      let!(:in_remediation_submission) do
+        create(:form526_submission, :backup_path, aasm_state: 'in_remediation')
+      end
+      let!(:complete_submission) do
+        create(:form526_submission, :backup_path, aasm_state: 'finalized_as_successful')
+      end
+      let!(:delivered_backup_submission_a) do
+        create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+      end
+      let!(:delivered_backup_submission_b) do
+        create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+      end
+
+      it 'returns records submitted to the backup path but lacking a decisive state' do
+        expect(Form526Submission.pending_backup_submissions).to contain_exactly(
+          delivered_backup_submission_a,
+          delivered_backup_submission_b
+        )
+      end
+    end
+  end
+
   shared_examples '#start_evss_submission' do
     context 'when it is all claims' do
       it 'queues an all claims job' do
@@ -48,7 +88,7 @@ RSpec.describe Form526Submission do
       expect(submission).to transition_from(:failed_primary_delivery)
         .to(:failed_backup_delivery).on_event(:fail_backup_delivery)
       expect(submission).to transition_from(:rejected_by_primary)
-        .to(:failed_backup_delivery).on_event(:reject_from_backup)
+        .to(:rejected_by_backup).on_event(:reject_from_backup)
       expect(submission).to transition_from(:unprocessed)
         .to(:rejected_by_primary).on_event(:reject_from_primary)
       expect(submission).to transition_from(:unprocessed)
@@ -56,7 +96,7 @@ RSpec.describe Form526Submission do
       expect(submission).to transition_from(:unprocessed)
         .to(:failed_backup_delivery).on_event(:fail_backup_delivery)
       expect(submission).to transition_from(:unprocessed)
-        .to(:failed_backup_delivery).on_event(:reject_from_backup)
+        .to(:rejected_by_backup).on_event(:reject_from_backup)
       expect(submission).to transition_from(:unprocessed)
         .to(:finalized_as_successful).on_event(:finalize_success)
       expect(submission).to transition_from(:unprocessed)

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Form526StatusPollingJob, type: :job do
+  describe '#perform' do
+    let!(:new_submission) { create(:form526_submission, aasm_state: 'unprocessed') }
+    let!(:failed_primary_submission) do
+      create(:form526_submission, aasm_state: 'failed_primary_delivery')
+    end
+    let!(:rejected_primary_submission) do
+      create(:form526_submission, aasm_state: 'rejected_by_primary')
+    end
+    let!(:complete_primary_submission) do
+      create(:form526_submission, aasm_state: 'delivered_to_primary')
+    end
+    let!(:failed_backup_submission) do
+      create(:form526_submission, aasm_state: 'failed_backup_delivery')
+    end
+    let!(:rejected_backup_submission) do
+      create(:form526_submission, aasm_state: 'rejected_by_backup')
+    end
+    let!(:in_remediation_submission) do
+      create(:form526_submission, :backup_path, aasm_state: 'in_remediation')
+    end
+    let!(:complete_submission) do
+      create(:form526_submission, :backup_path, aasm_state: 'finalized_as_successful')
+    end
+    let!(:delivered_backup_submission_a) do
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+    end
+    let!(:delivered_backup_submission_b) do
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+    end
+    let!(:delivered_backup_submission_c) do
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+    end
+    let!(:delivered_backup_submission_d) do
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+    end
+
+    describe 'submission to the bulk status report endpoint' do
+      it 'submits only pending form submissions' do
+        pending_claim_ids = Form526Submission.pending_backup_submissions.pluck(:backup_submitted_claim_id)
+        response = double
+        allow(response).to receive(:body).and_return({ 'data' => [] })
+
+        expect(pending_claim_ids).to contain_exactly(
+          delivered_backup_submission_a.backup_submitted_claim_id,
+          delivered_backup_submission_b.backup_submitted_claim_id,
+          delivered_backup_submission_c.backup_submitted_claim_id,
+          delivered_backup_submission_d.backup_submitted_claim_id
+        )
+
+        expect_any_instance_of(BenefitsIntakeService::Service)
+          .to receive(:get_bulk_status_of_uploads)
+          .with(pending_claim_ids)
+          .and_return(response)
+
+        Form526StatusPollingJob.new.perform
+      end
+    end
+
+    describe 'when batch size is greater than max batch size' do
+      it 'successfully submits batch intake via batch' do
+        response = double
+        service = double(get_bulk_status_of_uploads: response)
+        allow(response).to receive(:body).and_return({ 'data' => [] })
+        allow(BenefitsIntakeService::Service).to receive(:new).and_return(service)
+
+        Form526StatusPollingJob.new(max_batch_size: 3).perform
+
+        expect(service).to have_received(:get_bulk_status_of_uploads).twice
+      end
+    end
+
+    describe 'when bulk status update fails' do
+      it 'logs the error' do
+        service = double
+        message = 'error'
+        allow(BenefitsIntakeService::Service).to receive(:new).and_return(service)
+        allow(service).to receive(:get_bulk_status_of_uploads).and_raise(message)
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:error)
+
+        Form526StatusPollingJob.new.perform
+
+        expect(Rails.logger).to have_received(:error).with('Error processing 526 Intake Status batch',
+                                                           class: 'Form526StatusPollingJob', message:)
+        expect(Rails.logger).not_to have_received(:info).with('Form 526 Intake Status polling complete')
+      end
+    end
+
+    describe 'updating the form 526s local submission state' do
+      let(:api_response) do
+        {
+          'data' => [
+            {
+              'id' => delivered_backup_submission_a.backup_submitted_claim_id,
+              'attributes' => {
+                'guid' => delivered_backup_submission_a.backup_submitted_claim_id,
+                'status' => 'vbms'
+              }
+            },
+            {
+              'id' => delivered_backup_submission_b.backup_submitted_claim_id,
+              'attributes' => {
+                'guid' => delivered_backup_submission_b.backup_submitted_claim_id,
+                'status' => 'success'
+              }
+            },
+            {
+              'id' => delivered_backup_submission_c.backup_submitted_claim_id,
+              'attributes' => {
+                'guid' => delivered_backup_submission_c.backup_submitted_claim_id,
+                'status' => 'error'
+              }
+            },
+            {
+              'id' => delivered_backup_submission_d.backup_submitted_claim_id,
+              'attributes' => {
+                'guid' => delivered_backup_submission_d.backup_submitted_claim_id,
+                'status' => 'expired'
+              }
+            }
+          ]
+        }
+      end
+
+      it 'updates local state to reflect the returned statuses' do
+        pending_claim_ids = Form526Submission.pending_backup_submissions.pluck(:backup_submitted_claim_id)
+        response = double
+        allow(response).to receive(:body).and_return(api_response)
+        allow_any_instance_of(BenefitsIntakeService::Service)
+          .to receive(:get_bulk_status_of_uploads)
+          .with(pending_claim_ids)
+          .and_return(response)
+
+        Form526StatusPollingJob.new.perform
+
+        expect(delivered_backup_submission_a.reload.aasm_state).to eq 'finalized_as_successful'
+        expect(delivered_backup_submission_b.reload.aasm_state).to eq 'finalized_as_successful'
+        expect(delivered_backup_submission_c.reload.aasm_state).to eq 'rejected_by_backup'
+        expect(delivered_backup_submission_d.reload.aasm_state).to eq 'rejected_by_backup'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add a sidekiq job to poll the lighthouse benefits intake API for the status of form 526 submissions
- leverages the new  form 526 state to record results from the API
- adds a scope to the form 526 model for code readability
- schedules the job

## Related issue(s)

- [ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/77011)

## Testing done

- [ x ] *New code is covered by unit tests*
- previously we were manually polling these submissions and recording them in the state machine. This was relatively new, before that we simply weren't looking to see if things had failed.
- This job can be manually run in a production console safely, as data will only change in the way it's supposed to.

## What areas of the site does it impact?
Form 526 backup submission

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

