### PR TITLE
Require `ostruct` in Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'ostruct'
 module VSPDanger
   HEAD_SHA = `git rev-parse --abbrev-ref HEAD`.chomp.freeze
   BASE_SHA = 'origin/master'

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'ostruct'
+
 module VSPDanger
   HEAD_SHA = `git rev-parse --abbrev-ref HEAD`.chomp.freeze
   BASE_SHA = 'origin/master'

--- a/app/controllers/appeals_base_controller.rb
+++ b/app/controllers/appeals_base_controller.rb
@@ -3,6 +3,7 @@
 require 'caseflow/service'
 require 'decision_review/service'
 
+# test
 class AppealsBaseController < ApplicationController
   include ActionController::Serialization
   include FailedRequestLoggable

--- a/app/controllers/appeals_base_controller.rb
+++ b/app/controllers/appeals_base_controller.rb
@@ -3,7 +3,6 @@
 require 'caseflow/service'
 require 'decision_review/service'
 
-# test
 class AppealsBaseController < ApplicationController
   include ActionController::Serialization
   include FailedRequestLoggable


### PR DESCRIPTION
I'm not sure why, but the Danger CI check in PRs started failing last night. [Example output](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/8661505007/job/23752901332).
**Error**:
```
[!] Invalid Dangerfile file: uninitialized constant Danger::Dangerfile::VSPDanger::ChangeLimiter::OpenStruct
 #  from Dangerfile:128
 #  -------------------------------------------
 #  
 >          OpenStruct.new(
 #            total_changes: insertions + deletions,
 #  -------------------------------------------
```
The failure was reported to support: https://dsva.slack.com/archives/CBU0KDSB1/p1712923438985509