### PR TITLE
Api 35595 registration numbers

### DIFF
--- a/modules/check_in/app/services/check_in/vaos/base_service.rb
+++ b/modules/check_in/app/services/check_in/vaos/base_service.rb
@@ -9,13 +9,25 @@ module CheckIn
       include SentryLogging
       include Common::Client::Concerns::Monitoring
 
-      attr_reader :patient_icn, :token_service
+      attr_reader :check_in_session, :patient_icn
 
       STATSD_KEY_PREFIX = 'api.check_in.vaos'
 
-      def initialize(patient_icn:)
-        @patient_icn = patient_icn
-        @token_service = CheckIn::Map::TokenService.build({ patient_icn: })
+      ##
+      # Builds a Service instance
+      #
+      # @param opts [Hash] options to create the object
+      #
+      # @return [Service] an instance of this class
+      #
+      def self.build(opts = {})
+        new(opts)
+      end
+
+      def initialize(opts)
+        @check_in_session = opts[:check_in_session]
+        @patient_icn = ::V2::Lorota::RedisClient.build.icn(uuid: check_in_session.uuid)
+
         super()
       end
 
@@ -33,6 +45,10 @@ module CheckIn
           'X-VAMF-JWT' => token_service.token,
           'X-Request-ID' => RequestStore.store['request_id']
         }
+      end
+
+      def token_service
+        @token_service ||= Map::TokenService.build(patient_icn:)
       end
 
       def referrer

--- a/modules/check_in/spec/services/check_in/map/token_service_spec.rb
+++ b/modules/check_in/spec/services/check_in/map/token_service_spec.rb
@@ -3,14 +3,10 @@
 require 'rails_helper'
 
 describe CheckIn::Map::TokenService do
-  subject { described_class }
+  subject { described_class.build(opts) }
 
   let(:patient_icn) { '123' }
-  let(:opts) do
-    {
-      patient_icn:
-    }
-  end
+  let(:opts) { { patient_icn: } }
   let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   before do
@@ -21,13 +17,13 @@ describe CheckIn::Map::TokenService do
 
   describe '.build' do
     it 'returns an instance of Service' do
-      expect(subject.build(opts)).to be_an_instance_of(described_class)
+      expect(subject).to be_an_instance_of(described_class)
     end
   end
 
   describe '#initialize' do
     it 'has a redis client' do
-      expect(subject.build(opts).redis_client).to be_a(CheckIn::Map::RedisClient)
+      expect(subject.redis_client).to be_a(CheckIn::Map::RedisClient)
     end
   end
 
@@ -41,7 +37,7 @@ describe CheckIn::Map::TokenService do
       end
 
       it 'returns token from redis' do
-        expect(subject.build(opts).token).to eq(access_token)
+        expect(subject.token).to eq(access_token)
       end
     end
 
@@ -51,8 +47,11 @@ describe CheckIn::Map::TokenService do
           .and_return({ access_token:, expiration: })
       end
 
-      it 'returns token by calling client' do
-        expect(subject.build(opts).token).to eq(access_token)
+      it 'returns token by calling client and saves it in redis' do
+        redis_client = subject.redis_client
+        expect(redis_client).to receive(:save_token)
+
+        expect(subject.token).to eq(access_token)
       end
     end
   end

--- a/modules/check_in/spec/services/check_in/vaos/appointment_service_spec.rb
+++ b/modules/check_in/spec/services/check_in/vaos/appointment_service_spec.rb
@@ -3,17 +3,17 @@
 require 'rails_helper'
 
 describe CheckIn::VAOS::AppointmentService do
-  subject { described_class.new(patient_icn:) }
+  subject { described_class }
 
+  let(:uuid) { 'd602d9eb-9a31-484f-9637-13ab0b507e0d' }
+  let(:check_in_session) { CheckIn::V2::Session.build(data: { uuid: }) }
   let(:patient_icn) { '123' }
   let(:token) { 'test_token' }
   let(:request_id) { SecureRandom.uuid }
 
-  describe '#initialize' do
-    it 'returns an instance of service' do
-      service_obj = subject
-      expect(service_obj).to be_an_instance_of(CheckIn::VAOS::AppointmentService)
-      expect(service_obj.token_service).to be_an_instance_of(CheckIn::Map::TokenService)
+  describe '.build' do
+    it 'returns an instance of Service' do
+      expect(subject.build(check_in_session:)).to be_an_instance_of(described_class)
     end
   end
 
@@ -42,21 +42,27 @@ describe CheckIn::VAOS::AppointmentService do
     let(:faraday_response) { double('Faraday::Response') }
     let(:faraday_env) { double('Faraday::Env', status: 200, body: appointments_response.to_json) }
 
+    before do
+      allow_any_instance_of(V2::Lorota::RedisClient).to receive(:icn).with(uuid:)
+                                                                     .and_return(patient_icn)
+      allow_any_instance_of(CheckIn::Map::TokenService).to receive(:token)
+        .and_return(token)
+    end
+
     context 'when vaos returns successful response' do
       before do
-        allow_any_instance_of(CheckIn::Map::TokenService).to receive(:token)
-          .and_return(token)
-        allow_any_instance_of(Faraday::Connection).to receive(:get).with('/vaos/v1/patients/123/appointments',
-                                                                         { start: start_date, end: end_date,
-                                                                           statuses: })
-                                                                   .and_return(faraday_response)
+        allow_any_instance_of(Faraday::Connection).to receive(:get)
+          .with("/vaos/v1/patients/#{patient_icn}/appointments",
+                { start: start_date, end: end_date, statuses: })
+          .and_return(faraday_response)
         allow(faraday_response).to receive(:env).and_return(faraday_env)
       end
 
       it 'returns appointments' do
-        response = subject.get_appointments(DateTime.parse(start_date).in_time_zone,
-                                            DateTime.parse(end_date).in_time_zone,
-                                            statuses)
+        svc = subject.build(check_in_session:)
+        response = svc.get_appointments(DateTime.parse(start_date).in_time_zone,
+                                        DateTime.parse(end_date).in_time_zone,
+                                        statuses)
         expect(response).to eq(appointments_response)
       end
     end
@@ -66,8 +72,6 @@ describe CheckIn::VAOS::AppointmentService do
       let(:exception) { Common::Exceptions::BackendServiceException.new(nil, {}, resp.status, resp.body) }
 
       before do
-        allow_any_instance_of(CheckIn::Map::TokenService).to receive(:token)
-          .and_return(token)
         allow_any_instance_of(Faraday::Connection).to receive(:get).with('/vaos/v1/patients/123/appointments',
                                                                          { start: start_date, end: end_date,
                                                                            statuses: })
@@ -75,10 +79,11 @@ describe CheckIn::VAOS::AppointmentService do
       end
 
       it 'throws exception' do
+        svc = subject.build(check_in_session:)
         expect do
-          subject.get_appointments(DateTime.parse(start_date).in_time_zone,
-                                   DateTime.parse(end_date).in_time_zone,
-                                   statuses)
+          svc.get_appointments(DateTime.parse(start_date).in_time_zone,
+                               DateTime.parse(end_date).in_time_zone,
+                               statuses)
         end.to(raise_error do |error|
           expect(error).to be_a(Common::Exceptions::BackendServiceException)
         end)

--- a/modules/check_in/spec/services/check_in/vaos/base_service_spec.rb
+++ b/modules/check_in/spec/services/check_in/vaos/base_service_spec.rb
@@ -3,11 +3,34 @@
 require 'rails_helper'
 
 describe CheckIn::VAOS::BaseService do
-  subject { described_class.new(patient_icn:) }
+  subject { described_class.build(check_in_session:) }
 
+  let(:uuid) { 'd602d9eb-9a31-484f-9637-13ab0b507e0d' }
+  let(:check_in_session) { CheckIn::V2::Session.build(data: { uuid: }) }
   let(:patient_icn) { '123' }
   let(:token) { 'test_token' }
   let(:request_id) { SecureRandom.uuid }
+
+  describe '.build' do
+    it 'returns an instance of Service' do
+      expect(subject).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe '#initialize' do
+    before do
+      allow_any_instance_of(V2::Lorota::RedisClient).to receive(:icn).with(uuid:)
+                                                                     .and_return(patient_icn)
+    end
+
+    it 'has a check_in_session object' do
+      expect(subject.check_in_session).to be_a(CheckIn::V2::Session)
+    end
+
+    it 'has a patient icn' do
+      expect(subject.patient_icn).to eq(patient_icn)
+    end
+  end
 
   describe '#config' do
     it 'returns an instance of Configuration' do
@@ -17,8 +40,9 @@ describe CheckIn::VAOS::BaseService do
 
   describe '#headers' do
     before do
-      allow_any_instance_of(CheckIn::Map::TokenService).to receive(:token).and_return(token)
       RequestStore.store['request_id'] = request_id
+
+      allow_any_instance_of(CheckIn::Map::TokenService).to receive(:token).and_return(token)
     end
 
     it 'returns correct headers' do

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -967,7 +967,7 @@
                       "lighthouseId": null,
                       "maxEstClaimDate": null,
                       "minEstClaimDate": null,
-                      "status": "COMPLETE",
+                      "status": "CANCELED",
                       "submitterApplicationCode": "EBN",
                       "submitterRoleCode": "VET",
                       "supportingDocuments": [
@@ -1328,7 +1328,10 @@
                               }
                             },
                             "tempJurisdiction": {
-                              "type": "string",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Temporary jurisdiction of claim"
                             },
                             "trackedItems": {
@@ -1623,18 +1626,27 @@
                               ],
                               "properties": {
                                 "serviceNumber": {
-                                  "type": "string",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ],
                                   "description": "Service identification number",
                                   "nullable": true
                                 },
                                 "veteranNumber": {
                                   "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "properties": {
                                     "telephone": {
                                       "description": "Veteran's phone number.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\d{10}?$",
                                       "example": "5555555555",
                                       "minLength": 10,
@@ -1642,7 +1654,10 @@
                                       "nullable": true
                                     },
                                     "internationalTelephone": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "description": "Veteran's international phone number.",
                                       "example": "+44 20 1234 5678",
                                       "nullable": true
@@ -1669,7 +1684,10 @@
                                     },
                                     "addressLine2": {
                                       "description": "Address line 2 for the Veteran's current mailing address.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 20,
                                       "example": "Unit 4",
@@ -1677,7 +1695,10 @@
                                     },
                                     "addressLine3": {
                                       "description": "Address line 3 for the Veteran's current mailing address.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 20,
                                       "example": "Room 1",
@@ -1708,7 +1729,10 @@
                                     },
                                     "zipLastFour": {
                                       "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\d{4}?$",
                                       "example": "6789",
                                       "nullable": true
@@ -1717,18 +1741,27 @@
                                 },
                                 "emailAddress": {
                                   "description": "Information associated with the Veteran's email address.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "properties": {
                                     "email": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                       "description": "The most current email address of the Veteran.",
                                       "maxLength": 50,
                                       "nullable": true
                                     },
                                     "agreeToEmailRelatedToClaim": {
-                                      "type": "boolean",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ],
                                       "description": "Agreement to email information relating to this claim.",
                                       "example": true,
                                       "default": false,
@@ -1745,7 +1778,10 @@
                             },
                             "changeOfAddress": {
                               "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
@@ -1767,14 +1803,20 @@
                                 },
                                 "addressLine2": {
                                   "description": "Address line 2 for the Veteran's new address.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "maxLength": 20,
                                   "example": "Unit 4",
                                   "nullable": true
                                 },
                                 "addressLine3": {
                                   "description": "Address line 3 for the Veteran's new address.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "maxLength": 20,
                                   "example": "Room 1",
                                   "nullable": true
@@ -1804,7 +1846,10 @@
                                 },
                                 "zipLastFour": {
                                   "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "pattern": "^$|^\\d{4}?$",
                                   "example": "6789"
@@ -1820,7 +1865,10 @@
                                     },
                                     "endDate": {
                                       "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-04"
@@ -1830,18 +1878,27 @@
                               }
                             },
                             "homeless": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
                                 "currentlyHomeless": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "homelessSituationOptions": {
                                       "description": "Veteran's living situation.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "default": "other",
                                       "enum": [
@@ -1849,13 +1906,17 @@
                                         "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                         "STAYING_WITH_ANOTHER_PERSON",
                                         "FLEEING_CURRENT_RESIDENCE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ],
                                       "example": "FLEEING_CURRENT_RESIDENCE"
                                     },
                                     "otherDescription": {
                                       "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "maxLength": 500,
                                       "example": "other living situation"
@@ -1863,23 +1924,33 @@
                                   }
                                 },
                                 "riskOfBecomingHomeless": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "livingSituationOptions": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "enum": [
                                         "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                         "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     },
                                     "otherDescription": {
                                       "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "maxLength": 500,
                                       "example": "other living situation"
@@ -1888,7 +1959,10 @@
                                 },
                                 "pointOfContact": {
                                   "description": "Individual in direct contact with Veteran.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "minLength": 1,
                                   "maxLength": 100,
@@ -1896,13 +1970,19 @@
                                   "example": "Jane Doe"
                                 },
                                 "pointOfContactNumber": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "telephone": {
                                       "description": "Primary phone of point of contact.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\d{10}?$",
                                       "example": "5555555",
                                       "minLength": 10,
@@ -1911,7 +1991,10 @@
                                     },
                                     "internationalTelephone": {
                                       "description": "International phone of point of contact.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "example": "+44 20 1234 5678",
                                       "nullable": true
                                     }
@@ -1920,37 +2003,56 @@
                               }
                             },
                             "toxicExposure": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "properties": {
                                 "gulfWarHazardService": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "Toxic exposure related to the Gulf war.",
                                   "properties": {
                                     "servedInGulfWarHazardLocations": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                       "example": "YES",
                                       "enum": [
                                         "NO",
-                                        "YES"
+                                        "YES",
+                                        null
                                       ],
                                       "nullable": true
                                     },
                                     "serviceDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in Gulf War hazard location.",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for serving in Gulf War hazard location.",
                                           "example": "2018-06 or 2018"
@@ -1961,39 +2063,58 @@
                                 },
                                 "herbicideHazardService": {
                                   "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "properties": {
                                     "servedInHerbicideHazardLocations": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                       "example": "YES",
                                       "enum": [
                                         "NO",
-                                        "YES"
+                                        "YES",
+                                        null
                                       ],
                                       "nullable": true
                                     },
                                     "otherLocationsServed": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Other location(s) where Veteran served."
                                     },
                                     "serviceDates": {
                                       "description": "Date range for exposure in herbicide hazard location.",
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in herbicide location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for serving in herbicide location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2004,13 +2125,19 @@
                                   }
                                 },
                                 "additionalHazardExposures": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "Additional hazardous exposures.",
                                   "properties": {
                                     "additionalExposures": {
                                       "description": "Additional exposure incidents.",
-                                      "type": "array",
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "uniqueItems": true,
                                       "items": {
@@ -2023,30 +2150,43 @@
                                           "SHIPBOARD_HAZARD_AND_DEFENSE",
                                           "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                           "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                          "OTHER"
+                                          "OTHER",
+                                          null
                                         ]
                                       }
                                     },
                                     "specifyOtherExposures": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Exposure to asbestos."
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2057,7 +2197,10 @@
                                   }
                                 },
                                 "multipleExposures": {
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "minItems": 1,
                                   "uniqueItems": true,
@@ -2066,31 +2209,46 @@
                                     "additionalProperties": false,
                                     "properties": {
                                       "hazardExposedTo": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                         "description": "Hazard the Veteran was exposed to."
                                       },
                                       "exposureLocation": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                         "description": "Location where the exposure happened."
                                       },
                                       "exposureDates": {
-                                        "type": "object",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Date range for when the exposure happened.",
                                         "properties": {
                                           "beginDate": {
-                                            "type": "string",
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ],
                                             "nullable": true,
                                             "description": "Approximate begin date for exposure.",
                                             "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                             "example": "2018-06 or 2018"
                                           },
                                           "endDate": {
-                                            "type": "string",
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ],
                                             "nullable": true,
                                             "description": "Approximate end date for exposure.",
                                             "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2123,7 +2281,10 @@
                                     "maxLength": 255
                                   },
                                   "exposureOrEventOrInjury": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "What caused the disability?",
                                     "nullable": true,
                                     "examples": [
@@ -2134,13 +2295,19 @@
                                   },
                                   "serviceRelevance": {
                                     "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": "Heavy equipment operator in service."
                                   },
                                   "approximateDate": {
                                     "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                     "example": "2018-03-02 or 2018-03 or 2018",
                                     "nullable": true
@@ -2156,25 +2323,37 @@
                                     "example": "NEW"
                                   },
                                   "classificationCode": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                     "example": "249470",
                                     "nullable": true
                                   },
                                   "ratedDisabilityId": {
                                     "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "1100583",
                                     "nullable": true
                                   },
                                   "diagnosticCode": {
                                     "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "example": 9999,
                                     "nullable": true
                                   },
                                   "isRelatedToToxicExposure": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                     "example": true,
                                     "default": false,
@@ -2195,7 +2374,10 @@
                                           "maxLength": 255
                                         },
                                         "exposureOrEventOrInjury": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "description": "What caused the disability?",
                                           "nullable": true,
                                           "examples": [
@@ -2206,7 +2388,10 @@
                                         },
                                         "serviceRelevance": {
                                           "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "example": "Heavy equipment operator in service."
                                         },
@@ -2220,13 +2405,19 @@
                                         },
                                         "approximateDate": {
                                           "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                           "example": "2018-03-02 or 2018-03 or 2018",
                                           "nullable": true
                                         },
                                         "classificationCode": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                           "example": "249470",
                                           "nullable": true
@@ -2239,7 +2430,10 @@
                             },
                             "treatments": {
                               "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                              "type": "array",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
                               "nullable": true,
                               "uniqueItems": true,
                               "items": {
@@ -2248,14 +2442,20 @@
                                 "properties": {
                                   "beginDate": {
                                     "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                     "example": "2018-06 or 2018",
                                     "nullable": true
                                   },
                                   "treatedDisabilityNames": {
                                     "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxItems": 101,
                                     "items": {
@@ -2269,13 +2469,19 @@
                                   },
                                   "center": {
                                     "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "name": {
                                         "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                         "example": "Private Facility 2",
@@ -2283,14 +2489,20 @@
                                       },
                                       "city": {
                                         "description": "City of treatment facility.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                         "example": "Portland",
                                         "nullable": true
                                       },
                                       "state": {
                                         "description": "State of treatment facility.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^$|^[a-z,A-Z]{2}$",
                                         "example": "OR",
                                         "nullable": true
@@ -2309,7 +2521,10 @@
                               "properties": {
                                 "alternateNames": {
                                   "description": "List any other names under which the Veteran served, if applicable.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 100,
                                   "uniqueItems": true,
@@ -2365,7 +2580,10 @@
                                       },
                                       "separationLocationCode": {
                                         "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "example": "98283"
                                       }
@@ -2373,43 +2591,63 @@
                                   }
                                 },
                                 "servedInActiveCombatSince911": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "reservesNationalGuardService": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "component": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "",
                                       "enum": [
                                         "Reserves",
-                                        "National Guard"
+                                        "National Guard",
+                                        null
                                       ]
                                     },
                                     "obligationTermsOfService": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                       "additionalProperties": false,
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                           "example": "2018-06-06"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                           "example": "2018-06-06"
@@ -2417,29 +2655,44 @@
                                       }
                                     },
                                     "unitName": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                     },
                                     "unitAddress": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "nullable": true
                                     },
                                     "unitPhone": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "additionalProperties": false,
                                       "properties": {
                                         "areaCode": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "maxLength": 3,
                                           "pattern": "^$|^\\d{3}$",
                                           "example": "555"
                                         },
                                         "phoneNumber": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "maxLength": 20,
                                           "example": "5555555"
@@ -2447,10 +2700,14 @@
                                       }
                                     },
                                     "receivingInactiveDutyTrainingPay": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "enum": [
                                         "YES",
-                                        "NO"
+                                        "NO",
+                                        null
                                       ],
                                       "nullable": true,
                                       "example": "YES"
@@ -2458,20 +2715,29 @@
                                   }
                                 },
                                 "federalActivation": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "activationDate": {
                                       "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06",
                                       "nullable": true
                                     },
                                     "anticipatedSeparationDate": {
                                       "description": "Anticipated date of separation. Date must be in the future.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06",
                                       "nullable": true
@@ -2479,7 +2745,10 @@
                                   }
                                 },
                                 "confinements": {
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "uniqueItems": true,
                                   "items": {
@@ -2488,13 +2757,19 @@
                                     "properties": {
                                       "approximateBeginDate": {
                                         "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                         "example": "2018-06-06 or 2018-06"
                                       },
                                       "approximateEndDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                         "example": "2018-06-06 or 2018-06"
@@ -2505,50 +2780,73 @@
                               }
                             },
                             "servicePay": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
                                 "receivingMilitaryRetiredPay": {
                                   "description": "Is the Veteran receiving military retired pay?",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "futureMilitaryRetiredPay": {
                                   "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "futureMilitaryRetiredPayExplanation": {
                                   "description": "Explains why future pay will be received.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "example": "Will be retiring soon.",
                                   "nullable": true
                                 },
                                 "militaryRetiredPay": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "",
                                   "properties": {
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "Air Force"
                                     },
                                     "monthlyAmount": {
                                       "description": "Amount being received.",
-                                      "type": "integer",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "minimum": 1,
                                       "maximum": 999999,
@@ -2557,52 +2855,75 @@
                                   }
                                 },
                                 "retiredStatus": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "",
                                   "enum": [
                                     "RETIRED",
                                     "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                    "PERMANENT_DISABILITY_RETIRED_LIST"
+                                    "PERMANENT_DISABILITY_RETIRED_LIST",
+                                    null
                                   ]
                                 },
                                 "favorMilitaryRetiredPay": {
                                   "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": true,
                                   "default": false
                                 },
                                 "receivedSeparationOrSeverancePay": {
                                   "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "separationSeverancePay": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "",
                                   "properties": {
                                     "datePaymentReceived": {
                                       "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-03-02 or 2018-03 or 2018"
                                     },
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "Air Force"
                                     },
                                     "preTaxAmountReceived": {
                                       "description": "Amount being received.",
-                                      "type": "integer",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "minimum": 1,
                                       "maximum": 999999,
@@ -2612,7 +2933,10 @@
                                 },
                                 "favorTrainingPay": {
                                   "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": true,
                                   "default": false
@@ -2620,13 +2944,19 @@
                               }
                             },
                             "directDeposit": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                               "properties": {
                                 "noAccount": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                   "default": false
@@ -2634,31 +2964,44 @@
                                 "accountNumber": {
                                   "description": "Account number for the direct deposit.",
                                   "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "maxLength": 14,
                                   "nullable": true,
                                   "example": "123123123123"
                                 },
                                 "accountType": {
                                   "description": "Account type for the direct deposit.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "CHECKING",
                                   "enum": [
                                     "CHECKING",
-                                    "SAVINGS"
+                                    "SAVINGS",
+                                    null
                                   ]
                                 },
                                 "financialInstitutionName": {
                                   "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                   "maxLength": 35,
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "Some Bank"
                                 },
                                 "routingNumber": {
                                   "description": "Routing number for the direct deposit.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "pattern": "^(?:\\d{9})?$",
                                   "example": "123123123"
@@ -2849,7 +3192,13 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "claimantCertification",
+                        "claimProcessType",
+                        "disabilities",
+                        "serviceInformation",
+                        "veteranIdentification"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -2883,18 +3232,27 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": "string",
+                                "type": [
+                                  "null",
+                                  "string"
+                                ],
                                 "description": "Service identification number",
                                 "nullable": true
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "minLength": 10,
@@ -2902,7 +3260,10 @@
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "nullable": true
@@ -2929,7 +3290,10 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Unit 4",
@@ -2937,7 +3301,10 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Room 1",
@@ -2968,7 +3335,10 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789",
                                     "nullable": true
@@ -2977,18 +3347,27 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 50,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -3005,7 +3384,10 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -3027,14 +3409,20 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Room 1",
                                 "nullable": true
@@ -3064,7 +3452,10 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^$|^\\d{4}?$",
                                 "example": "6789"
@@ -3080,7 +3471,10 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -3090,18 +3484,27 @@
                             }
                           },
                           "homeless": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -3109,13 +3512,17 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -3123,23 +3530,33 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -3148,7 +3565,10 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 100,
@@ -3156,13 +3576,19 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555",
                                     "minLength": 10,
@@ -3171,7 +3597,10 @@
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "+44 20 1234 5678",
                                     "nullable": true
                                   }
@@ -3180,37 +3609,56 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
@@ -3221,39 +3669,58 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Other location(s) where Veteran served."
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3264,13 +3731,19 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "uniqueItems": true,
                                     "items": {
@@ -3283,30 +3756,43 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3317,7 +3803,10 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minItems": 1,
                                 "uniqueItems": true,
@@ -3326,31 +3815,46 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3383,7 +3887,10 @@
                                   "maxLength": 255
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "examples": [
@@ -3394,13 +3901,19 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true
@@ -3416,25 +3929,37 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": "integer",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -3455,7 +3980,10 @@
                                         "maxLength": 255
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "examples": [
@@ -3466,7 +3994,10 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "example": "Heavy equipment operator in service."
                                       },
@@ -3480,13 +4011,19 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true
                                       },
                                       "classificationCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -3499,7 +4036,10 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": "array",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
                             "nullable": true,
                             "uniqueItems": true,
                             "items": {
@@ -3508,14 +4048,20 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -3529,13 +4075,19 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -3543,14 +4095,20 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -3569,7 +4127,10 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 100,
                                 "uniqueItems": true,
@@ -3625,7 +4186,10 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -3633,43 +4197,63 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard"
+                                      "National Guard",
+                                      null
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -3677,29 +4261,44 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 3,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -3707,10 +4306,14 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "enum": [
                                       "YES",
-                                      "NO"
+                                      "NO",
+                                      null
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -3718,20 +4321,29 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -3739,7 +4351,10 @@
                                 }
                               },
                               "confinements": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "uniqueItems": true,
                                 "items": {
@@ -3748,13 +4363,19 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -3765,50 +4386,73 @@
                             }
                           },
                           "servicePay": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
                               "militaryRetiredPay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -3817,52 +4461,75 @@
                                 }
                               },
                               "retiredStatus": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST"
+                                  "PERMANENT_DISABILITY_RETIRED_LIST",
+                                  null
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -3872,7 +4539,10 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -3880,13 +4550,19 @@
                             }
                           },
                           "directDeposit": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
@@ -3894,31 +4570,44 @@
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
                                 "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS"
+                                  "SAVINGS",
+                                  null
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 35,
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^(?:\\d{9})?$",
                                 "example": "123123123"
@@ -4654,7 +5343,13 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "claimantCertification",
+                        "claimProcessType",
+                        "disabilities",
+                        "serviceInformation",
+                        "veteranIdentification"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -4688,18 +5383,27 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": "string",
+                                "type": [
+                                  "null",
+                                  "string"
+                                ],
                                 "description": "Service identification number",
                                 "nullable": true
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "minLength": 10,
@@ -4707,7 +5411,10 @@
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "nullable": true
@@ -4734,7 +5441,10 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Unit 4",
@@ -4742,7 +5452,10 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Room 1",
@@ -4773,7 +5486,10 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789",
                                     "nullable": true
@@ -4782,18 +5498,27 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 50,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -4810,7 +5535,10 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -4832,14 +5560,20 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Room 1",
                                 "nullable": true
@@ -4869,7 +5603,10 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^$|^\\d{4}?$",
                                 "example": "6789"
@@ -4885,7 +5622,10 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -4895,18 +5635,27 @@
                             }
                           },
                           "homeless": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -4914,13 +5663,17 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -4928,23 +5681,33 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -4953,7 +5716,10 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 100,
@@ -4961,13 +5727,19 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555",
                                     "minLength": 10,
@@ -4976,7 +5748,10 @@
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "+44 20 1234 5678",
                                     "nullable": true
                                   }
@@ -4985,37 +5760,56 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
@@ -5026,39 +5820,58 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Other location(s) where Veteran served."
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5069,13 +5882,19 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "uniqueItems": true,
                                     "items": {
@@ -5088,30 +5907,43 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5122,7 +5954,10 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minItems": 1,
                                 "uniqueItems": true,
@@ -5131,31 +5966,46 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5188,7 +6038,10 @@
                                   "maxLength": 255
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "examples": [
@@ -5199,13 +6052,19 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true
@@ -5221,25 +6080,37 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": "integer",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -5260,7 +6131,10 @@
                                         "maxLength": 255
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "examples": [
@@ -5271,7 +6145,10 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "example": "Heavy equipment operator in service."
                                       },
@@ -5285,13 +6162,19 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true
                                       },
                                       "classificationCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -5304,7 +6187,10 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": "array",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
                             "nullable": true,
                             "uniqueItems": true,
                             "items": {
@@ -5313,14 +6199,20 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -5334,13 +6226,19 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -5348,14 +6246,20 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -5374,7 +6278,10 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 100,
                                 "uniqueItems": true,
@@ -5430,7 +6337,10 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -5438,43 +6348,63 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard"
+                                      "National Guard",
+                                      null
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -5482,29 +6412,44 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 3,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -5512,10 +6457,14 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "enum": [
                                       "YES",
-                                      "NO"
+                                      "NO",
+                                      null
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -5523,20 +6472,29 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -5544,7 +6502,10 @@
                                 }
                               },
                               "confinements": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "uniqueItems": true,
                                 "items": {
@@ -5553,13 +6514,19 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -5570,50 +6537,73 @@
                             }
                           },
                           "servicePay": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
                               "militaryRetiredPay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -5622,52 +6612,75 @@
                                 }
                               },
                               "retiredStatus": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST"
+                                  "PERMANENT_DISABILITY_RETIRED_LIST",
+                                  null
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -5677,7 +6690,10 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -5685,13 +6701,19 @@
                             }
                           },
                           "directDeposit": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
@@ -5699,31 +6721,44 @@
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
                                 "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS"
+                                  "SAVINGS",
+                                  null
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 35,
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^(?:\\d{9})?$",
                                 "example": "123123123"
@@ -6003,7 +7038,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "cf532e4e-e89e-4f9c-aebd-ce8361336a41",
+                    "id": "e23f85eb-2896-40f2-a51c-3300790bb229",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -6302,7 +7337,13 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "claimantCertification",
+                        "claimProcessType",
+                        "disabilities",
+                        "serviceInformation",
+                        "veteranIdentification"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -6341,25 +7382,37 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": "string",
+                                "type": [
+                                  "null",
+                                  "string"
+                                ],
                                 "description": "Service identification number",
                                 "nullable": true,
                                 "maxLength": 1000
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number. Number including area code.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "nullable": true,
@@ -6387,7 +7440,10 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 325,
                                     "example": "Unit 4",
@@ -6395,7 +7451,10 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 325,
                                     "example": "Room 1",
@@ -6429,7 +7488,10 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "6789",
                                     "nullable": true,
                                     "maxLength": 500
@@ -6438,17 +7500,26 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 1000,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -6465,7 +7536,10 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -6487,14 +7561,20 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 325,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 325,
                                 "example": "Room 1",
                                 "nullable": true
@@ -6527,7 +7607,10 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "6789",
                                 "maxLength": 500
@@ -6543,7 +7626,10 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -6553,18 +7639,27 @@
                             }
                           },
                           "homeless": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -6572,13 +7667,17 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 5000,
                                     "example": "other living situation"
@@ -6586,23 +7685,33 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 5000,
                                     "example": "other living situation"
@@ -6611,7 +7720,10 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 1000,
@@ -6619,20 +7731,29 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "+44 20 1234 5678",
                                     "nullable": true,
                                     "maxLength": 1000
@@ -6642,37 +7763,56 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
@@ -6683,21 +7823,31 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Other location(s) where Veteran served.",
@@ -6705,18 +7855,27 @@
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6727,13 +7886,19 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxItems": 5000,
                                     "items": {
@@ -6746,31 +7911,44 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Exposure to asbestos.",
                                     "maxLength": 5000
                                   },
                                   "exposureDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6781,7 +7959,10 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "minItems": 0,
@@ -6790,33 +7971,48 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Hazard the Veteran was exposed to.",
                                       "maxLength": 1000
                                     },
                                     "exposureLocation": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Location where the exposure happened.",
                                       "maxLength": 1000
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6850,7 +8046,10 @@
                                   "maxLength": 1000
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "examples": [
@@ -6862,14 +8061,20 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "Heavy equipment operator in service.",
                                   "maxLength": 1000
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true,
@@ -6886,25 +8091,37 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": "integer",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -6925,7 +8142,10 @@
                                         "maxLength": 1000
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "examples": [
@@ -6937,7 +8157,10 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "example": "Heavy equipment operator in service.",
                                         "maxLength": 1000
@@ -6952,14 +8175,20 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true,
                                         "maxLength": 1000
                                       },
                                       "classificationCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -6972,7 +8201,10 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": "array",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
                             "nullable": true,
                             "maxItems": 5000,
                             "items": {
@@ -6981,14 +8213,20 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -7002,13 +8240,19 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -7016,14 +8260,20 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -7042,7 +8292,10 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "items": {
@@ -7098,7 +8351,10 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -7106,43 +8362,63 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard"
+                                      "National Guard",
+                                      null
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -7150,31 +8426,46 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 1000,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -7182,10 +8473,14 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "enum": [
                                       "YES",
-                                      "NO"
+                                      "NO",
+                                      null
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -7193,20 +8488,29 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -7214,7 +8518,10 @@
                                 }
                               },
                               "confinements": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "items": {
@@ -7223,13 +8530,19 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -7240,105 +8553,151 @@
                             }
                           },
                           "servicePay": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "example": "Will be retiring soon.",
                                 "nullable": true,
                                 "maxLength": 1000
                               },
                               "militaryRetiredPay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": 100
                                   }
                                 }
                               },
                               "retiredStatus": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST"
+                                  "PERMANENT_DISABILITY_RETIRED_LIST",
+                                  null
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": 100
                                   }
@@ -7346,7 +8705,10 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -7354,44 +8716,63 @@
                             }
                           },
                           "directDeposit": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS"
+                                  "SAVINGS",
+                                  null
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 1000,
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxLength": 9,
                                 "example": "123123123"
@@ -8087,8 +9468,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-03-26",
-                      "expirationDate": "2025-03-26",
+                      "creationDate": "2024-04-23",
+                      "expirationDate": "2025-04-23",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -8807,7 +10188,7 @@
                       "status": "422",
                       "detail": "Could not retrieve Power of Attorney due to multiple representatives with code: A1Q",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:112:in `representative'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:130:in `representative'"
                       }
                     }
                   ]
@@ -8905,15 +10286,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "id": "29b16b36-3108-411f-9f5f-2c1c2e147ea3",
-                    "type": "individual",
-                    "attributes": {
-                      "code": "083",
-                      "name": "Firstname Lastname",
-                      "phoneNumber": "555-555-5555"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9106,9 +10488,9 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/individual_controller.rb:35:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -9172,7 +10554,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "representative"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -9534,7 +10919,7 @@
                       },
                       "representative": {
                         "poaCode": "083",
-                        "registrationNumber": "67890",
+                        "registrationNumber": "999999999999",
                         "type": "ATTORNEY",
                         "address": {
                           "addressLine1": "123",
@@ -9601,15 +10986,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "id": "a7114d11-8ffd-4545-ad99-d70e74991e11",
-                    "type": "organization",
-                    "attributes": {
-                      "code": "083",
-                      "name": "083 - DISABLED AMERICAN VETERANS",
-                      "phoneNumber": "555-555-5555"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9810,9 +11196,9 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/organization_controller.rb:35:in `validate_org_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -9876,7 +11262,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "serviceOrganization"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -10180,7 +11569,7 @@
                       },
                       "serviceOrganization": {
                         "poaCode": "083",
-                        "registrationNumber": "67890"
+                        "registrationNumber": "999999999999"
                       }
                     }
                   }
@@ -10237,12 +11626,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "type": "form/21-22a/validation",
-                    "attributes": {
-                      "status": "valid"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10429,9 +11822,9 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/individual_controller.rb:35:in `validate_individual_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -10495,7 +11888,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "representative"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -10857,7 +12253,7 @@
                       },
                       "representative": {
                         "poaCode": "083",
-                        "registrationNumber": "67890",
+                        "registrationNumber": "999999999999",
                         "type": "ATTORNEY",
                         "address": {
                           "addressLine1": "123",
@@ -10924,12 +12320,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "type": "form/21-22/validation",
-                    "attributes": {
-                      "status": "valid"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -11124,9 +12524,9 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/organization_controller.rb:35:in `validate_org_poa_code!'"
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
                     }
                   ]
@@ -11190,7 +12590,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "serviceOrganization"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -11494,7 +12897,7 @@
                       },
                       "serviceOrganization": {
                         "poaCode": "083",
-                        "registrationNumber": "67890"
+                        "registrationNumber": "999999999999"
                       }
                     }
                   }
@@ -11562,11 +12965,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "7b0c58e1-4bf7-413c-a3ab-c8f6b95208b0",
+                    "id": "c4a6f2e4-2fb4-4dac-aa81-dbf56b1b4f55",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "status": "submitted",
-                      "dateRequestAccepted": "2024-03-26",
+                      "dateRequestAccepted": "2024-04-23",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/invalid_poa.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/invalid_poa.json
@@ -12,7 +12,7 @@
       },
       "serviceOrganization": {
         "poaCode": "aaa",
-        "registrationNumber": "67890"
+        "registrationNumber": "999999999999"
       }
     }
   }

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/valid.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/valid.json
@@ -12,7 +12,7 @@
       },
       "serviceOrganization": {
         "poaCode": "083",
-        "registrationNumber": "67890"
+        "registrationNumber": "999999999999"
       }
     }
   }

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/invalid_poa.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/invalid_poa.json
@@ -12,7 +12,7 @@
       },
       "representative": {
         "poaCode": "aaa",
-        "registrationNumber": "67890",
+        "registrationNumber": "999999999999",
         "type": "ATTORNEY",
         "address": {
           "addressLine1":  "123",

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/valid.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/valid.json
@@ -14,7 +14,7 @@
       },
       "representative": {
         "poaCode": "083",
-        "registrationNumber": "67890",
+        "registrationNumber": "999999999999",
         "type": "ATTORNEY",
         "address": {
           "addressLine1":  "123",

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_ind_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_ind_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
     before do
       Veteran::Service::Representative.create!(representative_id: '12345', poa_codes: [individual_poa_code],
                                                first_name: 'Abraham', last_name: 'Lincoln')
-      Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+      Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                first_name: 'George', last_name: 'Washington')
     end
 
@@ -346,7 +346,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
                     it 'returns a meaningful 404' do
                       mock_ccg(%w[claim.write claim.read]) do |auth_header|
-                        detail = 'Could not find an Accredited Representative with registration number: 67890 ' \
+                        detail = 'Could not find an Accredited Representative with registration number: 999999999999 ' \
                                  'and poa code: aaa'
 
                         post validate2122a_path, params: request_body, headers: auth_header

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
   describe 'PowerOfAttorney' do
     before do
-      Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+      Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                first_name: 'George', last_name: 'Washington')
       Veteran::Service::Organization.create!(poa: organization_poa_code,
                                              name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
@@ -39,7 +39,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
               },
               serviceOrganization: {
                 poaCode: organization_poa_code.to_s,
-                registrationNumber: '67890'
+                registrationNumber: '999999999999'
               }
             }
           }
@@ -103,7 +103,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
       context 'multiple reps with same poa code and registration number' do
         let(:rep_id) do
-          Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+          Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                    first_name: 'George', last_name: 'Washington-test').id
         end
 
@@ -181,7 +181,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
                 it 'returns a meaningful 404' do
                   mock_ccg(%w[claim.write claim.read]) do |auth_header|
-                    detail = 'Could not find an Accredited Representative with registration number: 67890 ' \
+                    detail = 'Could not find an Accredited Representative with registration number: 999999999999 ' \
                              'and poa code: aaa'
 
                     post validate2122_path, params: request_body, headers: auth_header

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
   describe 'PowerOfAttorney' do
     before do
-      Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
+      Veteran::Service::Representative.create!(representative_id: '999999999999',
+                                               poa_codes: [organization_poa_code],
                                                first_name: 'George', last_name: 'Washington')
       Veteran::Service::Organization.create!(poa: organization_poa_code,
                                              name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
@@ -103,7 +104,8 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
       context 'multiple reps with same poa code and registration number' do
         let(:rep_id) do
-          Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
+          Veteran::Service::Representative.create!(representative_id: '999999999999',
+                                                   poa_codes: [organization_poa_code],
                                                    first_name: 'George', last_name: 'Washington-test').id
         end
 

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -184,7 +184,7 @@ describe 'PowerOfAttorney',
             expect_any_instance_of(local_bgs).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
             allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
               .and_return({ person_poa_history: nil })
-            Veteran::Service::Representative.new(representative_id: '67890',
+            Veteran::Service::Representative.new(representative_id: '999999999999',
                                                  poa_codes: [poa_code],
                                                  first_name: 'Firstname',
                                                  last_name: 'Lastname',
@@ -352,7 +352,7 @@ describe 'PowerOfAttorney',
             Veteran::Service::Organization.create!(poa: organization_poa_code,
                                                    name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS",
                                                    phone: '555-555-5555')
-            Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+            Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                      first_name: 'Firstname', last_name: 'Lastname',
                                                      phone: '555-555-5555')
 
@@ -510,7 +510,7 @@ describe 'PowerOfAttorney',
           end
 
           before do |example|
-            Veteran::Service::Representative.new(representative_id: '67890',
+            Veteran::Service::Representative.new(representative_id: '999999999999',
                                                  poa_codes: [poa_code],
                                                  first_name: 'Firstname',
                                                  last_name: 'Lastname',
@@ -679,7 +679,7 @@ describe 'PowerOfAttorney',
 
           before do |example|
             Veteran::Service::Organization.create!(poa: poa_code)
-            Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [poa_code],
+            Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [poa_code],
                                                      first_name: 'Firstname', last_name: 'Lastname',
                                                      phone: '555-555-5555')
 

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -352,7 +352,8 @@ describe 'PowerOfAttorney',
             Veteran::Service::Organization.create!(poa: organization_poa_code,
                                                    name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS",
                                                    phone: '555-555-5555')
-            Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
+            Veteran::Service::Representative.create!(representative_id: '999999999999',
+                                                     poa_codes: [organization_poa_code],
                                                      first_name: 'Firstname', last_name: 'Lastname',
                                                      phone: '555-555-5555')
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates documentation examples to use a value of "999999999999" for registrationNumber attribute of 2122 and 2122a submissions, as well as corresponding validate calls.
- Updates tests where appropriate to accommodate value change.

## Related issue(s)

-[API-35595](https://jira.devops.va.gov/browse/API-35595)

## Testing done

- [x] *New code is covered by unit tests*
- Confirmed locally that documentation examples for affected endpoints reflect the update value for registrationNumber

## Screenshots
![Screenshot 2024-04-23 at 3 48 13 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/95487885/b4605a85-e13a-4250-804b-4688318e1f71)

## What areas of the site does it impact?
526 documentation.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

