### PR TITLE
Clean up 40-0247 errors

### DIFF
--- a/modules/simple_forms_api/app/form_mappings/vba_40_0247.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_40_0247.json.erb
@@ -1,5 +1,5 @@
 {
-  "form1[0].#subform[0].TextField1[0]": "<%= form.data.dig('veteran_full_name', 'first') + ' ' + (form.data.dig('veteran_full_name', 'middle') || '') + ' ' + form.data.dig('veteran_full_name', 'last') %>",
+  "form1[0].#subform[0].TextField1[0]": "<%= form.veteran_name %>",
   "form1[0].#subform[0].TextField1[1]": "<%= form.data.dig('veteran_id', 'ssn') || form.data.dig('veteran_id', 'va_file_number') %>",
   "form1[0].#subform[0].CheckBox5[0]": "",
   "form1[0].#subform[0].CheckBox5[1]": "",
@@ -13,8 +13,8 @@
   "form1[0].#subform[0].CheckBox5[9]": "",
   "form1[0].#subform[0].Date1[0]": "<%= form.data['veteran_date_of_birth'] %>",
   "form1[0].#subform[0].Date1[1]": "<%= form.data['veteran_date_of_death'] %>",
-  "form1[0].#subform[0].TextField1[2]": "<%= form.data.dig('applicant_full_name', 'first') + ' ' + (form.data.dig('applicant_full_name', 'middle') || '') + ' ' + form.data.dig('applicant_full_name', 'last') %>",
-  "form1[0].#subform[0].TextField4[0]": "<%= form.data.dig('applicant_address', 'street') + ', ' + (form.data.dig('applicant_address', 'street2') || '') + '\n' + form.data.dig('applicant_address', 'city') + ', ' + form.data.dig('applicant_address', 'state') + ' ' + form.data.dig('applicant_address', 'postal_code') + ' ' + form.data.dig('applicant_address', 'country') %>",
+  "form1[0].#subform[0].TextField1[2]": "<%= form.applicant_name %>",
+  "form1[0].#subform[0].TextField4[0]": "<%= form.applicant_address %>",
   "form1[0].#subform[0].TextField1[3]": "<%= form.data['applicant_phone'] %>",
   "form1[0].#subform[0].TextField1[4]": "<%= form.data['applicant_email'] %>",
   "form1[0].#subform[0].TextField2[0]": "<%= form.data['certificates'] %>",

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -22,6 +22,33 @@ module SimpleFormsApi
       }
     end
 
+    def veteran_name
+      first_name = data.dig('veteran_full_name', 'first') || ''
+      middle_name = data.dig('veteran_full_name', 'middle') || ''
+      last_name = data.dig('veteran_full_name', 'last') || ''
+
+      first_name + ' ' + middle_name + ' ' + last_name
+    end
+
+    def applicant_name
+      first_name = data.dig('applicant_full_name', 'first') || ''
+      middle_name = data.dig('applicant_full_name', 'middle') || ''
+      last_name = data.dig('applicant_full_name', 'last') || ''
+
+      first_name + ' ' + middle_name + ' ' + last_name
+    end
+
+    def applicant_address
+      street = data.dig('applicant_address', 'street') || ''
+      street2 = data.dig('applicant_address', 'street2') || ''
+      city = data.dig('applicant_address', 'city') || ''
+      state = data.dig('applicant_address', 'state') || ''
+      postal_code = data.dig('applicant_address', 'postal_code') || ''
+      country = data.dig('applicant_address', 'country') || ''
+
+      street + ', ' + street2 + '\n' + city + ', ' + state + ' ' + postal_code + ' ' + country
+    end
+
     def zip_code_is_us_based
       @data.dig('applicant_address', 'country') == 'USA'
     end
@@ -37,6 +64,10 @@ module SimpleFormsApi
 
         combined_pdf.save file_path
       end
+    end
+
+    def words_to_remove
+      veteran_ssn_and_file_number + veteran_dates_of_birth_and_death + applicant_zip + applicant_phone
     end
 
     def submission_date_config
@@ -84,6 +115,43 @@ module SimpleFormsApi
       )
 
       filler.generate
+    end
+
+    def veteran_ssn_and_file_number
+      [
+        data.dig('veteran_id', 'ssn')&.[](0..2),
+        data.dig('veteran_id', 'ssn')&.[](3..4),
+        data.dig('veteran_id', 'ssn')&.[](5..8),
+        data.dig('veteran_id', 'va_file_number')&.[](0..2),
+        data.dig('veteran_id', 'va_file_number')&.[](3..4),
+        data.dig('veteran_id', 'va_file_number')&.[](5..8)
+      ]
+    end
+
+    def veteran_dates_of_birth_and_death
+      [
+        data['veteran_date_of_birth']&.[](0..3),
+        data['veteran_date_of_birth']&.[](5..6),
+        data['veteran_date_of_birth']&.[](8..9),
+        data['veteran_date_of_death']&.[](0..3),
+        data['veteran_date_of_death']&.[](5..6),
+        data['veteran_date_of_death']&.[](8..9)
+      ]
+    end
+
+    def applicant_zip
+      [
+        data.dig('applicant_address', 'postal_code')&.[](0..4),
+        data.dig('applicant_address', 'postal_code')&.[](5..8)
+      ]
+    end
+
+    def applicant_phone
+      [
+        data['applicant_phone']&.gsub('-', '')&.[](0..2),
+        data['applicant_phone']&.gsub('-', '')&.[](3..5),
+        data['applicant_phone']&.gsub('-', '')&.[](6..9)
+      ]
     end
   end
 end

--- a/modules/simple_forms_api/lib/simple_forms_api.rb
+++ b/modules/simple_forms_api/lib/simple_forms_api.rb
@@ -32,6 +32,8 @@ module SimpleFormsApi
           words_to_remove += SimpleFormsApi::VBA21p0847.new(params).words_to_remove
         when '21-0845'
           words_to_remove += SimpleFormsApi::VBA210845.new(params).words_to_remove
+        when '40-0247'
+          words_to_remove += SimpleFormsApi::VBA400247.new(params).words_to_remove
         else
           return "something has gone wrong with your form, #{params[:form_number]} and the entire " \
                  'error message has been redacted to keep PII from getting leaked'


### PR DESCRIPTION
## Summary

This PR responds to our high error rate for form 40-0247 with two interventions:
1. Stop scrubbing the entire error messages by letting our more detailed scrubber do the work.
2. Pull out methods for the more complex fields (ones that include `+` on strings (or `nil`s!! 😱)) into the form's model.

## Related issue(s)
N/A
