### PR TITLE
Add poll option to ToU update_provisioning endpoint

### DIFF
--- a/app/services/terms_of_use/acceptor.rb
+++ b/app/services/terms_of_use/acceptor.rb
@@ -6,14 +6,15 @@ module TermsOfUse
   class Acceptor
     include ActiveModel::Validations
 
-    attr_reader :user_account, :icn, :common_name, :version
+    attr_reader :user_account, :icn, :common_name, :version, :async
 
     validates :user_account, :icn, :common_name, :version, presence: true
 
-    def initialize(user_account:, common_name:, version:)
+    def initialize(user_account:, common_name:, version:, async: true)
       @user_account = user_account
       @common_name = common_name
       @version = version
+      @async = async
       @icn = user_account&.icn
 
       validate!
@@ -22,13 +23,13 @@ module TermsOfUse
     end
 
     def perform!
-      terms_of_use_agreement.accepted!
       update_sign_up_service
+      terms_of_use_agreement.accepted!
 
       Logger.new(terms_of_use_agreement:).perform
 
       terms_of_use_agreement
-    rescue ActiveRecord::RecordInvalid => e
+    rescue ActiveRecord::RecordInvalid, StandardError => e
       log_and_raise_acceptor_error(e)
     end
 
@@ -39,7 +40,9 @@ module TermsOfUse
     end
 
     def update_sign_up_service
-      SignUpServiceUpdaterJob.perform_async(attr_package_key)
+      return SignUpServiceUpdaterJob.perform_async(attr_package_key) if async
+
+      SignUpServiceUpdaterJob.new.perform('attr_package_key')
     end
 
     def log_and_raise_acceptor_error(error)

--- a/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
+++ b/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
@@ -19,6 +19,7 @@ module TermsOfUse
     attr_reader :icn, :signature_name, :version
 
     def perform(attr_package_key)
+      raise 'test'
       attrs = Sidekiq::AttrPackage.find(attr_package_key)
 
       @icn = attrs[:icn]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -370,6 +370,7 @@ Rails.application.routes.draw do
 
     get 'terms_of_use_agreements/:version/latest', to: 'terms_of_use_agreements#latest'
     post 'terms_of_use_agreements/:version/accept', to: 'terms_of_use_agreements#accept'
+    post 'terms_of_use_agreements/:version/accept_and_provision', to: 'terms_of_use_agreements#accept_and_provision'
     post 'terms_of_use_agreements/:version/decline', to: 'terms_of_use_agreements#decline'
     put 'terms_of_use_agreements/update_provisioning', to: 'terms_of_use_agreements#update_provisioning'
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -984,7 +984,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_16_155705) do
     t.string "type"
     t.text "form_ciphertext"
     t.text "encrypted_kms_key"
-    t.string "uploaded_forms", default: [], array: true
+    t.string "uploaded_forms", array: true
     t.datetime "itf_datetime", precision: nil
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true


### PR DESCRIPTION
## Summary
-  Add optional 'poll' param to `update_provisioning` endpoint that will attempt to provision every 2 seconds for max 10 seconds

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81138

## Testing
- Sign in with SSOe as verified user
  - You'll need to sign in with this URL to force auto-upleveling since it is broken on localhost
- open browser console
  -  make `update_provisioning` call with no poll param
      ```js
      await (await fetch("http://localhost:3000/v0/terms_of_use_agreements/update_provisioning", {
        "method": "PUT",
        "credentials": "include"
      })).json()
      ```
    You should get a 200 with body `{provisioned: true}`
  - make `update_provisioning` call with poll param
     ```js
      await (await fetch("http://localhost:3000/v0/terms_of_use_agreements/update_provisioning?poll=true", {
        "method": "PUT",
        "credentials": "include"
      })).json()
      ```
    You should get a 200 with body `{provisioned: true}`


  - make `update_provisioning` call with poll param and simulate timeout
    - change [this line](https://github.com/department-of-veterans-affairs/vets-api/blob/d6787d218e818d92f84ec77dd90490c46974e1bf/app/controllers/v0/terms_of_use_agreements_controller.rb#L59) to `if false`
    - make call in browser console
       ```js
        await (await fetch("http://localhost:3000/v0/terms_of_use_agreements/update_provisioning?poll=true", {
          "method": "PUT",
          "credentials": "include"
        })).json()
       ```
      After 10 seconds you should get a `408` and response body `{error: 'Failed to provision. Poll timeout'}`


## What areas of the site does it impact?
Terms of Use

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
