### PR TITLE
manila timezone info logging

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -15,6 +15,7 @@ module VAOS
       FACILITY_ERROR_MSG = 'Error fetching facility details'
       AVS_ERROR_MESSAGE = 'Error retrieving AVS link'
       AVS_APPT_TEST_ID = '192308'
+      MANILA_PHILIPPINES_FACILITY_ID = '358'
 
       AVS_FLIPPER = :va_online_scheduling_after_visit_summary
       ORACLE_HEALTH_CANCELLATIONS = :va_online_scheduling_enable_OH_cancellations
@@ -410,6 +411,16 @@ module VAOS
       def convert_appointment_time(appt)
         if !appt[:start].nil?
           facility_timezone = get_facility_timezone_memoized(appt[:location_id])
+          if appt[:location_id] == MANILA_PHILIPPINES_FACILITY_ID
+            Rails.logger.info(
+              "Timezone info for Manila Philippines location_id #{appt[:location_id]}",
+              {
+                location_id: appt[:location_id],
+                facility_timezone:,
+                appt_start_time: appt[:start]
+              }.to_json
+            )
+          end
           appt[:local_start_time] = convert_utc_to_local_time(appt[:start], facility_timezone)
         elsif !appt.dig(:requested_periods, 0, :start).nil?
           appt[:requested_periods].each do |period|

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -411,24 +411,35 @@ module VAOS
       def convert_appointment_time(appt)
         if !appt[:start].nil?
           facility_timezone = get_facility_timezone_memoized(appt[:location_id])
-          if appt[:location_id] == MANILA_PHILIPPINES_FACILITY_ID
-            Rails.logger.info(
-              "Timezone info for Manila Philippines location_id #{appt[:location_id]}",
-              {
-                location_id: appt[:location_id],
-                facility_timezone:,
-                appt_start_time: appt[:start]
-              }.to_json
-            )
-          end
           appt[:local_start_time] = convert_utc_to_local_time(appt[:start], facility_timezone)
+
+          if appt[:location_id] == MANILA_PHILIPPINES_FACILITY_ID
+            log_timezone_info(appt[:location_id], facility_timezone, appt[:start], appt[:local_start_time])
+          end
+
         elsif !appt.dig(:requested_periods, 0, :start).nil?
           appt[:requested_periods].each do |period|
             facility_timezone = get_facility_timezone_memoized(appt[:location_id])
             period[:local_start_time] = convert_utc_to_local_time(period[:start], facility_timezone)
+
+            if appt[:location_id] == MANILA_PHILIPPINES_FACILITY_ID
+              log_timezone_info(appt[:location_id], facility_timezone, period[:start], period[:local_start_time])
+            end
           end
         end
         appt
+      end
+
+      def log_timezone_info(appt_location_id, facility_timezone, appt_start_time_utc, appt_start_time_local)
+        Rails.logger.info(
+          "Timezone info for Manila Philippines location_id #{appt_location_id}",
+          {
+            location_id: appt_location_id,
+            facility_timezone:,
+            appt_start_time_utc:,
+            appt_start_time_local:
+          }.to_json
+        )
       end
 
       # Returns a local [DateTime] object converted from UTC using the facility's timezone offset.

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -623,6 +623,33 @@ describe VAOS::V2::AppointmentsService do
     end
   end
 
+  describe '#convert_appointment_time' do
+    let(:manila_appt) do
+      {
+        id: '12345',
+        location_id: '358',
+        start: '2024-12-20T00:00:00Z'
+      }
+    end
+
+    context 'when appt location id is 358' do
+      it 'logs the appt location id, timezone info, and appt start time' do
+        allow_any_instance_of(VAOS::V2::AppointmentsService)
+          .to receive(:get_facility_timezone_memoized)
+          .and_return('Asia/Manila')
+        allow(Rails.logger).to receive(:info)
+
+        subject.send(:convert_appointment_time, manila_appt)
+        expect(Rails.logger).to have_received(:info).with('Timezone info for Manila Philippines location_id 358',
+                                                          {
+                                                            location_id: '358',
+                                                            facility_timezone: 'Asia/Manila',
+                                                            appt_start_time: '2024-12-20T00:00:00Z'
+                                                          }.to_json)
+      end
+    end
+  end
+
   describe '#convert_utc_to_local_time' do
     let(:start_datetime) { '2021-09-02T14:00:00Z'.to_datetime }
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -632,8 +632,16 @@ describe VAOS::V2::AppointmentsService do
       }
     end
 
+    let(:manila_appt_req) do
+      {
+        id: '12345',
+        location_id: '358',
+        requested_periods: [{ start: '2024-12-20T00:00:00Z', end: '2024-12-20T11:59:59.999Z' }]
+      }
+    end
+
     context 'when appt location id is 358' do
-      it 'logs the appt location id, timezone info, and appt start time' do
+      it 'logs the appt location id, timezone info, utc/local times of appt' do
         allow_any_instance_of(VAOS::V2::AppointmentsService)
           .to receive(:get_facility_timezone_memoized)
           .and_return('Asia/Manila')
@@ -644,7 +652,34 @@ describe VAOS::V2::AppointmentsService do
                                                           {
                                                             location_id: '358',
                                                             facility_timezone: 'Asia/Manila',
-                                                            appt_start_time: '2024-12-20T00:00:00Z'
+                                                            appt_start_time_utc: '2024-12-20T00:00:00Z',
+                                                            appt_start_time_local: subject.send(
+                                                              :convert_utc_to_local_time,
+                                                              manila_appt[:start],
+                                                              'Asia/Manila'
+                                                            )
+                                                          }.to_json)
+      end
+
+      it 'logs the appt location id, timezone info, utc/local times of appt request' do
+        allow_any_instance_of(VAOS::V2::AppointmentsService)
+          .to receive(:get_facility_timezone_memoized)
+          .and_return('Asia/Manila')
+        allow(Rails.logger).to receive(:info)
+
+        subject.send(:convert_appointment_time, manila_appt_req)
+        expect(Rails.logger).to have_received(:info).with('Timezone info for Manila Philippines location_id 358',
+                                                          {
+                                                            location_id: '358',
+                                                            facility_timezone: 'Asia/Manila',
+                                                            appt_start_time_utc: '2024-12-20T00:00:00Z',
+                                                            appt_start_time_local: subject.send(
+                                                              :convert_utc_to_local_time, manila_appt_req.dig(
+                                                                                            :requested_periods,
+                                                                                            0,
+                                                                                            :start
+                                                                                          ), 'Asia/Manila'
+                                                            )
                                                           }.to_json)
       end
     end


### PR DESCRIPTION
## Summary

- This work is to implement investigative logging into the timezone info returned for the Manila, Philippines facility location

## Testing Done
- New test to verify logging functionality, ran regression tests on preexisting functionality