### PR TITLE
Update feature flag for direct deposit merge

### DIFF
--- a/app/controllers/v0/profile/direct_deposits_controller.rb
+++ b/app/controllers/v0/profile/direct_deposits_controller.rb
@@ -19,6 +19,9 @@ module V0
         error = { status: exception.status_code, body: exception.errors.first }
         response = Lighthouse::DirectDeposit::ErrorParser.parse(error)
 
+        # temporary - will be removed after direct deposit merge is complete
+        update_error_code_prefix(response) if single_form_enabled?
+
         render status: response.status, json: response.body
       end
 
@@ -40,6 +43,14 @@ module V0
       end
 
       private
+
+      def single_form_enabled?
+        Flipper.enabled?(:profile_show_direct_deposit_single_form, @current_user)
+      end
+
+      def update_error_code_prefix(response)
+        response.code = response.code.sub('cnp.payment', 'direct.deposit')
+      end
 
       def client
         @client ||= DirectDeposit::Client.new(@current_user.icn)

--- a/lib/lighthouse/direct_deposit/error_parser.rb
+++ b/lib/lighthouse/direct_deposit/error_parser.rb
@@ -44,35 +44,29 @@ module Lighthouse
       end
 
       def self.parse_code(detail) # rubocop:disable Metrics/MethodLength
-        return "#{prefix}.api.rate.limit.exceeded" if detail.include? 'API rate limit exceeded'
-        return "#{prefix}.api.gateway.timeout" if detail.include? 'Did not receive a timely response'
-        return "#{prefix}.invalid.authentication.creds" if detail.include? 'Invalid authentication credentials'
-        return "#{prefix}.invalid.token" if detail.include? 'Invalid token'
-        return "#{prefix}.invalid.scopes" if detail.include? 'scopes are not configured'
-        return "#{prefix}.icn.not.found" if detail.include? 'No data found for ICN'
-        return "#{prefix}.icn.invalid" if detail.include? 'getDirectDeposit.icn size'
-        return "#{prefix}.account.number.invalid" if detail.include? 'payment.accountNumber.invalid'
-        return "#{prefix}.account.type.invalid" if detail.include? 'payment.accountType.invalid'
-        return "#{prefix}.account.number.fraud" if detail.include? 'Flashes on record'
-        return "#{prefix}.routing.number.invalid.checksum" if detail.include? 'accountRoutingNumber.invalidCheckSum'
-        return "#{prefix}.routing.number.invalid" if detail.include? 'payment.accountRoutingNumber.invalid'
-        return "#{prefix}.routing.number.fraud" if detail.include? 'Routing number related to potential fraud'
-        return "#{prefix}.restriction.indicators.present" if detail.include? 'restriction.indicators.present'
-        return "#{prefix}.day.phone.number.invalid" if detail.include? 'Day phone number is invalid'
-        return "#{prefix}.day.area.number.invalid" if detail.include? 'Day area number is invalid'
-        return "#{prefix}.night.phone.number.invalid" if detail.include? 'Night phone number is invalid'
-        return "#{prefix}.night.area.number.invalid" if detail.include? 'Night area number is invalid'
-        return "#{prefix}.mailing.address.invalid" if detail.include? 'field not entered for mailing address update'
-        return "#{prefix}.potential.fraud" if detail.include? 'GUIE50041'
-        return "#{prefix}.unspecified.error" if detail.include? 'GUIE50022'
+        return 'cnp.payment.api.rate.limit.exceeded' if detail.include? 'API rate limit exceeded'
+        return 'cnp.payment.api.gateway.timeout' if detail.include? 'Did not receive a timely response'
+        return 'cnp.payment.invalid.authentication.creds' if detail.include? 'Invalid authentication credentials'
+        return 'cnp.payment.invalid.token' if detail.include? 'Invalid token'
+        return 'cnp.payment.invalid.scopes' if detail.include? 'scopes are not configured'
+        return 'cnp.payment.icn.not.found' if detail.include? 'No data found for ICN'
+        return 'cnp.payment.icn.invalid' if detail.include? 'getDirectDeposit.icn size'
+        return 'cnp.payment.account.number.invalid' if detail.include? 'payment.accountNumber.invalid'
+        return 'cnp.payment.account.type.invalid' if detail.include? 'payment.accountType.invalid'
+        return 'cnp.payment.account.number.fraud' if detail.include? 'Flashes on record'
+        return 'cnp.payment.routing.number.invalid.checksum' if detail.include? 'accountRoutingNumber.invalidCheckSum'
+        return 'cnp.payment.routing.number.invalid' if detail.include? 'payment.accountRoutingNumber.invalid'
+        return 'cnp.payment.routing.number.fraud' if detail.include? 'Routing number related to potential fraud'
+        return 'cnp.payment.restriction.indicators.present' if detail.include? 'restriction.indicators.present'
+        return 'cnp.payment.day.phone.number.invalid' if detail.include? 'Day phone number is invalid'
+        return 'cnp.payment.day.area.number.invalid' if detail.include? 'Day area number is invalid'
+        return 'cnp.payment.night.phone.number.invalid' if detail.include? 'Night phone number is invalid'
+        return 'cnp.payment.night.area.number.invalid' if detail.include? 'Night area number is invalid'
+        return 'cnp.payment.mailing.address.invalid' if detail.include? 'field not entered for mailing address update'
+        return 'cnp.payment.potential.fraud' if detail.include? 'GUIE50041'
+        return 'cnp.payment.unspecified.error' if detail.include? 'GUIE50022'
 
-        "#{prefix}.generic.error"
-      end
-
-      def self.prefix
-        return 'direct.deposit' if Flipper.enabled?(:profile_show_direct_deposit_single_form)
-
-        'cnp.payment'
+        'cnp.payment.generic.error'
       end
 
       def self.data_source

--- a/lib/lighthouse/direct_deposit/error_response.rb
+++ b/lib/lighthouse/direct_deposit/error_response.rb
@@ -21,6 +21,10 @@ module Lighthouse
         { errors: @errors }
       end
 
+      def code=(code)
+        errors.first[:code] = code
+      end
+
       def code
         errors.first[:code]
       end

--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -405,43 +405,4 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
       end
     end
   end
-
-  describe '#update feature flag' do
-    let(:params) do
-      {
-        routing_number: '031000503',
-        account_number: '12345678'
-      }
-    end
-
-    context 'when feature flag is on' do
-      before do
-        Flipper.enable(:profile_show_direct_deposit_single_form)
-      end
-
-      it 'error code is prefixed with direct.deposit' do
-        VCR.use_cassette('lighthouse/direct_deposit/update/400_invalid_account_type') do
-          put(:update, params:)
-        end
-
-        json = JSON.parse(response.body)
-        e = json['errors'].first
-
-        expect(e['code']).to eq('direct.deposit.account.type.invalid')
-      end
-    end
-
-    context 'when feature flag is off' do
-      it 'error code is prefixed with cnp.payment' do
-        VCR.use_cassette('lighthouse/direct_deposit/update/400_invalid_account_type') do
-          put(:update, params:)
-        end
-
-        json = JSON.parse(response.body)
-        e = json['errors'].first
-
-        expect(e['code']).to eq('cnp.payment.account.type.invalid')
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Summary
Move `profile_show_direct_deposit_single_form` feature flag to direct deposit controller.  This flag will toggle error code prefixes for direct deposit.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/79767

## Testing done
- direct_deposits_controller_spec
- disability_compensations_controller_spec