### PR TITLE
Fixing missing atom symbol for field name.

### DIFF
--- a/db/migrate/20240411153944_create_average_days_for_claim_completions.rb
+++ b/db/migrate/20240411153944_create_average_days_for_claim_completions.rb
@@ -2,7 +2,7 @@
 class CreateAverageDaysForClaimCompletions < ActiveRecord::Migration[7.1]
   def change
     create_table :average_days_for_claim_completions do |t|
-      t.float average_days
+      t.float :average_days
 
       t.timestamps
     end


### PR DESCRIPTION
This is an immediate fix due to a missing colon which should've been done during the migration.