### PR TITLE
API-34439 option to not transform BGS response

### DIFF
--- a/modules/claims_api/lib/bgs_service/manage_representative_service.rb
+++ b/modules/claims_api/lib/bgs_service/manage_representative_service.rb
@@ -5,14 +5,15 @@ require_relative 'manage_representative_service/update_poa_request'
 
 module ClaimsApi
   class ManageRepresentativeService < ClaimsApi::LocalBGS
-    def endpoint
-      'VDC/ManageRepresentativeService'
-    end
+    private
 
-    def namespaces
-      {
-        'data' => '/data'
-      }
+    def make_request(**args)
+      super(
+        endpoint: 'VDC/ManageRepresentativeService',
+        namespaces: { 'data' => '/data' },
+        transform_response: false,
+        **args
+      )
     end
   end
 end

--- a/modules/claims_api/lib/bgs_service/manage_representative_service/read_poa_request.rb
+++ b/modules/claims_api/lib/bgs_service/manage_representative_service/read_poa_request.rb
@@ -30,7 +30,6 @@ module ClaimsApi
         end
 
       make_request(
-        endpoint:,
         action: 'readPOARequest',
         body: builder.doc.at('root').children.to_xml,
         key: 'POARequestRespondReturnVO'

--- a/modules/claims_api/lib/bgs_service/manage_representative_service/update_poa_request.rb
+++ b/modules/claims_api/lib/bgs_service/manage_representative_service/update_poa_request.rb
@@ -16,7 +16,6 @@ module ClaimsApi
         EOXML
 
       make_request(
-        endpoint:,
         action: 'updatePOARequest',
         body: body.to_s,
         key: 'POARequestUpdate'

--- a/modules/claims_api/spec/lib/claims_api/manage_representative_service/read_poa_request_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/manage_representative_service/read_poa_request_spec.rb
@@ -138,30 +138,30 @@ describe ClaimsApi::ManageRepresentativeService, metadata do
 
         let(:expected) do
           {
-            poa_request_respond_return_vo_list: {
-              vso_user_email: nil,
-              vso_user_first_name: 'VDC USER',
-              vso_user_last_name: nil,
-              change_address_auth: 'Y',
-              claimant_city: 'SEASIDE',
-              claimant_country: 'USA',
-              claimant_military_po: nil,
-              claimant_military_postal_code: nil,
-              claimant_state: 'MT',
-              claimant_zip: '95102',
-              date_request_actioned: '2015-08-05T11:33:20-05:00',
-              date_request_received: '2015-08-05T11:33:20-05:00',
-              declined_reason: nil,
-              health_info_auth: 'N',
-              poa_code: '091',
-              proc_id: '52095',
-              secondary_status: 'New',
-              vet_first_name: 'Wallace',
-              vet_last_name: 'Webb',
-              vet_middle_name: 'R',
-              vet_ptcpnt_id: '600043200'
+            'poaRequestRespondReturnVOList' => {
+              'VSOUserEmail' => nil,
+              'VSOUserFirstName' => 'VDC USER',
+              'VSOUserLastName' => nil,
+              'changeAddressAuth' => 'Y',
+              'claimantCity' => 'SEASIDE',
+              'claimantCountry' => 'USA',
+              'claimantMilitaryPO' => nil,
+              'claimantMilitaryPostalCode' => nil,
+              'claimantState' => 'MT',
+              'claimantZip' => '95102',
+              'dateRequestActioned' => '2015-08-05T11:33:20-05:00',
+              'dateRequestReceived' => '2015-08-05T11:33:20-05:00',
+              'declinedReason' => nil,
+              'healthInfoAuth' => 'N',
+              'poaCode' => '091',
+              'procID' => '52095',
+              'secondaryStatus' => 'New',
+              'vetFirstName' => 'Wallace',
+              'vetLastName' => 'Webb',
+              'vetMiddleName' => 'R',
+              'vetPtcpntID' => '600043200'
             },
-            total_nbr_of_records: '1'
+            'totalNbrOfRecords' => '1'
           }
         end
 

--- a/modules/claims_api/spec/lib/claims_api/manage_representative_service/update_poa_request_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/manage_representative_service/update_poa_request_spec.rb
@@ -47,13 +47,13 @@ describe ClaimsApi::ManageRepresentativeService, metadata do
         use_bgs_cassette('happy_path') do
           expect(subject).to eq(
             {
-              vso_user_email: nil,
-              vso_user_first_name: params[:representative].first_name,
-              vso_user_last_name: params[:representative].last_name,
-              declined_reason: nil,
-              proc_id: params[:proc_id],
-              secondary_status: 'OBS',
-              date_request_actioned:
+              'VSOUserEmail' => nil,
+              'VSOUserFirstName' => params[:representative].first_name,
+              'VSOUserLastName' => params[:representative].last_name,
+              'declinedReason' => nil,
+              'procId' => params[:proc_id],
+              'secondaryStatus' => 'OBS',
+              'dateRequestActioned' =>
                 # Formatting this to show the difference between the date returned
                 # in response and the date sent in request.
                 Time.current.in_time_zone('America/Chicago').iso8601


### PR DESCRIPTION
- Refactor `LocalBGS#parsed_response` to streamline all "special cases" as one, particularly extricating the ITF special case
- Refactor `make_request` customization to come from arguments that caller passes instead
- Make BGS response transformation optional and opt out in `ManageRepresentativeService` operations (hypothesis is that the transformation has downsides and doesn't really have upsides, at least for this use case or whatever I could imagine)