### PR TITLE
[81300] Update VSOReloader to correctly upsert organization data

### DIFF
--- a/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
+++ b/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
@@ -56,7 +56,7 @@ module Veteran
           state: vso_rep['Org State']
         }
       end.compact.uniq
-      Veteran::Service::Organization.import(vso_orgs, on_duplicate_key_ignore: true)
+      Veteran::Service::Organization.import(vso_orgs, on_duplicate_key_update: %i[name phone state])
 
       vso_reps
     end

--- a/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
@@ -46,6 +46,29 @@ RSpec.describe Veteran::VSOReloader, type: :job do
       end
     end
 
+    context 'existing organizations' do
+      let(:org) do
+        create(:organization, poa: '091', name: 'Testing', phone: '222-555-5555', state: 'ZZ', city: 'New York')
+      end
+
+      it 'only updates name, phone, and state' do
+        VCR.use_cassette('veteran/ogc_vso_rep_data') do
+          expect(org.name).to eq('Testing')
+          expect(org.phone).to eq('222-555-5555')
+          expect(org.state).to eq('ZZ')
+          expect(org.city).to eq('New York')
+
+          Veteran::VSOReloader.new.reload_vso_reps
+          org.reload
+
+          expect(org.name).to eq('African American PTSD Association')
+          expect(org.phone).to eq('253-589-0766')
+          expect(org.state).to eq('WA')
+          expect(org.city).to eq('New York')
+        end
+      end
+    end
+
     describe "storing a VSO's middle initial" do
       it 'stores the middle initial if it exists' do
         VCR.use_cassette('veteran/ogc_vso_rep_data') do


### PR DESCRIPTION
## Summary

- This pr fixes a bug with the VSOReloader that prevented organization data from updating

## Related issue(s)

- [81300](https://app.zenhub.com/workspaces/accredited-representation-management-team-64d0dc51d3e8f4788ac6ef96/issues/gh/department-of-veterans-affairs/va.gov-team/81300)
- [github link](https://github.com/department-of-veterans-affairs/va.gov-team/issues/81300)

## Testing done

- [x] *New code is covered by unit tests*
- Old behavior was that the organization attributes did not update
- tested `Veteran::Service::Organization.import(vso_orgs, on_duplicate_key_update: %i[name phone state])` vs `Veteran::Service::Organization.import(vso_orgs, on_duplicate_key_ignore: true)` in the rails console to confirm old behavior and intended behavior

## What areas of the site does it impact?
This will impact the active POA widget and anything that reads organization name, phone, and state

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
