### PR TITLE
Simple Forms, raise StampVerificationError separately from other errors

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -50,7 +50,7 @@ module SimpleFormsApi
         else
           submit_form_to_central_mail
         end
-      rescue Prawn::Errors::IncompatibleStringEncoding
+      rescue Prawn::Errors::IncompatibleStringEncoding, Exceptions::StampVerificationError
         raise
       rescue => e
         raise Exceptions::ScrubbedUploadsSubmitError.new(params), e

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -243,7 +243,7 @@ module SimpleFormsApi
     rescue Prawn::Errors::IncompatibleStringEncoding
       raise
     rescue => e
-      raise StandardError, "An error occurred while verifying stamp: #{e}"
+      raise Exceptions::StampVerificationError, "An error occurred while verifying stamp: #{e}"
     end
 
     def self.verified_multistamp(stamped_template_path, stamp_text, page_configuration, *)

--- a/modules/simple_forms_api/lib/simple_forms_api.rb
+++ b/modules/simple_forms_api/lib/simple_forms_api.rb
@@ -63,5 +63,7 @@ module SimpleFormsApi
         words.uniq.sort_by(&:length).reverse
       end
     end
+
+    class StampVerificationError < RuntimeError; end
   end
 end


### PR DESCRIPTION
## Summary
This PR raises `StampVerificationError`s separately from our heavily redacted catch-all. This will let the message come through unchanged. I don't _think_ this will leak any PII but it is inherently a bit risky.
