### PR TITLE
Vet360 Contact Info Logging Added

### DIFF
--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -272,9 +272,10 @@ class FormProfile
   def initialize_contact_information
     opt = {}
     opt.merge!(vets360_contact_info_hash) if vet360_contact_info
+    Rails.logger.info("User Vet360 Contact Info, Address? #{opt[:address].present?}
+      Email? #{opt[:email].present?}, Phone? #{opt[:home_phone].present?}")
 
     opt[:address] ||= user_address_hash
-
     opt[:email] ||= extract_pciu_data(:pciu_email)
     if opt[:home_phone].nil?
       opt[:home_phone] = pciu_primary_phone
@@ -293,6 +294,8 @@ class FormProfile
     @vet360_contact_info_retrieved = true
     if VAProfile::Configuration::SETTINGS.prefill && user.vet360_id.present?
       @vet360_contact_info = VAProfileRedis::ContactInformation.for_user(user)
+    else
+      Rails.logger.info('Vet360 Contact Info Null')
     end
     @vet360_contact_info
   end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

PCIU is deprecating. Supposedly, users that do not have a vet360_id are still using PCIU. This could have been an oversight during the upgrade from PCIU to VAProfile. Rails info log was added to ensure users are not using PCIU data. 

` if VAProfile::Configuration::SETTINGS.prefill && **user.vet360_id.present?**`
  ` @vet360_contact_info = VAProfileRedis::ContactInformation.for_user(user)`
`end`

## Related issues
- department-of-veterans-affairs/va.gov-team#76170


