### PR TITLE
79708: Add country to metadata to properly handle zipcode formatting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -957,6 +957,7 @@ modules/dhp_connected_devices @department-of-veterans-affairs/digital-health-pla
 modules/facilities_api @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 modules/health_quest @department-of-veterans-affairs/vsa-healthcare-health-quest-1-backend
 modules/income_limits @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+modules/ivc_champva @department-of-veterans-affairs/champva-engineering @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 modules/meb_api @department-of-veterans-affairs/my-education-benefits
 modules/mobile @department-of-veterans-affairs/mobile-api-team
 modules/mocked_authentication @department-of-veterans-affairs/octo-identity

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -91,10 +91,6 @@ module IvcChampva
           { form_number: params[:form_number] }
         )
       end
-
-      def should_authenticate
-        true
-      end
     end
   end
 end

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -23,6 +23,7 @@ module IvcChampva
         'sponsorLastName' => @data.fetch('applicants', [])&.first&.dig('full_name', 'last'),
         'fileNumber' => @data.dig('veteran', 'va_claim_number').presence || @data.dig('veteran', 'ssn_or_tin'),
         'zipCode' => @data.dig('veteran', 'address', 'postal_code') || '00000',
+        'country' => @data.dig('veteran', 'address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -17,6 +17,7 @@ module IvcChampva
         'veteranLastName' => @data.dig('applicants', 'full_name', 'last'),
         'fileNumber' => @data.dig('applicants', 'ssn_or_tin'),
         'zipCode' => @data.dig('applicants', 'address', 'postal_code') || '00000',
+        'country' => @data.dig('applicants', 'address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP'

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -17,6 +17,7 @@ module IvcChampva
         'veteranLastName' => @data.dig('veteran', 'full_name', 'last'),
         'fileNumber' => @data.dig('veteran', 'va_claim_number').presence || @data.dig('veteran', 'ssn'),
         'zipCode' => @data.dig('veteran', 'mailing_address', 'postal_code') || '00000',
+        'country' => @data.dig('veteran', 'mailing_address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP'

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
@@ -20,6 +20,7 @@ module IvcChampva
         'veteranLastName' => @data.dig('veteran', 'full_name', 'last'),
         'fileNumber' => @data.dig('veteran', 'va_claim_number').presence || @data.dig('veteran', 'ssn'),
         'zipCode' => @data.dig('veteran', 'mailing_address', 'postal_code') || '00000',
+        'country' => @data.dig('veteran', 'mailing_address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',

--- a/modules/ivc_champva/app/services/ivc_champva/metadata_validator.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/metadata_validator.rb
@@ -2,11 +2,11 @@
 
 module IvcChampva
   class MetadataValidator
-    def self.validate(metadata, zip_code_is_us_based: true)
+    def self.validate(metadata)
       validate_first_name(metadata)
         .then { |m| validate_last_name(m) }
         .then { |m| validate_file_number(m) }
-        .then { |m| validate_zip_code(m, zip_code_is_us_based) }
+        .then { |m| validate_zip_code(m) }
         .then { |m| validate_source(m) }
         .then { |m| validate_doc_type(m) }
     end
@@ -36,9 +36,9 @@ module IvcChampva
       metadata
     end
 
-    def self.validate_zip_code(metadata, zip_code_is_us_based)
+    def self.validate_zip_code(metadata)
       zip_code = metadata['zipCode']
-      if zip_code_is_us_based
+      if metadata['country'] == 'USA' && !zip_code.nil?
         validate_presence_and_stringiness(zip_code, 'zip code')
         zip_code = zip_code.dup.gsub(/[^0-9]/, '')
         zip_code.insert(5, '-') if zip_code.match?(/\A[0-9]{9}\z/)

--- a/modules/ivc_champva/lib/tasks/forms.rake
+++ b/modules/ivc_champva/lib/tasks/forms.rake
@@ -30,7 +30,8 @@ namespace :ivc_champva do
         'veteranFirstName' => @data.dig('veteran', 'full_name', 'first'),
         'veteranLastName' => @data.dig('veteran', 'full_name', 'last'),
         'fileNumber' => @data.dig('veteran', 'va_file_number').presence || @data.dig('veteran', 'ssn'),
-        'zipCode' => @data.dig('veteran', 'address', 'postal_code'),
+        'zipCode' => @data.dig('veteran', 'address', 'postal_code') || '00000',
+        'country' => @data.dig('veteran', 'address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP'

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe IvcChampva::VHA1010d do
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'va_claim_number' => '123456789',
-        'address' => { 'postal_code' => '12345' }
+        'address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => 'VHA1010d',
       'veteran_supporting_documents' => [
@@ -28,6 +28,7 @@ RSpec.describe IvcChampva::VHA1010d do
         'veteranLastName' => 'Doe',
         'fileNumber' => '123456789',
         'zipCode' => '12345',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => 'VHA1010d',
         'businessLine' => 'CMP'

--- a/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe IvcChampva::VHA107959c do
       'applicants' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'ssn_or_tin' => '123456789',
-        'address' => { 'postal_code' => '12345' }
+        'address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => '10-7959C',
       'veteran_supporting_documents' => [
@@ -29,6 +29,7 @@ RSpec.describe IvcChampva::VHA107959c do
         'veteranLastName' => 'Doe',
         'fileNumber' => '123456789',
         'zipCode' => '12345',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '10-7959C',
         'businessLine' => 'CMP'

--- a/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe IvcChampva::VHA107959f1 do
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'va_claim_number' => '123456789',
-        'mailing_address' => { 'postal_code' => '12345' }
+        'mailing_address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => '10-7959F-1',
       'veteran_supporting_documents' => [
@@ -29,6 +29,7 @@ RSpec.describe IvcChampva::VHA107959f1 do
         'veteranLastName' => 'Doe',
         'fileNumber' => '123456789',
         'zipCode' => '12345',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '10-7959F-1',
         'businessLine' => 'CMP'

--- a/modules/ivc_champva/spec/models/vha_10_7959f_2_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_2_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe IvcChampva::VHA107959f2 do
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'va_claim_number' => '123456789',
-        'mailing_address' => { 'postal_code' => '12345' }
+        'mailing_address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => '10-7959F-2',
       'veteran_supporting_documents' => [
@@ -29,6 +29,7 @@ RSpec.describe IvcChampva::VHA107959f2 do
         'veteranLastName' => 'Doe',
         'fileNumber' => '123456789',
         'zipCode' => '12345',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '10-7959F-2',
         'businessLine' => 'CMP'

--- a/modules/ivc_champva/spec/services/metadata_validator_spec.rb
+++ b/modules/ivc_champva/spec/services/metadata_validator_spec.rb
@@ -50,6 +50,7 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -59,6 +60,7 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -77,6 +79,7 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -86,6 +89,7 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -111,6 +115,7 @@ describe IvcChampva::MetadataValidator do
             nichteinfurchtvorangreifenvonandererintelligentgeschopfsvonhinzwischensternartigraum',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -120,6 +125,7 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => 'Wolfeschlegelsteinhausenbergerdorffwelchevoraltern',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -138,6 +144,7 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => '2Jöh’n~! - J\'o/hn?\\',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -147,6 +154,7 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => 'John - Jo/hn',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -186,6 +194,7 @@ describe IvcChampva::MetadataValidator do
         'veteranLastName' => 'Doe',
         'fileNumber' => '444444444',
         'zipCode' => '1234567890',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '21-0845',
         'businessLine' => 'CMP'
@@ -195,6 +204,7 @@ describe IvcChampva::MetadataValidator do
         'veteranLastName' => 'Doe',
         'fileNumber' => '444444444',
         'zipCode' => '00000',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '21-0845',
         'businessLine' => 'CMP'
@@ -213,6 +223,7 @@ describe IvcChampva::MetadataValidator do
         'veteranLastName' => 'Doe',
         'fileNumber' => '444444444',
         'zipCode' => '123456789',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '21-0845',
         'businessLine' => 'CMP'
@@ -222,6 +233,7 @@ describe IvcChampva::MetadataValidator do
         'veteranLastName' => 'Doe',
         'fileNumber' => '444444444',
         'zipCode' => '12345-6789',
+        'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '21-0845',
         'businessLine' => 'CMP'
@@ -240,6 +252,7 @@ describe IvcChampva::MetadataValidator do
         'veteranLastName' => 'Doe',
         'fileNumber' => '444444444',
         'zipCode' => '12345',
+        'country' => 'CA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '21-0845',
         'businessLine' => 'CMP'
@@ -249,12 +262,13 @@ describe IvcChampva::MetadataValidator do
         'veteranLastName' => 'Doe',
         'fileNumber' => '444444444',
         'zipCode' => '00000',
+        'country' => 'CA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '21-0845',
         'businessLine' => 'CMP'
       }
 
-      validated_metadata = IvcChampva::MetadataValidator.validate(metadata, zip_code_is_us_based: false)
+      validated_metadata = IvcChampva::MetadataValidator.validate(metadata)
 
       expect(validated_metadata).to eq expected_metadata
     end
@@ -265,6 +279,7 @@ describe IvcChampva::MetadataValidator do
           'veteranFirstName' => 'John',
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
@@ -274,12 +289,13 @@ describe IvcChampva::MetadataValidator do
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '00000',
+          'country' => 'USA',
           'source' => 'VA Platform Digital Forms',
           'docType' => '21-0845',
           'businessLine' => 'CMP'
         }
 
-        validated_metadata = IvcChampva::MetadataValidator.validate(metadata, zip_code_is_us_based: false)
+        validated_metadata = IvcChampva::MetadataValidator.validate(metadata)
 
         expect(validated_metadata).to eq expected_metadata
       end


### PR DESCRIPTION
Wire up the logic to handle zip code formatting based on metadata country value.

## Summary

- Add `country` to the form metadata methods
- Update tests accordingly
- Update `form.rake` for new forms
- Removed code that isn't in use

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79708

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
- None, all new
