### PR TITLE
Handle case where mutliple disabilities could have same diagnostic code.

### DIFF
--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -18,11 +18,11 @@ module ClaimFastTracking
 
       ratings = get_ratings(diagnostic_codes)
       if ratings.present?
-        ratings.each do |rating|
-          rated_disability = rated_disabilities_response.rated_disabilities.find do |disability|
-            disability.diagnostic_code == rating['diagnostic_code']
+        rated_disabilities_response.rated_disabilities.each do |rated_disability|
+          max_rating = ratings.find do |rating|
+            rated_disability.diagnostic_code == rating['diagnostic_code']
           end
-          rated_disability.maximum_rating_percentage = rating['max_rating'] if rated_disability.present?
+          rated_disability.maximum_rating_percentage = max_rating['max_rating'] if max_rating.present?
         end
       end
       rated_disabilities_response

--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -17,13 +17,12 @@ module ClaimFastTracking
       return rated_disabilities_response if diagnostic_codes.empty?
 
       ratings = get_ratings(diagnostic_codes)
-      if ratings.present?
-        rated_disabilities_response.rated_disabilities.each do |rated_disability|
-          max_rating = ratings.find do |rating|
-            rated_disability.diagnostic_code == rating['diagnostic_code']
-          end
-          rated_disability.maximum_rating_percentage = max_rating['max_rating'] if max_rating.present?
-        end
+      return rated_disabilities_response unless ratings
+
+      ratings_hash = ratings.to_h { |rating| [rating['diagnostic_code'], rating['max_rating']] }
+      rated_disabilities_response.rated_disabilities.each do |rated_disability|
+        max_rating = ratings_hash[rated_disability.diagnostic_code]
+        rated_disability.maximum_rating_percentage = max_rating if max_rating
       end
       rated_disabilities_response
     end

--- a/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
+++ b/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
           expect(max_ratings).to eq([10, nil, nil])
         end
       end
+
+      context 'when a disabilities response has two rated disabilities with same diagnostic code' do
+        let(:disabilities_data) do
+          [
+            { name: 'Tinnitus', diagnostic_code: 6260, rating_percentage: 10 },
+            { name: 'Tinnitus', diagnostic_code: 6260, rating_percentage: 10 }
+          ]
+        end
+
+        it 'mutates both rated disabilities with max ratings from VRO' do
+          VCR.use_cassette('virtual_regional_office/max_ratings') do
+            subject
+            max_ratings = disabilities_response.rated_disabilities.map(&:maximum_rating_percentage)
+            expect(max_ratings).to eq([10, 10])
+          end
+        end
+      end
     end
 
     context 'with disability_526_maximum_rating_api_all_conditions enabled' do


### PR DESCRIPTION
## Summary
- This work is behind a feature toggle (flipper): NO
- This PR adjusts the logic to handle multiple disabilities with the same diagnostic code when assigning the `maximum_rating` to disabilities returned in the rated disabilities response used to populate information on the rated disabilities page of the Form 526EZ. 
- I am part of the Claims Fast-Tracking crew's Employee Experience team. We work closely with the Disability Experience team which owns this code.

## Related issue(s)
- discovered during work on another ticket related to displaying the maximum rating: https://github.com/department-of-veterans-affairs/abd-vro/issues/2722 
- ticket to fix: https://github.com/department-of-veterans-affairs/abd-vro/issues/2849

## Testing done
- New code is covered by new unit tests for multiple disabilities with same diagnostic code
- Old unit tests still passing
- If rated disabilities included multiple disabilities with the same diagnostic code (e.g., tinnitus of left/right ear), the maximum rating notice would only be shown on the first. 
- Running locally:
  - enable toggle `disability_526_maximum_rating_api_all_conditions` so below users conditions are prefilled with max rating
  - log in with vets.gov.user+1@gmail.com
  - start new [526 form](http://localhost:3001/disability/file-disability-claim-form-21-526ez/introduction) to allow prefill of maximum rating data
  - progress to rated disabilities page to see both conditions with maximum rating notice


## Screenshots
| Before | After | 
| --- | --- |
| <img width="300" alt="Screenshot 2024-04-10 at 9 11 17 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/135860892/b41d0e7c-00cc-4f44-9cfc-6596243a7af9"> | <img width="300" src="https://github.com/department-of-veterans-affairs/vets-api/assets/135860892/56477192-9857-4a07-ae9e-23daaf9207cf"> |

## What areas of the 
site does it impact?
* Backend calls on 526 prefill
* display on maximum rating notices on rated disabilities page of 526

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

