### PR TITLE
80872: Add ivc_champva_form model, factory and tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -265,6 +265,7 @@ app/models/identifier_index.rb @department-of-veterans-affairs/vsa-debt-resoluti
 app/models/inherited_proofing @department-of-veterans-affairs/octo-identity
 app/models/inherited_proof_verified_user_account.rb @department-of-veterans-affairs/octo-identity
 app/models/in_progress_form.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/ivc_champva_form.rb @department-of-veterans-affairs/champva-engineering @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/lighthouse_document.rb @department-of-veterans-affairs/backend-review-group
 app/models/maintenance_window.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/message_draft.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1108,6 +1109,7 @@ spec/factories/iam_user_identities.rb @department-of-veterans-affairs/octo-ident
 spec/factories/iam_users.rb @department-of-veterans-affairs/octo-identity
 spec/factories/inherited_proofing @department-of-veterans-affairs/octo-identity
 spec/factories/in_progress_forms @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/factories/ivc_champva_forms.rb @department-of-veterans-affairs/champva-engineering @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/lighthouse @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/maintenance_windows.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/message_drafts.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1456,6 +1458,7 @@ spec/models/iam_user_identity_spec.rb @department-of-veterans-affairs/octo-ident
 spec/models/inherited_proofing @department-of-veterans-affairs/octo-identity
 spec/models/inherited_proof_verified_user_account_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/in_progress_form_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/models/ivc_champva_forms_spec.rb @department-of-veterans-affairs/champva-engineering @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/message_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mhv_opt_in_flag_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mpi_data_spec.rb @department-of-veterans-affairs/octo-identity

--- a/app/models/ivc_champva_form.rb
+++ b/app/models/ivc_champva_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class IvcChampvaForm < ApplicationRecord
+  validates :email, presence: true
+  validates :email, uniqueness: true
+
+  # Add more complex data modeling here outside of CRUD
+end

--- a/app/models/ivc_champva_form.rb
+++ b/app/models/ivc_champva_form.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class IvcChampvaForm < ApplicationRecord
-  validates :email, presence: true
-  validates :email, uniqueness: true
+  validates :email, presence: true, uniqueness: true
 
   # Add more complex data modeling here outside of CRUD
 end

--- a/spec/factories/ivc_champva_forms.rb
+++ b/spec/factories/ivc_champva_forms.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ivc_champva_form do
+    email { Faker::Internet.email }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    form_number { '10-10D' }
+    file_name { Faker::File.file_name }
+    form_uuid { SecureRandom.uuid }
+    s3_status { 200 }
+    pega_status { %w[pending processing completed].sample }
+  end
+end

--- a/spec/models/ivc_champva_forms_spec.rb
+++ b/spec/models/ivc_champva_forms_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IvcChampvaForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_uniqueness_of(:email) }
+  end
+
+  describe 'factory' do
+    it 'is valid' do
+      expect(build(:ivc_champva_form)).to be_valid
+    end
+  end
+
+  describe 'methods' do
+    describe '#create' do
+      it 'creates a new form' do
+        expect { create(:ivc_champva_form) }.to change(IvcChampvaForm, :count).by(1)
+      end
+    end
+
+    describe '#update' do
+      let(:form) { create(:ivc_champva_form) }
+
+      it 'updates an existing form' do
+        new_email = 'new_email@example.com'
+        form.update(email: new_email)
+        expect(form.reload.email).to eq(new_email)
+      end
+    end
+
+    describe '#destroy' do
+      let!(:form) { create(:ivc_champva_form) }
+
+      it 'deletes an existing form' do
+        expect { form.destroy }.to change(IvcChampvaForm, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/models/ivc_champva_forms_spec.rb
+++ b/spec/models/ivc_champva_forms_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe IvcChampvaForm, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_uniqueness_of(:email) }
+
+    context 'when email is missing' do
+      it 'is invalid' do
+        form = build(:ivc_champva_form, email: nil)
+        expect(form).not_to be_valid
+        expect(form.errors[:email]).to include("can't be blank")
+      end
+    end
+
+    context 'when email already exists' do
+      let!(:existing_form) { create(:ivc_champva_form, email: 'existing@aol.com') }
+
+      it 'is invalid' do
+        form = build(:ivc_champva_form, email: 'existing@aol.com')
+        expect(form).not_to be_valid
+        expect(form.errors[:email]).to include('has already been taken')
+      end
+    end
   end
 
   describe 'factory' do


### PR DESCRIPTION
## Summary
After creating the table [here](https://github.com/department-of-veterans-affairs/vets-api/pull/16367) we needed to create a basic model with some lightweight tests.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80872

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
None right now, new logic

## Acceptance criteria
Given that the system requires validation and tests for a new model,
When a IvcChampvaForms model is added,
Then I should be able to create, read, update, and delete products.
