### PR TITLE
API-35478-synchronous-request 

### DIFF
--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -3950,13 +3950,18 @@ RSpec.describe 'Disability Claims', type: :request do
   describe 'POST #synchronous' do
     let(:veteran_id) { '1012832025V743496' }
     let(:synchronous_path) { "/services/claims/v2/veterans/#{veteran_id}/526/synchronous" }
+    let(:data) do
+      Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans', 'disability_compensation',
+                      'form_526_json_api.json').read
+    end
+    let(:schema) { Rails.root.join('modules', 'claims_api', 'config', 'schemas', 'v2', '526.json').read }
 
     context 'when the endpoint is hit' do
       it 'returns an empty test object' do
         mock_ccg(scopes) do |auth_header|
-          post synchronous_path, params: {}.to_json, headers: auth_header
-
-          expect(JSON.parse(response.body)).to eq({})
+          post synchronous_path, params: data, headers: auth_header
+          parsed_res = JSON.parse(response.body)
+          expect(parsed_res['data']).to include('id')
         end
       end
     end


### PR DESCRIPTION
## Summary

- Adds working calls to 526#submit and 526#synchronous. 
- Adds shared submit method, and 
- adjusts the test to expect data to be returned.

## Related issue(s)

- [API-35478](https://jira.devops.va.gov/browse/API-35478)

## Testing done

- new rspec test
- Postman - tested both endpoints

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
	modified:   modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature