### PR TITLE
Simple Forms: Log time to transition for forms in BI API

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -37,11 +37,11 @@ class BenefitsIntakeStatusJob
 
       if submission.dig('attributes', 'status') == 'error' || submission.dig('attributes', 'status') == 'expired'
         form_submission_attempt = handle_failure(submission)
-        time_to_transition = (Time.now - form_submission_attempt.created_at).truncate
+        time_to_transition = (Time.zone.now - form_submission_attempt.created_at).truncate
         log_result('failure', form_id, time_to_transition)
       elsif submission.dig('attributes', 'status') == 'vbms'
         form_submission_attempt = handle_success(submission)
-        time_to_transition = (Time.now - form_submission_attempt.created_at).truncate
+        time_to_transition = (Time.zone.now - form_submission_attempt.created_at).truncate
         log_result('success', form_id, time_to_transition)
       else
         log_result('pending', form_id)


### PR DESCRIPTION
## Summary
This PR begins logging time to transition for our forms as they work their ways through the Benefits Intake API. Ideally, I'll be able to graph average times on DataDog but I'm not 100% sure I'll know how to do that, or if my logging changes here will do what I want (so I'm open to recommendations if anyone has any!!). But hopefully this will be a reasonable first step.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1197

## Testing done
I opted not to test anything here since it was all only logging to an exterior service, nothing application-critical. I'm happy to be convinced otherwise, though! 😄 