### PR TITLE
[CST] [Backend] Added feature toggle for CST to use DataDog RUM monitoring

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -184,6 +184,10 @@ features:
     actor_type: user
     description: When enabled, claims status tool uses the new claim details design
     enable_in_development: true
+  cst_use_dd_rum:
+    actor_type: user
+    description: When enabled, claims status tool uses DataDog's Real User Monitoring logging
+    enable_in_development: false
   coe_access:
     actor_type: user
     description: Feature gates the certificate of eligibility application


### PR DESCRIPTION
Added `cst_use_dd_rum` feature toggle to `vets-api`.

Files affected:

- `config/features.yml`

Ticket for this work: [Create feature toggle to test RUM PII masking](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79925)
Related Frontend PR: [[CST] [Frontend] Added cst_use_dd_rum feature flag for used with CST DataDog RUM logging](https://github.com/department-of-veterans-affairs/vets-website/pull/29076)