### PR TITLE
80367: Add form profile for 10-7959F-1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -662,6 +662,7 @@ config/form_profile_mappings/0873.yml @department-of-veterans-affairs/vfs-virtua
 config/form_profile_mappings/1010ez.yml @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/10-10EZR.yml @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/10182.yml @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+config/form_profile_mappings/10-7959F-1.yml @department-of-veterans-affairs/champva-engineering @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/20-0995.yml @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/20-0996.yml @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/21-526EZ.yml @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -101,7 +101,8 @@ class FormProfile
     vre_readiness: ['28-1900'],
     coe: ['26-1880'],
     adapted_housing: ['26-4555'],
-    intent_to_file: ['21-0966']
+    intent_to_file: ['21-0966'],
+    ivc_champva: ['10-7959F-1']
   }.freeze
 
   FORM_ID_TO_CLASS = {
@@ -138,7 +139,8 @@ class FormProfile
     '22-1990EZ' => ::FormProfiles::VA1990ez,
     '26-1880' => ::FormProfiles::VA261880,
     '26-4555' => ::FormProfiles::VA264555,
-    '21-0966' => ::FormProfiles::VA210966
+    '21-0966' => ::FormProfiles::VA210966,
+    '10-7959F-1' => ::FormProfiles::VA107959f1
   }.freeze
 
   APT_REGEX = /\S\s+((apt|apartment|unit|ste|suite).+)/i

--- a/app/models/form_profiles/va_107959f1.rb
+++ b/app/models/form_profiles/va_107959f1.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FormProfiles::VA107959f1 < FormProfile
+  FORM_ID = '10-7959F-1'
+
+  def metadata
+    {
+      version: 0,
+      prefill: true,
+      returnUrl: '/review-and-submit'
+    }
+  end
+end

--- a/config/form_profile_mappings/10-7959F-1.yml
+++ b/config/form_profile_mappings/10-7959F-1.yml
@@ -1,0 +1,22 @@
+
+veteran:
+  date_of_birth: [identity_information, date_of_birth]
+  full_name: [identity_information, full_name]
+  first: [identity_information, first]
+  middle: [identity_information, middle]
+  last: [identity_information, last]
+physical_address:
+  country: [contact_information, country]
+  street: [contact_information, street]
+  city: [contact_information, city]
+  state: [contact_information, state]
+  postal_code: [contact_information, postal_code]
+mailing_address:
+  country: [contact_information, country]
+  street: [contact_information, street]
+  city: [contact_information, city]
+  state: [contact_information, state]
+  postal_code: [contact_information, postal_code]
+ssn: [identity_information, ssn]
+phone_number: [contact_information, us_phone]
+email_address: [contact_information, email]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -404,6 +404,9 @@ adapted_housing:
 intent_to_file:
   prefill: true
 
+ivc_champva:
+  prefill: true
+
 # Settings for Expiry Scanner
 expiry_scanner:
   slack:

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -893,6 +893,35 @@ RSpec.describe FormProfile, type: :model do
     }
   end
 
+  let(:v10_7959f_1_expected) do
+    {
+      'veteran' => {
+        'date_of_birth' => user.birth_date,
+        'full_name' => {
+          'first' => user.first_name&.capitalize,
+          'middle' => user.middle_name&.capitalize,
+          'last' => user.last_name&.capitalize
+        },
+        'physical_address' => {
+          'country' => user.address[:country],
+          'street' => user.address[:street],
+          'city' => user.address[:city],
+          'state' => user.address[:state],
+          'postal_code' => user.address[:postal_code]
+        },
+        'mailing_address' => {
+          'country' => user.address[:country],
+          'street' => user.address[:street],
+          'city' => user.address[:city],
+          'state' => user.address[:state],
+          'postal_code' => user.address[:postal_code]
+        },
+        'phone_number' => us_phone,
+        'email_address' => user.pciu_email
+      }
+    }
+  end
+
   let(:initialize_va_profile_prefill_military_information_expected) do
     expected_service_episodes_by_date = [
       {
@@ -1560,6 +1589,7 @@ RSpec.describe FormProfile, type: :model do
           28-1900
           26-1880
           26-4555
+          10-7959F-1
         ].each do |form_id|
           it "returns prefilled #{form_id}" do
             VCR.use_cassette('va_profile/military_personnel/service_history_200_many_episodes',

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -893,35 +893,6 @@ RSpec.describe FormProfile, type: :model do
     }
   end
 
-  let(:v10_7959f_1_expected) do
-    {
-      'veteran' => {
-        'date_of_birth' => user.birth_date,
-        'full_name' => {
-          'first' => user.first_name&.capitalize,
-          'middle' => user.middle_name&.capitalize,
-          'last' => user.last_name&.capitalize
-        },
-        'physical_address' => {
-          'country' => user.address[:country],
-          'street' => user.address[:street],
-          'city' => user.address[:city],
-          'state' => user.address[:state],
-          'postal_code' => user.address[:postal_code]
-        },
-        'mailing_address' => {
-          'country' => user.address[:country],
-          'street' => user.address[:street],
-          'city' => user.address[:city],
-          'state' => user.address[:state],
-          'postal_code' => user.address[:postal_code]
-        },
-        'phone_number' => us_phone,
-        'email_address' => user.pciu_email
-      }
-    }
-  end
-
   let(:initialize_va_profile_prefill_military_information_expected) do
     expected_service_episodes_by_date = [
       {
@@ -1589,7 +1560,6 @@ RSpec.describe FormProfile, type: :model do
           28-1900
           26-1880
           26-4555
-          10-7959F-1
         ].each do |form_id|
           it "returns prefilled #{form_id}" do
             VCR.use_cassette('va_profile/military_personnel/service_history_200_many_episodes',


### PR DESCRIPTION
Add back-end logic to enable prefill for vets-website. 


## Summary

- Added 10-7959F-1 for FormProfile

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80367

## Testing done

- No actual testing. Can't add tests as we are moving from vets-json-schema. WAiting on FE

## What areas of the site does it impact?
- Nothing live
