### PR TITLE
80349: Drop pega_tables; Create table for ivc_champva_forms

### DIFF
--- a/db/migrate/20240416155611_drop_pega_tables.rb
+++ b/db/migrate/20240416155611_drop_pega_tables.rb
@@ -1,0 +1,5 @@
+class DropPegaTables < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :pega_tables, if_exists: true
+  end
+end

--- a/db/migrate/20240416155705_create_ivc_champva_forms.rb
+++ b/db/migrate/20240416155705_create_ivc_champva_forms.rb
@@ -1,0 +1,18 @@
+class CreateIvcChampvaForms < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ivc_champva_forms do |t|
+      t.string :email
+      t.string :first_name
+      t.string :last_name
+      t.string :form_number
+      t.string :file_name
+      t.uuid   :form_uuid
+      t.string :s3_status
+      t.string :pega_status
+
+      t.timestamps
+    end
+
+    add_index :ivc_champva_forms, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_11_235242) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_16_155705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -242,8 +242,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_235242) do
     t.index ["user_uuid"], name: "index_async_transactions_on_user_uuid"
   end
 
-  create_table "average_days_for_claim_completions", id: :serial, force: :cascade do |t|
-    t.float "average_days", null: false
+  create_table "average_days_for_claim_completions", force: :cascade do |t|
+    t.float "average_days"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -793,6 +793,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_235242) do
     t.index ["edipi"], name: "index_invalid_letter_address_edipis_on_edipi"
   end
 
+  create_table "ivc_champva_forms", force: :cascade do |t|
+    t.string "email"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "form_number"
+    t.string "file_name"
+    t.uuid "form_uuid"
+    t.string "s3_status"
+    t.string "pega_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_ivc_champva_forms_on_email", unique: true
+  end
+
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
     t.string "pagerduty_id"
     t.string "external_service"
@@ -859,23 +873,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_235242) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["va_profile_id", "dismissed"], name: "show_onsite_notifications_index"
-  end
-
-  create_table "pega_tables", force: :cascade do |t|
-    t.uuid "uuid"
-    t.string "veteranfirstname"
-    t.string "veteranmiddlename"
-    t.string "veteranlastname"
-    t.string "applicantfirstname"
-    t.string "applicantmiddlename"
-    t.string "applicantlastname"
-    t.jsonb "response"
-    t.string "filenumber"
-    t.string "doctype"
-    t.datetime "date_created"
-    t.datetime "date_completed"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "pension_ipf_notifications", force: :cascade do |t|
@@ -950,7 +947,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_235242) do
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.string "uploaded_forms", array: true
+    t.string "uploaded_forms", default: [], array: true
     t.datetime "itf_datetime", precision: nil
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true


### PR DESCRIPTION
## Summary

After some communication, we decided it was best to rename the table and adjust the column names

- Change table name from `pega_tables` to `ivc_champva_forms`
- Update the columns to be a bit cleaner and agnostic
- Added unique index on :email

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80349

## Testing done

- Ran `rails db:migrate` with no errors

## Screenshots
<img width="641" alt="Screenshot 2024-04-16 at 4 10 31 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/1422922/a2e64c95-42ce-4a0b-ad39-f160db2110b7">


## Acceptance criteria

- [ ]  New DB is accessible and has the ability to CRUD data
