### PR TITLE
Ensure logging is disabled on facilities retrieval error

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -263,7 +263,9 @@ module VAOS
       def merge_facilities(appointments)
         appointments.each do |appt|
           appt[:location] = get_facility_memoized(appt[:location_id]) unless appt[:location_id].nil?
-          if cerner?(appt) && appt[:location]&.values&.any? { |v| v.include?('COL OR 1') }
+          if cerner?(appt) && appt[:location].is_a?(Hash) && appt[:location]&.values&.any? do |v|
+               v.include?('COL OR 1')
+             end
             log_appt_id_location_name(appt)
           end
         end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We are not handling facilities lookup errors gracefully for logging purposes leading to an exception. This changes ensures we disable logging for these error cases. More details are in the linked issue.
- Appointments team

## Related issue(s)

- Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/80022

## Testing done

- [x] *New code is covered by unit tests*
- A new test to ensure no logging is detected on facilities lookup error is added to ensure we handle this case gracefully.

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
