### PR TITLE
Fix 20-10207 mapping and date stamp bug

### DIFF
--- a/modules/simple_forms_api/app/form_mappings/vba_20_10207.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_20_10207.json.erb
@@ -49,6 +49,7 @@
   "form1[0].#subform[3].CheckBox1[1]": "<%= nil %>",
   "form1[0].#subform[3].Email_Address[3]": "<%= nil %>",
   "form1[0].#subform[3].VA_File_Number_If_Applicable[1]": "<%= form.data.dig('veteran_id', 'va_file_number') %>",
+  "form1[0].#subform[3].CurrentlyHomeless[0]": "<%= form.data.dig('living_situation', 'none') ? 1 : 0 %>",
 
   "form1[0].#subform[4].I_Live_Or_Sleep_In_A_Place_That_Is_Not_Meant_For_Regular_Sleeping[0]": "<%= form.data.dig('living_situation', 'overnight') ? 1 : 0 %>",
   "form1[0].#subform[4].I_Live_In_A_Shelter[0]": "<%= form.data.dig('living_situation', 'shelter') ? 1 : 0 %>",
@@ -57,10 +58,8 @@
   "form1[0].#subform[4].IN_THE_NEXT_30_DAYS_I_WILL_LOSE_MY_HOME[0]": "<%= form.data.dig('living_situation', 'losing_home') ? 1 : 0 %>",
   "form1[0].#subform[4].NONE_OF_THESE_SITUATIONS_APPLY_TO_ME[0]": "<%= form.data.dig('living_situation', 'none') ? 1 : 0 %>",
   "form1[0].#subform[4].OTHER_Specify[0]": "<%= form.data.dig('living_situation', 'other_risk') ? 1 : 0 %>",
-
-  "form1[0].#subform[3].CurrentlyHomeless[0]": "<%= form.data.dig('living_situation', 'none') ? 1 : 0 %>",
+  "form1[0].#subform[4].Other1[0]": "<%= form.data['other_housing_risks'] %>",
   
-  "form1[0].#subform[3].Other1[0]": "<%= form.data['other_housing_risks'] %>",
   "form1[0].#subform[4].Veterans_SocialSecurityNumber_LastFourNumbers[1]": "<%= form.data.dig('veteran_id', 'ssn')&.[](5..8) %>",
   "form1[0].#subform[4].Veterans_SocialSecurityNumber_SecondTwoNumbers[1]": "<%= form.data.dig('veteran_id', 'ssn')&.[](3..4) %>",
   "form1[0].#subform[4].Veterans_SocialSecurityNumber_FirstThreeNumbers[1]": "<%= form.data.dig('veteran_id', 'ssn')&.[](0..2) %>",

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -37,8 +37,7 @@ module SimpleFormsApi
                   end
       coords = [10, 10]
       text = SUBMISSION_TEXT + current_time
-      page = 0
-      desired_stamp = { coords:, text:, page: }
+      desired_stamp = { coords:, text: }
       verify(stamped_template_path) do
         stamp(desired_stamp, stamped_template_path, append_to_stamp: auth_text, text_only: false)
       end

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-veteran.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-veteran.json
@@ -11,7 +11,8 @@
   },
   "living_situation": {
     "overnight": true,
-    "losing_home": true
+    "losing_home": true,
+    "other_risk": true
   },
   "other_housing_risks": "Other housing risks",
   "mailing_address_yes_no": true,


### PR DESCRIPTION
## Summary
This small PR does two things:
1. Fix another data mapping bug with 20-10207 (the `Other1[0]` is on page 4 not 3)
2. When stamping the auth text, we want it to stamp on every page. Therefore we should _not_ pass a `page` argument.
The JSON update is incidental. It just makes the data make more sense.
