### PR TITLE
[DBX-80624] add 526 states for remediation audit

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -80,7 +80,7 @@ class Form526Submission < ApplicationRecord
     end
 
     # A special state to indicate this was part of our remediation 'batching'
-    # process in 2023.  These were handled manually and are distinct fom `in_remediation`
+    # process in 2023.  These were handled manually and are distinct from `in_remediation`
     # in that they were not tracked at the time of remediation, but rather later in
     # the 2024 526 State audit.
     #
@@ -97,10 +97,10 @@ class Form526Submission < ApplicationRecord
     # Duplicates are identified by comparing form_json, using this script:
     # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/benefits/scripts/526/submission_deduper.rb
     # The result of this script can be evaluated by a qualified stakeholder to make
-    # a judgement call on wether or not a submission is a 'perfect' duplicate.
+    # a judgement call on whether or not a submission is a 'perfect' duplicate.
     #
     # IF a submission is found to be an exact duplicate of another
-    # AND it's duplicate was previously submitted / remediated successfully
+    # AND its duplicate was previously submitted / remediated successfully
     # THEN we can ignore it as a duplicate
     event :ignore_as_duplicate do
       transitions to: :ignorable_duplicate

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -18,7 +18,8 @@ class Form526Submission < ApplicationRecord
     state :unprocessed, initial: true
     state :delivered_to_primary, :failed_primary_delivery, :rejected_by_primary,
           :delivered_to_backup, :failed_backup_delivery, :rejected_by_backup,
-          :in_remediation, :finalized_as_successful, :unprocessable
+          :in_remediation, :finalized_as_successful, :unprocessable,
+          :processed_in_batch_remediation, :ignorable_duplicate
 
     # - a submission has been delivered to our happy path
     # - requires polling to finalize
@@ -62,7 +63,6 @@ class Form526Submission < ApplicationRecord
       transitions to: :in_remediation
     end
 
-    # TODO: add this transition when we add 526 completion polling
     # - The only state that means we no longer own completion of this submission
     # - There is nothing more to do.  E.G.
     #   - VBMS has accepted and returned the applicable status to us via
@@ -77,6 +77,33 @@ class Form526Submission < ApplicationRecord
     # - we probably want to avoid using this state
     event :mark_as_unprocessable do
       transitions to: :unprocessable
+    end
+
+    # A special state to indicate this was part of our remediation 'batching'
+    # process in 2023.  These were handled manually and are distinct fom `in_remediation`
+    # in that they were not tracked at the time of remediation, but rather later in
+    # the 2024 526 State audit.
+    #
+    # This state is useful to us at the time of creation, but may be something
+    # to flatten to a simple `finalized_as_successful` in the future.
+    event :process_in_batch_remediation do
+      transitions to: :processed_in_batch_remediation
+    end
+
+    # A special state to indicate this was part of our remediation 'batching'
+    # process in 2023.  These submissions may have been processed or not, but
+    # we don't care because they have an earlier, successful duplicate.
+    #
+    # Duplicates are identified by comparing form_json, using this script:
+    # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/benefits/scripts/526/submission_deduper.rb
+    # The result of this script can be evaluated by a qualified stakeholder to make
+    # a judgement call on wether or not a submission is a 'perfect' duplicate.
+    #
+    # IF a submission is found to be an exact duplicate of another
+    # AND it's duplicate was previously submitted / remediated successfully
+    # THEN we can ignore it as a duplicate
+    event :ignore_as_duplicate do
+      transitions to: :ignorable_duplicate
     end
   end
 

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe Form526Submission do
         .to(:unprocessable).on_event(:mark_as_unprocessable)
       expect(submission).to transition_from(:unprocessed)
         .to(:in_remediation).on_event(:begin_remediation)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:processed_in_batch_remediation).on_event(:process_in_batch_remediation)
+      expect(submission).to transition_from(:unprocessed)
+        .to(:ignorable_duplicate).on_event(:ignore_as_duplicate)
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Two new states are being added to support the 526 state Audit (code yellow).  These are part of a larger project to 'exclude' submissions that have been processed, leaving us with a list of 'untouched' submissions
- The 526 'state machine' is really more of an end-of-life tagging system that was introduced to support our remediation and state auditing following multiple related code yellows.
- I'm part of the Disability & Benefits Experience team 2 (aka team crabs)

## Related issue(s)

- [Ticket with context on the overarching problem, as well as this specific change](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/80624)

## Testing done

- [x] *New code is covered by unit tests*
- Prior to this change there were no states to represent this subsection of 'excluded' submissions
- To verify these changes work, instantiate a Form526Submission object (easiest using RSpec and fatcories) and call the new state transition methods on them

## What areas of the site does it impact?
This is not a veteran facing change.  This data will only be added to the database via script; there is no automatic transitioning to these states

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
