### PR TITLE
DBEX: make pdf extension evaluation case insensitive

### DIFF
--- a/app/models/form_attachment.rb
+++ b/app/models/form_attachment.rb
@@ -36,7 +36,7 @@ class FormAttachment < ApplicationRecord
   private
 
   def unlock_pdf(file, file_password)
-    return file unless File.extname(file) == '.pdf'
+    return file unless File.extname(file).downcase == '.pdf'
 
     pdftk = PdfForms.new(Settings.binaries.pdftk)
     tmpf = Tempfile.new(['decrypted_form_attachment', '.pdf'])
@@ -44,7 +44,7 @@ class FormAttachment < ApplicationRecord
     begin
       pdftk.call_pdftk(file.tempfile.path, 'input_pw', file_password, 'output', tmpf.path)
     rescue PdfForms::PdftkError => e
-      file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}
+      file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}i
       password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
       log_message_to_sentry(sanitized_message, 'warn')

--- a/app/models/form_attachment.rb
+++ b/app/models/form_attachment.rb
@@ -13,7 +13,7 @@ class FormAttachment < ApplicationRecord
 
   def set_file_data!(file, file_password = nil)
     attachment_uploader = get_attachment_uploader
-    file = unlock_pdf(file, file_password) if file_password.present?
+    file = unlock_pdf(file, file_password) if File.extname(file).downcase == '.pdf' && file_password.present?
     attachment_uploader.store!(file)
     self.file_data = { filename: attachment_uploader.filename }.to_json
   rescue CarrierWave::IntegrityError => e
@@ -36,8 +36,6 @@ class FormAttachment < ApplicationRecord
   private
 
   def unlock_pdf(file, file_password)
-    return file unless File.extname(file).downcase == '.pdf'
-
     pdftk = PdfForms.new(Settings.binaries.pdftk)
     tmpf = Tempfile.new(['decrypted_form_attachment', '.pdf'])
 

--- a/spec/models/form_attachment_spec.rb
+++ b/spec/models/form_attachment_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FormAttachment do
     end
 
     describe '#unlock_pdf' do
-      let(:file_name) { 'locked_pdf_password_is_test.pdf' }
+      let(:file_name) { 'locked_pdf_password_is_test.Pdf' }
       let(:bad_password) { 'bad_pw' }
 
       context 'when provided password is incorrect' do


### PR DESCRIPTION
This PR fixes an issue where password-protected PDFs whose extensions were not downcased were uploaded to S3 without first being unlocked, thus resulting in the documents being inaccessible to downstream services.

## Summary

- This work is behind a feature toggle (flipper): ~YES~/NO
- In addition to making the pdf extension evaluation case insensitive, the RegEx utilized for sanitizing error messages has also been modified to match the extension pattern case-insensitively.
- Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- [78539](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/78539)

## Testing done

- Corresponding test file passes with extension casing change

## What areas of the site does it impact?

526EZ application document uploads and other forms that accept password-protected PDFs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
