### PR TITLE
Simple Forms delete InProgressForm with every successful form submission

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -47,6 +47,8 @@ module SimpleFormsApi
           response = submit_form_to_central_mail
         end
 
+        clear_saved_form(params[:form_number])
+
         render response
       rescue Prawn::Errors::IncompatibleStringEncoding
         raise

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -37,15 +37,14 @@ module SimpleFormsApi
 
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
-        response = nil
 
-        if form_is210966 && icn && first_party?
-          response = handle_210966_authenticated
-        elsif form_is264555_and_should_use_lgy_api
-          response = handle_264555
-        else
-          response = submit_form_to_central_mail
-        end
+        response = if form_is210966 && icn && first_party?
+                     handle_210966_authenticated
+                   elsif form_is264555_and_should_use_lgy_api
+                     handle264555
+                   else
+                     submit_form_to_central_mail
+                   end
 
         clear_saved_form(params[:form_number])
 
@@ -105,7 +104,7 @@ module SimpleFormsApi
         } }
       end
 
-      def handle_264555
+      def handle264555
         parsed_form_data = JSON.parse(params.to_json)
         form = SimpleFormsApi::VBA264555.new(parsed_form_data)
         lgy_response = LGY::Service.new.post_grant_application(payload: form.as_payload)

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Forms uploader', type: :request do
     'vba_20_10207-non-veteran.json'
   ]
 
-  authenticated_non_ivc_forms = non_ivc_forms - %w[vba_40_0247.json vba_21_10210.json vba_21p_0847.json vba_40_10007.json]
+  authenticated_non_ivc_forms = non_ivc_forms - %w[vba_40_0247.json vba_21_10210.json vba_21p_0847.json
+                                                   vba_40_10007.json]
 
   ivc_forms = [
     'vha_10_10d.json',


### PR DESCRIPTION
## Summary
This PR clears an InProgressForm whenever the authenticated user successfully submits that form. Not having this has caused some strange/buggy behavior and it seems like it's on us to clean these up on each submission.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/80432

## Testing done
New test written.
