### PR TITLE
[80904] Creating a terms of use application check that occurs during secondary authentications with custom

### DIFF
--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -63,8 +63,7 @@ module SAML
     end
 
     def terms_of_use_redirect_url
-      application = @tracker&.payload_attr(:application) || 'vaweb'
-      if enabled_tou_clients.include?(application)
+      if terms_of_use_enabled_application
         Rails.logger.info('Redirecting to /terms-of-use', type: :ssoe)
         add_query(terms_of_use_url, { redirect_url: login_redirect_url })
       else
@@ -78,6 +77,32 @@ module SAML
     end
 
     private
+
+    def terms_of_use_enabled_application
+      cache_key = "terms_of_use_redirect_user_#{user.uuid}"
+      cached_application = retrieve_and_delete_terms_of_use_redirect_user(cache_key)
+      current_application = @tracker&.payload_attr(:application)
+      write_terms_of_use_redirect_user(cache_key, current_application) if should_cache_application?(current_application)
+      terms_of_use_redirect_enabled?(cached_application, current_application)
+    end
+
+    def terms_of_use_redirect_enabled?(cached_application, current_application)
+      enabled_tou_clients.include?(cached_application || current_application || 'vaweb')
+    end
+
+    def should_cache_application?(application)
+      enabled_tou_clients.include?(application)
+    end
+
+    def retrieve_and_delete_terms_of_use_redirect_user(cache_key)
+      application = Rails.cache.read(cache_key)
+      Rails.cache.delete(cache_key)
+      application
+    end
+
+    def write_terms_of_use_redirect_user(cache_key, application)
+      Rails.cache.write(cache_key, application, expires_in: 5.minutes)
+    end
 
     def terms_of_use_url
       if Settings.review_instance_slug.present?

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -613,29 +613,102 @@ RSpec.describe SAML::PostURLService do
             let(:expected_log_message) { 'Redirecting to /terms-of-use' }
             let(:expected_log_payload) { { type: :ssoe } }
 
-            context 'when tracker application is within Settings.terms_of_use.enabled_clients' do
+            context 'when associated terms of use redirect user cache object exists' do
+              let(:cache_key) { "terms_of_use_redirect_user_#{user.uuid}" }
+              let(:enabled_clients) { application }
+              let(:cache_expiration) { 5.minutes }
+
               before do
-                allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+                allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(enabled_clients)
+                allow(Rails.cache).to receive(:read).with(cache_key).and_return(application)
               end
 
-              context 'and authentication is occuring on a review instance' do
-                let(:review_instance_slug) { 'some-review-instance-slug' }
-                let(:review_instance_url) { "#{review_instance_slug}.review.vetsgov-internal" }
+              context 'and application is within Settings.terms_of_use.enabled_clients' do
+                let(:enabled_clients) { application }
 
-                before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
+                context 'and authentication is occuring on a review instance' do
+                  let(:review_instance_slug) { 'some-review-instance-slug' }
+                  let(:review_instance_url) { "#{review_instance_slug}.review.vetsgov-internal" }
 
-                it 'has a login redirect url as a parameter embedded in review instance terms of use page' do
-                  expect(subject.terms_of_use_redirect_url)
-                    .to eq("http://#{review_instance_url}/terms-of-use?#{expected_redirect_url_param}")
+                  before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
+
+                  it 'has a login redirect url as a parameter embedded in review instance terms of use page' do
+                    expect(subject.terms_of_use_redirect_url)
+                      .to eq("http://#{review_instance_url}/terms-of-use?#{expected_redirect_url_param}")
+                  end
+
+                  it 'logs expected message and payload' do
+                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                    subject.terms_of_use_redirect_url
+                  end
                 end
 
-                it 'logs expected message and payload' do
-                  expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
-                  subject.terms_of_use_redirect_url
+                context 'and authentication is not occurring on a review instance' do
+                  it 'has a login redirect url as a parameter embedded in terms of use page with success' do
+                    expect(subject.terms_of_use_redirect_url)
+                      .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
+                  end
+
+                  it 'logs expected message and payload' do
+                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                    subject.terms_of_use_redirect_url
+                  end
                 end
               end
 
-              context 'and authentication is not occurring on a review instance' do
+              context 'and stored application is not within Settings.terms_of_use.enabled_clients' do
+                let(:enabled_clients) { '' }
+
+                it 'has a login redirect url with success not embedded in a terms of use page' do
+                  expect(subject.terms_of_use_redirect_url).to eq(expected_login_redirect_url)
+                end
+              end
+
+              it 'deletes the cached terms of use redirect user object' do
+                expect(Rails.cache).to receive(:delete).with(cache_key)
+                subject.terms_of_use_redirect_url
+              end
+            end
+
+            context 'when associated terms of use redirect user cache object does not exist' do
+              context 'when tracker application is within Settings.terms_of_use.enabled_clients' do
+                before do
+                  allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+                end
+
+                context 'and authentication is occuring on a review instance' do
+                  let(:review_instance_slug) { 'some-review-instance-slug' }
+                  let(:review_instance_url) { "#{review_instance_slug}.review.vetsgov-internal" }
+
+                  before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
+
+                  it 'has a login redirect url as a parameter embedded in review instance terms of use page' do
+                    expect(subject.terms_of_use_redirect_url)
+                      .to eq("http://#{review_instance_url}/terms-of-use?#{expected_redirect_url_param}")
+                  end
+
+                  it 'logs expected message and payload' do
+                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                    subject.terms_of_use_redirect_url
+                  end
+                end
+
+                context 'and authentication is not occurring on a review instance' do
+                  it 'has a login redirect url as a parameter embedded in terms of use page with success' do
+                    expect(subject.terms_of_use_redirect_url)
+                      .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
+                  end
+
+                  it 'logs expected message and payload' do
+                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                    subject.terms_of_use_redirect_url
+                  end
+                end
+              end
+
+              context 'when tracker application is nil' do
+                let(:application) { nil }
+
                 it 'has a login redirect url as a parameter embedded in terms of use page with success' do
                   expect(subject.terms_of_use_redirect_url)
                     .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
@@ -646,30 +719,16 @@ RSpec.describe SAML::PostURLService do
                   subject.terms_of_use_redirect_url
                 end
               end
-            end
 
-            context 'when tracker application is nil' do
-              let(:application) { nil }
+              context 'when tracker application is not within Settings.terms_of_use.enabled_clients' do
+                before do
+                  allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
+                end
 
-              it 'has a login redirect url as a parameter embedded in terms of use page with success' do
-                expect(subject.terms_of_use_redirect_url)
-                  .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
-              end
-
-              it 'logs expected message and payload' do
-                expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
-                subject.terms_of_use_redirect_url
-              end
-            end
-
-            context 'when tracker application is not within Settings.terms_of_use.enabled_clients' do
-              before do
-                allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
-              end
-
-              it 'has a login redirect url with success not embedded in a terms of use page' do
-                expect(subject.terms_of_use_redirect_url)
-                  .to eq(expected_login_redirect_url)
+                it 'has a login redirect url with success not embedded in a terms of use page' do
+                  expect(subject.terms_of_use_redirect_url)
+                    .to eq(expected_login_redirect_url)
+                end
               end
             end
           end


### PR DESCRIPTION
## Summary

- This PR updates the logic to determine whether to display the terms of use page to include authentication paths that may have originated with a Terms of Use enabled application but are now being authenticated with `custom` as a secondary part of the flow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80904

## Testing done

- [ ] Confirmed that a user who initially authenticates with a terms of use enabled application, and then authenticates with `custom`, will still see the terms of use page on the second call
- [ ] Confirmed that a user who did not initially authenticate with a terms of use enabled application is not shown the terms of use page, even if they attempt a second authentication with `custom`

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ]  Remove `vaweb` from `Settings.terms_of_use.enabled_clients`
- [ ] Authenticate normally and confirm terms of use page is not seen
- [ ] Authenticate with parameter `application=mhv` or `application=myvahealth`
- [ ] Authenticate and confirm terms of use page is not seen (don't accept terms yet)
- [ ] Within 5 minutes, authenticate with `custom` type, confirm terms of use page is seen

