### PR TITLE
Add OH appointment requests feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1119,6 +1119,10 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for routing eligibility requests to the VetsAPI Gateway Service(VPG) instead of vaos-service
+  va_online_scheduling_enable_OH_requests:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle for routing new appointment requests to the VetsAPI Gateway Service(VPG) instead of vaos-service
   va_online_scheduling_enable_OH_slots_search:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR adds a feature flag that will route new appointment requests to the new VPG service if enabled. If it is disabled new appointment requests will continue to use vaos-service.
- Unified Appointment Experience team
- The success criteria being targeted is the ability to support appointment requests at Oracle Health sites by using VPG instead of vaos-service.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/77017

## Testing done

- Confirmed that the new feature flag is displayed when running locally at http://localhost:3000/flipper/features

## What areas of the site does it impact?
This change only impacts flipper

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature