### PR TITLE
81196 sign in service terms of use user error

### DIFF
--- a/app/models/sign_in/terms_code_container.rb
+++ b/app/models/sign_in/terms_code_container.rb
@@ -7,8 +7,8 @@ module SignIn
     redis_key :code
 
     attribute :code, String
-    attribute :user_uuid, String
+    attribute :user_account_uuid, String
 
-    validates(:code, :user_uuid, presence: true)
+    validates(:code, :user_account_uuid, presence: true)
   end
 end

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -42,11 +42,11 @@ module SignIn
     end
 
     def create_user_acceptable_verified_credential
-      Login::UserAcceptableVerifiedCredentialUpdater.new(user_account: user_verification.user_account).perform
+      Login::UserAcceptableVerifiedCredentialUpdater.new(user_account:).perform
     end
 
     def create_terms_code_container
-      TermsCodeContainer.new(code: terms_code, user_uuid:).save!
+      TermsCodeContainer.new(code: terms_code, user_account_uuid: user_account.id).save!
     end
 
     def create_code_container
@@ -79,6 +79,10 @@ module SignIn
       @user_verification ||= Login::UserVerifier.new(user_verifier_object).perform
     end
 
+    def user_account
+      @user_account ||= user_verification.user_account
+    end
+
     def sign_in
       @sign_in ||= {
         service_name: state_payload.type,
@@ -98,7 +102,7 @@ module SignIn
     end
 
     def needs_accepted_terms_of_use?
-      client_config.va_terms_enforced? && user_verification.user_account.needs_accepted_terms_of_use?
+      client_config.va_terms_enforced? && user_account.needs_accepted_terms_of_use?
     end
 
     def client_config

--- a/spec/factories/sign_in/terms_code_containers.rb
+++ b/spec/factories/sign_in/terms_code_containers.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :terms_code_container, class: 'SignIn::TermsCodeContainer' do
     code { SecureRandom.hex }
-    user_uuid { SecureRandom.uuid }
+    user_account_uuid { create(:user_account).id }
   end
 end

--- a/spec/models/sign_in/terms_code_container_spec.rb
+++ b/spec/models/sign_in/terms_code_container_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe SignIn::TermsCodeContainer, type: :model do
-  let(:terms_code_container) { create(:terms_code_container, user_uuid:, code:) }
+  let(:terms_code_container) { create(:terms_code_container, user_account_uuid:, code:) }
 
   let(:code) { SecureRandom.hex }
-  let(:user_uuid) { SecureRandom.uuid }
+  let(:user_account_uuid) { SecureRandom.uuid }
 
   describe 'validations' do
     describe '#code' do
@@ -23,11 +23,11 @@ RSpec.describe SignIn::TermsCodeContainer, type: :model do
       end
     end
 
-    describe '#user_uuid' do
-      subject { terms_code_container.user_uuid }
+    describe '#user_account_uuid' do
+      subject { terms_code_container.user_account_uuid }
 
-      context 'when user_uuid is nil' do
-        let(:user_uuid) { nil }
+      context 'when user_account_uuid is nil' do
+        let(:user_account_uuid) { nil }
         let(:expected_error) { Common::Exceptions::ValidationErrors }
         let(:expected_error_message) { 'Validation error' }
 

--- a/spec/services/sign_in/user_code_map_creator_spec.rb
+++ b/spec/services/sign_in/user_code_map_creator_spec.rb
@@ -77,14 +77,16 @@ RSpec.describe SignIn::UserCodeMapCreator do
 
     context 'if client config enforced terms is set to va terms' do
       let(:enforced_terms) { SignIn::Constants::Auth::VA_TERMS }
+      let(:user_account_uuid) { user_verification.user_account.id }
 
       context 'and user needs accepted terms of use' do
         it 'sets terms_code on returned user code map' do
           expect(subject.terms_code).not_to eq(nil)
         end
 
-        it 'creates a terms code container associated with terms code' do
-          expect(SignIn::TermsCodeContainer.find(subject.terms_code)).not_to eq(nil)
+        it 'creates a terms code container associated with terms code and with expected user attributes' do
+          terms_code_container = SignIn::TermsCodeContainer.find(subject.terms_code)
+          expect(terms_code_container.user_account_uuid).to eq(user_account_uuid)
         end
       end
 


### PR DESCRIPTION
## Summary

- This PR fixes the Terms of Use authentication flow for Sign in Service. A regression was introduced here when we removed the creation of the User model from the Sign in Service authentication flow itself, in favor of creating the user model after the auth flow was completed.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81196

## Testing done

- [ ] Authenticated on Sign in Service with a user who has never accepted/declined terms of use
- [ ] Confirmed user was able to see terms of use page
- [ ] Confirmed user can accept terms

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ]  Authenticate with a user who has not accepted terms of use using sign in service authentication flow
- [ ] Confirm you can see the terms of use page
- [ ] Confirm you can accept/deny the terms of use page