### PR TITLE
Update direct deposit account number validation

### DIFF
--- a/lib/lighthouse/direct_deposit/payment_account.rb
+++ b/lib/lighthouse/direct_deposit/payment_account.rb
@@ -8,11 +8,11 @@ module Lighthouse
       attr_accessor :name, :account_number, :routing_number
       attr_writer :account_type
 
-      ACCOUNT_NUM_REGEX = /\A\d*\z/
+      ACCOUNT_NUM_REGEX = /\A[a-zA-Z0-9]+\z/
       ROUTING_NUM_REGEX = /\A\d{9}\z/
 
       validates :account_type, inclusion: { in: %w[Checking Savings] }, presence: true
-      validates :account_number, presence: true
+      validates :account_number, length: { in: 4..17 }, allow_blank: false
       validates :routing_number, presence: true
 
       validates_format_of :account_number, with: ACCOUNT_NUM_REGEX

--- a/spec/lib/lighthouse/direct_deposit/payment_account_spec.rb
+++ b/spec/lib/lighthouse/direct_deposit/payment_account_spec.rb
@@ -4,19 +4,71 @@ require 'rails_helper'
 require 'lighthouse/direct_deposit/payment_account'
 
 RSpec.describe Lighthouse::DirectDeposit::PaymentAccount do
+  let(:account) do
+    described_class.new(
+      account_type: 'CHECKING',
+      routing_number: '123456789',
+      account_number: 'ABC456789'
+    )
+  end
+
   describe '#account_type' do
-    context 'when account_type is valid' do
+    context 'when in list' do
       it 'returns the capitalized account_type' do
-        account = described_class.new(account_type: 'CHECKING')
         expect(account.account_type).to eq('Checking')
       end
     end
 
-    context 'when account_type is not valid' do
-      it 'returns an error' do
-        account = described_class.new(account_type: 'invalid')
-        account.valid?
+    context 'when not in list' do
+      it 'is invalid' do
+        account.account_type = 'invalid'
+        expect(account).not_to be_valid
         expect(account.errors[:account_type]).to include('is not included in the list')
+      end
+    end
+  end
+
+  describe '#account_number' do
+    it 'must be present' do
+      account.account_number = nil
+      expect(account).not_to be_valid
+      expect(account.errors[:account_number]).to include(
+        'is too short (minimum is 4 characters)',
+        'is too long (maximum is 17 characters)'
+      )
+    end
+
+    it 'accepts letters and digits' do
+      expect(account).to be_valid
+    end
+
+    it 'does not allow non-alphanumeric characters' do
+      account.account_number = '%as.12-'
+      expect(account).not_to be_valid
+    end
+
+    context 'when length is between 4 and 17' do
+      it 'is invalid' do
+        (4..17).each do |length|
+          account.account_number = ('1' * length)
+          expect(account).to be_valid
+        end
+      end
+    end
+
+    context 'when length is less than 4' do
+      it 'is invalid' do
+        account.account_number = '123'
+        expect(account).not_to be_valid
+        expect(account.errors[:account_number]).to include('is too short (minimum is 4 characters)')
+      end
+    end
+
+    context 'when length is more than 17' do
+      it 'is invalid' do
+        account.account_number = '1' * 18
+        expect(account).not_to be_valid
+        expect(account.errors[:account_number]).to include('is too long (maximum is 17 characters)')
       end
     end
   end


### PR DESCRIPTION
## Summary
Added validation rules to the direct deposit account number:
- allow alphanumeric
- ensure length is between 4 and 17

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/80306


## Testing done
- additional specs in `payment_account_spec.rb`