### PR TITLE
[78005] updates logout redirect generator to accept access_token derived user…

### DIFF
--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -34,20 +34,12 @@ module SignIn
       nil
     end
 
-    def access_token_authenticate
+    def access_token_authenticate(skip_error_handling: false)
       access_token.present?
     rescue Errors::AccessTokenExpiredError => e
-      render json: { errors: e }, status: :forbidden
+      render json: { errors: e }, status: :forbidden unless skip_error_handling
     rescue Errors::StandardError => e
-      handle_authenticate_error(e)
-    end
-
-    def access_token_optional_authenticate(skip_expiration_check: false)
-      access_token.present?
-    rescue Errors::AccessTokenExpiredError => e
-      render json: { errors: e }, status: :forbidden unless skip_expiration_check
-    rescue Errors::StandardError
-      nil
+      handle_authenticate_error(e) unless skip_error_handling
     end
 
     private

--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -34,7 +34,15 @@ module SignIn
       nil
     end
 
-    def access_token_authenticate(skip_expiration_check: false)
+    def access_token_authenticate
+      access_token.present?
+    rescue Errors::AccessTokenExpiredError => e
+      render json: { errors: e }, status: :forbidden
+    rescue Errors::StandardError
+      handle_authenticate_error(e)
+    end
+
+    def access_token_optional_authenticate(skip_expiration_check: false)
       access_token.present?
     rescue Errors::AccessTokenExpiredError => e
       render json: { errors: e }, status: :forbidden unless skip_expiration_check

--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -34,12 +34,12 @@ module SignIn
       nil
     end
 
-    def access_token_authenticate(required: true)
+    def access_token_authenticate(skip_expiration_check: false)
       access_token.present?
     rescue Errors::AccessTokenExpiredError => e
-      render json: { errors: e }, status: :forbidden if required
-    rescue Errors::StandardError => e
-      handle_authenticate_error(e)
+      render json: { errors: e }, status: :forbidden unless skip_expiration_check
+    rescue Errors::StandardError
+      nil
     end
 
     private

--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -38,7 +38,7 @@ module SignIn
       access_token.present?
     rescue Errors::AccessTokenExpiredError => e
       render json: { errors: e }, status: :forbidden
-    rescue Errors::StandardError
+    rescue Errors::StandardError => e
       handle_authenticate_error(e)
     end
 

--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -34,6 +34,14 @@ module SignIn
       nil
     end
 
+    def access_token_authenticate(required: true)
+      access_token.present?
+    rescue Errors::AccessTokenExpiredError => e
+      render json: { errors: e }, status: :forbidden if required
+    rescue Errors::StandardError => e
+      handle_authenticate_error(e)
+    end
+
     private
 
     def access_token

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -184,7 +184,7 @@ module V0
         raise SignIn::Errors::MalformedParamsError.new message: 'Client id is not valid'
       end
 
-      unless access_token_optional_authenticate(skip_expiration_check: true)
+      unless access_token_authenticate(skip_error_handling: true)
         raise SignIn::Errors::LogoutAuthorizationError.new message: 'Unable to authorize access token'
       end
 

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -196,6 +196,10 @@ module V0
       end
 
       if client_id
+        if client_config(client_id).blank?
+          raise SignIn::Errors::MalformedParamsError.new message: 'Client id is not valid'
+        end
+
         logout_redirect = SignIn::LogoutRedirectGenerator.new(user_verification:,
                                                               client_config: client_config(client_id)).perform
         logout_redirect ? redirect_to(logout_redirect) : render(status: :ok)

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -6,7 +6,7 @@ module V0
   class SignInController < SignIn::ApplicationController
     skip_before_action :authenticate,
                        only: %i[authorize callback token refresh revoke logout logingov_logout_proxy]
-    before_action -> { access_token_authenticate(required: false) }, only: %i[logout]
+    before_action -> { access_token_authenticate(skip_expiration_check: true) }, only: %i[logout]
 
     def authorize # rubocop:disable Metrics/MethodLength
       type = params[:type].presence
@@ -176,36 +176,33 @@ module V0
 
     def logout # rubocop:disable Metrics/MethodLength
       client_id = params[:client_id].presence
+      if client_id && client_config(client_id).blank?
+        raise SignIn::Errors::MalformedParamsError.new message: 'Client id is not valid'
+      end
+
       user_verification = nil
 
-      if @access_token&.session_handle.present?
-        session = SignIn::OAuthSession.find_by(handle: @access_token.session_handle)
+      if (session = SignIn::OAuthSession.find_by(handle: @access_token&.session_handle))
         user_verification = session.user_verification
-        client_id = session.client_id
+        client_id = session.client_id if client_id.blank?
         anti_csrf_token = anti_csrf_token_param.presence
 
         SignIn::SessionRevoker.new(access_token: @access_token, anti_csrf_token:).perform
         delete_cookies if token_cookies
-
+        logout_redirect = SignIn::LogoutRedirectGenerator.new(user_verification:,
+                                                              client_config: client_config(client_id)).perform
         sign_in_logger.info('logout', @access_token.to_s)
         StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_SUCCESS)
       else
         user_verification = OpenStruct.new(credential_type: nil)
-        sign_in_logger.info('logout error', { errors: 'No valid Session found' })
         delete_cookies if token_cookies
-      end
-
-      if client_id
-        if client_config(client_id).blank?
-          raise SignIn::Errors::MalformedParamsError.new message: 'Client id is not valid'
-        end
-
         logout_redirect = SignIn::LogoutRedirectGenerator.new(user_verification:,
                                                               client_config: client_config(client_id)).perform
-        logout_redirect ? redirect_to(logout_redirect) : render(status: :ok)
-      else
-        render status: :ok
+        sign_in_logger.info('logout error', { errors: 'No valid Session found' })
+        StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_FAILURE)
       end
+
+      logout_redirect ? redirect_to(logout_redirect) : render(status: :ok)
     rescue SignIn::Errors::SessionNotAuthorizedError => e
       sign_in_logger.info('logout error', { errors: e.message })
       StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_FAILURE)

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -5,7 +5,8 @@ require 'sign_in/logger'
 module V0
   class SignInController < SignIn::ApplicationController
     skip_before_action :authenticate,
-                       only: %i[authorize callback token refresh revoke logingov_logout_proxy]
+                       only: %i[authorize callback token refresh revoke logout logingov_logout_proxy]
+    before_action -> { access_token_authenticate(required: false) }, only: %i[logout]
 
     def authorize # rubocop:disable Metrics/MethodLength
       type = params[:type].presence
@@ -174,25 +175,32 @@ module V0
     end
 
     def logout # rubocop:disable Metrics/MethodLength
-      session = SignIn::OAuthSession.find_by(handle: @access_token.session_handle)
-      user_verification = session.user_verification
-      client_id = params[:client_id].presence || session.client_id
-      anti_csrf_token = anti_csrf_token_param.presence
+      client_id = params[:client_id].presence
 
-      if client_config(client_id).blank?
-        raise SignIn::Errors::MalformedParamsError.new message: 'Client id is not valid'
+      if @access_token&.session_handle.present?
+        session = SignIn::OAuthSession.find_by(handle: @access_token.session_handle)
+        user_verification = session.user_verification
+        client_id = session.client_id
+        anti_csrf_token = anti_csrf_token_param.presence
+
+        SignIn::SessionRevoker.new(access_token: @access_token, anti_csrf_token:).perform
+        delete_cookies if token_cookies
+
+        sign_in_logger.info('logout', @access_token.to_s)
+        StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_SUCCESS)
+      else
+        user_verification = OpenStruct.new(:credential_type => nil)
+        sign_in_logger.info('logout error', { errors: 'No valid Session found' })
+        delete_cookies if token_cookies
       end
 
-      SignIn::SessionRevoker.new(access_token: @access_token, anti_csrf_token:).perform
-      delete_cookies if token_cookies
-
-      sign_in_logger.info('logout', @access_token.to_s)
-      StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_SUCCESS)
-
-      logout_redirect = SignIn::LogoutRedirectGenerator.new(user_verification:,
-                                                            client_config: client_config(client_id)).perform
-
-      logout_redirect ? redirect_to(logout_redirect) : render(status: :ok)
+      if client_id
+        logout_redirect = SignIn::LogoutRedirectGenerator.new(user_verification:,
+                                                              client_config: client_config(client_id)).perform
+        logout_redirect ? redirect_to(logout_redirect) : render(status: :ok)
+      else
+        render status: :ok
+      end
     rescue SignIn::Errors::SessionNotAuthorizedError => e
       sign_in_logger.info('logout error', { errors: e.message })
       StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_FAILURE)

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -176,6 +176,7 @@ module V0
 
     def logout # rubocop:disable Metrics/MethodLength
       client_id = params[:client_id].presence
+      user_verification = nil
 
       if @access_token&.session_handle.present?
         session = SignIn::OAuthSession.find_by(handle: @access_token.session_handle)
@@ -189,7 +190,7 @@ module V0
         sign_in_logger.info('logout', @access_token.to_s)
         StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_SUCCESS)
       else
-        user_verification = OpenStruct.new(:credential_type => nil)
+        user_verification = OpenStruct.new(credential_type: nil)
         sign_in_logger.info('logout error', { errors: 'No valid Session found' })
         delete_cookies if token_cookies
       end

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -188,7 +188,7 @@ module V0
         raise SignIn::Errors::LogoutAuthorizationError.new message: 'Unable to authorize access token'
       end
 
-      session = SignIn::OAuthSession.find_by(handle: @access_token&.session_handle)
+      session = SignIn::OAuthSession.find_by(handle: @access_token.session_handle)
       credential_type = session.user_verification.credential_type
 
       SignIn::SessionRevoker.new(access_token: @access_token, anti_csrf_token:).perform
@@ -203,8 +203,7 @@ module V0
     rescue SignIn::Errors::LogoutAuthorizationError, SignIn::Errors::SessionNotAuthorizedError => e
       sign_in_logger.info('logout error', { errors: e.message })
       StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_FAILURE)
-      logout_redirect = SignIn::LogoutRedirectGenerator.new(credential_type: nil,
-                                                            client_config: client_config(client_id)).perform
+      logout_redirect = SignIn::LogoutRedirectGenerator.new(client_config: client_config(client_id)).perform
 
       logout_redirect ? redirect_to(logout_redirect) : render(status: :ok)
     rescue => e

--- a/app/services/sign_in/logout_redirect_generator.rb
+++ b/app/services/sign_in/logout_redirect_generator.rb
@@ -32,7 +32,7 @@ module SignIn
     end
 
     def logout_redirect_uri
-      @logout_redirect_uri ||= client_config.logout_redirect_uri
+      @logout_redirect_uri ||= client_config&.logout_redirect_uri
     end
 
     def logingov_service

--- a/app/services/sign_in/logout_redirect_generator.rb
+++ b/app/services/sign_in/logout_redirect_generator.rb
@@ -4,10 +4,10 @@ require 'sign_in/logingov/service'
 
 module SignIn
   class LogoutRedirectGenerator
-    attr_reader :user, :client_config
+    attr_reader :user_verification, :client_config
 
-    def initialize(user:, client_config:)
-      @user = user
+    def initialize(user_verification:, client_config:)
+      @user_verification = user_verification
       @client_config = client_config
     end
 
@@ -28,15 +28,11 @@ module SignIn
     end
 
     def authenticated_with_logingov?
-      authenticated_credential == Constants::Auth::LOGINGOV
+      user_verification.credential_type == Constants::Auth::LOGINGOV
     end
 
     def logout_redirect_uri
       @logout_redirect_uri ||= client_config.logout_redirect_uri
-    end
-
-    def authenticated_credential
-      @authenticated_credential ||= user.nil? ? nil : user.identity.sign_in[:service_name]
     end
 
     def logingov_service

--- a/app/services/sign_in/logout_redirect_generator.rb
+++ b/app/services/sign_in/logout_redirect_generator.rb
@@ -4,10 +4,10 @@ require 'sign_in/logingov/service'
 
 module SignIn
   class LogoutRedirectGenerator
-    attr_reader :user_verification, :client_config
+    attr_reader :credential_type, :client_config
 
-    def initialize(user_verification:, client_config:)
-      @user_verification = user_verification
+    def initialize(credential_type:, client_config:)
+      @credential_type = credential_type
       @client_config = client_config
     end
 
@@ -28,7 +28,7 @@ module SignIn
     end
 
     def authenticated_with_logingov?
-      user_verification.credential_type == Constants::Auth::LOGINGOV
+      credential_type == Constants::Auth::LOGINGOV
     end
 
     def logout_redirect_uri

--- a/app/services/sign_in/logout_redirect_generator.rb
+++ b/app/services/sign_in/logout_redirect_generator.rb
@@ -6,7 +6,7 @@ module SignIn
   class LogoutRedirectGenerator
     attr_reader :credential_type, :client_config
 
-    def initialize(credential_type:, client_config:)
+    def initialize(client_config:, credential_type: nil)
       @credential_type = credential_type
       @client_config = client_config
     end

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
@@ -45,10 +45,11 @@ module AccreditedRepresentativePortal
     end
 
     def authn_context
-      if user_verification.credential_type == SignIn::Constants::Auth::IDME
-        SignIn::Constants::Auth::IDME_LOA3
-      else
+      case user_verification.credential_type
+      when SignIn::Constants::Auth::LOGINGOV
         SignIn::Constants::Auth::LOGIN_GOV_IAL2
+      when SignIn::Constants::Auth::IDME
+        SignIn::Constants::Auth::IDME_LOA3
       end
     end
 

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
     skip_before_action :authenticate, only: %w[index_optional_auth access_token_auth access_token_optional_auth]
     before_action :load_user, only: %(index_optional_auth)
     before_action :access_token_authenticate, only: %(access_token_auth)
-    before_action :access_token_optional_authenticate, only: %(access_token_optional_auth)
 
     attr_reader :payload
 
@@ -49,7 +48,6 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       get 'index' => 'sign_in/application#index'
       get 'index_optional_auth' => 'sign_in/application#index_optional_auth'
       get 'access_token_auth' => 'sign_in/application#access_token_auth'
-      get 'access_token_optional_auth' => 'sign_in/application#access_token_optional_auth'
     end
   end
 
@@ -458,106 +456,6 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
         let(:access_token) { 'some-arbitrary-access-token' }
         let(:expected_error) { 'Access token JWT is malformed' }
         let(:expected_error_json) { { 'errors' => expected_error } }
-
-        it_behaves_like 'error response'
-      end
-
-      context 'and access_token is an expired JWT' do
-        let(:access_token_object) { create(:access_token, expiration_time:) }
-        let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-        let(:expiration_time) { Time.zone.now - 1.day }
-        let(:expected_error) { 'Access token has expired' }
-        let(:expected_error_json) { { 'errors' => expected_error } }
-
-        it 'renders Access Token Expired error' do
-          expect(JSON.parse(subject.body)).to eq(expected_error_json)
-        end
-
-        it 'returns forbidden status' do
-          expect(subject).to have_http_status(:forbidden)
-        end
-      end
-
-      context 'and access_token is an active JWT' do
-        let(:access_token_object) { create(:access_token) }
-        let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-
-        it 'returns ok status' do
-          expect(subject).to have_http_status(:ok)
-        end
-      end
-    end
-  end
-
-  describe '#access_token_optional_authenticate' do
-    subject { get :access_token_optional_auth }
-
-    shared_context 'error response' do
-      it 'returns ok status' do
-        expect(subject).to have_http_status(:ok)
-      end
-    end
-
-    context 'when authorization header does not exist' do
-      let(:access_token) { nil }
-
-      context 'and access token cookie does not exist' do
-        let(:access_token_cookie) { nil }
-
-        it_behaves_like 'error response'
-      end
-
-      context 'and access token cookie exists' do
-        let(:access_token_cookie) { 'some-access-token' }
-
-        before do
-          cookies[SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME] = access_token_cookie
-        end
-
-        context 'and access_token is some arbitrary value' do
-          let(:access_token_cookie) { 'some-arbitrary-access-token' }
-
-          it_behaves_like 'error response'
-        end
-
-        context 'and access_token is an expired JWT' do
-          let(:access_token_object) { create(:access_token, expiration_time:) }
-          let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-          let(:expiration_time) { Time.zone.now - 1.day }
-          let(:expected_error) { 'Access token has expired' }
-          let(:expected_error_json) { { 'errors' => expected_error } }
-
-          it 'renders Access Token Expired error' do
-            expect(JSON.parse(subject.body)).to eq(expected_error_json)
-          end
-
-          it 'returns forbidden status' do
-            expect(subject).to have_http_status(:forbidden)
-          end
-        end
-
-        context 'and access_token is an active JWT' do
-          let(:access_token_object) { create(:access_token) }
-          let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-
-          it 'returns ok status' do
-            expect(subject).to have_http_status(:ok)
-          end
-        end
-      end
-    end
-
-    context 'when authorization header exists' do
-      let(:authorization) { "Bearer #{access_token}" }
-      let(:access_token) { 'some-access-token' }
-      let(:access_token_cookie) { nil }
-
-      before do
-        request.headers['Authorization'] = authorization
-      end
-
-      context 'and access_token is some arbitrary value' do
-        let(:access_token) { 'some-arbitrary-access-token' }
 
         it_behaves_like 'error response'
       end

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -437,7 +437,6 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
         context 'and access_token is an active JWT' do
           let(:access_token_object) { create(:access_token) }
           let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-          let(:expected_error) { SignIn::Errors::AccessTokenMalformedJWTError.to_s }
 
           it 'returns ok status' do
             expect(subject).to have_http_status(:ok)

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -2349,9 +2349,7 @@ RSpec.describe V0::SignInController, type: :controller do
     let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
     let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
     let(:authorization) { "Bearer #{access_token}" }
-    let(:oauth_session) do
-      create(:oauth_session, user_verification:)
-    end
+    let(:oauth_session) { create(:oauth_session, user_verification:) }
     let(:user_verification) { create(:user_verification) }
     let(:access_token_object) do
       create(:access_token, session_handle: oauth_session.handle, client_id: client_config.client_id, expiration_time:)

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -2528,15 +2528,6 @@ RSpec.describe V0::SignInController, type: :controller do
           end
         end
       end
-
-      context 'and client_id is not present' do
-        let(:client_id_value) { nil }
-        let(:expected_error_status) { :bad_request }
-        let(:expected_error) { SignIn::Errors::MalformedParamsError }
-        let(:expected_error_message) { 'Client id is not valid' }
-
-        it_behaves_like 'error response'
-      end
     end
 
     context 'when not successfully authenticated' do
@@ -2556,37 +2547,26 @@ RSpec.describe V0::SignInController, type: :controller do
           subject
         end
 
-        context 'and client_id is present' do
-          context 'and client_id has a client configuration with a configured logout redirect uri' do
-            let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
-            let(:expected_status) { :redirect }
+        context 'and client_id has a client configuration with a configured logout redirect uri' do
+          let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
+          let(:expected_status) { :redirect }
 
-            it 'returns redirect status' do
-              expect(subject).to have_http_status(expected_status)
-            end
-
-            it 'redirects to the configured logout redirect uri' do
-              expect(subject).to redirect_to(logout_redirect_uri)
-            end
+          it 'returns redirect status' do
+            expect(subject).to have_http_status(expected_status)
           end
 
-          context 'and client_id does not have a client configuration with a configured logout redirect uri' do
-            let(:logout_redirect_uri) { nil }
-            let(:expected_status) { :ok }
-
-            it 'returns ok status' do
-              expect(subject).to have_http_status(expected_status)
-            end
+          it 'redirects to the configured logout redirect uri' do
+            expect(subject).to redirect_to(logout_redirect_uri)
           end
         end
 
-        context 'and client_id is not present' do
-          let(:client_id_value) { nil }
-          let(:expected_error_status) { :bad_request }
-          let(:expected_error) { SignIn::Errors::MalformedParamsError }
-          let(:expected_error_message) { 'Client id is not valid' }
+        context 'and client_id does not have a client configuration with a configured logout redirect uri' do
+          let(:logout_redirect_uri) { nil }
+          let(:expected_status) { :ok }
 
-          it_behaves_like 'error response'
+          it 'returns ok status' do
+            expect(subject).to have_http_status(expected_status)
+          end
         end
       end
 

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -2350,10 +2350,9 @@ RSpec.describe V0::SignInController, type: :controller do
     let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
     let(:authorization) { "Bearer #{access_token}" }
     let(:oauth_session) do
-      create(:oauth_session, user_account:, user_verification:, client_id: client_config.client_id)
+      create(:oauth_session, user_verification:)
     end
-    let(:user_account) { create(:user_account) }
-    let(:user_verification) { create(:user_verification, user_account:) }
+    let(:user_verification) { create(:user_verification) }
     let(:access_token_object) do
       create(:access_token, session_handle: oauth_session.handle, client_id: client_config.client_id, expiration_time:)
     end
@@ -2461,7 +2460,7 @@ RSpec.describe V0::SignInController, type: :controller do
       end
 
       context 'and authenticated credential is Login.gov' do
-        let(:user_verification) { create(:logingov_user_verification, user_account:) }
+        let(:user_verification) { create(:logingov_user_verification) }
 
         context 'and client configuration has not configured a logout redirect uri' do
           let(:logout_redirect_uri) { nil }

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -2347,6 +2347,22 @@ RSpec.describe V0::SignInController, type: :controller do
     let(:client_id_value) { client_config.client_id }
     let!(:client_config) { create(:client_config, logout_redirect_uri:) }
     let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
+    let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
+    let(:authorization) { "Bearer #{access_token}" }
+    let(:oauth_session) do
+      create(:oauth_session, user_account:, user_verification:, client_id: client_config.client_id)
+    end
+    let(:user_account) { create(:user_account) }
+    let(:user_verification) { create(:user_verification, user_account:) }
+    let(:access_token_object) do
+      create(:access_token, session_handle: oauth_session.handle, client_id: client_config.client_id, expiration_time:)
+    end
+    let(:expiration_time) { Time.zone.now + SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
+
+    before do
+      request.headers['Authorization'] = authorization
+      allow(Rails.logger).to receive(:info)
+    end
 
     shared_context 'error response' do
       let(:statsd_failure) { SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_FAILURE }
@@ -2354,10 +2370,6 @@ RSpec.describe V0::SignInController, type: :controller do
       let(:expected_error_context) { { errors: expected_error_message } }
       let(:expected_error_status) { :bad_request }
       let(:expected_error_json) { { 'errors' => expected_error_message } }
-
-      before do
-        allow(Rails.logger).to receive(:info)
-      end
 
       it 'renders expected error' do
         expect(JSON.parse(subject.body)).to eq(expected_error_json)
@@ -2381,10 +2393,6 @@ RSpec.describe V0::SignInController, type: :controller do
       let(:statsd_failure) { SignIn::Constants::Statsd::STATSD_SIS_LOGOUT_FAILURE }
       let(:expected_error_log) { '[SignInService] [V0::SignInController] logout error' }
       let(:expected_error_context) { { errors: expected_error_message } }
-
-      before do
-        allow(Rails.logger).to receive(:info)
-      end
 
       it 'triggers statsd increment for failed call' do
         expect { subject }.to trigger_statsd_increment(statsd_failure)
@@ -2419,12 +2427,6 @@ RSpec.describe V0::SignInController, type: :controller do
     end
 
     context 'when successfully authenticated' do
-      let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-      let(:authorization) { "Bearer #{access_token}" }
-      let(:oauth_session) { create(:oauth_session) }
-      let(:access_token_object) do
-        create(:access_token, session_handle: oauth_session.handle, client_id: client_config.client_id)
-      end
       let!(:user) do
         create(:user, :loa3, :api_auth, uuid: access_token_object.user_uuid, logingov_uuid:)
       end
@@ -2446,11 +2448,6 @@ RSpec.describe V0::SignInController, type: :controller do
       end
       let(:expected_status) { :redirect }
 
-      before do
-        request.headers['Authorization'] = authorization
-        allow(Rails.logger).to receive(:info)
-      end
-
       it 'deletes the OAuthSession object matching the session_handle in the access token' do
         expect { subject }.to change {
           SignIn::OAuthSession.find_by(handle: access_token_object.session_handle)
@@ -2468,6 +2465,7 @@ RSpec.describe V0::SignInController, type: :controller do
 
       context 'and authenticated credential is Login.gov' do
         let!(:user) { create(:user, :ial1, uuid: access_token_object.user_uuid) }
+        let(:user_verification) { create(:logingov_user_verification, user_account:) }
 
         context 'and client configuration has not configured a logout redirect uri' do
           let(:logout_redirect_uri) { nil }
@@ -2537,27 +2535,96 @@ RSpec.describe V0::SignInController, type: :controller do
           end
         end
       end
+
+      context 'and client_id is not present' do
+        let(:client_id_value) { nil }
+
+        context 'and client configuration has not configured a logout redirect uri' do
+          let(:logout_redirect_uri) { nil }
+          let(:expected_status) { :ok }
+
+          it 'returns ok status' do
+            expect(subject).to have_http_status(expected_status)
+          end
+        end
+
+        context 'and client configuration has configured a logout redirect uri' do
+          let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
+          let(:expected_status) { :redirect }
+
+          it 'returns redirect status' do
+            expect(subject).to have_http_status(expected_status)
+          end
+
+          it 'redirects to the configured logout redirect uri' do
+            expect(subject).to redirect_to(logout_redirect_uri)
+          end
+        end
+      end
     end
 
     context 'when not successfully authenticated' do
-      let(:expected_error) { SignIn::Errors::LogoutAuthorizationError }
-      let(:expected_error_message) { 'Unable to Authorize User' }
+      let(:expected_error) { 'No valid Session found' }
 
-      it_behaves_like 'authorization error response'
+      context 'and the access token is expired' do
+        let(:expiration_time) { Time.zone.now - SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
+
+        it 'does not delete the OAuthSession object and clears cookies' do
+          expect { subject }.not_to change(SignIn::OAuthSession, :count)
+          expect(subject.cookies).to be_empty
+        end
+
+        it 'logs a logout error' do
+          expect(Rails.logger).to receive(:info).with('[SignInService] [V0::SignInController] logout error',
+                                                      { errors: expected_error })
+          subject
+        end
+
+        context 'and client_id is present' do
+          context 'and client_id has a client configuration with a configured logout redirect uri' do
+            let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
+            let(:expected_status) { :redirect }
+
+            it 'returns redirect status' do
+              expect(subject).to have_http_status(expected_status)
+            end
+
+            it 'redirects to the configured logout redirect uri' do
+              expect(subject).to redirect_to(logout_redirect_uri)
+            end
+          end
+
+          context 'and client_id does not have a client configuration with a configured logout redirect uri' do
+            let(:logout_redirect_uri) { nil }
+            let(:expected_status) { :ok }
+
+            it 'returns ok status' do
+              expect(subject).to have_http_status(expected_status)
+            end
+          end
+        end
+
+        context 'and client_id is not present' do
+          let(:client_id_value) { nil }
+          let(:expected_status) { :ok }
+
+          it 'returns ok status' do
+            expect(subject).to have_http_status(expected_status)
+          end
+        end
+      end
+
+      context 'and the access token is invalid' do
+        let(:access_token) { 'some-invalid-access-token' }
+        let(:expected_error) { SignIn::Errors::LogoutAuthorizationError }
+        let(:expected_error_message) { 'No valid Session found' }
+
+        it_behaves_like 'authorization error response'
+      end
     end
 
     context 'when client_id is arbitrary' do
       let(:client_id_value) { 'some-client-id' }
-      let(:expected_error_status) { :ok }
-      let(:expected_error) { SignIn::Errors::MalformedParamsError }
-      let(:expected_error_message) { 'Client id is not valid' }
-      let(:logout_redirect_uri) { nil }
-
-      it_behaves_like 'error response'
-    end
-
-    context 'when client_id is not given' do
-      let(:client_id_value) { nil }
       let(:expected_error_status) { :ok }
       let(:expected_error) { SignIn::Errors::MalformedParamsError }
       let(:expected_error_message) { 'Client id is not valid' }

--- a/spec/services/sign_in/logout_redirect_generator_spec.rb
+++ b/spec/services/sign_in/logout_redirect_generator_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe SignIn::LogoutRedirectGenerator do
   describe '#perform' do
     subject do
-      SignIn::LogoutRedirectGenerator.new(user_verification:, client_config:).perform
+      SignIn::LogoutRedirectGenerator.new(credential_type:, client_config:).perform
     end
 
     describe '#perform' do
-      let(:user_verification) { create(:user_verification) }
+      let(:credential_type) { 'logingov' }
       let(:client_config) { create(:client_config, logout_redirect_uri:) }
       let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
 
@@ -17,7 +17,6 @@ RSpec.describe SignIn::LogoutRedirectGenerator do
         let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
 
         context 'and the user is authenticated with login.gov credential' do
-          let(:user_verification) { create(:logingov_user_verification) }
           let(:logingov_client_id) { Settings.logingov.client_id }
           let(:logingov_logout_redirect_uri) { Settings.logingov.logout_redirect_uri }
           let(:random_seed) { 'some-random-seed' }
@@ -47,7 +46,7 @@ RSpec.describe SignIn::LogoutRedirectGenerator do
         end
 
         context 'and the user is not authenticated with the login.gov credential' do
-          let(:user_verification) { create(:idme_user_verification) }
+          let(:credential_type) { 'idme' }
           let(:expected_url) { URI.parse(logout_redirect_uri).to_s }
 
           it 'returns a logout redirect properly parsing logout redirect uri' do

--- a/spec/services/sign_in/logout_redirect_generator_spec.rb
+++ b/spec/services/sign_in/logout_redirect_generator_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe SignIn::LogoutRedirectGenerator do
             expect(subject).to eq(expected_url)
           end
         end
+
+        context 'and no credential type is provided' do
+          let(:credential_type) { nil }
+          let(:expected_url) { URI.parse(logout_redirect_uri).to_s }
+
+          it 'returns a logout redirect properly parsing logout redirect uri' do
+            expect(subject).to eq(expected_url)
+          end
+        end
       end
 
       context 'when logout redirect uri is not defined in the client configuration' do

--- a/spec/services/sign_in/logout_redirect_generator_spec.rb
+++ b/spec/services/sign_in/logout_redirect_generator_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe SignIn::LogoutRedirectGenerator do
   describe '#perform' do
     subject do
-      SignIn::LogoutRedirectGenerator.new(user:, client_config:).perform
+      SignIn::LogoutRedirectGenerator.new(user_verification:, client_config:).perform
     end
 
     describe '#perform' do
-      let(:user) { create(:user) }
+      let(:user_verification) { create(:user_verification) }
       let(:client_config) { create(:client_config, logout_redirect_uri:) }
       let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
 
@@ -17,7 +17,7 @@ RSpec.describe SignIn::LogoutRedirectGenerator do
         let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
 
         context 'and the user is authenticated with login.gov credential' do
-          let(:user) { create(:user, :ial1) }
+          let(:user_verification) { create(:logingov_user_verification) }
           let(:logingov_client_id) { Settings.logingov.client_id }
           let(:logingov_logout_redirect_uri) { Settings.logingov.logout_redirect_uri }
           let(:random_seed) { 'some-random-seed' }
@@ -47,7 +47,7 @@ RSpec.describe SignIn::LogoutRedirectGenerator do
         end
 
         context 'and the user is not authenticated with the login.gov credential' do
-          let(:user) { create(:user) }
+          let(:user_verification) { create(:idme_user_verification) }
           let(:expected_url) { URI.parse(logout_redirect_uri).to_s }
 
           it 'returns a logout redirect properly parsing logout redirect uri' do


### PR DESCRIPTION
## Summary

- Creates a new method to validate SiS access_tokens, `access_token_authenticate`. This method only checks access_token validity (no attempt to create a User object)
- `access_token_authenticate` default behavior is modeled after `authenticate`, it will render an error. It can take the `skip_error_handling` param to prevent any token authentication error from rendering an error response
- `/revoke_all_sessions` now uses `access_token_authenticate`, then obtains a session from the access_token
- `/logout` now uses `access_token_authenticate` with `skip_error_handling`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78005

## Testing done

- [x] *New code is covered by unit tests*
- Perform a SiS authentication (standard users or ARP users), then test the following `/revoke_all_sessions` scenarios
    - active access_token - 200 OK
    - expired access_token - 403 forbidden
- Perform a SiS authentication (standard users or ARP users), then test the following `/logout` scenarios
    - active access_token - no error, redirects if one exists in Client Config
    - expired access_token - Rails info log error, redirects if one exists in Client Config


## Logs

* `/logout` expired or invalid access_token: `[SignInService] [V0::SignInController] logout error -- { :errors => "Unable to authorize access token" }`
* `/revoke_all_sessions` & `/logout` no session found matching access_token session_handle: `[SignInService] [V0::SignInController] revoke all sessions error -- { :errors => "Session not found" }`
## What areas of the site does it impact?
- SiS `/logout`

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected