### PR TITLE
Api 35334 526 docs max length

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -967,7 +967,7 @@
                       "lighthouseId": null,
                       "maxEstClaimDate": null,
                       "minEstClaimDate": null,
-                      "status": "COMPLETE",
+                      "status": "CANCELED",
                       "submitterApplicationCode": "EBN",
                       "submitterRoleCode": "VET",
                       "supportingDocuments": [
@@ -1625,6 +1625,7 @@
                                 "serviceNumber": {
                                   "type": "string",
                                   "description": "Service identification number",
+                                  "maxLength": 1000,
                                   "nullable": true
                                 },
                                 "veteranNumber": {
@@ -1645,6 +1646,7 @@
                                       "type": "string",
                                       "description": "Veteran's international phone number.",
                                       "example": "+44 20 1234 5678",
+                                      "maxLength": 1000,
                                       "nullable": true
                                     }
                                   }
@@ -1687,6 +1689,7 @@
                                       "description": "City for the Veteran's current mailing address.",
                                       "type": "string",
                                       "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                      "maxLength": 1000,
                                       "example": "Portland"
                                     },
                                     "state": {
@@ -1698,6 +1701,7 @@
                                     "country": {
                                       "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "example": "USA"
                                     },
                                     "zipFirstFive": {
@@ -1783,6 +1787,7 @@
                                   "description": "City for the Veteran's new address.",
                                   "type": "string",
                                   "pattern": "^$|^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                  "maxLength": 1000,
                                   "example": "Portland"
                                 },
                                 "state": {
@@ -1794,6 +1799,7 @@
                                 "country": {
                                   "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "example": "USA"
                                 },
                                 "zipFirstFive": {
@@ -1913,6 +1919,7 @@
                                       "description": "International phone of point of contact.",
                                       "type": "string",
                                       "example": "+44 20 1234 5678",
+                                      "maxLength": 1000,
                                       "nullable": true
                                     }
                                   }
@@ -1947,12 +1954,14 @@
                                           "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in Gulf War hazard location.",
+                                          "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
                                           "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for serving in Gulf War hazard location.",
+                                          "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         }
                                       }
@@ -1978,6 +1987,7 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 5000,
                                       "description": "Other location(s) where Veteran served."
                                     },
                                     "serviceDates": {
@@ -2031,6 +2041,7 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
                                     "exposureDates": {
@@ -2069,12 +2080,14 @@
                                         "type": "string",
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                        "maxLength": 1000,
                                         "description": "Hazard the Veteran was exposed to."
                                       },
                                       "exposureLocation": {
                                         "type": "string",
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                        "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
                                       "exposureDates": {
@@ -2126,6 +2139,7 @@
                                     "type": "string",
                                     "description": "What caused the disability?",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "examples": [
                                       "Agent Orange",
                                       "radiation",
@@ -2136,6 +2150,7 @@
                                     "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "example": "Heavy equipment operator in service."
                                   },
                                   "approximateDate": {
@@ -2198,6 +2213,7 @@
                                           "type": "string",
                                           "description": "What caused the disability?",
                                           "nullable": true,
+                                          "maxLength": 1000,
                                           "examples": [
                                             "Agent Orange",
                                             "radiation",
@@ -2208,6 +2224,7 @@
                                           "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
                                           "type": "string",
                                           "nullable": true,
+                                          "maxLength": 1000,
                                           "example": "Heavy equipment operator in service."
                                         },
                                         "disabilityActionType": {
@@ -2340,6 +2357,7 @@
                                       "serviceBranch": {
                                         "description": "Branch of service during period. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                         "type": "string",
+                                        "maxLength": 1000,
                                         "example": "Air Force"
                                       },
                                       "serviceComponent": {
@@ -2419,10 +2437,12 @@
                                     "unitName": {
                                       "type": "string",
                                       "nullable": true,
+                                      "maxLength": 1000,
                                       "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                     },
                                     "unitAddress": {
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "nullable": true
                                     },
@@ -2532,6 +2552,7 @@
                                 "futureMilitaryRetiredPayExplanation": {
                                   "description": "Explains why future pay will be received.",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "example": "Will be retiring soon.",
                                   "nullable": true
                                 },
@@ -2543,6 +2564,7 @@
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "nullable": true,
                                       "example": "Air Force"
                                     },
@@ -2598,6 +2620,7 @@
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
                                       "nullable": true,
+                                      "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "preTaxAmountReceived": {
@@ -2885,6 +2908,7 @@
                               "serviceNumber": {
                                 "type": "string",
                                 "description": "Service identification number",
+                                "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
@@ -2905,6 +2929,7 @@
                                     "type": "string",
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -2947,6 +2972,7 @@
                                     "description": "City for the Veteran's current mailing address.",
                                     "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                    "maxLength": 1000,
                                     "example": "Portland"
                                   },
                                   "state": {
@@ -2958,6 +2984,7 @@
                                   "country": {
                                     "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "example": "USA"
                                   },
                                   "zipFirstFive": {
@@ -3043,6 +3070,7 @@
                                 "description": "City for the Veteran's new address.",
                                 "type": "string",
                                 "pattern": "^$|^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                "maxLength": 1000,
                                 "example": "Portland"
                               },
                               "state": {
@@ -3054,6 +3082,7 @@
                               "country": {
                                 "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "USA"
                               },
                               "zipFirstFive": {
@@ -3173,6 +3202,7 @@
                                     "description": "International phone of point of contact.",
                                     "type": "string",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -3207,12 +3237,14 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       }
                                     }
@@ -3238,6 +3270,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
                                   "serviceDates": {
@@ -3291,6 +3324,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
@@ -3329,12 +3363,14 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
@@ -3386,6 +3422,7 @@
                                   "type": "string",
                                   "description": "What caused the disability?",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "examples": [
                                     "Agent Orange",
                                     "radiation",
@@ -3396,6 +3433,7 @@
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
                                   "type": "string",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
@@ -3458,6 +3496,7 @@
                                         "type": "string",
                                         "description": "What caused the disability?",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "examples": [
                                           "Agent Orange",
                                           "radiation",
@@ -3468,6 +3507,7 @@
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
                                         "type": "string",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
                                       },
                                       "disabilityActionType": {
@@ -3600,6 +3640,7 @@
                                     "serviceBranch": {
                                       "description": "Branch of service during period. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "serviceComponent": {
@@ -3679,10 +3720,12 @@
                                   "unitName": {
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
@@ -3792,6 +3835,7 @@
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
@@ -3803,6 +3847,7 @@
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
@@ -3858,6 +3903,7 @@
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
@@ -4690,6 +4736,7 @@
                               "serviceNumber": {
                                 "type": "string",
                                 "description": "Service identification number",
+                                "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
@@ -4710,6 +4757,7 @@
                                     "type": "string",
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -4752,6 +4800,7 @@
                                     "description": "City for the Veteran's current mailing address.",
                                     "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                    "maxLength": 1000,
                                     "example": "Portland"
                                   },
                                   "state": {
@@ -4763,6 +4812,7 @@
                                   "country": {
                                     "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "example": "USA"
                                   },
                                   "zipFirstFive": {
@@ -4848,6 +4898,7 @@
                                 "description": "City for the Veteran's new address.",
                                 "type": "string",
                                 "pattern": "^$|^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                "maxLength": 1000,
                                 "example": "Portland"
                               },
                               "state": {
@@ -4859,6 +4910,7 @@
                               "country": {
                                 "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "USA"
                               },
                               "zipFirstFive": {
@@ -4978,6 +5030,7 @@
                                     "description": "International phone of point of contact.",
                                     "type": "string",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -5012,12 +5065,14 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       }
                                     }
@@ -5043,6 +5098,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
                                   "serviceDates": {
@@ -5096,6 +5152,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
@@ -5134,12 +5191,14 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
@@ -5191,6 +5250,7 @@
                                   "type": "string",
                                   "description": "What caused the disability?",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "examples": [
                                     "Agent Orange",
                                     "radiation",
@@ -5201,6 +5261,7 @@
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
                                   "type": "string",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
@@ -5263,6 +5324,7 @@
                                         "type": "string",
                                         "description": "What caused the disability?",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "examples": [
                                           "Agent Orange",
                                           "radiation",
@@ -5273,6 +5335,7 @@
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
                                         "type": "string",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
                                       },
                                       "disabilityActionType": {
@@ -5405,6 +5468,7 @@
                                     "serviceBranch": {
                                       "description": "Branch of service during period. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "serviceComponent": {
@@ -5484,10 +5548,12 @@
                                   "unitName": {
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
@@ -5597,6 +5663,7 @@
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
@@ -5608,6 +5675,7 @@
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
@@ -5663,6 +5731,7 @@
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
@@ -6003,7 +6072,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "cf532e4e-e89e-4f9c-aebd-ce8361336a41",
+                    "id": "bcf33b41-f27f-429c-b860-f2b71567d87e",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -8087,8 +8156,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-03-26",
-                      "expirationDate": "2025-03-26",
+                      "creationDate": "2024-04-23",
+                      "expirationDate": "2025-04-23",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -8807,7 +8876,7 @@
                       "status": "422",
                       "detail": "Could not retrieve Power of Attorney due to multiple representatives with code: A1Q",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:112:in `representative'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:130:in `representative'"
                       }
                     }
                   ]
@@ -8906,7 +8975,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "29b16b36-3108-411f-9f5f-2c1c2e147ea3",
+                    "id": "48a79d49-eccd-4a89-adb8-e2c91ed3fab5",
                     "type": "individual",
                     "attributes": {
                       "code": "083",
@@ -9108,7 +9177,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/individual_controller.rb:35:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -9602,7 +9671,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "a7114d11-8ffd-4545-ad99-d70e74991e11",
+                    "id": "7610ed19-baac-46fe-8ba5-5aa3e64a92ff",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -9812,7 +9881,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/organization_controller.rb:35:in `validate_org_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -10431,7 +10500,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/individual_controller.rb:35:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -11126,7 +11195,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/organization_controller.rb:35:in `validate_org_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -11562,11 +11631,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "7b0c58e1-4bf7-413c-a3ab-c8f6b95208b0",
+                    "id": "09a36719-ad88-46b9-97d1-80a746ef9e81",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "status": "submitted",
-                      "dateRequestAccepted": "2024-03-26",
+                      "dateRequestAccepted": "2024-04-23",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -684,7 +684,7 @@
                       "lighthouseId": null,
                       "maxEstClaimDate": null,
                       "minEstClaimDate": null,
-                      "status": "COMPLETE",
+                      "status": "CANCELED",
                       "submitterApplicationCode": "EBN",
                       "submitterRoleCode": "VET",
                       "supportingDocuments": [
@@ -1342,6 +1342,7 @@
                                 "serviceNumber": {
                                   "type": "string",
                                   "description": "Service identification number",
+                                  "maxLength": 1000,
                                   "nullable": true
                                 },
                                 "veteranNumber": {
@@ -1362,6 +1363,7 @@
                                       "type": "string",
                                       "description": "Veteran's international phone number.",
                                       "example": "+44 20 1234 5678",
+                                      "maxLength": 1000,
                                       "nullable": true
                                     }
                                   }
@@ -1404,6 +1406,7 @@
                                       "description": "City for the Veteran's current mailing address.",
                                       "type": "string",
                                       "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                      "maxLength": 1000,
                                       "example": "Portland"
                                     },
                                     "state": {
@@ -1415,6 +1418,7 @@
                                     "country": {
                                       "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "example": "USA"
                                     },
                                     "zipFirstFive": {
@@ -1500,6 +1504,7 @@
                                   "description": "City for the Veteran's new address.",
                                   "type": "string",
                                   "pattern": "^$|^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                  "maxLength": 1000,
                                   "example": "Portland"
                                 },
                                 "state": {
@@ -1511,6 +1516,7 @@
                                 "country": {
                                   "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "example": "USA"
                                 },
                                 "zipFirstFive": {
@@ -1630,6 +1636,7 @@
                                       "description": "International phone of point of contact.",
                                       "type": "string",
                                       "example": "+44 20 1234 5678",
+                                      "maxLength": 1000,
                                       "nullable": true
                                     }
                                   }
@@ -1664,12 +1671,14 @@
                                           "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in Gulf War hazard location.",
+                                          "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
                                           "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for serving in Gulf War hazard location.",
+                                          "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         }
                                       }
@@ -1695,6 +1704,7 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 5000,
                                       "description": "Other location(s) where Veteran served."
                                     },
                                     "serviceDates": {
@@ -1748,6 +1758,7 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
                                     "exposureDates": {
@@ -1786,12 +1797,14 @@
                                         "type": "string",
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                        "maxLength": 1000,
                                         "description": "Hazard the Veteran was exposed to."
                                       },
                                       "exposureLocation": {
                                         "type": "string",
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                        "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
                                       "exposureDates": {
@@ -1843,6 +1856,7 @@
                                     "type": "string",
                                     "description": "What caused the disability?",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "examples": [
                                       "Agent Orange",
                                       "radiation",
@@ -1853,6 +1867,7 @@
                                     "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "example": "Heavy equipment operator in service."
                                   },
                                   "approximateDate": {
@@ -1915,6 +1930,7 @@
                                           "type": "string",
                                           "description": "What caused the disability?",
                                           "nullable": true,
+                                          "maxLength": 1000,
                                           "examples": [
                                             "Agent Orange",
                                             "radiation",
@@ -1925,6 +1941,7 @@
                                           "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
                                           "type": "string",
                                           "nullable": true,
+                                          "maxLength": 1000,
                                           "example": "Heavy equipment operator in service."
                                         },
                                         "disabilityActionType": {
@@ -2057,6 +2074,7 @@
                                       "serviceBranch": {
                                         "description": "Branch of service during period. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                         "type": "string",
+                                        "maxLength": 1000,
                                         "example": "Air Force"
                                       },
                                       "serviceComponent": {
@@ -2136,10 +2154,12 @@
                                     "unitName": {
                                       "type": "string",
                                       "nullable": true,
+                                      "maxLength": 1000,
                                       "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                     },
                                     "unitAddress": {
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "nullable": true
                                     },
@@ -2249,6 +2269,7 @@
                                 "futureMilitaryRetiredPayExplanation": {
                                   "description": "Explains why future pay will be received.",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "example": "Will be retiring soon.",
                                   "nullable": true
                                 },
@@ -2260,6 +2281,7 @@
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "nullable": true,
                                       "example": "Air Force"
                                     },
@@ -2315,6 +2337,7 @@
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
                                       "nullable": true,
+                                      "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "preTaxAmountReceived": {
@@ -2602,6 +2625,7 @@
                               "serviceNumber": {
                                 "type": "string",
                                 "description": "Service identification number",
+                                "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
@@ -2622,6 +2646,7 @@
                                     "type": "string",
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -2664,6 +2689,7 @@
                                     "description": "City for the Veteran's current mailing address.",
                                     "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                    "maxLength": 1000,
                                     "example": "Portland"
                                   },
                                   "state": {
@@ -2675,6 +2701,7 @@
                                   "country": {
                                     "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "example": "USA"
                                   },
                                   "zipFirstFive": {
@@ -2760,6 +2787,7 @@
                                 "description": "City for the Veteran's new address.",
                                 "type": "string",
                                 "pattern": "^$|^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                "maxLength": 1000,
                                 "example": "Portland"
                               },
                               "state": {
@@ -2771,6 +2799,7 @@
                               "country": {
                                 "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "USA"
                               },
                               "zipFirstFive": {
@@ -2890,6 +2919,7 @@
                                     "description": "International phone of point of contact.",
                                     "type": "string",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -2924,12 +2954,14 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       }
                                     }
@@ -2955,6 +2987,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
                                   "serviceDates": {
@@ -3008,6 +3041,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
@@ -3046,12 +3080,14 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
@@ -3103,6 +3139,7 @@
                                   "type": "string",
                                   "description": "What caused the disability?",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "examples": [
                                     "Agent Orange",
                                     "radiation",
@@ -3113,6 +3150,7 @@
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
                                   "type": "string",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
@@ -3175,6 +3213,7 @@
                                         "type": "string",
                                         "description": "What caused the disability?",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "examples": [
                                           "Agent Orange",
                                           "radiation",
@@ -3185,6 +3224,7 @@
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
                                         "type": "string",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
                                       },
                                       "disabilityActionType": {
@@ -3317,6 +3357,7 @@
                                     "serviceBranch": {
                                       "description": "Branch of service during period. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "serviceComponent": {
@@ -3396,10 +3437,12 @@
                                   "unitName": {
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
@@ -3509,6 +3552,7 @@
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
@@ -3520,6 +3564,7 @@
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
@@ -3575,6 +3620,7 @@
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
@@ -4407,6 +4453,7 @@
                               "serviceNumber": {
                                 "type": "string",
                                 "description": "Service identification number",
+                                "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
@@ -4427,6 +4474,7 @@
                                     "type": "string",
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -4469,6 +4517,7 @@
                                     "description": "City for the Veteran's current mailing address.",
                                     "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                    "maxLength": 1000,
                                     "example": "Portland"
                                   },
                                   "state": {
@@ -4480,6 +4529,7 @@
                                   "country": {
                                     "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "example": "USA"
                                   },
                                   "zipFirstFive": {
@@ -4565,6 +4615,7 @@
                                 "description": "City for the Veteran's new address.",
                                 "type": "string",
                                 "pattern": "^$|^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+                                "maxLength": 1000,
                                 "example": "Portland"
                               },
                               "state": {
@@ -4576,6 +4627,7 @@
                               "country": {
                                 "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "USA"
                               },
                               "zipFirstFive": {
@@ -4695,6 +4747,7 @@
                                     "description": "International phone of point of contact.",
                                     "type": "string",
                                     "example": "+44 20 1234 5678",
+                                    "maxLength": 1000,
                                     "nullable": true
                                   }
                                 }
@@ -4729,12 +4782,14 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
+                                        "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       }
                                     }
@@ -4760,6 +4815,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
                                   "serviceDates": {
@@ -4813,6 +4869,7 @@
                                     "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
@@ -4851,12 +4908,14 @@
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
@@ -4908,6 +4967,7 @@
                                   "type": "string",
                                   "description": "What caused the disability?",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "examples": [
                                     "Agent Orange",
                                     "radiation",
@@ -4918,6 +4978,7 @@
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
                                   "type": "string",
                                   "nullable": true,
+                                  "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
@@ -4980,6 +5041,7 @@
                                         "type": "string",
                                         "description": "What caused the disability?",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "examples": [
                                           "Agent Orange",
                                           "radiation",
@@ -4990,6 +5052,7 @@
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
                                         "type": "string",
                                         "nullable": true,
+                                        "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
                                       },
                                       "disabilityActionType": {
@@ -5122,6 +5185,7 @@
                                     "serviceBranch": {
                                       "description": "Branch of service during period. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                       "type": "string",
+                                      "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "serviceComponent": {
@@ -5201,10 +5265,12 @@
                                   "unitName": {
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
@@ -5314,6 +5380,7 @@
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
@@ -5325,6 +5392,7 @@
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
+                                    "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
@@ -5380,6 +5448,7 @@
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                                     "type": "string",
                                     "nullable": true,
+                                    "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
@@ -5720,7 +5789,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "8b3c6607-078b-419b-8549-726da40193df",
+                    "id": "cfe5b467-a176-4987-80a9-4350ba73f350",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -7804,8 +7873,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-03-26",
-                      "expirationDate": "2025-03-26",
+                      "creationDate": "2024-04-23",
+                      "expirationDate": "2025-04-23",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -8524,7 +8593,7 @@
                       "status": "422",
                       "detail": "Could not retrieve Power of Attorney due to multiple representatives with code: A1Q",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:112:in `representative'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:130:in `representative'"
                       }
                     }
                   ]
@@ -8623,7 +8692,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "9a9b6db5-abfc-45f3-ab60-785e3fb052ed",
+                    "id": "74658dd8-0176-4bd4-ac22-beedcef627df",
                     "type": "individual",
                     "attributes": {
                       "code": "083",
@@ -8825,7 +8894,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/individual_controller.rb:35:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -9319,7 +9388,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "618d9ba4-44cf-490a-bd56-8012b59b30e7",
+                    "id": "f8eefcaa-020f-473e-9382-11dbd36f32ff",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -9529,7 +9598,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/organization_controller.rb:35:in `validate_org_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -10148,7 +10217,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/individual_controller.rb:35:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -10843,7 +10912,7 @@
                       "status": "404",
                       "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/organization_controller.rb:35:in `validate_org_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -11279,11 +11348,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "5d78a9f2-fffb-4867-a621-6ddee5bd5e58",
+                    "id": "c08567c4-6f1d-49bb-8416-01b91642b301",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "status": "submitted",
-                      "dateRequestAccepted": "2024-03-26",
+                      "dateRequestAccepted": "2024-04-23",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -98,7 +98,6 @@
               "description": "State for the Veteran's current mailing address.",
               "type": "string",
               "pattern": "^[a-z,A-Z]{2}$",
-              "maxLength": 1000,
               "example": "OR"
             },
             "country": {
@@ -194,7 +193,6 @@
           "description": "State for the Veteran's new address.",
           "type": "string",
           "pattern": "^$|^[a-z,A-Z]{2}$",
-          "maxLength": 1000,
           "example": "OR"
         },
         "country": {

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -27,6 +27,7 @@
         "serviceNumber": {
           "type": ["null", "string"],
           "description": "Service identification number",
+          "maxLength": 1000,
           "nullable": true
         },
         "veteranNumber": {
@@ -47,6 +48,7 @@
               "type": ["string", "null"],
               "description": "Veteran's international phone number.",
               "example": "+44 20 1234 5678",
+              "maxLength": 1000,
               "nullable": true
             }
           }
@@ -89,17 +91,20 @@
               "description": "City for the Veteran's current mailing address.",
               "type": "string",
               "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+              "maxLength": 1000,
               "example": "Portland"
             },
             "state": {
               "description": "State for the Veteran's current mailing address.",
               "type": "string",
               "pattern": "^[a-z,A-Z]{2}$",
+              "maxLength": 1000,
               "example": "OR"
             },
             "country": {
               "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
               "type": "string",
+              "maxLength": 1000,
               "example": "USA"
             },
             "zipFirstFive": {
@@ -182,17 +187,20 @@
           "description": "City for the Veteran's new address.",
           "type": "string",
           "pattern": "^$|^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+          "maxLength": 1000,
           "example": "Portland"
         },
         "state": {
           "description": "State for the Veteran's new address.",
           "type": "string",
           "pattern": "^$|^[a-z,A-Z]{2}$",
+          "maxLength": 1000,
           "example": "OR"
         },
         "country": {
           "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
           "type": "string",
+          "maxLength": 1000,
           "example": "USA"
         },
         "zipFirstFive": {
@@ -314,6 +322,7 @@
               "description": "International phone of point of contact.",
               "type": ["string", "null"],
               "example": "+44 20 1234 5678",
+              "maxLength": 1000,
               "nullable": true
             }
           }
@@ -345,12 +354,14 @@
                   "type": ["string", "null"],
                   "nullable": true,
                   "description": "Approximate begin date for serving in Gulf War hazard location.",
+                  "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                   "example": "2018-06 or 2018"
                 },
                 "endDate": {
                   "type": ["string", "null"],
                   "nullable": true,
                   "description": "Approximate end date for serving in Gulf War hazard location.",
+                  "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                   "example": "2018-06 or 2018"
                 }
               }
@@ -373,6 +384,7 @@
               "type": ["string", "null"],
               "nullable": true,
               "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+              "maxLength": 5000,
               "description": "Other location(s) where Veteran served."
             },
             "serviceDates": {
@@ -427,6 +439,7 @@
               "type": ["string", "null"],
               "nullable": true,
               "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+              "maxLength": 5000,
               "description": "Exposure to asbestos."
             },
             "exposureDates": {
@@ -465,12 +478,14 @@
                 "type": ["string", "null"],
                 "nullable": true,
                 "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                "maxLength": 1000,
                 "description": "Hazard the Veteran was exposed to."
               },
               "exposureLocation": {
                 "type": ["string", "null"],
                 "nullable": true,
                 "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                "maxLength": 1000,
                 "description": "Location where the exposure happened."
               },
               "exposureDates": {
@@ -519,12 +534,14 @@
             "type": ["string", "null"],
             "description": "What caused the disability?",
             "nullable": true,
+            "maxLength": 1000,
             "examples": ["Agent Orange", "radiation", "burn pits"]
           },
           "serviceRelevance": {
             "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
             "type": ["string", "null"],
             "nullable": true,
+            "maxLength": 1000,
             "example": "Heavy equipment operator in service."
           },
           "approximateDate": {
@@ -583,12 +600,14 @@
                   "type": ["string", "null"],
                   "description": "What caused the disability?",
                   "nullable": true,
+                  "maxLength": 1000,
                   "examples": ["Agent Orange", "radiation", "burn pits"]
                 },
                 "serviceRelevance": {
                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
                   "type": ["string", "null"],
                   "nullable": true,
+                  "maxLength": 1000,
                   "example": "Heavy equipment operator in service."
                 },
                 "disabilityActionType": {
@@ -705,6 +724,7 @@
               "serviceBranch": {
                 "description": "Branch of service during period. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
                 "type": "string",
+                "maxLength": 1000,
                 "example": "Air Force"
               },
               "serviceComponent": {
@@ -774,10 +794,12 @@
             "unitName": {
               "type": ["string", "null"],
               "nullable": true,
+              "maxLength": 1000,
               "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
             },
             "unitAddress": {
               "type": ["string", "null"],
+              "maxLength": 1000,
               "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
               "nullable": true
             },
@@ -878,6 +900,7 @@
         "futureMilitaryRetiredPayExplanation": {
           "description": "Explains why future pay will be received.",
           "type": ["string", "null"],
+          "maxLength": 1000,
           "example": "Will be retiring soon.",
           "nullable": true
         },
@@ -889,6 +912,7 @@
             "branchOfService": {
               "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
               "type": ["string", "null"],
+              "maxLength": 1000,
               "nullable": true,
               "example": "Air Force"
             },
@@ -942,6 +966,7 @@
               "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
               "type": ["string", "null"],
               "nullable": true,
+              "maxLength": 1000,
               "example": "Air Force"
             },
             "preTaxAmountReceived": {


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds max length as specified in the [PDF generator schema](https://blue.qa.lighthouse.va.gov/form-526ez-pdf-generator/v1/openapi.json) to 526 fields that do no currently specify a max length in 526.json.

## Related issue(s)

[API-35334](https://jira.devops.va.gov/browse/API-35334)

## Testing done

- [ ] *New code is covered by unit tests*
- Confirmed locally that max lengths added to schema appear as expected in documentation.
- Confirmed max lengths added are enforced when validating or submitting a 526 submission


## What areas of the site does it impact?
526 validation and submission

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

