### PR TITLE
Add new CustomCop/EnforceSidekiqPolicy cop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -808,7 +808,7 @@ lib/common/client/middleware/request/remove_cookies.rb @department-of-veterans-a
 lib/common/client/middleware/response/soap_parser.rb @department-of-veterans-affairs/backend-review-group
 lib/common/exceptions/open_id_service_error.rb @department-of-veterans-affairs/lighthouse-pivot
 lib/common/file_helpers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/custom_cops/enforce_sidekiq_policy.rb @department-of-veterans-affairs/octo-benefits-portfolio-code-reviewers
+lib/custom_cops/enforce_sidekiq_policy.rb @department-of-veterans-affairs/backend-review-group
 lib/debt_management_center @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/decision_review @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/decision_review_v1 @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -808,6 +808,7 @@ lib/common/client/middleware/request/remove_cookies.rb @department-of-veterans-a
 lib/common/client/middleware/response/soap_parser.rb @department-of-veterans-affairs/backend-review-group
 lib/common/exceptions/open_id_service_error.rb @department-of-veterans-affairs/lighthouse-pivot
 lib/common/file_helpers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/custom_cops/enforce_sidekiq_policy.rb @department-of-veterans-affairs/octo-benefits-portfolio-code-reviewers
 lib/debt_management_center @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/decision_review @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/decision_review_v1 @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ require:
   - rubocop-rspec
   - rubocop-thread_safety
   - rubocop-factory_bot
+  - ./lib/custom_cops/enforce_sidekiq_policy.rb
 
 AllCops:
   NewCops: disable
@@ -349,3 +350,6 @@ Lint/EmptyBlock:
 
 Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
+
+CustomCops/EnforceSidekiqPolicy:
+  Enabled: true

--- a/lib/custom_cops/enforce_sidekiq_policy.rb
+++ b/lib/custom_cops/enforce_sidekiq_policy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CustomCops
+  class EnforceSidekiqPolicy < RuboCop::Cop::Cop
+    def_node_search :sidekiq_job?, <<~PATTERN
+      (send nil? :include (const (const nil? :Sidekiq) :Job))
+    PATTERN
+
+    def_node_search :retry_option?, <<~PATTERN
+      (send nil? :sidekiq_options (hash <(pair (sym :retry) _) ...>))
+    PATTERN
+
+    def_node_search :retries_exhausted_block?, <<~PATTERN
+      (block (send nil? :sidekiq_retries_exhausted) ...)
+    PATTERN
+
+    def on_class(node)
+      return unless sidekiq_job?(node)
+
+      retry_option = retry_option?(node.body)
+      exhausted_block = retries_exhausted_block?(node.body)
+
+      if retry_option
+        retries_disabled = node.body.children.find { |n| n.type == :send && n.method_name == :sidekiq_options }
+                              .arguments.first.children.find { |n| n.type == :pair && n.children[0].value == :retry }
+                              .children[1].type == :false
+        return if retries_disabled
+
+        add_offense(node, message: 'Ensure Sidekiq jobs define a sidekiq_retries_exhausted block.') unless exhausted_block
+      else
+        add_offense(node, message: 'Ensure Sidekiq jobs define a retry policy (integer or false).')
+      end
+    end
+  end
+end

--- a/lib/custom_cops/enforce_sidekiq_policy.rb
+++ b/lib/custom_cops/enforce_sidekiq_policy.rb
@@ -23,7 +23,7 @@ module CustomCops
       if retry_option
         retries_disabled = node.body.children.find { |n| n.type == :send && n.method_name == :sidekiq_options }
                                .arguments.first.children.find { |n| n.type == :pair && n.children[0].value == :retry }
-                               .children[1].type == false
+                               .children[1].type == :false # rubocop:disable Lint/BooleanSymbol
         return if retries_disabled
 
         unless exhausted_block

--- a/lib/custom_cops/enforce_sidekiq_policy.rb
+++ b/lib/custom_cops/enforce_sidekiq_policy.rb
@@ -22,11 +22,13 @@ module CustomCops
 
       if retry_option
         retries_disabled = node.body.children.find { |n| n.type == :send && n.method_name == :sidekiq_options }
-                              .arguments.first.children.find { |n| n.type == :pair && n.children[0].value == :retry }
-                              .children[1].type == :false
+                               .arguments.first.children.find { |n| n.type == :pair && n.children[0].value == :retry }
+                               .children[1].type == false
         return if retries_disabled
 
-        add_offense(node, message: 'Ensure Sidekiq jobs define a sidekiq_retries_exhausted block.') unless exhausted_block
+        unless exhausted_block
+          add_offense(node, message: 'Ensure Sidekiq jobs define a sidekiq_retries_exhausted block.')
+        end
       else
         add_offense(node, message: 'Ensure Sidekiq jobs define a retry policy (integer or false).')
       end


### PR DESCRIPTION
## Summary

Adds a RuboCop check for Sidekiq jobs to improve capturing/handling errors explicitly.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/pull/1622

## Testing done

- Prior to this automated check, Sidekiq jobs were inspected manually for adherence to our standards.
- [Tested in CI](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/8741336267/job/23987123035?pr=16404#step:5:8).
- Ran RuboCop locally (see screenshot).

## Screenshots
![Screenshot 2024-04-18 at 11 59 12 AM](https://github.com/department-of-veterans-affairs/vets-api/assets/1930139/15f80186-1d7f-4916-b29d-e82dd4865c07)

## What areas of the site does it impact?
Impacts code reviews only.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

It's worth discussing how we integrate this into the PR process.

- Should PRs be rejected based on this rule?
- Should it apply only to new Sidekiq jobs to start?
