### PR TITLE
Send version information to datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -13,6 +13,7 @@ Datadog.configure do |c|
     # Namespace our app
     c.service = 'vets-api'
     c.env = Settings.vsp_environment unless ENV['DD_ENV']
+    c.version = AppInfo::GIT_REVISION unless ENV['DD_VERSION']
 
     # Enable instruments
     c.tracing.instrument :rails


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*

This PR adds configuration for [Datadog version tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/). This will support various quality of life improvements in datadog, and functionality like [faulty deployment detection](https://docs.datadoghq.com/watchdog/faulty_deployment_detection/).

## Dependencies

This relies on https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2807, but can be committed before it is.

## What areas of the site does it impact?

- datadog service configuration
