### PR TITLE
Rreate new org, rep and org_reps tables

### DIFF
--- a/db/migrate/20240404182018_create_new_org_and_rep_tables.rb
+++ b/db/migrate/20240404182018_create_new_org_and_rep_tables.rb
@@ -1,0 +1,85 @@
+class CreateNewOrgAndRepTables < ActiveRecord::Migration[7.1]
+  # rubocop:disable Metrics/MethodLength
+  def change
+    create_table :accredited_representatives, id: false do |t|
+      t.string :registration_number, null: false
+      t.string :poa_code
+      t.string :types, array: true
+      t.string :first_name
+      t.string :middle_initial
+      t.string :last_name
+      t.string :full_name
+      t.string :email
+      t.string :phone
+      t.string :address_type
+      t.string :address_line1
+      t.string :address_line2
+      t.string :address_line3
+      t.string :city
+      t.string :country_code_iso3
+      t.string :country_name
+      t.string :county_name
+      t.string :county_code
+      t.string :international_postal_code
+      t.string :province
+      t.string :state_code
+      t.string :zip_code
+      t.string :zip_suffix
+      t.jsonb :raw_address
+      t.float :lat
+      t.float :long
+      t.geography :location, limit: { srid: 4326, type: 'st_point', geographic: true }
+      t.timestamps
+    end
+    # rubocop:enable Metrics/MethodLength
+    safety_assured do
+      execute 'ALTER TABLE accredited_representatives ADD PRIMARY KEY (registration_number);' # rubocop:disable Rails/ReversibleMigration
+    end
+    add_index :accredited_representatives, :full_name
+    add_index :accredited_representatives, :location, using: :gist
+    add_index :accredited_representatives, :registration_number, unique: true
+
+    create_table :accredited_organizations, id: false do |t|
+      t.string :poa_code, limit: 3, null: false
+      t.string :name
+      t.string :phone
+      t.string :state, limit: 2
+      t.string :address_type
+      t.string :address_line1
+      t.string :address_line2
+      t.string :address_line3
+      t.string :city
+      t.string :country_code_iso3
+      t.string :country_name
+      t.string :county_name
+      t.string :county_code
+      t.string :international_postal_code
+      t.string :province
+      t.string :state_code
+      t.string :zip_code
+      t.string :zip_suffix
+      t.jsonb :raw_address
+      t.float :lat
+      t.float :long
+      t.geography :location, limit: { srid: 4326, type: 'st_point', geographic: true }
+      t.timestamps
+    end
+    safety_assured do
+      execute 'ALTER TABLE accredited_organizations ADD PRIMARY KEY (poa_code);' # rubocop:disable Rails/ReversibleMigration
+    end
+    add_index :accredited_organizations, :location, using: :gist
+    add_index :accredited_organizations, :name
+    add_index :accredited_organizations, :poa_code, unique: true
+
+    create_table :accredited_organization_accredited_representatives, id: false do |t|
+      t.string :accredited_representative_registration_number
+      t.string :accredited_organization_poa_code
+    end
+    add_index :accredited_organization_accredited_representatives,
+              %i[accredited_representative_registration_number accredited_organization_poa_code], unique: true, name: 'index_organization_representatives_on_rep_and_org' # rubocop:disable Layout/LineLength
+    add_foreign_key :accredited_organization_accredited_representatives, :accredited_representatives,
+                    column: :accredited_representative_registration_number, primary_key: :registration_number, validate: false
+    add_foreign_key :accredited_organization_accredited_representatives, :accredited_organizations,
+                    column: :accredited_organization_poa_code, primary_key: :poa_code, validate: false
+  end
+end

--- a/db/migrate/20240405141726_validate_org_rep_foreign_keys.rb
+++ b/db/migrate/20240405141726_validate_org_rep_foreign_keys.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ValidateOrgRepForeignKeys < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :accredited_organization_accredited_representatives, :accredited_representatives
+    validate_foreign_key :accredited_organization_accredited_representatives, :accredited_organizations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_05_141726) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -51,6 +51,75 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
     t.index ["logingov_uuid"], name: "index_accounts_on_logingov_uuid", unique: true
     t.index ["sec_id"], name: "index_accounts_on_sec_id"
     t.index ["uuid"], name: "index_accounts_on_uuid", unique: true
+  end
+
+  create_table "accredited_organization_accredited_representatives", id: false, force: :cascade do |t|
+    t.string "accredited_representative_registration_number"
+    t.string "accredited_organization_poa_code"
+    t.index ["accredited_representative_registration_number", "accredited_organization_poa_code"], name: "index_organization_representatives_on_rep_and_org", unique: true
+  end
+
+  create_table "accredited_organizations", primary_key: "poa_code", id: { type: :string, limit: 3 }, force: :cascade do |t|
+    t.string "name"
+    t.string "phone"
+    t.string "state", limit: 2
+    t.string "address_type"
+    t.string "address_line1"
+    t.string "address_line2"
+    t.string "address_line3"
+    t.string "city"
+    t.string "country_code_iso3"
+    t.string "country_name"
+    t.string "county_name"
+    t.string "county_code"
+    t.string "international_postal_code"
+    t.string "province"
+    t.string "state_code"
+    t.string "zip_code"
+    t.string "zip_suffix"
+    t.jsonb "raw_address"
+    t.float "lat"
+    t.float "long"
+    t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location"], name: "index_accredited_organizations_on_location", using: :gist
+    t.index ["name"], name: "index_accredited_organizations_on_name"
+    t.index ["poa_code"], name: "index_accredited_organizations_on_poa_code", unique: true
+  end
+
+  create_table "accredited_representatives", primary_key: "registration_number", id: :string, force: :cascade do |t|
+    t.string "poa_code"
+    t.string "types", array: true
+    t.string "first_name"
+    t.string "middle_initial"
+    t.string "last_name"
+    t.string "full_name"
+    t.string "email"
+    t.string "phone"
+    t.string "address_type"
+    t.string "address_line1"
+    t.string "address_line2"
+    t.string "address_line3"
+    t.string "city"
+    t.string "country_code_iso3"
+    t.string "country_name"
+    t.string "county_name"
+    t.string "county_code"
+    t.string "international_postal_code"
+    t.string "province"
+    t.string "state_code"
+    t.string "zip_code"
+    t.string "zip_suffix"
+    t.jsonb "raw_address"
+    t.float "lat"
+    t.float "long"
+    t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["full_name"], name: "index_accredited_representatives_on_full_name"
+    t.index ["location"], name: "index_accredited_representatives_on_location", using: :gist
+    t.index ["registration_number"], name: "index_accredited_representatives_on_registration_number", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -1422,6 +1491,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_141429) do
   end
 
   add_foreign_key "account_login_stats", "accounts"
+  add_foreign_key "accredited_organization_accredited_representatives", "accredited_organizations", column: "accredited_organization_poa_code", primary_key: "poa_code"
+  add_foreign_key "accredited_organization_accredited_representatives", "accredited_representatives", column: "accredited_representative_registration_number", primary_key: "registration_number"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "appeal_submissions", "user_accounts"


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/78731

## Summary
This PR creates the following new tables:
- accredited_organizations
- accredited_representatives
- accredited_organization_accredited_representatives

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78731

## Testing done
- NA

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
The database
The schema.rb file

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
