### PR TITLE
[DR-65544] Log KPIs for Higher Level Reviews (create + contestable issues)

### DIFF
--- a/lib/decision_review_v1/service.rb
+++ b/lib/decision_review_v1/service.rb
@@ -38,7 +38,7 @@ module DecisionReviewV1
       with_monitoring_and_error_handling do
         headers = create_higher_level_review_headers(user)
         common_log_params = { key: :overall_claim_submission, form_id: '996', user_uuid: user.uuid,
-                                downstream_system: 'Lighthouse' }
+                              downstream_system: 'Lighthouse' }
         begin
           response = perform :post, 'higher_level_reviews', request_body, headers
           log_formatted(**common_log_params.merge(is_success: true, status_code: response.status, body: '[Redacted]'))
@@ -81,7 +81,7 @@ module DecisionReviewV1
         path = "contestable_issues/higher_level_reviews?benefit_type=#{benefit_type}"
         headers = get_contestable_issues_headers(user)
         common_log_params = { key: :get_contestable_issues, form_id: '996', user_uuid: user.uuid,
-                                upstream_system: 'Lighthouse' }
+                              upstream_system: 'Lighthouse' }
         begin
           response = perform :get, path, nil, headers
           log_formatted(**common_log_params.merge(is_success: true, status_code: response.status, body: '[Redacted]'))


### PR DESCRIPTION
## Summary

In #13973, Eugene added more comprehensive logging for our NOD form and in #16176 / #16179 I added similar logging for Supplemental Claims — this PR adds similarly structured logging for Higher Level Reviews

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/65544

## Testing done

- [x] *New code is covered by unit tests*
- [x] Tested that form submission and contestable issues works locally. 
- Will do a test on staging to check that form submission and contestable issues work and logs are showing up in DataDog as expected


## What areas of the site does it impact?
The Higher Level Reviews form

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)

