### PR TITLE
Add sts scopes support

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1667,6 +1667,9 @@ brd:
 
 
 travel_pay:
+  sts:
+    service_account_id: ~
+    scope: '' 
   mock: true
   veis:
     client_id: ~

--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -115,6 +115,7 @@ module TravelPay
       service_account_id = Settings.travel_pay.sts.service_account_id
       host_baseurl = build_host_baseurl({ ip_form: false })
       audience_baseurl = build_host_baseurl({ ip_form: true })
+      scope = Settings.travel_pay.sts.scope
 
       current_time = Time.now.to_i
       jti = SecureRandom.uuid
@@ -125,7 +126,7 @@ module TravelPay
         'aud' => "#{audience_baseurl}/v0/sign_in/token",
         'iat' => current_time,
         'exp' => current_time + 300,
-        'scopes' => [],
+        'scopes' => [scope],
         'service_account_id' => service_account_id,
         'jti' => jti,
         'user_attributes' => { 'icn' => user.icn }


### PR DESCRIPTION
Adds vets-api support for reading the appropriate environment scope to send to the btsss api token route. This is required to be authorized by BTSSS.