### PR TITLE
add new keys to attachment keys in anticipation of v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -290,6 +290,7 @@ app/models/rate_limited_search.rb @department-of-veterans-affairs/va-api-enginee
 app/models/saml_request_tracker.rb @department-of-veterans-affairs/octo-identity
 app/models/saved_claim.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/session.rb @department-of-veterans-affairs/octo-identity
+app/models/saved_claim/burial.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pensions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/pension.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/sign_in @department-of-veterans-affairs/octo-identity

--- a/app/models/saved_claim/burial.rb
+++ b/app/models/saved_claim/burial.rb
@@ -32,7 +32,7 @@ class SavedClaim::Burial < CentralMailClaim
   end
 
   def attachment_keys
-    %i[transportationReceipts deathCertificate].freeze
+    %i[transportationReceipts deathCertificate militarySeparationDocuments additionalEvidence].freeze
   end
 
   def email


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *NO*
- Added two new keys in anticipation of new upload keys for 530EZ V2
- Solution is adding the two new keys so that uploads can process
- VA Benefits and Claims

## Related issue(s)

- [*Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/80173)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- Complete a V2 burial claim and confirm the uploads for additional evidence and military separation documents are attached.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Burials V2

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
