### PR TITLE
Move terms_of_use enabled_clients to settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,6 +83,7 @@ sign_in:
 terms_of_use:
   current_version: v1
   provisioner_cookie_domain: localhost
+  enabled_clients: vaweb, mhv, myvahealth
 
 lockbox:
   master_key: "0d78eaf0e90d4e7b8910c9112e16e66d8b00ec4054a89aa426e32712a13371e9"

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -114,11 +114,7 @@ module SAML
     end
 
     def enabled_tou_clients
-      if Settings.vsp_environment == 'production'
-        TERMS_OF_USE_ENABLED_CLIENTS
-      else
-        TERMS_OF_USE_ENABLED_CLIENTS_LOWERS
-      end
+      Settings.terms_of_use.enabled_clients.split(',').collect(&:strip)
     end
   end
 end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -25,8 +25,6 @@ module SAML
     WEB_CLIENT_ID = 'web'
     MOBILE_CLIENT_ID = 'mobile'
     UNIFIED_SIGN_IN_CLIENTS = %w[vaweb mhv myvahealth ebenefits vamobile vaoccmobile].freeze
-    TERMS_OF_USE_ENABLED_CLIENTS = %w[].freeze
-    TERMS_OF_USE_ENABLED_CLIENTS_LOWERS = %w[vaweb mhv myvahealth].freeze
     TERMS_OF_USE_DECLINED_PATH = '/terms-of-use/declined'
 
     attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :tracker

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -502,13 +502,16 @@ RSpec.describe V1::SessionsController, type: :controller do
 
       context 'when user has not accepted the current terms of use' do
         let(:user) { build(:user, loa, uuid:, idme_uuid: uuid) }
+        let(:application) { 'some-applicaton' }
 
         before do
           SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: })
         end
 
-        context 'and authentication occurred with a application in TERMS_OF_USE_ENABLED_CLIENTS' do
-          let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS.first }
+        context 'and authentication occurred with a application in Settings.terms_of_use.enabled_clients' do
+          before do
+            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+          end
 
           it 'redirects to terms of use page' do
             expect(call_endpoint).to redirect_to(
@@ -517,8 +520,10 @@ RSpec.describe V1::SessionsController, type: :controller do
           end
         end
 
-        context 'and authentication occurred with an application not in TERMS_OF_USE_ENABLED_CLIENTS' do
-          let(:application) { 'foobar' }
+        context 'and authentication occurred with an application not in Settings.terms_of_use.enabled_clients' do
+          before do
+            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
+          end
 
           it 'redirects to expected auth page' do
             expect(call_endpoint).to redirect_to(expected_redirect_url)
@@ -540,13 +545,16 @@ RSpec.describe V1::SessionsController, type: :controller do
 
       context 'when user has not accepted the current terms of use' do
         let(:user) { build(:user, loa, uuid:, idme_uuid: uuid) }
+        let(:application) { 'some-applicaton' }
 
         before do
           SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: })
         end
 
-        context 'and authentication occurred with a application in TERMS_OF_USE_ENABLED_CLIENTS' do
-          let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS.first }
+        context 'and authentication occurred with a application in Settings.terms_of_use.enabled_clients' do
+          before do
+            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+          end
 
           it 'redirects to terms of use page' do
             expect(call_endpoint).to redirect_to(
@@ -555,8 +563,10 @@ RSpec.describe V1::SessionsController, type: :controller do
           end
         end
 
-        context 'and authentication occurred with an application not in TERMS_OF_USE_ENABLED_CLIENTS' do
-          let(:application) { 'foobar' }
+        context 'and authentication occurred with an application not in Settings.terms_of_use.enabled_clients' do
+          before do
+            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
+          end
 
           it 'redirects to expected auth page' do
             expect(call_endpoint).to redirect_to(expected_redirect_url)

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -613,8 +613,10 @@ RSpec.describe SAML::PostURLService do
             let(:expected_log_message) { 'Redirecting to /terms-of-use' }
             let(:expected_log_payload) { { type: :ssoe } }
 
-            context 'when tracker application is within TERMS_OF_USE_ENABLED_CLIENTS' do
-              let(:application) { SAML::URLService::TERMS_OF_USE_ENABLED_CLIENTS_LOWERS.first }
+            context 'when tracker application is within Settings.terms_of_use.enabled_clients' do
+              before do
+                allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+              end
 
               context 'and authentication is occuring on a review instance' do
                 let(:review_instance_slug) { 'some-review-instance-slug' }
@@ -660,8 +662,10 @@ RSpec.describe SAML::PostURLService do
               end
             end
 
-            context 'when tracker application is not within TERMS_OF_USE_ENABLED_CLIENTS' do
-              let(:application) { 'some-application' }
+            context 'when tracker application is not within Settings.terms_of_use.enabled_clients' do
+              before do
+                allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
+              end
 
               it 'has a login redirect url with success not embedded in a terms of use page' do
                 expect(subject.terms_of_use_redirect_url)


### PR DESCRIPTION
## Summary
- Move terms of use enabled_clients to settings

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80260
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2803
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2804

## Testing
- Sign in with SSOe with a user that hasn't accepted ToU
- You should be required to accept before you're able to proceed 

## What areas of the site does it impact?
Terms of use

