### PR TITLE
Enabling myvahealth Terms of Use enforcement

### DIFF
--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -25,7 +25,7 @@ module SAML
     WEB_CLIENT_ID = 'web'
     MOBILE_CLIENT_ID = 'mobile'
     UNIFIED_SIGN_IN_CLIENTS = %w[vaweb mhv myvahealth ebenefits vamobile vaoccmobile].freeze
-    TERMS_OF_USE_ENABLED_CLIENTS = %w[].freeze
+    TERMS_OF_USE_ENABLED_CLIENTS = %w[myvahealth].freeze
     TERMS_OF_USE_ENABLED_CLIENTS_LOWERS = %w[vaweb mhv myvahealth].freeze
     TERMS_OF_USE_DECLINED_PATH = '/terms-of-use/declined'
 


### PR DESCRIPTION
## Summary

- This PR turns on myvahealth as an enforced terms of use client on production