### PR TITLE
[78003] removes MHV, DSLogon, and IAL/LOA1 references from rep user loader

### DIFF
--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
@@ -41,8 +41,11 @@ module AccreditedRepresentativePortal
     end
 
     def authn_context
-      user_verification.credential_type == SignIn::Constants::Auth::IDME ? SignIn::Constants::Auth::IDME_LOA3 :
-                                                                           SignIn::Constants::Auth::LOGIN_GOV_IAL2
+      if user_verification.credential_type == SignIn::Constants::Auth::IDME
+        SignIn::Constants::Auth::IDME_LOA3
+      else
+        SignIn::Constants::Auth::LOGIN_GOV_IAL2
+      end
     end
 
     def session

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/representative_user_loader.rb
@@ -31,8 +31,7 @@ module AccreditedRepresentativePortal
     end
 
     def loa
-      current_loa = user_is_verified? ? SignIn::Constants::Auth::LOA_THREE : SignIn::Constants::Auth::LOA_ONE
-      { current: current_loa, highest: SignIn::Constants::Auth::LOA_THREE }
+      { current: SignIn::Constants::Auth::LOA_THREE, highest: SignIn::Constants::Auth::LOA_THREE }
     end
 
     def sign_in
@@ -42,20 +41,8 @@ module AccreditedRepresentativePortal
     end
 
     def authn_context
-      case user_verification.credential_type
-      when  SignIn::Constants::Auth::IDME
-        user_is_verified? ?  SignIn::Constants::Auth::IDME_LOA3 : SignIn::Constants::Auth::IDME_LOA1
-      when  SignIn::Constants::Auth::DSLOGON
-        user_is_verified? ?  SignIn::Constants::Auth::IDME_DSLOGON_LOA3 : SignIn::Constants::Auth::IDME_DSLOGON_LOA1
-      when  SignIn::Constants::Auth::MHV
-        user_is_verified? ?  SignIn::Constants::Auth::IDME_MHV_LOA3 : SignIn::Constants::Auth::IDME_MHV_LOA1
-      when  SignIn::Constants::Auth::LOGINGOV
-        user_is_verified? ?  SignIn::Constants::Auth::LOGIN_GOV_IAL2 : SignIn::Constants::Auth::LOGIN_GOV_IAL1
-      end
-    end
-
-    def user_is_verified?
-      session.user_account.verified?
+      user_verification.credential_type == SignIn::Constants::Auth::IDME ? SignIn::Constants::Auth::IDME_LOA3 :
+                                                                           SignIn::Constants::Auth::LOGIN_GOV_IAL2
     end
 
     def session
@@ -93,7 +80,7 @@ module AccreditedRepresentativePortal
       user.logingov_uuid = user_verification.logingov_uuid
       user.ogc_number = ogc_number # TODO-ARF 80297: Determine how to get ogc_number into RepresentativeUserLoader
       user.poa_codes = get_poa_codes
-      user.idme_uuid = user_verification.idme_uuid || user_verification.backing_idme_uuid
+      user.idme_uuid = user_verification.idme_uuid
       user.last_signed_in = session.created_at
       user.sign_in = sign_in
       user.save


### PR DESCRIPTION
## Summary

- Small updates to the `AccreditedRepresentativePortal::RepresentativeUserLoader` to remove unneeded logic related to MHV & DSLogon logins, as well as non-verified logins.
- These CSP types and ACRs are unavailable to ARP clients on USiP & will be blocked for ARP client authentications in new [SiS validation code](https://github.com/department-of-veterans-affairs/vets-api/pull/16241).

## Related Issues
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78003

## Testing done

- ARP authentication with ID.me & Login.gov users performed.
- Existing tests pass, CSP & ACR blocking logic covered in validation PR.
