### PR TITLE
KmsKeyRotation::BatchInitiatorJob nil encrypted_kms_key error

### DIFF
--- a/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
+++ b/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
@@ -45,6 +45,7 @@ module KmsKeyRotation
 
       model
         .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%")
+        .or(model.where(encrypted_kms_key: nil))
         .limit(max_records_per_batch)
         .pluck(model.primary_key)
         .map { |id| URI::GID.build(app: GlobalID.app, model_name: model.name, model_id: id).to_s }


### PR DESCRIPTION
## Summary

- KmsKeyRotation::BatchInitiatorJob#gids_for_model doesn't include records with nil key
- Add `.or(model.where(encrypted_kms_key: nil))` to include in key rotation job

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80721

## Testing done
- Manual testing

## Acceptance criteria

- [X]  `gids_for_model` returns records with `encrypted_kms_key = nil`
