### PR TITLE
Simple Forms: Refactor PDF Stamper Part 1

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -82,6 +82,17 @@ module SimpleFormsApi
       end
     end
 
+    def desired_stamps
+      coords = if %w[veteran non-veteran].include? data['preparer_type']
+                 [[50, 685]]
+               elsif data['third_party_type'] == 'power-of-attorney'
+                 [[50, 440]]
+               elsif %w[third-party-veteran third-party-non-veteran].include? data['preparer_type']
+                 [[50, 565]]
+               end
+      [{ coords:, text: data['statement_of_truth_signature'], page: 4 }]
+    end
+
     def submission_date_config
       {
         should_stamp_date?: false

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -37,6 +37,10 @@ module SimpleFormsApi
         person_address + organization_address
     end
 
+    def desired_stamps
+      [{ coords: [50, 240], text: data['statement_of_truth_signature'], page: 2 }]
+    end
+
     def submission_date_config
       {
         should_stamp_date?: true,

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -59,6 +59,10 @@ module SimpleFormsApi
       end
     end
 
+    def desired_stamps
+      [{ coords: [50, 415], text: data['statement_of_truth_signature'], page: 1 }]
+    end
+
     def submission_date_config
       {
         should_stamp_date?: true,

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -27,6 +27,10 @@ module SimpleFormsApi
       @data.dig('preparer_address', 'country') == 'USA'
     end
 
+    def desired_stamps
+      [{ coords: [50, 465], text: data['statement_of_truth_signature'], page: 2 }]
+    end
+
     def submission_date_config
       {
         should_stamp_date?: true,

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -33,6 +33,10 @@ module SimpleFormsApi
         statement + witness_phone + witness_email
     end
 
+    def desired_stamps
+      [{ coords: [50, 160], text: data['statement_of_truth_signature'], page: 2 }]
+    end
+
     def submission_date_config
       {
         should_stamp_date?: true,

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -33,13 +33,7 @@ module SimpleFormsApi
     end
 
     def desired_stamps
-      [
-        {
-          coords: [50, 560],
-          text: data['statement_of_truth_signature'],
-          page: 1
-        }
-      ]
+      [{ coords: [50, 560], text: data['statement_of_truth_signature'], page: 1 }]
     end
 
     def submission_date_config

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -32,6 +32,16 @@ module SimpleFormsApi
       @data.dig('veteran', 'address', 'country') == 'USA'
     end
 
+    def desired_stamps
+      [
+        {
+          coords: [50, 560],
+          text: data['statement_of_truth_signature'],
+          page: 1
+        }
+      ]
+    end
+
     def submission_date_config
       {
         should_stamp_date?: true,

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -31,6 +31,10 @@ module SimpleFormsApi
       @data.dig('preparer_address', 'country') == 'USA'
     end
 
+    def desired_stamps
+      [{ coords: [50, 190], text: data['statement_of_truth_signature'], page: 1 }]
+    end
+
     def submission_date_config
       {
         should_stamp_date?: true,

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -49,8 +49,10 @@ module SimpleFormsApi
       return [] unless data
 
       [].tap do |stamps|
-        stamps << { coords: [73, 390], text: 'X' } unless data.dig('previous_sah_application', 'has_previous_sah_application')
-        stamps << { coords: [73, 355], text: 'X' } unless data.dig('previous_hi_application', 'has_previous_hi_application')
+        stamps << { coords: [73, 390], text: 'X' } unless data.dig('previous_sah_application',
+                                                                   'has_previous_sah_application')
+        stamps << { coords: [73, 355], text: 'X' } unless data.dig('previous_hi_application',
+                                                                   'has_previous_hi_application')
         stamps << { coords: [73, 320], text: 'X' } unless data.dig('living_situation', 'is_in_care_facility')
       end.compact
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -49,9 +49,9 @@ module SimpleFormsApi
       return [] unless data
 
       [].tap do |stamps|
-        stamps << [73, 390, 'X'] unless data.dig('previous_sah_application', 'has_previous_sah_application')
-        stamps << [73, 355, 'X'] unless data.dig('previous_hi_application', 'has_previous_hi_application')
-        stamps << [73, 320, 'X'] unless data.dig('living_situation', 'is_in_care_facility')
+        stamps << { coords: [73, 390], text: 'X' } unless data.dig('previous_sah_application', 'has_previous_sah_application')
+        stamps << { coords: [73, 355], text: 'X' } unless data.dig('previous_hi_application', 'has_previous_hi_application')
+        stamps << { coords: [73, 320], text: 'X' } unless data.dig('living_situation', 'is_in_care_facility')
       end.compact
     end
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -47,11 +47,11 @@ module SimpleFormsApi
 
     def desired_stamps
       return [] unless data
-      
+
       [].tap do |stamps|
         stamps << [73, 390, 'X'] unless data.dig('previous_sah_application', 'has_previous_sah_application')
         stamps << [73, 355, 'X'] unless data.dig('previous_hi_application', 'has_previous_hi_application')
-stamps << [73, 320, 'X'] unless data.dig('living_situation', 'is_in_care_facility')
+        stamps << [73, 320, 'X'] unless data.dig('living_situation', 'is_in_care_facility')
       end.compact
     end
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -45,6 +45,23 @@ module SimpleFormsApi
       @data.dig('veteran', 'address', 'country') == 'USA'
     end
 
+    def desired_stamps
+      desired_stamps = []
+      unless data['previous_sah_application']['has_previous_sah_application']
+        desired_stamps.append({ coords: [73, 390], text: 'X',
+                                page: 0 })
+      end
+      unless data['previous_hi_application']['has_previous_hi_application']
+        desired_stamps.append({ coords: [73, 355], text: 'X',
+                                page: 0 })
+      end
+      unless data['living_situation']['is_in_care_facility']
+        desired_stamps.append({ coords: [73, 320], text: 'X',
+                                page: 0 })
+      end
+      desired_stamps
+    end
+
     def submission_date_config
       { should_stamp_date?: false }
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -46,20 +46,13 @@ module SimpleFormsApi
     end
 
     def desired_stamps
-      desired_stamps = []
-      unless data['previous_sah_application']['has_previous_sah_application']
-        desired_stamps.append({ coords: [73, 390], text: 'X',
-                                page: 0 })
-      end
-      unless data['previous_hi_application']['has_previous_hi_application']
-        desired_stamps.append({ coords: [73, 355], text: 'X',
-                                page: 0 })
-      end
-      unless data['living_situation']['is_in_care_facility']
-        desired_stamps.append({ coords: [73, 320], text: 'X',
-                                page: 0 })
-      end
-      desired_stamps
+      return [] unless data
+      
+      [].tap do |stamps|
+        stamps << [73, 390, 'X'] unless data.dig('previous_sah_application', 'has_previous_sah_application')
+        stamps << [73, 355, 'X'] unless data.dig('previous_hi_application', 'has_previous_hi_application')
+stamps << [73, 320, 'X'] unless data.dig('living_situation', 'is_in_care_facility')
+      end.compact
     end
 
     def submission_date_config

--- a/modules/simple_forms_api/app/models/simple_forms_api/vha_10_7959f_1.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vha_10_7959f_1.rb
@@ -27,6 +27,10 @@ module SimpleFormsApi
       true
     end
 
+    def desired_stamps
+      [{ coords: [26, 82.5], text: data['statement_of_truth_signature'], page: 0 }]
+    end
+
     def submission_date_config
       { should_stamp_date?: false }
     end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -83,7 +83,7 @@ module SimpleFormsApi
       page = desired_stamp[:page]
       x = coords[0]
       y = coords[1]
-      if page.positive?
+      if page
         page_configuration = get_page_configuration(page, coords)
         verified_multistamp(stamped_template_path, text, page_configuration)
       else

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -9,12 +9,23 @@ module SimpleFormsApi
     SUBMISSION_DATE_TITLE = 'Application Submitted:'
 
     def self.stamp_pdf(stamped_template_path, form, current_loa)
+      stamp_signature(stamped_template_path, form)
+
+      stamp_auth_text(stamped_template_path, current_loa)
+
+      stamp_submission_date(stamped_template_path, form.submission_date_config)
+    end
+
+    def self.stamp_signature(stamped_template_path, form)
       form_number = form.data['form_number']
       if FORM_REQUIRES_STAMP.include? form_number
-        stamp_method = "stamp#{form_number.gsub('-', '')}".downcase
-        send(stamp_method, stamped_template_path, form)
+        form.desired_stamps.each do |desired_stamp|
+          stamp(desired_stamp, stamped_template_path)
+        end
       end
+    end
 
+    def self.stamp_auth_text(stamped_template_path, current_loa)
       current_time = "#{Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S')} "
       auth_text = case current_loa
                   when 3
@@ -24,116 +35,13 @@ module SimpleFormsApi
                   else
                     'Signee not signed in.'
                   end
-      stamp_text = SUBMISSION_TEXT + current_time
-      desired_stamps = [[10, 10, stamp_text]]
-      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, auth_text, text_only: false) }
-
-      stamp_submission_date(stamped_template_path, form.submission_date_config)
-    end
-
-    def self.stamp107959f1(stamped_template_path, form)
-      desired_stamps = [[26, 82.5, form.data['statement_of_truth_signature']]]
-      append_to_stamp = false
-      verify(stamped_template_path) { stamp(desired_stamps, stamped_template_path, append_to_stamp) }
-    end
-
-    def self.stamp264555(stamped_template_path, form)
-      desired_stamps = []
-      desired_stamps.append([73, 390, 'X']) unless form.data['previous_sah_application']['has_previous_sah_application']
-      desired_stamps.append([73, 355, 'X']) unless form.data['previous_hi_application']['has_previous_hi_application']
-      desired_stamps.append([73, 320, 'X']) unless form.data['living_situation']['is_in_care_facility']
-      append_to_stamp = false
-      stamp(desired_stamps, stamped_template_path, append_to_stamp)
-    end
-
-    def self.stamp214142(stamped_template_path, form)
-      desired_stamps = [[50, 560]]
-      signature_text = form.data['statement_of_truth_signature']
-      page_configuration = [
-        { type: :new_page },
-        { type: :text, position: desired_stamps[0] },
-        { type: :new_page }
-      ]
-
-      verified_multistamp(stamped_template_path, signature_text, page_configuration)
-    end
-
-    def self.stamp2110210(stamped_template_path, form)
-      desired_stamps = [[50, 160]]
-      signature_text = form.data['statement_of_truth_signature']
-      page_configuration = [
-        { type: :new_page },
-        { type: :new_page },
-        { type: :text, position: desired_stamps[0] }
-      ]
-
-      verified_multistamp(stamped_template_path, signature_text, page_configuration)
-    end
-
-    def self.stamp210845(stamped_template_path, form)
-      desired_stamps = [[50, 240]]
-      signature_text = form.data['statement_of_truth_signature']
-      page_configuration = [
-        { type: :new_page },
-        { type: :new_page },
-        { type: :text, position: desired_stamps[0] }
-      ]
-
-      verified_multistamp(stamped_template_path, signature_text, page_configuration)
-    end
-
-    def self.stamp21p0847(stamped_template_path, form)
-      desired_stamps = [[50, 190]]
-      signature_text = form.data['statement_of_truth_signature']
-      page_configuration = [
-        { type: :new_page },
-        { type: :text, position: desired_stamps[0] }
-      ]
-
-      verified_multistamp(stamped_template_path, signature_text, page_configuration)
-    end
-
-    def self.stamp210972(stamped_template_path, form)
-      desired_stamps = [[50, 465]]
-      signature_text = form.data['statement_of_truth_signature']
-      page_configuration = [
-        { type: :new_page },
-        { type: :new_page },
-        { type: :text, position: desired_stamps[0] }
-      ]
-
-      verified_multistamp(stamped_template_path, signature_text, page_configuration)
-    end
-
-    def self.stamp210966(stamped_template_path, form)
-      desired_stamps = [[50, 415]]
-      signature_text = form.data['statement_of_truth_signature']
-      page_configuration = [
-        { type: :new_page },
-        { type: :text, position: desired_stamps[0] }
-      ]
-
-      verified_multistamp(stamped_template_path, signature_text, page_configuration)
-    end
-
-    def self.stamp2010207(stamped_template_path, form)
-      desired_stamps = if %w[veteran non-veteran].include? form.data['preparer_type']
-                         [[50, 685]]
-                       elsif form.data['third_party_type'] == 'power-of-attorney'
-                         [[50, 440]]
-                       elsif %w[third-party-veteran third-party-non-veteran].include? form.data['preparer_type']
-                         [[50, 565]]
-                       end
-      signature_text = form.data['statement_of_truth_signature']
-      page_configuration = [
-        { type: :new_page },
-        { type: :new_page },
-        { type: :new_page },
-        { type: :new_page },
-        { type: :text, position: desired_stamps[0] }
-      ]
-
-      verified_multistamp(stamped_template_path, signature_text, page_configuration)
+      coords = [10, 10]
+      text = SUBMISSION_TEXT + current_time
+      page = 0
+      desired_stamp = { coords:, text:, page: }
+      verify(stamped_template_path) do
+        stamp(desired_stamp, stamped_template_path, append_to_stamp: auth_text, text_only: false)
+      end
     end
 
     def self.stamp4010007_uuid(uuid)
@@ -168,13 +76,21 @@ module SimpleFormsApi
       Common::FileHelpers.delete_file_if_exists(stamp_path) if defined?(stamp_path)
     end
 
-    def self.stamp(desired_stamps, stamped_template_path, append_to_stamp, text_only: true)
+    def self.stamp(desired_stamp, stamped_template_path, append_to_stamp: false, text_only: true)
       current_file_path = stamped_template_path
-      desired_stamps.each do |x, y, text|
+      coords = desired_stamp[:coords]
+      text = desired_stamp[:text]
+      page = desired_stamp[:page]
+      x = coords[0]
+      y = coords[1]
+      if page.positive?
+        page_configuration = get_page_configuration(page, coords)
+        verified_multistamp(stamped_template_path, text, page_configuration)
+      else
         datestamp_instance = CentralMail::DatestampPdf.new(current_file_path, append_to_stamp:)
         current_file_path = datestamp_instance.run(text:, x:, y:, text_only:, size: 9)
+        File.rename(current_file_path, stamped_template_path)
       end
-      File.rename(current_file_path, stamped_template_path)
     end
 
     def self.perform_multistamp(stamped_template_path, stamp_path)
@@ -230,6 +146,17 @@ module SimpleFormsApi
         { type: :new_page },
         { type: :new_page }
       ]
+    end
+
+    def self.get_page_configuration(page, position)
+      config = [
+        { type: :new_page },
+        { type: :new_page },
+        { type: :new_page },
+        { type: :new_page }
+      ]
+      config[page] = { type: :text, position: }
+      config
     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -149,14 +149,14 @@ module SimpleFormsApi
     end
 
     def self.get_page_configuration(page, position)
-      config = [
+      [
         { type: :new_page },
         { type: :new_page },
         { type: :new_page },
         { type: :new_page }
-      ]
-      config[page] = { type: :text, position: }
-      config
+      ].tap do |config|
+        config[page] = { type: :text, position: }
+      end
     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -56,33 +56,6 @@ module SimpleFormsApi
       ]
 
       verified_multistamp(stamped_template_path, signature_text, page_configuration)
-
-      # This is a one-off case where we need to stamp a date on the first page of 21-4142 when resubmitting
-      if form.data['in_progress_form_created_at']
-        date_title = 'Application Submitted:'
-        date_text = form.data['in_progress_form_created_at']
-        stamp214142_date_stamp_for_resubmission(stamped_template_path, date_title, date_text)
-      end
-    end
-
-    def self.stamp214142_date_stamp_for_resubmission(stamped_template_path, date_title, date_text)
-      date_title_stamp_position = [440, 710]
-      date_text_stamp_position = [440, 690]
-      page_configuration = [
-        { type: :text, position: date_title_stamp_position },
-        { type: :new_page },
-        { type: :new_page }
-      ]
-
-      verified_multistamp(stamped_template_path, date_title, page_configuration, 12)
-
-      page_configuration = [
-        { type: :text, position: date_text_stamp_position },
-        { type: :new_page },
-        { type: :new_page }
-      ]
-
-      verified_multistamp(stamped_template_path, date_text, page_configuration, 12)
     end
 
     def self.stamp2110210(stamped_template_path, form)

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -8,78 +8,52 @@ describe SimpleFormsApi::PdfStamper do
   let(:form) { "SimpleFormsApi::#{test_payload.titleize.gsub(' ', '')}".constantize.new(data) }
   let(:path) { 'tmp/stuff.json' }
 
-  describe 'form-specific stamp methods' do
-    subject(:stamp) { described_class.send(stamp_method, generated_form_path, form) }
+  describe '.stamp_signature' do
+    subject(:stamp_signature) { described_class.stamp_signature(path, form) }
 
     before do
-      allow(Common::FileHelpers).to receive(:random_file_path).and_return('fake/stamp_path')
-      allow(Common::FileHelpers).to receive(:delete_file_if_exists)
-    end
-
-    %w[21-4142 21-10210 21p-0847].each do |form_number|
-      context "when generating a stamped file for form #{form_number}" do
-        let(:stamp_method) { "stamp#{form_number.gsub('-', '')}" }
-        let(:test_payload) { "vba_#{form_number.gsub('-', '_')}" }
-        let(:generated_form_path) { 'fake/generated_form_path' }
-
-        it 'raises an error' do
-          expect { stamp }.to raise_error(StandardError, /An error occurred while verifying stamp/)
-        end
-      end
-    end
-  end
-
-  describe '.stamp107959f1' do
-    subject(:stamp107959f1) { described_class.stamp107959f1(path, form) }
-
-    before do
-      allow(described_class).to receive(:stamp).and_return(true)
       allow(File).to receive(:size).and_return(1, 2)
     end
 
     context 'when statement_of_truth_signature is provided' do
-      before { stamp107959f1 }
+      before do
+        allow(described_class).to receive(:stamp).and_return(true)
+        stamp_signature
+      end
 
       let(:test_payload) { 'vha_10_7959f_1' }
-      let(:signature) { form.data['statement_of_truth_signature'] }
-      let(:stamps) { [[26, 82.5, signature]] }
+      let(:desired_stamp) do
+        {
+          coords: [26, 82.5],
+          text: form.data['statement_of_truth_signature'],
+          page: 0
+        }
+      end
 
       it 'calls stamp with correct desired_stamp' do
-        expect(described_class).to have_received(:stamp).with(stamps, path, false)
+        expect(described_class).to have_received(:stamp).with(desired_stamp, path)
       end
     end
-  end
 
-  describe '.stamp264555' do
-    subject(:stamp264555) { described_class.stamp264555(path, form) }
-
-    before do
-      allow(described_class).to receive(:stamp).and_return(true)
-      allow(File).to receive(:size).and_return(1, 2)
-    end
-
-    context 'when it is called with legitimate parameters' do
-      before { stamp264555 }
+    context 'when no stamps are needed' do
+      before do
+        allow(described_class).to receive(:stamp).and_return(true)
+        stamp_signature
+      end
 
       let(:test_payload) { 'vba_26_4555' }
       let(:stamps) { [] }
 
-      it 'calls stamp correctly' do
-        expect(described_class).to have_received(:stamp).with(stamps, path, false)
+      it 'does not call :stamp' do
+        expect(described_class).not_to have_received(:stamp)
       end
-    end
-  end
-
-  describe '.stamp210845' do
-    subject(:stamp210845) { described_class.stamp210845(path, form) }
-
-    before do
-      allow(described_class).to receive(:multistamp).and_return(true)
-      allow(File).to receive(:size).and_return(1, 2)
     end
 
     context 'when it is called with legitimate parameters' do
-      before { stamp210845 }
+      before do
+        allow(described_class).to receive(:multistamp).and_return(true)
+        stamp_signature
+      end
 
       let(:test_payload) { 'vba_21_0845' }
       let(:signature) { form.data['statement_of_truth_signature'] }
@@ -87,7 +61,8 @@ describe SimpleFormsApi::PdfStamper do
         [
           { type: :new_page },
           { type: :new_page },
-          { type: :text, position: [50, 240] }
+          { type: :text, position: [50, 240] },
+          { type: :new_page }
         ]
       end
 


### PR DESCRIPTION
## Summary
This PR takes part of the work from this draft PR: https://github.com/department-of-veterans-affairs/vets-api/pull/16242 and separates it into its own standalone PR. This should be more easily reviewable. I can then come back and apply part 2 in a separate PR and close out the aforementioned draft PR.

This is some refactoring of our PDF Stamper class with the ultimate aim of making it more uniform in how it handles desired stamps.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1198

## Testing done
Tests altered and passing.
