### PR TITLE
Add logging around tou provisioning

### DIFF
--- a/app/controllers/v0/terms_of_use_agreements_controller.rb
+++ b/app/controllers/v0/terms_of_use_agreements_controller.rb
@@ -42,8 +42,10 @@ module V0
                                                 mpi_gcids: current_user.mpi_gcids)
       if provisioner.perform
         create_cerner_cookie
+        Rails.logger.info('[TermsOfUseAgreementsController] update_provisioning success', { icn: current_user.icn })
         render json: { provisioned: true }, status: :ok
       else
+        Rails.logger.error('[TermsOfUseAgreementsController] update_provisioning error', { icn: current_user.icn })
         render_error('Failed to provision')
       end
     rescue TermsOfUse::Errors::ProvisionerError => e

--- a/app/services/terms_of_use/provisioner.rb
+++ b/app/services/terms_of_use/provisioner.rb
@@ -24,7 +24,11 @@ module TermsOfUse
 
     def perform
       response = update_provisioning
-      raise(Errors::ProvisionerError, 'Agreement not accepted') if response[:agreement_signed].blank?
+
+      if response[:agreement_signed].blank?
+        Rails.logger.error('[TermsOfUse] [Provisioner] update_provisioning error', { icn:, response: })
+        raise(Errors::ProvisionerError, 'Agreement not accepted')
+      end
 
       ActiveModel::Type::Boolean.new.cast(response[:agreement_signed])
     rescue Common::Client::Errors::ClientError => e

--- a/spec/services/terms_of_use/provisioner_spec.rb
+++ b/spec/services/terms_of_use/provisioner_spec.rb
@@ -79,12 +79,17 @@ RSpec.describe TermsOfUse::Provisioner do
     end
 
     context 'when agreement is not signed' do
+      let(:expected_log) { '[TermsOfUse] [Provisioner] update_provisioning error' }
+      let(:service_response) { { agreement_signed: false } }
+
       before do
-        allow(service).to receive(:update_provisioning).and_return({ agreement_signed: false })
+        allow(Rails.logger).to receive(:error)
+        allow(service).to receive(:update_provisioning).and_return(service_response)
       end
 
-      it 'raises an error' do
+      it 'raises and logs an error' do
         expect { provisioner.perform }.to raise_error(TermsOfUse::Errors::ProvisionerError)
+        expect(Rails.logger).to have_received(:error).with(expected_log, { icn:, response: service_response })
       end
     end
 


### PR DESCRIPTION
## Summary

-Add more logging around ToU provisioning step

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80259

## Testing
- change [services/terms_of_use/provisioner.rb#L28](https://github.com/department-of-veterans-affairs/vets-api/blob/c7d8500391342fbbe7e92cc3442861a871c5fb79/app/services/terms_of_use/provisioner.rb#L28) to `if true`:
   ```ruby
     if true
       Rails.logger.error('[TermsOfUse] [Provisioner] update_provisioning error', { icn:, response: })
       raise(Errors::ProvisionerError, 'Agreement not accepted')
     end
   ``` 
- in rails console run:
   ```ruby
   TermsOfUse::Provisioner.new(icn: '1234567V8902', first_name: 'Test', last_name: 'User', mpi_gcids: ['test']).perform
   ```
   you should see the error log printed
   ```ruby
   2024-04-08 11:00:40.710601 E [76673:12120 provisioner.rb:29] Rails -- [TermsOfUse] [Provisioner] update_provisioning error -- { :icn => "1234567V8902", :response => { :agreement_signed => true, :opt_out => false, :cerner_provisioned => false, :bypass_eligible => true } }
   ```
## What areas of the site does it impact?
Terms of use
