### PR TITLE
78732 Part 1 - add uniqueness constraint to poa_code for accredited_organizations

### DIFF
--- a/db/migrate/20240410184931_add_unique_index_accredited_organizations_poa.rb
+++ b/db/migrate/20240410184931_add_unique_index_accredited_organizations_poa.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexAccreditedOrganizationsPoa < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :accredited_organizations, :poa_code, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_08_152120) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_10_184931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -149,6 +149,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_08_152120) do
     t.datetime "updated_at", null: false
     t.index ["location"], name: "index_accredited_organizations_on_location", using: :gist
     t.index ["name"], name: "index_accredited_organizations_on_name"
+    t.index ["poa_code"], name: "index_accredited_organizations_on_poa_code", unique: true
   end
 
   create_table "accredited_organizations_accredited_representatives", id: false, force: :cascade do |t|


### PR DESCRIPTION
## Summary

- This pr adds a db level uniqueness constraint on `poa_code` for the new `accredited_organizations` table
- This is necessary as part of creating the models listed in the ticket

## Related issue(s)
- [78732](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78732)

## Testing done

- NA as it is purely a migration on an empty table

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature