### PR TITLE
8346: fix excludeProvidedMessage false handling

### DIFF
--- a/modules/mobile/app/controllers/mobile/v1/messages_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v1/messages_controller.rb
@@ -8,7 +8,9 @@ module Mobile
         resource = client.get_messages_for_thread(message_id)
         raise Common::Exceptions::RecordNotFound, message_id if resource.blank?
 
-        resource.data = resource.data.filter { |m| m.message_id.to_s != params[:id] } if params[:excludeProvidedMessage]
+        if ActiveModel::Type::Boolean.new.cast(params[:excludeProvidedMessage])
+          resource.data = resource.data.filter { |m| m.message_id.to_s != params[:id] }
+        end
         resource.metadata.merge!(message_counts(resource))
 
         render json: resource.data,

--- a/modules/mobile/spec/request/v1/messages_request_spec.rb
+++ b/modules/mobile/spec/request/v1/messages_request_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe 'Mobile Messages V1 Integration', type: :request do
         expect(response.parsed_body['data'].any? { |m| m['id'] == thread_id.to_s }).to be true
       end
 
-      it 'filters the provided message' do
+      it 'filters the provided message when excludeProvidedMessage is true' do
         VCR.use_cassette('mobile/messages/v1_get_thread') do
           get "/mobile/v1/messaging/health/messages/#{thread_id}/thread",
               headers: sis_headers,
@@ -163,6 +163,18 @@ RSpec.describe 'Mobile Messages V1 Integration', type: :request do
         expect(response).to be_successful
         expect(response.parsed_body['data']).to eq(thread_response['data'].filter { |m| m['id'] != thread_id.to_s })
         expect(response.parsed_body['data'].any? { |m| m['id'] == thread_id.to_s }).to be false
+      end
+
+      it 'does not filter the provided message when excludeProvidedMessage is false' do
+        VCR.use_cassette('mobile/messages/v1_get_thread') do
+          get "/mobile/v1/messaging/health/messages/#{thread_id}/thread",
+              headers: sis_headers,
+              params: { excludeProvidedMessage: false }
+        end
+
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq(thread_response)
+        expect(response.parsed_body['data'].any? { |m| m['id'] == thread_id.to_s }).to be true
       end
 
       it 'provides a count in the meta of read' do


### PR DESCRIPTION
## Summary

Fixes handling when excludeProvidedMessage param is false.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8346

## Testing done
Specs. Will be tested on staging. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Just the handling of this one param in this one controller. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback