### PR TITLE
Removed feature toggle profile_show_proof_of_veteran_status

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -824,9 +824,6 @@ features:
   profile_show_quick_submit_notification_setting:
     actor_type: user
     description: Show/Hide the quick submit section of notification settings in profile
-  profile_show_proof_of_veteran_status:
-    actor_type: user
-    description: Show/Hide the proof of veteran status page and links
   profile_use_experimental:
     description: Use experimental features for Profile application - Do not remove
     enable_in_development: true


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Summary: removed feature toggle profile_show_proof_of_veteran_status
- Team IIR, we are the new owners of this component

## Related issue(s)

- [Ticket 533](https://github.com/department-of-veterans-affairs/va-iir/issues/533)
- Not inside an epic

## Testing done

- [ ] *New code is covered by unit tests*
- Prior to this change, the component was behind a feature toggle.  Now it is not.
- The feature toggle is no longer available in the Flipper UI.  The component is always available to users with an honorable discharge and at least one period of service..

## Screenshots
None

## What areas of the site does it impact?
This only impacts [one page](https://va.gov/profile/military-information).

## Acceptance criteria

- [ ]  I updated unit tests for this feature.
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None
