### PR TITLE
[BUG] - Fixing mismatch between website and pdf mapper

### DIFF
--- a/lib/pdf_fill/forms/va21p530v2.rb
+++ b/lib/pdf_fill/forms/va21p530v2.rb
@@ -282,10 +282,10 @@ module PdfFill
           'executor' => {
             key: 'form1[0].#subform[82].CheckboxExecutor[0]'
           },
-          'funeralHome' => {
+          'funeralDirector' => {
             key: 'form1[0].#subform[82].CheckboxFuneralHome[0]'
           },
-          'other' => {
+          'otherFamily' => {
             key: 'form1[0].#subform[82].CheckboxOther[0]'
           }
         },
@@ -714,8 +714,8 @@ module PdfFill
           'child' => select_checkbox(relationship_to_veteran == 'child'),
           'executor' => select_checkbox(relationship_to_veteran == 'executor'),
           'parent' => select_checkbox(relationship_to_veteran == 'parent'),
-          'funeralHome' => select_checkbox(relationship_to_veteran == 'funeralHome'),
-          'other' => select_checkbox(relationship_to_veteran == 'other')
+          'funeralDirector' => select_checkbox(relationship_to_veteran == 'funeralDirector'),
+          'otherFamily' => select_checkbox(relationship_to_veteran == 'otherFamily')
         }
 
         # special case for transportation being the only option selected.

--- a/spec/fixtures/pdf_fill/21P-530V2/merge_fields.json
+++ b/spec/fixtures/pdf_fill/21P-530V2/merge_fields.json
@@ -68,7 +68,7 @@
     "claimantSocialSecurityNumber":{"first":"987", "second":"65", "third":"4321"},
     "claimantDateOfBirth":{"month":"01", "day":"01", "year":"1960"},
     "formV2":true,
-    "relationshipToVeteran":{"spouse":"On", "child":"Off", "executor":"Off", "parent":"Off", "funeralHome":"Off", "other":"Off"},
+    "relationshipToVeteran":{"spouse":"On", "child":"Off", "executor":"Off", "parent":"Off", "funeralDirector":"Off", "otherFamily":"Off"},
     "privacyAgreementAccepted":true,
     "signature":"test spouse",
     "signatureDate":"2024-03-21",


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- bug discovered in E2E testing where PDF filler was not marking checkbox correctly. this ticket syncs the field names to match what vets-website sends 
- Fill out v2 Burial form, mark relationship to Veteran as Other or Funeral Home, submit form, pull PDF from Benefits Intake and validate it is marked correctly

## Related issue(s)

- https://app.zenhub.com/workspaces/benefits-non-disability-645913c7d909c20011380ae8/issues/gh/department-of-veterans-affairs/va.gov-team/80575

## Testing done

- Manual testing of PDF after submission

## Screenshots
<img width="967" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/7817263/77d86aa2-2434-4fa6-96b4-86b667f6cc88">
<img width="967" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/7817263/fbdce6e6-b7ba-4b7a-a2c5-bf7a2609fc7d">


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
