### PR TITLE
Remove mobile sm policy feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -753,10 +753,6 @@ features:
     actor_type: user
     description: Logs decision letter info on both claims and decision letter endpoint
     enable_in_development: true
-  mobile_sm_session_policy:
-    actor_type: user
-    description: changes secure messaging policy to use sm sessions endpoint for authorization
-    enable_in_development: true
   mobile_v1_lighthouse_facilities:
     actor_type: user
     description: change mobile lighthouse facility calls to use new v1 endpoint

--- a/modules/mobile/app/controllers/mobile/messaging_controller.rb
+++ b/modules/mobile/app/controllers/mobile/messaging_controller.rb
@@ -47,11 +47,7 @@ module Mobile
     private
 
     def mhv_messaging_authorized?
-      if Flipper.enabled?(:mobile_sm_session_policy, current_user)
-        current_user.authorize(:mhv_messaging, :mobile_access?)
-      else
-        current_user.authorize(:legacy_mhv_messaging, :access?)
-      end
+      current_user.authorize(:mhv_messaging, :mobile_access?)
     end
   end
 end

--- a/modules/mobile/app/models/mobile/v0/user_accessible_services.rb
+++ b/modules/mobile/app/models/mobile/v0/user_accessible_services.rb
@@ -37,8 +37,7 @@ module Mobile
           preferredName: access?(demographics: :access_update?) && access?(mpi: :queryable?),
           prescriptions: access?(mhv_prescriptions: :access?),
           scheduleAppointments: access?(schedule_appointment: :access?),
-          secureMessaging: flagged_access?(:mobile_sm_session_policy, { mhv_messaging: :mobile_access? },
-                                           { legacy_mhv_messaging: :access? }),
+          secureMessaging: access?(mhv_messaging: :mobile_access?),
           userProfileUpdate: access?(vet360: :access?)
         }
       end

--- a/modules/mobile/spec/models/user_accessible_services_spec.rb
+++ b/modules/mobile/spec/models/user_accessible_services_spec.rb
@@ -397,39 +397,16 @@ describe Mobile::V0::UserAccessibleServices, aggregate_failures: true, type: :mo
       before { Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z')) }
       after { Timecop.return }
 
-      context 'when using old authorization policy' do
-        before { Flipper.disable(:mobile_sm_session_policy) }
-
-        context 'when user does not have mhv_messaging access' do
-          it 'is false' do
-            expect(user_services.service_auth_map[:secureMessaging]).to be(false)
-          end
-        end
-
-        context 'when user does have mhv_messaging access' do
-          let(:user) { build(:user, :mhv) }
-
-          it 'is true' do
-            expect(user_services.service_auth_map[:secureMessaging]).to be_truthy
-          end
+      context 'when user does not have mhv_messaging access' do
+        it 'is false' do
+          expect(user_services.service_auth_map[:secureMessaging]).to be(false)
         end
       end
 
-      context 'when using new session authorization policy' do
-        before { Flipper.enable_actor(:mobile_sm_session_policy, user) }
-        after { Flipper.disable(:mobile_sm_session_policy) }
-
-        context 'when user does not have mhv_messaging access' do
-          it 'is false' do
-            expect(user_services.service_auth_map[:secureMessaging]).to be(false)
-          end
-        end
-
-        context 'when user does have mhv_messaging access' do
-          it 'is true' do
-            VCR.use_cassette('sm_client/session') do
-              expect(user_services.service_auth_map[:secureMessaging]).to be_truthy
-            end
+      context 'when user does have mhv_messaging access' do
+        it 'is true' do
+          VCR.use_cassette('sm_client/session') do
+            expect(user_services.service_auth_map[:secureMessaging]).to be_truthy
           end
         end
       end

--- a/modules/mobile/spec/request/attachments_request_spec.rb
+++ b/modules/mobile/spec/request/attachments_request_spec.rb
@@ -10,12 +10,10 @@ RSpec.describe 'Mobile Message Attachments Integration', type: :request do
   let(:message_id) { 573_302 }
 
   before do
-    Flipper.enable_actor(:mobile_sm_session_policy, user)
     Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z'))
   end
 
   after do
-    Flipper.disable(:mobile_sm_session_policy)
     Timecop.return
   end
 

--- a/modules/mobile/spec/request/folders_request_spec.rb
+++ b/modules/mobile/spec/request/folders_request_spec.rb
@@ -10,12 +10,10 @@ RSpec.describe 'Mobile Folders Integration', type: :request do
   let(:inbox_id) { 0 }
 
   before do
-    Flipper.enable_actor(:mobile_sm_session_policy, user)
     Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z'))
   end
 
   after do
-    Flipper.disable(:mobile_sm_session_policy)
     Timecop.return
   end
 

--- a/modules/mobile/spec/request/message_drafts_request_spec.rb
+++ b/modules/mobile/spec/request/message_drafts_request_spec.rb
@@ -15,12 +15,10 @@ RSpec.describe 'Mobile Message Drafts Integration', type: :request do
   let(:draft_signature_only) { attributes_for(:message, body: '\n\n\n\nSignature\nExample', subject: 'Subject 1') }
 
   before do
-    Flipper.enable_actor(:mobile_sm_session_policy, user)
     Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z'))
   end
 
   after do
-    Flipper.disable(:mobile_sm_session_policy)
     Timecop.return
   end
 

--- a/modules/mobile/spec/request/messages_request_spec.rb
+++ b/modules/mobile/spec/request/messages_request_spec.rb
@@ -12,246 +12,215 @@ RSpec.describe 'Mobile Messages Integration', type: :request do
   before { Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z')) }
 
   after do
-    Flipper.disable(:mobile_sm_session_policy)
     Timecop.return
   end
 
-  context 'when using old authorization policy' do
-    before { Flipper.disable(:mobile_sm_session_policy) }
+  context 'when user does not have access' do
+    let!(:user) { sis_user(:mhv, mhv_correlation_id: nil) }
 
-    context 'when user does not have access' do
-      let!(:user) { sis_user(:mhv, mhv_account_type: 'Free') }
+    it 'returns forbidden' do
+      get '/mobile/v0/messaging/health/messages/categories', headers: sis_headers
 
-      it 'returns forbidden' do
-        get '/mobile/v0/messaging/health/messages/categories', headers: sis_headers
-
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    it 'responds to GET messages/categories' do
-      VCR.use_cassette('sm_client/session') do
-        VCR.use_cassette('sm_client/messages/gets_message_categories') do
-          get '/mobile/v0/messaging/health/messages/categories', headers: sis_headers
-        end
-      end
-
-      expect(response).to be_successful
-      expect(response.body).to be_a(String)
-      expect(response).to match_camelized_response_schema('category')
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
-  context 'when using new session authorization policy' do
-    before { Flipper.enable_actor(:mobile_sm_session_policy, user) }
-
-    context 'when user does not have access' do
-      let!(:user) { sis_user(:mhv, mhv_correlation_id: nil) }
-
-      it 'returns forbidden' do
+  context 'when not authorized' do
+    it 'responds with 403 error' do
+      VCR.use_cassette('mobile/messages/session_error') do
         get '/mobile/v0/messaging/health/messages/categories', headers: sis_headers
-
-        expect(response).to have_http_status(:forbidden)
       end
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context 'when authorized' do
+    before do
+      VCR.insert_cassette('sm_client/session')
     end
 
-    context 'when not authorized' do
-      it 'responds with 403 error' do
-        VCR.use_cassette('mobile/messages/session_error') do
+    after do
+      VCR.eject_cassette
+    end
+
+    context 'with authorization to use service' do
+      it 'responds to GET messages/categories' do
+        VCR.use_cassette('sm_client/messages/gets_message_categories') do
           get '/mobile/v0/messaging/health/messages/categories', headers: sis_headers
         end
-        expect(response).not_to be_successful
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
 
-    context 'when authorized' do
-      before do
-        VCR.insert_cassette('sm_client/session')
+        expect(response).to be_successful
+        expect(response.body).to be_a(String)
+        expect(response).to match_camelized_response_schema('category')
       end
 
-      after do
-        VCR.eject_cassette
+      it 'responds to GET #show' do
+        VCR.use_cassette('sm_client/messages/gets_a_message_with_id') do
+          VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_triage_team_recipients') do
+            get "/mobile/v0/messaging/health/messages/#{message_id}", headers: sis_headers
+          end
+        end
+
+        expect(response).to be_successful
+        expect(response.body).to be_a(String)
+        response_hash = JSON.parse(response.body)
+        response_hash.delete('meta')
+        response.body = response_hash.to_json
+        expect(response).to match_camelized_response_schema('message')
+        link = response.parsed_body.dig('data', 'links', 'self')
+        expect(link).to eq('http://www.example.com/mobile/v0/messaging/health/messages/573059')
       end
 
-      context 'with authorization to use service' do
-        it 'responds to GET messages/categories' do
-          VCR.use_cassette('sm_client/messages/gets_message_categories') do
-            get '/mobile/v0/messaging/health/messages/categories', headers: sis_headers
+      it 'generates mobile-specific metadata links' do
+        VCR.use_cassette('sm_client/messages/gets_a_message_with_id') do
+          VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_triage_team_recipients') do
+            get "/mobile/v0/messaging/health/messages/#{message_id}", headers: sis_headers
           end
-
-          expect(response).to be_successful
-          expect(response.body).to be_a(String)
-          expect(response).to match_camelized_response_schema('category')
         end
 
-        it 'responds to GET #show' do
-          VCR.use_cassette('sm_client/messages/gets_a_message_with_id') do
-            VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_triage_team_recipients') do
-              get "/mobile/v0/messaging/health/messages/#{message_id}", headers: sis_headers
-            end
-          end
+        result = JSON.parse(response.body)
+        expect(result['data']['links']['self']).to match(%r{/mobile/v0})
+        expect(result['meta']['userInTriageTeam?']).to eq(false)
+      end
 
-          expect(response).to be_successful
-          expect(response.body).to be_a(String)
-          response_hash = JSON.parse(response.body)
-          response_hash.delete('meta')
-          response.body = response_hash.to_json
-          expect(response).to match_camelized_response_schema('message')
-          link = response.parsed_body.dig('data', 'links', 'self')
-          expect(link).to eq('http://www.example.com/mobile/v0/messaging/health/messages/573059')
+      it 'returns message signature preferences' do
+        VCR.use_cassette('sm_client/messages/gets_message_signature') do
+          get '/mobile/v0/messaging/health/messages/signature', headers: sis_headers
         end
 
-        it 'generates mobile-specific metadata links' do
-          VCR.use_cassette('sm_client/messages/gets_a_message_with_id') do
-            VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_triage_team_recipients') do
-              get "/mobile/v0/messaging/health/messages/#{message_id}", headers: sis_headers
-            end
-          end
+        result = JSON.parse(response.body)
+        expect(result['data']['attributes']['signatureName']).to eq('test-api Name')
+        expect(result['data']['attributes']['includeSignature']).to eq(true)
+        expect(result['data']['attributes']['signatureTitle']).to eq('test-api title')
+      end
 
-          result = JSON.parse(response.body)
-          expect(result['data']['links']['self']).to match(%r{/mobile/v0})
-          expect(result['meta']['userInTriageTeam?']).to eq(false)
-        end
-
-        it 'returns message signature preferences' do
-          VCR.use_cassette('sm_client/messages/gets_message_signature') do
+      context 'when signature prefs are empty' do
+        it 'returns empty message signature preferences' do
+          VCR.use_cassette('sm_client/messages/gets_empty_message_signature') do
             get '/mobile/v0/messaging/health/messages/signature', headers: sis_headers
           end
 
           result = JSON.parse(response.body)
-          expect(result['data']['attributes']['signatureName']).to eq('test-api Name')
-          expect(result['data']['attributes']['includeSignature']).to eq(true)
-          expect(result['data']['attributes']['signatureTitle']).to eq('test-api title')
+          expect(result['data']['attributes']['signatureName']).to eq(nil)
+          expect(result['data']['attributes']['includeSignature']).to eq(false)
+          expect(result['data']['attributes']['signatureTitle']).to eq(nil)
         end
+      end
 
-        context 'when signature prefs are empty' do
-          it 'returns empty message signature preferences' do
-            VCR.use_cassette('sm_client/messages/gets_empty_message_signature') do
-              get '/mobile/v0/messaging/health/messages/signature', headers: sis_headers
-            end
-
-            result = JSON.parse(response.body)
-            expect(result['data']['attributes']['signatureName']).to eq(nil)
-            expect(result['data']['attributes']['includeSignature']).to eq(false)
-            expect(result['data']['attributes']['signatureTitle']).to eq(nil)
-          end
+      describe 'POST create' do
+        let(:attachment_type) { 'image/jpg' }
+        let(:uploads) do
+          [
+            Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file1.jpg', attachment_type),
+            Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file2.jpg', attachment_type),
+            Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file3.jpg', attachment_type),
+            Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file4.jpg', attachment_type)
+          ]
         end
+        let(:message_params) { attributes_for(:message, subject: 'CI Run', body: 'Continuous Integration') }
+        let(:params) { message_params.slice(:subject, :category, :recipient_id, :body) }
+        let(:params_with_attachments) { { message: params }.merge(uploads:) }
 
-        describe 'POST create' do
-          let(:attachment_type) { 'image/jpg' }
-          let(:uploads) do
-            [
-              Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file1.jpg', attachment_type),
-              Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file2.jpg', attachment_type),
-              Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file3.jpg', attachment_type),
-              Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file4.jpg', attachment_type)
-            ]
-          end
-          let(:message_params) { attributes_for(:message, subject: 'CI Run', body: 'Continuous Integration') }
-          let(:params) { message_params.slice(:subject, :category, :recipient_id, :body) }
-          let(:params_with_attachments) { { message: params }.merge(uploads:) }
-
-          context 'message' do
-            it 'without attachments' do
-              VCR.use_cassette('sm_client/messages/creates/a_new_message_without_attachments') do
-                post '/mobile/v0/messaging/health/messages', headers: sis_headers, params: { message: params }
-              end
-
-              expect(response).to be_successful
-              expect(response.body).to be_a(String)
-              expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
-              expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
-              expect(response).to match_camelized_response_schema('message')
-            end
-
-            it 'with attachments' do
-              VCR.use_cassette('sm_client/messages/creates/a_new_message_with_4_attachments') do
-                post '/mobile/v0/messaging/health/messages', headers: sis_headers, params: params_with_attachments
-              end
-
-              expect(response).to be_successful
-              expect(response.body).to be_a(String)
-              expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
-              expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
-              expect(response).to match_camelized_response_schema('message_with_attachment')
-              link = response.parsed_body.dig('data', 'links', 'self')
-              expect(link).to eq('http://www.example.com/mobile/v0/messaging/health/messages/674852')
-            end
-          end
-
-          context 'reply' do
-            let(:reply_message_id) { 674_838 }
-
-            it 'without attachments' do
-              VCR.use_cassette('sm_client/messages/creates/a_reply_without_attachments') do
-                post "/mobile/v0/messaging/health/messages/#{reply_message_id}/reply",
-                     headers: sis_headers, params: { message: params }
-              end
-
-              expect(response).to be_successful
-              expect(response.body).to be_a(String)
-              expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
-              expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
-              expect(response).to match_camelized_response_schema('message')
-            end
-
-            it 'with attachments' do
-              VCR.use_cassette('sm_client/messages/creates/a_reply_with_4_attachments') do
-                post "/mobile/v0/messaging/health/messages/#{reply_message_id}/reply",
-                     headers: sis_headers, params: params_with_attachments
-              end
-
-              expect(response).to be_successful
-              expect(response.body).to be_a(String)
-              expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
-              expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
-              expect(JSON.parse(response.body)['included'][0]['attributes']['attachment_size']).to be_positive.or be_nil
-              expect(response).to match_camelized_response_schema('message_with_attachment')
-            end
-          end
-        end
-
-        describe '#thread' do
-          let(:thread_id) { 573_059 }
-
-          it 'responds to GET #thread' do
-            VCR.use_cassette('mobile/messages/v0_gets_a_message_thread') do
-              get "/mobile/v0/messaging/health/messages/#{thread_id}/thread", headers: sis_headers
+        context 'message' do
+          it 'without attachments' do
+            VCR.use_cassette('sm_client/messages/creates/a_new_message_without_attachments') do
+              post '/mobile/v0/messaging/health/messages', headers: sis_headers, params: { message: params }
             end
 
             expect(response).to be_successful
             expect(response.body).to be_a(String)
-            expect(response).to match_camelized_response_schema('messages_thread')
-            expect(response.parsed_body.dig('meta', 'messageCounts', 'read')).to eq(1)
-            expect(response.parsed_body.dig('meta', 'messageCounts', 'unread')).to eq(1)
+            expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+            expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+            expect(response).to match_camelized_response_schema('message')
           end
-        end
 
-        describe '#destroy' do
-          let(:message_id) { 573_052 }
-
-          it 'responds to DELETE' do
-            VCR.use_cassette('sm_client/messages/deletes_the_message_with_id') do
-              delete "/mobile/v0/messaging/health/messages/#{message_id}", headers: sis_headers
+          it 'with attachments' do
+            VCR.use_cassette('sm_client/messages/creates/a_new_message_with_4_attachments') do
+              post '/mobile/v0/messaging/health/messages', headers: sis_headers, params: params_with_attachments
             end
 
             expect(response).to be_successful
-            expect(response).to have_http_status(:no_content)
+            expect(response.body).to be_a(String)
+            expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+            expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+            expect(response).to match_camelized_response_schema('message_with_attachment')
+            link = response.parsed_body.dig('data', 'links', 'self')
+            expect(link).to eq('http://www.example.com/mobile/v0/messaging/health/messages/674852')
           end
         end
 
-        describe '#move' do
-          let(:message_id) { 573_052 }
+        context 'reply' do
+          let(:reply_message_id) { 674_838 }
 
-          it 'responds to PATCH messages/move' do
-            VCR.use_cassette('sm_client/messages/moves_a_message_with_id') do
-              patch "/mobile/v0/messaging/health/messages/#{message_id}/move?folder_id=0", headers: sis_headers
+          it 'without attachments' do
+            VCR.use_cassette('sm_client/messages/creates/a_reply_without_attachments') do
+              post "/mobile/v0/messaging/health/messages/#{reply_message_id}/reply",
+                   headers: sis_headers, params: { message: params }
             end
 
             expect(response).to be_successful
-            expect(response).to have_http_status(:no_content)
+            expect(response.body).to be_a(String)
+            expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+            expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+            expect(response).to match_camelized_response_schema('message')
           end
+
+          it 'with attachments' do
+            VCR.use_cassette('sm_client/messages/creates/a_reply_with_4_attachments') do
+              post "/mobile/v0/messaging/health/messages/#{reply_message_id}/reply",
+                   headers: sis_headers, params: params_with_attachments
+            end
+
+            expect(response).to be_successful
+            expect(response.body).to be_a(String)
+            expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+            expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+            expect(JSON.parse(response.body)['included'][0]['attributes']['attachment_size']).to be_positive.or be_nil
+            expect(response).to match_camelized_response_schema('message_with_attachment')
+          end
+        end
+      end
+
+      describe '#thread' do
+        let(:thread_id) { 573_059 }
+
+        it 'responds to GET #thread' do
+          VCR.use_cassette('mobile/messages/v0_gets_a_message_thread') do
+            get "/mobile/v0/messaging/health/messages/#{thread_id}/thread", headers: sis_headers
+          end
+
+          expect(response).to be_successful
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('messages_thread')
+          expect(response.parsed_body.dig('meta', 'messageCounts', 'read')).to eq(1)
+          expect(response.parsed_body.dig('meta', 'messageCounts', 'unread')).to eq(1)
+        end
+      end
+
+      describe '#destroy' do
+        let(:message_id) { 573_052 }
+
+        it 'responds to DELETE' do
+          VCR.use_cassette('sm_client/messages/deletes_the_message_with_id') do
+            delete "/mobile/v0/messaging/health/messages/#{message_id}", headers: sis_headers
+          end
+
+          expect(response).to be_successful
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+
+      describe '#move' do
+        let(:message_id) { 573_052 }
+
+        it 'responds to PATCH messages/move' do
+          VCR.use_cassette('sm_client/messages/moves_a_message_with_id') do
+            patch "/mobile/v0/messaging/health/messages/#{message_id}/move?folder_id=0", headers: sis_headers
+          end
+
+          expect(response).to be_successful
+          expect(response).to have_http_status(:no_content)
         end
       end
     end

--- a/modules/mobile/spec/request/threads_request_spec.rb
+++ b/modules/mobile/spec/request/threads_request_spec.rb
@@ -10,12 +10,10 @@ RSpec.describe 'Mobile Messages Integration', type: :request do
   let(:inbox_id) { 0 }
 
   before do
-    Flipper.enable_actor(:mobile_sm_session_policy, user)
     Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z'))
   end
 
   after do
-    Flipper.disable(:mobile_sm_session_policy)
     Timecop.return
   end
 

--- a/modules/mobile/spec/request/triage_teams_request_spec.rb
+++ b/modules/mobile/spec/request/triage_teams_request_spec.rb
@@ -9,12 +9,10 @@ RSpec.describe 'Mobile Triage Teams Integration', type: :request do
   let!(:user) { sis_user(:mhv, mhv_correlation_id: '123', mhv_account_type: 'Premium') }
 
   before do
-    Flipper.enable_actor(:mobile_sm_session_policy, user)
     Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z'))
   end
 
   after do
-    Flipper.disable(:mobile_sm_session_policy)
     Timecop.return
   end
 

--- a/modules/mobile/spec/request/v1/messages_request_spec.rb
+++ b/modules/mobile/spec/request/v1/messages_request_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe 'Mobile Messages V1 Integration', type: :request do
   let!(:user) { sis_user(:mhv, :api_auth, mhv_correlation_id: '123', mhv_account_type: 'Premium') }
 
   before do
-    Flipper.enable_actor(:mobile_sm_session_policy, user)
     Timecop.freeze(Time.zone.parse('2017-05-01T19:25:00Z'))
   end
 
   after do
-    Flipper.disable(:mobile_sm_session_policy)
     Timecop.return
   end
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Remove the sm policy feature flag because it has been working in prod for long enough to determine its success

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8328

## Testing done
Removed tests related to the flipper being off

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
