### PR TITLE
Raise if ITF does not respond properly

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -25,7 +25,7 @@ module SimpleFormsApi
         confirmation_number = response.dig('data', 'id')
         expiration_date = response.dig('data', 'attributes', 'expirationDate')
 
-        raise unless confirmation_number && expiration_date
+        raise response unless confirmation_number && expiration_date
       end
 
       [confirmation_number, expiration_date]

--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -24,6 +24,8 @@ module SimpleFormsApi
         response = benefits_claims_lighthouse_service.create_intent_to_file(type, ssn)
         confirmation_number = response.dig('data', 'id')
         expiration_date = response.dig('data', 'attributes', 'expirationDate')
+
+        raise unless confirmation_number && expiration_date
       end
 
       [confirmation_number, expiration_date]

--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -25,7 +25,7 @@ module SimpleFormsApi
         confirmation_number = response.dig('data', 'id')
         expiration_date = response.dig('data', 'attributes', 'expirationDate')
 
-        raise response unless confirmation_number && expiration_date
+        raise StandardError, response unless confirmation_number && expiration_date
       end
 
       [confirmation_number, expiration_date]

--- a/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
+++ b/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
@@ -105,11 +105,11 @@ describe SimpleFormsApi::IntentToFile do
       allow_any_instance_of(BenefitsClaims::Service).to receive(:create_intent_to_file).with(
         'compensation',
         ssn
-      ).and_return({})
+      ).and_raise(Faraday::ServerError)
 
       expect do
         intent_to_file_service.submit
-      end.to raise_error
+      end.to raise_error Faraday::ServerError
     end
   end
 end

--- a/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
+++ b/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
@@ -97,6 +97,14 @@ describe SimpleFormsApi::IntentToFile do
 
     it 'raises error' do
       icn = 'fake-icn'
+      return_value = {
+        errors: [
+          {
+            title: 'Unprocessable Entity',
+            detail: 'Invalid claimantSsn parameter'
+          }
+        ]
+      }
       intent_to_file_service = SimpleFormsApi::IntentToFile.new(icn, params)
       allow_any_instance_of(BenefitsClaims::Service).to receive(:get_intent_to_file).with('compensation')
                                                                                     .and_return(nil)
@@ -105,11 +113,11 @@ describe SimpleFormsApi::IntentToFile do
       allow_any_instance_of(BenefitsClaims::Service).to receive(:create_intent_to_file).with(
         'compensation',
         ssn
-      ).and_raise(Faraday::ServerError)
+      ).and_return(return_value)
 
       expect do
         intent_to_file_service.submit
-      end.to raise_error Faraday::ServerError
+      end.to raise_error StandardError
     end
   end
 end

--- a/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
+++ b/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
@@ -107,9 +107,9 @@ describe SimpleFormsApi::IntentToFile do
         ssn
       ).and_return({})
 
-      expect {
+      expect do
         intent_to_file_service.submit
-      }.to raise_error
+      end.to raise_error
     end
   end
 end


### PR DESCRIPTION
## Summary
This PR raises an error if we get a bad response from the ITF API. Currently, the error is swallowed and the call fails silently.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1196
