### PR TITLE
rename hide dd toggle, add uat toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -798,9 +798,9 @@ features:
     actor_type: user
     description: When enabled, profile service history will include military academy attendance.
     enable_in_development: true
-  profile_hide_direct_deposit_comp_and_pen:
+  profile_hide_direct_deposit:
     actor_type: user
-    description: Hides disability comp and pen section of the Profile - Direct Deposit page during a service outage
+    description: Hides the Profile - Direct Deposit page content during a service outage
     enable_in_development: false
   profile_show_credential_retirement_messaging:
     actor_type: user
@@ -808,6 +808,9 @@ features:
   profile_show_direct_deposit_single_form:
     actor_type: user
     description: Show/hide the single direct deposit form in profile for all users
+  profile_show_direct_deposit_single_form_uat:
+    actor_type: user
+    description: Show/hide the single direct deposit form just for users during UAT only
   profile_show_direct_deposit_single_form_alert:
     actor_type: user
     description: Show/hide an alert with information around migrating to a single direct deposit form in profile


### PR DESCRIPTION
## Summary

- We need a secondary feature toggle to turn on the new direct deposit single form for users during UAT. This PR adds a flag for that called `profile_show_direct_deposit_single_form_uat`
- We are also renaming the `profile_hide_direct_deposit_comp_and_pen` to be `profile_hide_direct_deposit` since it will no longer be related to comp and pen.
- 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79412
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80973

## Testing done

- [x] Tested both toggles locally.

## Screenshots
No UI changes

## What areas of the site does it impact?
Profile -> Direct Deposit

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
