### PR TITLE
Api 35595 registration numbers

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -1328,7 +1328,10 @@
                               }
                             },
                             "tempJurisdiction": {
-                              "type": "string",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Temporary jurisdiction of claim"
                             },
                             "trackedItems": {
@@ -1623,19 +1626,28 @@
                               ],
                               "properties": {
                                 "serviceNumber": {
-                                  "type": "string",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ],
                                   "description": "Service identification number",
                                   "maxLength": 1000,
                                   "nullable": true
                                 },
                                 "veteranNumber": {
                                   "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "properties": {
                                     "telephone": {
                                       "description": "Veteran's phone number.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\d{10}?$",
                                       "example": "5555555555",
                                       "minLength": 10,
@@ -1643,7 +1655,10 @@
                                       "nullable": true
                                     },
                                     "internationalTelephone": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "description": "Veteran's international phone number.",
                                       "example": "+44 20 1234 5678",
                                       "maxLength": 1000,
@@ -1671,7 +1686,10 @@
                                     },
                                     "addressLine2": {
                                       "description": "Address line 2 for the Veteran's current mailing address.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 20,
                                       "example": "Unit 4",
@@ -1679,7 +1697,10 @@
                                     },
                                     "addressLine3": {
                                       "description": "Address line 3 for the Veteran's current mailing address.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 20,
                                       "example": "Room 1",
@@ -1712,7 +1733,10 @@
                                     },
                                     "zipLastFour": {
                                       "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\d{4}?$",
                                       "example": "6789",
                                       "nullable": true
@@ -1721,18 +1745,27 @@
                                 },
                                 "emailAddress": {
                                   "description": "Information associated with the Veteran's email address.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "properties": {
                                     "email": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                       "description": "The most current email address of the Veteran.",
                                       "maxLength": 50,
                                       "nullable": true
                                     },
                                     "agreeToEmailRelatedToClaim": {
-                                      "type": "boolean",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ],
                                       "description": "Agreement to email information relating to this claim.",
                                       "example": true,
                                       "default": false,
@@ -1749,7 +1782,10 @@
                             },
                             "changeOfAddress": {
                               "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
@@ -1771,14 +1807,20 @@
                                 },
                                 "addressLine2": {
                                   "description": "Address line 2 for the Veteran's new address.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "maxLength": 20,
                                   "example": "Unit 4",
                                   "nullable": true
                                 },
                                 "addressLine3": {
                                   "description": "Address line 3 for the Veteran's new address.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "maxLength": 20,
                                   "example": "Room 1",
                                   "nullable": true
@@ -1810,7 +1852,10 @@
                                 },
                                 "zipLastFour": {
                                   "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "pattern": "^$|^\\d{4}?$",
                                   "example": "6789"
@@ -1826,7 +1871,10 @@
                                     },
                                     "endDate": {
                                       "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-04"
@@ -1836,18 +1884,27 @@
                               }
                             },
                             "homeless": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
                                 "currentlyHomeless": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "homelessSituationOptions": {
                                       "description": "Veteran's living situation.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "default": "other",
                                       "enum": [
@@ -1855,13 +1912,17 @@
                                         "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                         "STAYING_WITH_ANOTHER_PERSON",
                                         "FLEEING_CURRENT_RESIDENCE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ],
                                       "example": "FLEEING_CURRENT_RESIDENCE"
                                     },
                                     "otherDescription": {
                                       "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "maxLength": 500,
                                       "example": "other living situation"
@@ -1869,23 +1930,33 @@
                                   }
                                 },
                                 "riskOfBecomingHomeless": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "livingSituationOptions": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "enum": [
                                         "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                         "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     },
                                     "otherDescription": {
                                       "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "maxLength": 500,
                                       "example": "other living situation"
@@ -1894,7 +1965,10 @@
                                 },
                                 "pointOfContact": {
                                   "description": "Individual in direct contact with Veteran.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "minLength": 1,
                                   "maxLength": 100,
@@ -1902,13 +1976,19 @@
                                   "example": "Jane Doe"
                                 },
                                 "pointOfContactNumber": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "telephone": {
                                       "description": "Primary phone of point of contact.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^\\d{10}?$",
                                       "example": "5555555",
                                       "minLength": 10,
@@ -1917,7 +1997,10 @@
                                     },
                                     "internationalTelephone": {
                                       "description": "International phone of point of contact.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "example": "+44 20 1234 5678",
                                       "maxLength": 1000,
                                       "nullable": true
@@ -1927,38 +2010,57 @@
                               }
                             },
                             "toxicExposure": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "properties": {
                                 "gulfWarHazardService": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "Toxic exposure related to the Gulf war.",
                                   "properties": {
                                     "servedInGulfWarHazardLocations": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                       "example": "YES",
                                       "enum": [
                                         "NO",
-                                        "YES"
+                                        "YES",
+                                        null
                                       ],
                                       "nullable": true
                                     },
                                     "serviceDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in Gulf War hazard location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for serving in Gulf War hazard location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -1970,21 +2072,31 @@
                                 },
                                 "herbicideHazardService": {
                                   "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "properties": {
                                     "servedInHerbicideHazardLocations": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                       "example": "YES",
                                       "enum": [
                                         "NO",
-                                        "YES"
+                                        "YES",
+                                        null
                                       ],
                                       "nullable": true
                                     },
                                     "otherLocationsServed": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 5000,
@@ -1992,18 +2104,27 @@
                                     },
                                     "serviceDates": {
                                       "description": "Date range for exposure in herbicide hazard location.",
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in herbicide location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for serving in herbicide location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2014,13 +2135,19 @@
                                   }
                                 },
                                 "additionalHazardExposures": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "Additional hazardous exposures.",
                                   "properties": {
                                     "additionalExposures": {
                                       "description": "Additional exposure incidents.",
-                                      "type": "array",
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "uniqueItems": true,
                                       "items": {
@@ -2033,31 +2160,44 @@
                                           "SHIPBOARD_HAZARD_AND_DEFENSE",
                                           "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                           "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                          "OTHER"
+                                          "OTHER",
+                                          null
                                         ]
                                       }
                                     },
                                     "specifyOtherExposures": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2068,7 +2208,10 @@
                                   }
                                 },
                                 "multipleExposures": {
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "minItems": 1,
                                   "uniqueItems": true,
@@ -2077,33 +2220,48 @@
                                     "additionalProperties": false,
                                     "properties": {
                                       "hazardExposedTo": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Hazard the Veteran was exposed to."
                                       },
                                       "exposureLocation": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
                                       "exposureDates": {
-                                        "type": "object",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Date range for when the exposure happened.",
                                         "properties": {
                                           "beginDate": {
-                                            "type": "string",
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ],
                                             "nullable": true,
                                             "description": "Approximate begin date for exposure.",
                                             "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                             "example": "2018-06 or 2018"
                                           },
                                           "endDate": {
-                                            "type": "string",
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ],
                                             "nullable": true,
                                             "description": "Approximate end date for exposure.",
                                             "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2136,7 +2294,10 @@
                                     "maxLength": 255
                                   },
                                   "exposureOrEventOrInjury": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "What caused the disability?",
                                     "nullable": true,
                                     "maxLength": 1000,
@@ -2148,14 +2309,20 @@
                                   },
                                   "serviceRelevance": {
                                     "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Heavy equipment operator in service."
                                   },
                                   "approximateDate": {
                                     "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                     "example": "2018-03-02 or 2018-03 or 2018",
                                     "nullable": true
@@ -2171,25 +2338,37 @@
                                     "example": "NEW"
                                   },
                                   "classificationCode": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                     "example": "249470",
                                     "nullable": true
                                   },
                                   "ratedDisabilityId": {
                                     "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "1100583",
                                     "nullable": true
                                   },
                                   "diagnosticCode": {
                                     "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "example": 9999,
                                     "nullable": true
                                   },
                                   "isRelatedToToxicExposure": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                     "example": true,
                                     "default": false,
@@ -2210,7 +2389,10 @@
                                           "maxLength": 255
                                         },
                                         "exposureOrEventOrInjury": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "description": "What caused the disability?",
                                           "nullable": true,
                                           "maxLength": 1000,
@@ -2222,7 +2404,10 @@
                                         },
                                         "serviceRelevance": {
                                           "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "maxLength": 1000,
                                           "example": "Heavy equipment operator in service."
@@ -2237,13 +2422,19 @@
                                         },
                                         "approximateDate": {
                                           "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                           "example": "2018-03-02 or 2018-03 or 2018",
                                           "nullable": true
                                         },
                                         "classificationCode": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                           "example": "249470",
                                           "nullable": true
@@ -2256,7 +2447,10 @@
                             },
                             "treatments": {
                               "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                              "type": "array",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
                               "nullable": true,
                               "uniqueItems": true,
                               "items": {
@@ -2265,14 +2459,20 @@
                                 "properties": {
                                   "beginDate": {
                                     "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                     "example": "2018-06 or 2018",
                                     "nullable": true
                                   },
                                   "treatedDisabilityNames": {
                                     "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxItems": 101,
                                     "items": {
@@ -2286,13 +2486,19 @@
                                   },
                                   "center": {
                                     "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "name": {
                                         "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                         "example": "Private Facility 2",
@@ -2300,14 +2506,20 @@
                                       },
                                       "city": {
                                         "description": "City of treatment facility.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                         "example": "Portland",
                                         "nullable": true
                                       },
                                       "state": {
                                         "description": "State of treatment facility.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^$|^[a-z,A-Z]{2}$",
                                         "example": "OR",
                                         "nullable": true
@@ -2326,7 +2538,10 @@
                               "properties": {
                                 "alternateNames": {
                                   "description": "List any other names under which the Veteran served, if applicable.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 100,
                                   "uniqueItems": true,
@@ -2383,7 +2598,10 @@
                                       },
                                       "separationLocationCode": {
                                         "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "example": "98283"
                                       }
@@ -2391,43 +2609,63 @@
                                   }
                                 },
                                 "servedInActiveCombatSince911": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "reservesNationalGuardService": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "component": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "",
                                       "enum": [
                                         "Reserves",
-                                        "National Guard"
+                                        "National Guard",
+                                        null
                                       ]
                                     },
                                     "obligationTermsOfService": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                       "additionalProperties": false,
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                           "example": "2018-06-06"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                           "example": "2018-06-06"
@@ -2435,31 +2673,46 @@
                                       }
                                     },
                                     "unitName": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "maxLength": 1000,
                                       "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                     },
                                     "unitAddress": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "maxLength": 1000,
                                       "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "nullable": true
                                     },
                                     "unitPhone": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "additionalProperties": false,
                                       "properties": {
                                         "areaCode": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "maxLength": 3,
                                           "pattern": "^$|^\\d{3}$",
                                           "example": "555"
                                         },
                                         "phoneNumber": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "maxLength": 20,
                                           "example": "5555555"
@@ -2467,10 +2720,14 @@
                                       }
                                     },
                                     "receivingInactiveDutyTrainingPay": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "enum": [
                                         "YES",
-                                        "NO"
+                                        "NO",
+                                        null
                                       ],
                                       "nullable": true,
                                       "example": "YES"
@@ -2478,20 +2735,29 @@
                                   }
                                 },
                                 "federalActivation": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "activationDate": {
                                       "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06",
                                       "nullable": true
                                     },
                                     "anticipatedSeparationDate": {
                                       "description": "Anticipated date of separation. Date must be in the future.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06",
                                       "nullable": true
@@ -2499,7 +2765,10 @@
                                   }
                                 },
                                 "confinements": {
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "uniqueItems": true,
                                   "items": {
@@ -2508,13 +2777,19 @@
                                     "properties": {
                                       "approximateBeginDate": {
                                         "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                         "example": "2018-06-06 or 2018-06"
                                       },
                                       "approximateEndDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                         "example": "2018-06-06 or 2018-06"
@@ -2525,52 +2800,75 @@
                               }
                             },
                             "servicePay": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
                                 "receivingMilitaryRetiredPay": {
                                   "description": "Is the Veteran receiving military retired pay?",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "futureMilitaryRetiredPay": {
                                   "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "futureMilitaryRetiredPayExplanation": {
                                   "description": "Explains why future pay will be received.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "maxLength": 1000,
                                   "example": "Will be retiring soon.",
                                   "nullable": true
                                 },
                                 "militaryRetiredPay": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "",
                                   "properties": {
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "maxLength": 1000,
                                       "nullable": true,
                                       "example": "Air Force"
                                     },
                                     "monthlyAmount": {
                                       "description": "Amount being received.",
-                                      "type": "integer",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "minimum": 1,
                                       "maximum": 999999,
@@ -2579,53 +2877,76 @@
                                   }
                                 },
                                 "retiredStatus": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "",
                                   "enum": [
                                     "RETIRED",
                                     "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                    "PERMANENT_DISABILITY_RETIRED_LIST"
+                                    "PERMANENT_DISABILITY_RETIRED_LIST",
+                                    null
                                   ]
                                 },
                                 "favorMilitaryRetiredPay": {
                                   "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": true,
                                   "default": false
                                 },
                                 "receivedSeparationOrSeverancePay": {
                                   "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "enum": [
                                     "YES",
-                                    "NO"
+                                    "NO",
+                                    null
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "separationSeverancePay": {
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "",
                                   "properties": {
                                     "datePaymentReceived": {
                                       "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-03-02 or 2018-03 or 2018"
                                     },
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "preTaxAmountReceived": {
                                       "description": "Amount being received.",
-                                      "type": "integer",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "minimum": 1,
                                       "maximum": 999999,
@@ -2635,7 +2956,10 @@
                                 },
                                 "favorTrainingPay": {
                                   "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": true,
                                   "default": false
@@ -2643,13 +2967,19 @@
                               }
                             },
                             "directDeposit": {
-                              "type": "object",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
                               "nullable": true,
                               "additionalProperties": false,
                               "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                               "properties": {
                                 "noAccount": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                   "default": false
@@ -2657,31 +2987,44 @@
                                 "accountNumber": {
                                   "description": "Account number for the direct deposit.",
                                   "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "maxLength": 14,
                                   "nullable": true,
                                   "example": "123123123123"
                                 },
                                 "accountType": {
                                   "description": "Account type for the direct deposit.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "CHECKING",
                                   "enum": [
                                     "CHECKING",
-                                    "SAVINGS"
+                                    "SAVINGS",
+                                    null
                                   ]
                                 },
                                 "financialInstitutionName": {
                                   "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                   "maxLength": 35,
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "Some Bank"
                                 },
                                 "routingNumber": {
                                   "description": "Routing number for the direct deposit.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "pattern": "^(?:\\d{9})?$",
                                   "example": "123123123"
@@ -2872,7 +3215,13 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "claimantCertification",
+                        "claimProcessType",
+                        "disabilities",
+                        "serviceInformation",
+                        "veteranIdentification"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -2906,19 +3255,28 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": "string",
+                                "type": [
+                                  "null",
+                                  "string"
+                                ],
                                 "description": "Service identification number",
                                 "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "minLength": 10,
@@ -2926,7 +3284,10 @@
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
@@ -2954,7 +3315,10 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Unit 4",
@@ -2962,7 +3326,10 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Room 1",
@@ -2995,7 +3362,10 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789",
                                     "nullable": true
@@ -3004,18 +3374,27 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 50,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -3032,7 +3411,10 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -3054,14 +3436,20 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Room 1",
                                 "nullable": true
@@ -3093,7 +3481,10 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^$|^\\d{4}?$",
                                 "example": "6789"
@@ -3109,7 +3500,10 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -3119,18 +3513,27 @@
                             }
                           },
                           "homeless": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -3138,13 +3541,17 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -3152,23 +3559,33 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -3177,7 +3594,10 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 100,
@@ -3185,13 +3605,19 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555",
                                     "minLength": 10,
@@ -3200,7 +3626,10 @@
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
                                     "nullable": true
@@ -3210,38 +3639,57 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3253,21 +3701,31 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
@@ -3275,18 +3733,27 @@
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3297,13 +3764,19 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "uniqueItems": true,
                                     "items": {
@@ -3316,31 +3789,44 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3351,7 +3837,10 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minItems": 1,
                                 "uniqueItems": true,
@@ -3360,33 +3849,48 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3419,7 +3923,10 @@
                                   "maxLength": 255
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "maxLength": 1000,
@@ -3431,14 +3938,20 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true
@@ -3454,25 +3967,37 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": "integer",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -3493,7 +4018,10 @@
                                         "maxLength": 255
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "maxLength": 1000,
@@ -3505,7 +4033,10 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
@@ -3520,13 +4051,19 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true
                                       },
                                       "classificationCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -3539,7 +4076,10 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": "array",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
                             "nullable": true,
                             "uniqueItems": true,
                             "items": {
@@ -3548,14 +4088,20 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -3569,13 +4115,19 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -3583,14 +4135,20 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -3609,7 +4167,10 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 100,
                                 "uniqueItems": true,
@@ -3666,7 +4227,10 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -3674,43 +4238,63 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard"
+                                      "National Guard",
+                                      null
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -3718,31 +4302,46 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 3,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -3750,10 +4349,14 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "enum": [
                                       "YES",
-                                      "NO"
+                                      "NO",
+                                      null
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -3761,20 +4364,29 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -3782,7 +4394,10 @@
                                 }
                               },
                               "confinements": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "uniqueItems": true,
                                 "items": {
@@ -3791,13 +4406,19 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -3808,52 +4429,75 @@
                             }
                           },
                           "servicePay": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
                               "militaryRetiredPay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -3862,53 +4506,76 @@
                                 }
                               },
                               "retiredStatus": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST"
+                                  "PERMANENT_DISABILITY_RETIRED_LIST",
+                                  null
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -3918,7 +4585,10 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -3926,13 +4596,19 @@
                             }
                           },
                           "directDeposit": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
@@ -3940,31 +4616,44 @@
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
                                 "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS"
+                                  "SAVINGS",
+                                  null
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 35,
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^(?:\\d{9})?$",
                                 "example": "123123123"
@@ -4700,7 +5389,13 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "claimantCertification",
+                        "claimProcessType",
+                        "disabilities",
+                        "serviceInformation",
+                        "veteranIdentification"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -4734,19 +5429,28 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": "string",
+                                "type": [
+                                  "null",
+                                  "string"
+                                ],
                                 "description": "Service identification number",
                                 "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "minLength": 10,
@@ -4754,7 +5458,10 @@
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
@@ -4782,7 +5489,10 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Unit 4",
@@ -4790,7 +5500,10 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Room 1",
@@ -4823,7 +5536,10 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789",
                                     "nullable": true
@@ -4832,18 +5548,27 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 50,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -4860,7 +5585,10 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -4882,14 +5610,20 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 20,
                                 "example": "Room 1",
                                 "nullable": true
@@ -4921,7 +5655,10 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^$|^\\d{4}?$",
                                 "example": "6789"
@@ -4937,7 +5674,10 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -4947,18 +5687,27 @@
                             }
                           },
                           "homeless": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -4966,13 +5715,17 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -4980,23 +5733,33 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -5005,7 +5768,10 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 100,
@@ -5013,13 +5779,19 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555",
                                     "minLength": 10,
@@ -5028,7 +5800,10 @@
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
                                     "nullable": true
@@ -5038,38 +5813,57 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5081,21 +5875,31 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
@@ -5103,18 +5907,27 @@
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5125,13 +5938,19 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "uniqueItems": true,
                                     "items": {
@@ -5144,31 +5963,44 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5179,7 +6011,10 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minItems": 1,
                                 "uniqueItems": true,
@@ -5188,33 +6023,48 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5247,7 +6097,10 @@
                                   "maxLength": 255
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "maxLength": 1000,
@@ -5259,14 +6112,20 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true
@@ -5282,25 +6141,37 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": "integer",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -5321,7 +6192,10 @@
                                         "maxLength": 255
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "maxLength": 1000,
@@ -5333,7 +6207,10 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
@@ -5348,13 +6225,19 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true
                                       },
                                       "classificationCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -5367,7 +6250,10 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": "array",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
                             "nullable": true,
                             "uniqueItems": true,
                             "items": {
@@ -5376,14 +6262,20 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -5397,13 +6289,19 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -5411,14 +6309,20 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -5437,7 +6341,10 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 100,
                                 "uniqueItems": true,
@@ -5494,7 +6401,10 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -5502,43 +6412,63 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard"
+                                      "National Guard",
+                                      null
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -5546,31 +6476,46 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 3,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -5578,10 +6523,14 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "enum": [
                                       "YES",
-                                      "NO"
+                                      "NO",
+                                      null
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -5589,20 +6538,29 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -5610,7 +6568,10 @@
                                 }
                               },
                               "confinements": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "uniqueItems": true,
                                 "items": {
@@ -5619,13 +6580,19 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -5636,52 +6603,75 @@
                             }
                           },
                           "servicePay": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
                               "militaryRetiredPay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -5690,53 +6680,76 @@
                                 }
                               },
                               "retiredStatus": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST"
+                                  "PERMANENT_DISABILITY_RETIRED_LIST",
+                                  null
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -5746,7 +6759,10 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -5754,13 +6770,19 @@
                             }
                           },
                           "directDeposit": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
@@ -5768,31 +6790,44 @@
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
                                 "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS"
+                                  "SAVINGS",
+                                  null
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 35,
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "pattern": "^(?:\\d{9})?$",
                                 "example": "123123123"
@@ -6371,7 +7406,13 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "claimantCertification",
+                        "claimProcessType",
+                        "disabilities",
+                        "serviceInformation",
+                        "veteranIdentification"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -6410,25 +7451,37 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": "string",
+                                "type": [
+                                  "null",
+                                  "string"
+                                ],
                                 "description": "Service identification number",
                                 "nullable": true,
                                 "maxLength": 1000
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number. Number including area code.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "nullable": true,
@@ -6456,7 +7509,10 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 325,
                                     "example": "Unit 4",
@@ -6464,7 +7520,10 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 325,
                                     "example": "Room 1",
@@ -6498,7 +7557,10 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "6789",
                                     "nullable": true,
                                     "maxLength": 500
@@ -6507,17 +7569,26 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 1000,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": "boolean",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ],
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -6534,7 +7605,10 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -6556,14 +7630,20 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 325,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 325,
                                 "example": "Room 1",
                                 "nullable": true
@@ -6596,7 +7676,10 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "6789",
                                 "maxLength": 500
@@ -6612,7 +7695,10 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -6622,18 +7708,27 @@
                             }
                           },
                           "homeless": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -6641,13 +7736,17 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 5000,
                                     "example": "other living situation"
@@ -6655,23 +7754,33 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER"
+                                      "OTHER",
+                                      null
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 5000,
                                     "example": "other living situation"
@@ -6680,7 +7789,10 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 1000,
@@ -6688,20 +7800,29 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "example": "+44 20 1234 5678",
                                     "nullable": true,
                                     "maxLength": 1000
@@ -6711,37 +7832,56 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
@@ -6752,21 +7892,31 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES"
+                                      "YES",
+                                      null
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Other location(s) where Veteran served.",
@@ -6774,18 +7924,27 @@
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6796,13 +7955,19 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": "array",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxItems": 5000,
                                     "items": {
@@ -6815,31 +7980,44 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER"
+                                        "OTHER",
+                                        null
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Exposure to asbestos.",
                                     "maxLength": 5000
                                   },
                                   "exposureDates": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6850,7 +8028,10 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "minItems": 0,
@@ -6859,33 +8040,48 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Hazard the Veteran was exposed to.",
                                       "maxLength": 1000
                                     },
                                     "exposureLocation": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Location where the exposure happened.",
                                       "maxLength": 1000
                                     },
                                     "exposureDates": {
-                                      "type": "object",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": "string",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6919,7 +8115,10 @@
                                   "maxLength": 1000
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "examples": [
@@ -6931,14 +8130,20 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "example": "Heavy equipment operator in service.",
                                   "maxLength": 1000
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true,
@@ -6955,25 +8160,37 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": "integer",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": "boolean",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ],
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -6994,7 +8211,10 @@
                                         "maxLength": 1000
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "examples": [
@@ -7006,7 +8226,10 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "example": "Heavy equipment operator in service.",
                                         "maxLength": 1000
@@ -7021,14 +8244,20 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true,
                                         "maxLength": 1000
                                       },
                                       "classificationCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -7041,7 +8270,10 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": "array",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
                             "nullable": true,
                             "maxItems": 5000,
                             "items": {
@@ -7050,14 +8282,20 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": "string",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -7071,13 +8309,19 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": "object",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -7085,14 +8329,20 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -7111,7 +8361,10 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "items": {
@@ -7167,7 +8420,10 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -7175,43 +8431,63 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard"
+                                      "National Guard",
+                                      null
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -7219,31 +8495,46 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": "object",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 1000,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": "string",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ],
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -7251,10 +8542,14 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "enum": [
                                       "YES",
-                                      "NO"
+                                      "NO",
+                                      null
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -7262,20 +8557,29 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -7283,7 +8587,10 @@
                                 }
                               },
                               "confinements": {
-                                "type": "array",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "items": {
@@ -7292,13 +8599,19 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": "string",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ],
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -7309,105 +8622,151 @@
                             }
                           },
                           "servicePay": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "example": "Will be retiring soon.",
                                 "nullable": true,
                                 "maxLength": 1000
                               },
                               "militaryRetiredPay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": 100
                                   }
                                 }
                               },
                               "retiredStatus": {
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST"
+                                  "PERMANENT_DISABILITY_RETIRED_LIST",
+                                  null
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "enum": [
                                   "YES",
-                                  "NO"
+                                  "NO",
+                                  null
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": "object",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": "string",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": "integer",
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ],
                                     "nullable": true,
                                     "example": 100
                                   }
@@ -7415,7 +8774,10 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -7423,44 +8785,63 @@
                             }
                           },
                           "directDeposit": {
-                            "type": "object",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": "boolean",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS"
+                                  "SAVINGS",
+                                  null
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 1000,
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": "string",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "nullable": true,
                                 "maxLength": 9,
                                 "example": "123123123"
@@ -8974,15 +10355,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "id": "48a79d49-eccd-4a89-adb8-e2c91ed3fab5",
-                    "type": "individual",
-                    "attributes": {
-                      "code": "083",
-                      "name": "Firstname Lastname",
-                      "phoneNumber": "555-555-5555"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9175,7 +10557,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -9241,7 +10623,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "representative"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -9603,7 +10988,7 @@
                       },
                       "representative": {
                         "poaCode": "083",
-                        "registrationNumber": "67890",
+                        "registrationNumber": "999999999999",
                         "type": "ATTORNEY",
                         "address": {
                           "addressLine1": "123",
@@ -9670,15 +11055,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "id": "7610ed19-baac-46fe-8ba5-5aa3e64a92ff",
-                    "type": "organization",
-                    "attributes": {
-                      "code": "083",
-                      "name": "083 - DISABLED AMERICAN VETERANS",
-                      "phoneNumber": "555-555-5555"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9879,7 +11265,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -9945,7 +11331,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "serviceOrganization"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -10249,7 +11638,7 @@
                       },
                       "serviceOrganization": {
                         "poaCode": "083",
-                        "registrationNumber": "67890"
+                        "registrationNumber": "999999999999"
                       }
                     }
                   }
@@ -10306,12 +11695,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "type": "form/21-22a/validation",
-                    "attributes": {
-                      "status": "valid"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10498,7 +11891,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -10564,7 +11957,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "representative"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -10926,7 +12322,7 @@
                       },
                       "representative": {
                         "poaCode": "083",
-                        "registrationNumber": "67890",
+                        "registrationNumber": "999999999999",
                         "type": "ATTORNEY",
                         "address": {
                           "addressLine1": "123",
@@ -10993,12 +12389,16 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "type": "form/21-22/validation",
-                    "attributes": {
-                      "status": "valid"
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
+                      "source": {
+                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
+                      }
                     }
-                  }
+                  ]
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -11193,7 +12593,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -11259,7 +12659,10 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      null
+                      [
+                        "veteran",
+                        "serviceOrganization"
+                      ]
                     ],
                     "properties": {
                       "attributes": {
@@ -11563,7 +12966,7 @@
                       },
                       "serviceOrganization": {
                         "poaCode": "083",
-                        "registrationNumber": "67890"
+                        "registrationNumber": "999999999999"
                       }
                     }
                   }
@@ -11631,7 +13034,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "09a36719-ad88-46b9-97d1-80a746ef9e81",
+                    "id": "c4a6f2e4-2fb4-4dac-aa81-dbf56b1b4f55",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "status": "submitted",

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -1328,10 +1328,7 @@
                               }
                             },
                             "tempJurisdiction": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
+                              "type": "string",
                               "description": "Temporary jurisdiction of claim"
                             },
                             "trackedItems": {
@@ -1626,28 +1623,19 @@
                               ],
                               "properties": {
                                 "serviceNumber": {
-                                  "type": [
-                                    "null",
-                                    "string"
-                                  ],
+                                  "type": "string",
                                   "description": "Service identification number",
                                   "maxLength": 1000,
                                   "nullable": true
                                 },
                                 "veteranNumber": {
                                   "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "properties": {
                                     "telephone": {
                                       "description": "Veteran's phone number.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^\\d{10}?$",
                                       "example": "5555555555",
                                       "minLength": 10,
@@ -1655,10 +1643,7 @@
                                       "nullable": true
                                     },
                                     "internationalTelephone": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "description": "Veteran's international phone number.",
                                       "example": "+44 20 1234 5678",
                                       "maxLength": 1000,
@@ -1686,10 +1671,7 @@
                                     },
                                     "addressLine2": {
                                       "description": "Address line 2 for the Veteran's current mailing address.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 20,
                                       "example": "Unit 4",
@@ -1697,10 +1679,7 @@
                                     },
                                     "addressLine3": {
                                       "description": "Address line 3 for the Veteran's current mailing address.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 20,
                                       "example": "Room 1",
@@ -1733,10 +1712,7 @@
                                     },
                                     "zipLastFour": {
                                       "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^\\d{4}?$",
                                       "example": "6789",
                                       "nullable": true
@@ -1745,27 +1721,18 @@
                                 },
                                 "emailAddress": {
                                   "description": "Information associated with the Veteran's email address.",
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "properties": {
                                     "email": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                       "description": "The most current email address of the Veteran.",
                                       "maxLength": 50,
                                       "nullable": true
                                     },
                                     "agreeToEmailRelatedToClaim": {
-                                      "type": [
-                                        "boolean",
-                                        "null"
-                                      ],
+                                      "type": "boolean",
                                       "description": "Agreement to email information relating to this claim.",
                                       "example": true,
                                       "default": false,
@@ -1782,10 +1749,7 @@
                             },
                             "changeOfAddress": {
                               "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                              "type": [
-                                "object",
-                                "null"
-                              ],
+                              "type": "object",
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
@@ -1807,20 +1771,14 @@
                                 },
                                 "addressLine2": {
                                   "description": "Address line 2 for the Veteran's new address.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "maxLength": 20,
                                   "example": "Unit 4",
                                   "nullable": true
                                 },
                                 "addressLine3": {
                                   "description": "Address line 3 for the Veteran's new address.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "maxLength": 20,
                                   "example": "Room 1",
                                   "nullable": true
@@ -1852,10 +1810,7 @@
                                 },
                                 "zipLastFour": {
                                   "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "pattern": "^$|^\\d{4}?$",
                                   "example": "6789"
@@ -1871,10 +1826,7 @@
                                     },
                                     "endDate": {
                                       "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-04"
@@ -1884,27 +1836,18 @@
                               }
                             },
                             "homeless": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
+                              "type": "object",
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
                                 "currentlyHomeless": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "homelessSituationOptions": {
                                       "description": "Veteran's living situation.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "default": "other",
                                       "enum": [
@@ -1912,17 +1855,13 @@
                                         "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                         "STAYING_WITH_ANOTHER_PERSON",
                                         "FLEEING_CURRENT_RESIDENCE",
-                                        "OTHER",
-                                        null
+                                        "OTHER"
                                       ],
                                       "example": "FLEEING_CURRENT_RESIDENCE"
                                     },
                                     "otherDescription": {
                                       "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "maxLength": 500,
                                       "example": "other living situation"
@@ -1930,33 +1869,23 @@
                                   }
                                 },
                                 "riskOfBecomingHomeless": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "livingSituationOptions": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "enum": [
                                         "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                         "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                        "OTHER",
-                                        null
+                                        "OTHER"
                                       ]
                                     },
                                     "otherDescription": {
                                       "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "maxLength": 500,
                                       "example": "other living situation"
@@ -1965,10 +1894,7 @@
                                 },
                                 "pointOfContact": {
                                   "description": "Individual in direct contact with Veteran.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "minLength": 1,
                                   "maxLength": 100,
@@ -1976,19 +1902,13 @@
                                   "example": "Jane Doe"
                                 },
                                 "pointOfContactNumber": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "telephone": {
                                       "description": "Primary phone of point of contact.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^\\d{10}?$",
                                       "example": "5555555",
                                       "minLength": 10,
@@ -1997,10 +1917,7 @@
                                     },
                                     "internationalTelephone": {
                                       "description": "International phone of point of contact.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "example": "+44 20 1234 5678",
                                       "maxLength": 1000,
                                       "nullable": true
@@ -2010,57 +1927,38 @@
                               }
                             },
                             "toxicExposure": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
+                              "type": "object",
                               "nullable": true,
                               "properties": {
                                 "gulfWarHazardService": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "description": "Toxic exposure related to the Gulf war.",
                                   "properties": {
                                     "servedInGulfWarHazardLocations": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                       "example": "YES",
                                       "enum": [
                                         "NO",
-                                        "YES",
-                                        null
+                                        "YES"
                                       ],
                                       "nullable": true
                                     },
                                     "serviceDates": {
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in Gulf War hazard location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for serving in Gulf War hazard location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2072,31 +1970,21 @@
                                 },
                                 "herbicideHazardService": {
                                   "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "properties": {
                                     "servedInHerbicideHazardLocations": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                       "example": "YES",
                                       "enum": [
                                         "NO",
-                                        "YES",
-                                        null
+                                        "YES"
                                       ],
                                       "nullable": true
                                     },
                                     "otherLocationsServed": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 5000,
@@ -2104,27 +1992,18 @@
                                     },
                                     "serviceDates": {
                                       "description": "Date range for exposure in herbicide hazard location.",
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "properties": {
                                         "beginDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for serving in herbicide location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for serving in herbicide location.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2135,19 +2014,13 @@
                                   }
                                 },
                                 "additionalHazardExposures": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "description": "Additional hazardous exposures.",
                                   "properties": {
                                     "additionalExposures": {
                                       "description": "Additional exposure incidents.",
-                                      "type": [
-                                        "array",
-                                        "null"
-                                      ],
+                                      "type": "array",
                                       "nullable": true,
                                       "uniqueItems": true,
                                       "items": {
@@ -2160,44 +2033,31 @@
                                           "SHIPBOARD_HAZARD_AND_DEFENSE",
                                           "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                           "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                          "OTHER",
-                                          null
+                                          "OTHER"
                                         ]
                                       }
                                     },
                                     "specifyOtherExposures": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
                                     "exposureDates": {
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2208,10 +2068,7 @@
                                   }
                                 },
                                 "multipleExposures": {
-                                  "type": [
-                                    "array",
-                                    "null"
-                                  ],
+                                  "type": "array",
                                   "nullable": true,
                                   "minItems": 1,
                                   "uniqueItems": true,
@@ -2220,48 +2077,33 @@
                                     "additionalProperties": false,
                                     "properties": {
                                       "hazardExposedTo": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Hazard the Veteran was exposed to."
                                       },
                                       "exposureLocation": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
                                       "exposureDates": {
-                                        "type": [
-                                          "object",
-                                          "null"
-                                        ],
+                                        "type": "object",
                                         "nullable": true,
                                         "description": "Date range for when the exposure happened.",
                                         "properties": {
                                           "beginDate": {
-                                            "type": [
-                                              "string",
-                                              "null"
-                                            ],
+                                            "type": "string",
                                             "nullable": true,
                                             "description": "Approximate begin date for exposure.",
                                             "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                             "example": "2018-06 or 2018"
                                           },
                                           "endDate": {
-                                            "type": [
-                                              "string",
-                                              "null"
-                                            ],
+                                            "type": "string",
                                             "nullable": true,
                                             "description": "Approximate end date for exposure.",
                                             "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -2294,10 +2136,7 @@
                                     "maxLength": 255
                                   },
                                   "exposureOrEventOrInjury": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "What caused the disability?",
                                     "nullable": true,
                                     "maxLength": 1000,
@@ -2309,20 +2148,14 @@
                                   },
                                   "serviceRelevance": {
                                     "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Heavy equipment operator in service."
                                   },
                                   "approximateDate": {
                                     "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                     "example": "2018-03-02 or 2018-03 or 2018",
                                     "nullable": true
@@ -2338,37 +2171,25 @@
                                     "example": "NEW"
                                   },
                                   "classificationCode": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                     "example": "249470",
                                     "nullable": true
                                   },
                                   "ratedDisabilityId": {
                                     "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "example": "1100583",
                                     "nullable": true
                                   },
                                   "diagnosticCode": {
                                     "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
+                                    "type": "integer",
                                     "example": 9999,
                                     "nullable": true
                                   },
                                   "isRelatedToToxicExposure": {
-                                    "type": [
-                                      "boolean",
-                                      "null"
-                                    ],
+                                    "type": "boolean",
                                     "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                     "example": true,
                                     "default": false,
@@ -2389,10 +2210,7 @@
                                           "maxLength": 255
                                         },
                                         "exposureOrEventOrInjury": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "description": "What caused the disability?",
                                           "nullable": true,
                                           "maxLength": 1000,
@@ -2404,10 +2222,7 @@
                                         },
                                         "serviceRelevance": {
                                           "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "maxLength": 1000,
                                           "example": "Heavy equipment operator in service."
@@ -2422,19 +2237,13 @@
                                         },
                                         "approximateDate": {
                                           "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                           "example": "2018-03-02 or 2018-03 or 2018",
                                           "nullable": true
                                         },
                                         "classificationCode": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                           "example": "249470",
                                           "nullable": true
@@ -2447,10 +2256,7 @@
                             },
                             "treatments": {
                               "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                              "type": [
-                                "array",
-                                "null"
-                              ],
+                              "type": "array",
                               "nullable": true,
                               "uniqueItems": true,
                               "items": {
@@ -2459,20 +2265,14 @@
                                 "properties": {
                                   "beginDate": {
                                     "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                     "example": "2018-06 or 2018",
                                     "nullable": true
                                   },
                                   "treatedDisabilityNames": {
                                     "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                    "type": [
-                                      "array",
-                                      "null"
-                                    ],
+                                    "type": "array",
                                     "nullable": true,
                                     "maxItems": 101,
                                     "items": {
@@ -2486,19 +2286,13 @@
                                   },
                                   "center": {
                                     "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "name": {
                                         "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                         "example": "Private Facility 2",
@@ -2506,20 +2300,14 @@
                                       },
                                       "city": {
                                         "description": "City of treatment facility.",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                         "example": "Portland",
                                         "nullable": true
                                       },
                                       "state": {
                                         "description": "State of treatment facility.",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "pattern": "^$|^[a-z,A-Z]{2}$",
                                         "example": "OR",
                                         "nullable": true
@@ -2538,10 +2326,7 @@
                               "properties": {
                                 "alternateNames": {
                                   "description": "List any other names under which the Veteran served, if applicable.",
-                                  "type": [
-                                    "array",
-                                    "null"
-                                  ],
+                                  "type": "array",
                                   "nullable": true,
                                   "maxItems": 100,
                                   "uniqueItems": true,
@@ -2598,10 +2383,7 @@
                                       },
                                       "separationLocationCode": {
                                         "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "example": "98283"
                                       }
@@ -2609,63 +2391,43 @@
                                   }
                                 },
                                 "servedInActiveCombatSince911": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "enum": [
                                     "YES",
-                                    "NO",
-                                    null
+                                    "NO"
                                   ],
                                   "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "reservesNationalGuardService": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "component": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "description": "",
                                       "enum": [
                                         "Reserves",
-                                        "National Guard",
-                                        null
+                                        "National Guard"
                                       ]
                                     },
                                     "obligationTermsOfService": {
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                       "additionalProperties": false,
                                       "properties": {
                                         "beginDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                           "example": "2018-06-06"
                                         },
                                         "endDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                           "example": "2018-06-06"
@@ -2673,46 +2435,31 @@
                                       }
                                     },
                                     "unitName": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "maxLength": 1000,
                                       "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                     },
                                     "unitAddress": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "maxLength": 1000,
                                       "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "nullable": true
                                     },
                                     "unitPhone": {
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "additionalProperties": false,
                                       "properties": {
                                         "areaCode": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "maxLength": 3,
                                           "pattern": "^$|^\\d{3}$",
                                           "example": "555"
                                         },
                                         "phoneNumber": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "maxLength": 20,
                                           "example": "5555555"
@@ -2720,14 +2467,10 @@
                                       }
                                     },
                                     "receivingInactiveDutyTrainingPay": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "enum": [
                                         "YES",
-                                        "NO",
-                                        null
+                                        "NO"
                                       ],
                                       "nullable": true,
                                       "example": "YES"
@@ -2735,29 +2478,20 @@
                                   }
                                 },
                                 "federalActivation": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "activationDate": {
                                       "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06",
                                       "nullable": true
                                     },
                                     "anticipatedSeparationDate": {
                                       "description": "Anticipated date of separation. Date must be in the future.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06",
                                       "nullable": true
@@ -2765,10 +2499,7 @@
                                   }
                                 },
                                 "confinements": {
-                                  "type": [
-                                    "array",
-                                    "null"
-                                  ],
+                                  "type": "array",
                                   "nullable": true,
                                   "uniqueItems": true,
                                   "items": {
@@ -2777,19 +2508,13 @@
                                     "properties": {
                                       "approximateBeginDate": {
                                         "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                         "example": "2018-06-06 or 2018-06"
                                       },
                                       "approximateEndDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                         "example": "2018-06-06 or 2018-06"
@@ -2800,75 +2525,52 @@
                               }
                             },
                             "servicePay": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
+                              "type": "object",
                               "nullable": true,
                               "additionalProperties": false,
                               "properties": {
                                 "receivingMilitaryRetiredPay": {
                                   "description": "Is the Veteran receiving military retired pay?",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "enum": [
                                     "YES",
-                                    "NO",
-                                    null
+                                    "NO"
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "futureMilitaryRetiredPay": {
                                   "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "enum": [
                                     "YES",
-                                    "NO",
-                                    null
+                                    "NO"
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "futureMilitaryRetiredPayExplanation": {
                                   "description": "Explains why future pay will be received.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "maxLength": 1000,
                                   "example": "Will be retiring soon.",
                                   "nullable": true
                                 },
                                 "militaryRetiredPay": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "description": "",
                                   "properties": {
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "maxLength": 1000,
                                       "nullable": true,
                                       "example": "Air Force"
                                     },
                                     "monthlyAmount": {
                                       "description": "Amount being received.",
-                                      "type": [
-                                        "integer",
-                                        "null"
-                                      ],
+                                      "type": "integer",
                                       "nullable": true,
                                       "minimum": 1,
                                       "maximum": 999999,
@@ -2877,76 +2579,53 @@
                                   }
                                 },
                                 "retiredStatus": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "description": "",
                                   "enum": [
                                     "RETIRED",
                                     "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                    "PERMANENT_DISABILITY_RETIRED_LIST",
-                                    null
+                                    "PERMANENT_DISABILITY_RETIRED_LIST"
                                   ]
                                 },
                                 "favorMilitaryRetiredPay": {
                                   "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                  "type": [
-                                    "boolean",
-                                    "null"
-                                  ],
+                                  "type": "boolean",
                                   "nullable": true,
                                   "example": true,
                                   "default": false
                                 },
                                 "receivedSeparationOrSeverancePay": {
                                   "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "enum": [
                                     "YES",
-                                    "NO",
-                                    null
+                                    "NO"
                                   ],
                                   "example": "YES",
                                   "nullable": true
                                 },
                                 "separationSeverancePay": {
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "description": "",
                                   "properties": {
                                     "datePaymentReceived": {
                                       "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-03-02 or 2018-03 or 2018"
                                     },
                                     "branchOfService": {
                                       "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "maxLength": 1000,
                                       "example": "Air Force"
                                     },
                                     "preTaxAmountReceived": {
                                       "description": "Amount being received.",
-                                      "type": [
-                                        "integer",
-                                        "null"
-                                      ],
+                                      "type": "integer",
                                       "nullable": true,
                                       "minimum": 1,
                                       "maximum": 999999,
@@ -2956,10 +2635,7 @@
                                 },
                                 "favorTrainingPay": {
                                   "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                  "type": [
-                                    "boolean",
-                                    "null"
-                                  ],
+                                  "type": "boolean",
                                   "nullable": true,
                                   "example": true,
                                   "default": false
@@ -2967,19 +2643,13 @@
                               }
                             },
                             "directDeposit": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
+                              "type": "object",
                               "nullable": true,
                               "additionalProperties": false,
                               "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                               "properties": {
                                 "noAccount": {
-                                  "type": [
-                                    "boolean",
-                                    "null"
-                                  ],
+                                  "type": "boolean",
                                   "nullable": true,
                                   "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                   "default": false
@@ -2987,44 +2657,31 @@
                                 "accountNumber": {
                                   "description": "Account number for the direct deposit.",
                                   "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "maxLength": 14,
                                   "nullable": true,
                                   "example": "123123123123"
                                 },
                                 "accountType": {
                                   "description": "Account type for the direct deposit.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "example": "CHECKING",
                                   "enum": [
                                     "CHECKING",
-                                    "SAVINGS",
-                                    null
+                                    "SAVINGS"
                                   ]
                                 },
                                 "financialInstitutionName": {
                                   "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                   "maxLength": 35,
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "example": "Some Bank"
                                 },
                                 "routingNumber": {
                                   "description": "Routing number for the direct deposit.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "pattern": "^(?:\\d{9})?$",
                                   "example": "123123123"
@@ -3215,13 +2872,7 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      [
-                        "claimantCertification",
-                        "claimProcessType",
-                        "disabilities",
-                        "serviceInformation",
-                        "veteranIdentification"
-                      ]
+                      null
                     ],
                     "properties": {
                       "attributes": {
@@ -3255,28 +2906,19 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": [
-                                  "null",
-                                  "string"
-                                ],
+                                "type": "string",
                                 "description": "Service identification number",
                                 "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "minLength": 10,
@@ -3284,10 +2926,7 @@
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
@@ -3315,10 +2954,7 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Unit 4",
@@ -3326,10 +2962,7 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Room 1",
@@ -3362,10 +2995,7 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789",
                                     "nullable": true
@@ -3374,27 +3004,18 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 50,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": [
-                                      "boolean",
-                                      "null"
-                                    ],
+                                    "type": "boolean",
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -3411,10 +3032,7 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -3436,20 +3054,14 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 20,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 20,
                                 "example": "Room 1",
                                 "nullable": true
@@ -3481,10 +3093,7 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "pattern": "^$|^\\d{4}?$",
                                 "example": "6789"
@@ -3500,10 +3109,7 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -3513,27 +3119,18 @@
                             }
                           },
                           "homeless": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -3541,17 +3138,13 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER",
-                                      null
+                                      "OTHER"
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -3559,33 +3152,23 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER",
-                                      null
+                                      "OTHER"
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -3594,10 +3177,7 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 100,
@@ -3605,19 +3185,13 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555",
                                     "minLength": 10,
@@ -3626,10 +3200,7 @@
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
                                     "nullable": true
@@ -3639,57 +3210,38 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES",
-                                      null
+                                      "YES"
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3701,31 +3253,21 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES",
-                                      null
+                                      "YES"
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
@@ -3733,27 +3275,18 @@
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3764,19 +3297,13 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": [
-                                      "array",
-                                      "null"
-                                    ],
+                                    "type": "array",
                                     "nullable": true,
                                     "uniqueItems": true,
                                     "items": {
@@ -3789,44 +3316,31 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER",
-                                        null
+                                        "OTHER"
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3837,10 +3351,7 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "minItems": 1,
                                 "uniqueItems": true,
@@ -3849,48 +3360,33 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -3923,10 +3419,7 @@
                                   "maxLength": 255
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "maxLength": 1000,
@@ -3938,20 +3431,14 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true
@@ -3967,37 +3454,25 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": [
-                                    "integer",
-                                    "null"
-                                  ],
+                                  "type": "integer",
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": [
-                                    "boolean",
-                                    "null"
-                                  ],
+                                  "type": "boolean",
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -4018,10 +3493,7 @@
                                         "maxLength": 255
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "maxLength": 1000,
@@ -4033,10 +3505,7 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
@@ -4051,19 +3520,13 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true
                                       },
                                       "classificationCode": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -4076,10 +3539,7 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": [
-                              "array",
-                              "null"
-                            ],
+                            "type": "array",
                             "nullable": true,
                             "uniqueItems": true,
                             "items": {
@@ -4088,20 +3548,14 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": [
-                                    "array",
-                                    "null"
-                                  ],
+                                  "type": "array",
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -4115,19 +3569,13 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -4135,20 +3583,14 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -4167,10 +3609,7 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "maxItems": 100,
                                 "uniqueItems": true,
@@ -4227,10 +3666,7 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -4238,63 +3674,43 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard",
-                                      null
+                                      "National Guard"
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -4302,46 +3718,31 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 3,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -4349,14 +3750,10 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "enum": [
                                       "YES",
-                                      "NO",
-                                      null
+                                      "NO"
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -4364,29 +3761,20 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -4394,10 +3782,7 @@
                                 }
                               },
                               "confinements": {
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "uniqueItems": true,
                                 "items": {
@@ -4406,19 +3791,13 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -4429,75 +3808,52 @@
                             }
                           },
                           "servicePay": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
                               "militaryRetiredPay": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
+                                    "type": "integer",
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -4506,76 +3862,53 @@
                                 }
                               },
                               "retiredStatus": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST",
-                                  null
+                                  "PERMANENT_DISABILITY_RETIRED_LIST"
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
+                                    "type": "integer",
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -4585,10 +3918,7 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -4596,19 +3926,13 @@
                             }
                           },
                           "directDeposit": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
@@ -4616,44 +3940,31 @@
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
                                 "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS",
-                                  null
+                                  "SAVINGS"
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 35,
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "pattern": "^(?:\\d{9})?$",
                                 "example": "123123123"
@@ -5389,13 +4700,7 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      [
-                        "claimantCertification",
-                        "claimProcessType",
-                        "disabilities",
-                        "serviceInformation",
-                        "veteranIdentification"
-                      ]
+                      null
                     ],
                     "properties": {
                       "attributes": {
@@ -5429,28 +4734,19 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": [
-                                  "null",
-                                  "string"
-                                ],
+                                "type": "string",
                                 "description": "Service identification number",
                                 "maxLength": 1000,
                                 "nullable": true
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "minLength": 10,
@@ -5458,10 +4754,7 @@
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
@@ -5489,10 +4782,7 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Unit 4",
@@ -5500,10 +4790,7 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 20,
                                     "example": "Room 1",
@@ -5536,10 +4823,7 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789",
                                     "nullable": true
@@ -5548,27 +4832,18 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$",
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 50,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": [
-                                      "boolean",
-                                      "null"
-                                    ],
+                                    "type": "boolean",
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -5585,10 +4860,7 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -5610,20 +4882,14 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 20,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 20,
                                 "example": "Room 1",
                                 "nullable": true
@@ -5655,10 +4921,7 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "pattern": "^$|^\\d{4}?$",
                                 "example": "6789"
@@ -5674,10 +4937,7 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -5687,27 +4947,18 @@
                             }
                           },
                           "homeless": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -5715,17 +4966,13 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER",
-                                      null
+                                      "OTHER"
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -5733,33 +4980,23 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER",
-                                      null
+                                      "OTHER"
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 500,
                                     "example": "other living situation"
@@ -5768,10 +5005,7 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 100,
@@ -5779,19 +5013,13 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555",
                                     "minLength": 10,
@@ -5800,10 +5028,7 @@
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "example": "+44 20 1234 5678",
                                     "maxLength": 1000,
                                     "nullable": true
@@ -5813,57 +5038,38 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES",
-                                      null
+                                      "YES"
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5875,31 +5081,21 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES",
-                                      null
+                                      "YES"
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
@@ -5907,27 +5103,18 @@
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -5938,19 +5125,13 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": [
-                                      "array",
-                                      "null"
-                                    ],
+                                    "type": "array",
                                     "nullable": true,
                                     "uniqueItems": true,
                                     "items": {
@@ -5963,44 +5144,31 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER",
-                                        null
+                                        "OTHER"
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
                                   "exposureDates": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6011,10 +5179,7 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "minItems": 1,
                                 "uniqueItems": true,
@@ -6023,48 +5188,33 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Hazard the Veteran was exposed to."
                                     },
                                     "exposureLocation": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
                                     "exposureDates": {
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -6097,10 +5247,7 @@
                                   "maxLength": 255
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "maxLength": 1000,
@@ -6112,20 +5259,14 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "maxLength": 1000,
                                   "example": "Heavy equipment operator in service."
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true
@@ -6141,37 +5282,25 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": [
-                                    "integer",
-                                    "null"
-                                  ],
+                                  "type": "integer",
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": [
-                                    "boolean",
-                                    "null"
-                                  ],
+                                  "type": "boolean",
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -6192,10 +5321,7 @@
                                         "maxLength": 255
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "maxLength": 1000,
@@ -6207,10 +5333,7 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 1000,
                                         "example": "Heavy equipment operator in service."
@@ -6225,19 +5348,13 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true
                                       },
                                       "classificationCode": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -6250,10 +5367,7 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": [
-                              "array",
-                              "null"
-                            ],
+                            "type": "array",
                             "nullable": true,
                             "uniqueItems": true,
                             "items": {
@@ -6262,20 +5376,14 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": [
-                                    "array",
-                                    "null"
-                                  ],
+                                  "type": "array",
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -6289,19 +5397,13 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -6309,20 +5411,14 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -6341,10 +5437,7 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "maxItems": 100,
                                 "uniqueItems": true,
@@ -6401,10 +5494,7 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -6412,63 +5502,43 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard",
-                                      null
+                                      "National Guard"
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -6476,46 +5546,31 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 3,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -6523,14 +5578,10 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "enum": [
                                       "YES",
-                                      "NO",
-                                      null
+                                      "NO"
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -6538,29 +5589,20 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -6568,10 +5610,7 @@
                                 }
                               },
                               "confinements": {
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "uniqueItems": true,
                                 "items": {
@@ -6580,19 +5619,13 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -6603,75 +5636,52 @@
                             }
                           },
                           "servicePay": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 1000,
                                 "example": "Will be retiring soon.",
                                 "nullable": true
                               },
                               "militaryRetiredPay": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
+                                    "type": "integer",
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -6680,76 +5690,53 @@
                                 }
                               },
                               "retiredStatus": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST",
-                                  null
+                                  "PERMANENT_DISABILITY_RETIRED_LIST"
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
+                                    "type": "integer",
                                     "nullable": true,
                                     "minimum": 1,
                                     "maximum": 999999,
@@ -6759,10 +5746,7 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -6770,19 +5754,13 @@
                             }
                           },
                           "directDeposit": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
@@ -6790,44 +5768,31 @@
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
                                 "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS",
-                                  null
+                                  "SAVINGS"
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 35,
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "pattern": "^(?:\\d{9})?$",
                                 "example": "123123123"
@@ -7107,7 +6072,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "bcf33b41-f27f-429c-b860-f2b71567d87e",
+                    "id": "6be9b240-267c-4c9c-b8d5-af1cd4068308",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -7406,13 +6371,7 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      [
-                        "claimantCertification",
-                        "claimProcessType",
-                        "disabilities",
-                        "serviceInformation",
-                        "veteranIdentification"
-                      ]
+                      null
                     ],
                     "properties": {
                       "attributes": {
@@ -7451,37 +6410,25 @@
                             ],
                             "properties": {
                               "serviceNumber": {
-                                "type": [
-                                  "null",
-                                  "string"
-                                ],
+                                "type": "string",
                                 "description": "Service identification number",
                                 "nullable": true,
                                 "maxLength": 1000
                               },
                               "veteranNumber": {
                                 "description": "If there is no phone number in VBMS for the Veteran, the exams will not be ordered. Including the phone number is recommended to avoid claim processing delays.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "telephone": {
                                     "description": "Veteran's phone number. Number including area code.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Veteran's international phone number.",
                                     "example": "+44 20 1234 5678",
                                     "nullable": true,
@@ -7509,10 +6456,7 @@
                                   },
                                   "addressLine2": {
                                     "description": "Address line 2 for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 325,
                                     "example": "Unit 4",
@@ -7520,10 +6464,7 @@
                                   },
                                   "addressLine3": {
                                     "description": "Address line 3 for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "maxLength": 325,
                                     "example": "Room 1",
@@ -7557,10 +6498,7 @@
                                   },
                                   "zipLastFour": {
                                     "description": "Zip code (Last 4 digits) for the Veteran's current mailing address.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "example": "6789",
                                     "nullable": true,
                                     "maxLength": 500
@@ -7569,26 +6507,17 @@
                               },
                               "emailAddress": {
                                 "description": "Information associated with the Veteran's email address.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "email": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "The most current email address of the Veteran.",
                                     "maxLength": 1000,
                                     "nullable": true
                                   },
                                   "agreeToEmailRelatedToClaim": {
-                                    "type": [
-                                      "boolean",
-                                      "null"
-                                    ],
+                                    "type": "boolean",
                                     "description": "Agreement to email information relating to this claim.",
                                     "example": true,
                                     "default": false,
@@ -7605,10 +6534,7 @@
                           },
                           "changeOfAddress": {
                             "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
@@ -7630,20 +6556,14 @@
                               },
                               "addressLine2": {
                                 "description": "Address line 2 for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 325,
                                 "example": "Unit 4",
                                 "nullable": true
                               },
                               "addressLine3": {
                                 "description": "Address line 3 for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 325,
                                 "example": "Room 1",
                                 "nullable": true
@@ -7676,10 +6596,7 @@
                               },
                               "zipLastFour": {
                                 "description": "Zip code (Last 4 digits) for the Veteran's new address.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "example": "6789",
                                 "maxLength": 500
@@ -7695,10 +6612,7 @@
                                   },
                                   "endDate": {
                                     "description": "Date in YYYY-MM-DD the changed address expires, if change is temporary.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-04"
@@ -7708,27 +6622,18 @@
                             }
                           },
                           "homeless": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "currentlyHomeless": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "homelessSituationOptions": {
                                     "description": "Veteran's living situation.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "default": "other",
                                     "enum": [
@@ -7736,17 +6641,13 @@
                                       "NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT",
                                       "STAYING_WITH_ANOTHER_PERSON",
                                       "FLEEING_CURRENT_RESIDENCE",
-                                      "OTHER",
-                                      null
+                                      "OTHER"
                                     ],
                                     "example": "FLEEING_CURRENT_RESIDENCE"
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'homelessSituationOptions' is 'OTHER'.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 5000,
                                     "example": "other living situation"
@@ -7754,33 +6655,23 @@
                                 }
                               },
                               "riskOfBecomingHomeless": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "livingSituationOptions": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "default": "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                     "enum": [
                                       "HOUSING_WILL_BE_LOST_IN_30_DAYS",
                                       "LEAVING_PUBLICLY_FUNDED_SYSTEM_OF_CARE",
-                                      "OTHER",
-                                      null
+                                      "OTHER"
                                     ]
                                   },
                                   "otherDescription": {
                                     "description": "Explanation of living situation. Required if 'livingSituationOptions' is 'OTHER'.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 5000,
                                     "example": "other living situation"
@@ -7789,10 +6680,7 @@
                               },
                               "pointOfContact": {
                                 "description": "Individual in direct contact with Veteran.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "minLength": 1,
                                 "maxLength": 1000,
@@ -7800,29 +6688,20 @@
                                 "example": "Jane Doe"
                               },
                               "pointOfContactNumber": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "telephone": {
                                     "description": "Primary phone of point of contact.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^\\d{10}?$",
                                     "example": "5555555555",
                                     "nullable": true
                                   },
                                   "internationalTelephone": {
                                     "description": "International phone of point of contact.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "example": "+44 20 1234 5678",
                                     "nullable": true,
                                     "maxLength": 1000
@@ -7832,56 +6711,37 @@
                             }
                           },
                           "toxicExposure": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "properties": {
                               "gulfWarHazardService": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "Toxic exposure related to the Gulf war.",
                                 "properties": {
                                   "servedInGulfWarHazardLocations": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Set to true if the Veteran served in any of the following Gulf War hazard locations: Iraq; Kuwait; Saudi Arabia; the neutral zone between Iraq and Saudi Arabia; Bahrain; Qatar; the United Arab Emirates; Oman; Yemen; Lebanon; Somalia; Afghanistan; Israel; Egypt; Turkey; Syria; Jordan; Djibouti; Uzbekistan; the Gulf of Aden; the Gulf of Oman; the Persian Gulf; the Arabian Sea; and the Red Sea.",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES",
-                                      null
+                                      "YES"
                                     ],
                                     "nullable": true
                                   },
                                   "serviceDates": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in Gulf War hazard location.",
                                         "example": "2018-06 or 2018"
@@ -7892,31 +6752,21 @@
                               },
                               "herbicideHazardService": {
                                 "description": "Toxic exposure related to herbicide (Agent Orange) hazards.",
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "properties": {
                                   "servedInHerbicideHazardLocations": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "description": "Set to true if the Veteran served in any of the following herbicide/Agent Orange locations: Republic of Vietnam to include the 12 nautical mile territorial waters; Thailand at any United States or Royal Thai base; Laos; Cambodia at Mimot or Krek; Kampong Cham Province; Guam or American Samoa; or in the territorial waters thereof; Johnston Atoll or a ship that called at Johnston Atoll; Korean demilitarized zone; aboard (to include repeated operations and maintenance with) a C-123 aircraft known to have been used to spray an herbicide agent (during service in the Air Force and Air Force Reserves).",
                                     "example": "YES",
                                     "enum": [
                                       "NO",
-                                      "YES",
-                                      null
+                                      "YES"
                                     ],
                                     "nullable": true
                                   },
                                   "otherLocationsServed": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Other location(s) where Veteran served.",
@@ -7924,27 +6774,18 @@
                                   },
                                   "serviceDates": {
                                     "description": "Date range for exposure in herbicide hazard location.",
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for serving in herbicide location.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -7955,19 +6796,13 @@
                                 }
                               },
                               "additionalHazardExposures": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "Additional hazardous exposures.",
                                 "properties": {
                                   "additionalExposures": {
                                     "description": "Additional exposure incidents.",
-                                    "type": [
-                                      "array",
-                                      "null"
-                                    ],
+                                    "type": "array",
                                     "nullable": true,
                                     "maxItems": 5000,
                                     "items": {
@@ -7980,44 +6815,31 @@
                                         "SHIPBOARD_HAZARD_AND_DEFENSE",
                                         "MILITARY_OCCUPATIONAL_SPECIALTY_RELATED_TOXIN",
                                         "CONTAMINATED_WATER_AT_CAMP_LEJEUNE",
-                                        "OTHER",
-                                        null
+                                        "OTHER"
                                       ]
                                     }
                                   },
                                   "specifyOtherExposures": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "description": "Exposure to asbestos.",
                                     "maxLength": 5000
                                   },
                                   "exposureDates": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "Date range for when the exposure happened.",
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate begin date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                         "example": "2018-06 or 2018"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "description": "Approximate end date for exposure.",
                                         "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -8028,10 +6850,7 @@
                                 }
                               },
                               "multipleExposures": {
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "minItems": 0,
@@ -8040,48 +6859,33 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "hazardExposedTo": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Hazard the Veteran was exposed to.",
                                       "maxLength": 1000
                                     },
                                     "exposureLocation": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                       "description": "Location where the exposure happened.",
                                       "maxLength": 1000
                                     },
                                     "exposureDates": {
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ],
+                                      "type": "object",
                                       "nullable": true,
                                       "description": "Date range for when the exposure happened.",
                                       "properties": {
                                         "beginDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate begin date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                           "example": "2018-06 or 2018"
                                         },
                                         "endDate": {
-                                          "type": [
-                                            "string",
-                                            "null"
-                                          ],
+                                          "type": "string",
                                           "nullable": true,
                                           "description": "Approximate end date for exposure.",
                                           "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
@@ -8115,10 +6919,7 @@
                                   "maxLength": 1000
                                 },
                                 "exposureOrEventOrInjury": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "description": "What caused the disability?",
                                   "nullable": true,
                                   "examples": [
@@ -8130,20 +6931,14 @@
                                 },
                                 "serviceRelevance": {
                                   "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury. If the disabilityActionType is 'NEW', the serviceRelevance is required.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "nullable": true,
                                   "example": "Heavy equipment operator in service.",
                                   "maxLength": 1000
                                 },
                                 "approximateDate": {
                                   "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                   "example": "2018-03-02 or 2018-03 or 2018",
                                   "nullable": true,
@@ -8160,37 +6955,25 @@
                                   "example": "NEW"
                                 },
                                 "classificationCode": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                   "example": "249470",
                                   "nullable": true
                                 },
                                 "ratedDisabilityId": {
                                   "description": "When submitting a contention with action type 'INCREASE', the previously rated disability id may be included.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "example": "1100583",
                                   "nullable": true
                                 },
                                 "diagnosticCode": {
                                   "description": "If the disabilityActionType is 'NONE' or 'INCREASE', the diagnosticCode should correspond to an existing rated disability.",
-                                  "type": [
-                                    "integer",
-                                    "null"
-                                  ],
+                                  "type": "integer",
                                   "example": 9999,
                                   "nullable": true
                                 },
                                 "isRelatedToToxicExposure": {
-                                  "type": [
-                                    "boolean",
-                                    "null"
-                                  ],
+                                  "type": "boolean",
                                   "description": "Is the disability related to toxic exposures? If true, related 'toxicExposure' must be included.",
                                   "example": true,
                                   "default": false,
@@ -8211,10 +6994,7 @@
                                         "maxLength": 1000
                                       },
                                       "exposureOrEventOrInjury": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "description": "What caused the disability?",
                                         "nullable": true,
                                         "examples": [
@@ -8226,10 +7006,7 @@
                                       },
                                       "serviceRelevance": {
                                         "description": "Explanation of how the disability(ies) relates to the in-service event/exposure/injury.",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "example": "Heavy equipment operator in service.",
                                         "maxLength": 1000
@@ -8244,20 +7021,14 @@
                                       },
                                       "approximateDate": {
                                         "description": "Approximate date disability began. Date must be in the past. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "pattern": "^(?:[0-9]{4}(?:-(?!00)(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[1-2][0-9]|3[0-1]))?)?)$",
                                         "example": "2018-03-02 or 2018-03 or 2018",
                                         "nullable": true,
                                         "maxLength": 1000
                                       },
                                       "classificationCode": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "description": "Classification code for the associated body system. Must match an active code returned by the /disabilities endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
                                         "example": "249470",
                                         "nullable": true
@@ -8270,10 +7041,7 @@
                           },
                           "treatments": {
                             "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
-                            "type": [
-                              "array",
-                              "null"
-                            ],
+                            "type": "array",
                             "nullable": true,
                             "maxItems": 5000,
                             "items": {
@@ -8282,20 +7050,14 @@
                               "properties": {
                                 "beginDate": {
                                   "description": "Begin date for treatment. If treatment began from 2005 to present, you do not need to provide dates. Each treatment begin date must be after the first 'servicePeriod.activeDutyBeginDate'.",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ],
+                                  "type": "string",
                                   "pattern": "^(?:19|20)[0-9][0-9]$|^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])$",
                                   "example": "2018-06 or 2018",
                                   "nullable": true
                                 },
                                 "treatedDisabilityNames": {
                                   "description": "Name(s) of disabilities treated in this time frame. Name must match 'name' of a disability included on this claim.",
-                                  "type": [
-                                    "array",
-                                    "null"
-                                  ],
+                                  "type": "array",
                                   "nullable": true,
                                   "maxItems": 101,
                                   "items": {
@@ -8309,19 +7071,13 @@
                                 },
                                 "center": {
                                   "description": "VA Medical Center(s) and Department of Defense Military Treatment Facilities where the Veteran received treatment after discharge for any claimed disabilities.",
-                                  "type": [
-                                    "object",
-                                    "null"
-                                  ],
+                                  "type": "object",
                                   "nullable": true,
                                   "additionalProperties": false,
                                   "properties": {
                                     "name": {
                                       "description": "Name of facility Veteran was treated in. The /treatment-centers endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve possible treatment center names.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^$|(?!(?: )$)([a-zA-Z0-9\"\\/&\\(\\)\\-'.,# ]([a-zA-Z0-9(\\)\\-'.,# ])?)+$",
                                       "example": "Private Facility 2",
@@ -8329,20 +7085,14 @@
                                     },
                                     "city": {
                                       "description": "City of treatment facility.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^$|^([-a-zA-Z'.#]([-a-zA-Z'.# ])?)+$",
                                       "example": "Portland",
                                       "nullable": true
                                     },
                                     "state": {
                                       "description": "State of treatment facility.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "pattern": "^$|^[a-z,A-Z]{2}$",
                                       "example": "OR",
                                       "nullable": true
@@ -8361,10 +7111,7 @@
                             "properties": {
                               "alternateNames": {
                                 "description": "List any other names under which the Veteran served, if applicable.",
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "items": {
@@ -8420,10 +7167,7 @@
                                     },
                                     "separationLocationCode": {
                                       "description": "Location code for the facility the Veteran plans to separate from. Required if 'servicePeriod.activeDutyEndDate' is in the future. Code must match the values returned by the /intake-sites endpoint on the [Benefits reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "example": "98283"
                                     }
@@ -8431,63 +7175,43 @@
                                 }
                               },
                               "servedInActiveCombatSince911": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "description": "Did Veteran serve in a combat zone since 9-11-2001?",
                                 "example": "YES",
                                 "nullable": true
                               },
                               "reservesNationalGuardService": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "component": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "description": "",
                                     "enum": [
                                       "Reserves",
-                                      "National Guard",
-                                      null
+                                      "National Guard"
                                     ]
                                   },
                                   "obligationTermsOfService": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "description": "If 'obligationTermsOfService' is included, the following attributes are required: 'beginDate ' and 'endDate'.",
                                     "additionalProperties": false,
                                     "properties": {
                                       "beginDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
                                       },
                                       "endDate": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -8495,46 +7219,31 @@
                                     }
                                   },
                                   "unitName": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "pattern": "^$|([a-zA-Z0-9\\-'.,# ][a-zA-Z0-9\\-'.,# ]?)*$"
                                   },
                                   "unitAddress": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "maxLength": 1000,
                                     "pattern": "^$|^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
                                     "nullable": true
                                   },
                                   "unitPhone": {
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ],
+                                    "type": "object",
                                     "nullable": true,
                                     "additionalProperties": false,
                                     "properties": {
                                       "areaCode": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 1000,
                                         "pattern": "^$|^\\d{3}$",
                                         "example": "555"
                                       },
                                       "phoneNumber": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ],
+                                        "type": "string",
                                         "nullable": true,
                                         "maxLength": 20,
                                         "example": "5555555"
@@ -8542,14 +7251,10 @@
                                     }
                                   },
                                   "receivingInactiveDutyTrainingPay": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "enum": [
                                       "YES",
-                                      "NO",
-                                      null
+                                      "NO"
                                     ],
                                     "nullable": true,
                                     "example": "YES"
@@ -8557,29 +7262,20 @@
                                 }
                               },
                               "federalActivation": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "additionalProperties": false,
                                 "properties": {
                                   "activationDate": {
                                     "description": "Date cannot be in the future and must be after the earliest servicePeriod.activeDutyBeginDate.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
                                   },
                                   "anticipatedSeparationDate": {
                                     "description": "Anticipated date of separation. Date must be in the future.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "2018-06-06",
                                     "nullable": true
@@ -8587,10 +7283,7 @@
                                 }
                               },
                               "confinements": {
-                                "type": [
-                                  "array",
-                                  "null"
-                                ],
+                                "type": "array",
                                 "nullable": true,
                                 "maxItems": 5000,
                                 "items": {
@@ -8599,19 +7292,13 @@
                                   "properties": {
                                     "approximateBeginDate": {
                                       "description": "The approximateBeginDate must be after the earliest servicePeriod activeDutyBeginDate.",
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
                                     },
                                     "approximateEndDate": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ],
+                                      "type": "string",
                                       "nullable": true,
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                       "example": "2018-06-06 or 2018-06"
@@ -8622,151 +7309,105 @@
                             }
                           },
                           "servicePay": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "properties": {
                               "receivingMilitaryRetiredPay": {
                                 "description": "Is the Veteran receiving military retired pay?",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPay": {
                                 "description": "Will the Veteran receive military retired pay pay in future? \n If true, then 'futurePayExplanation' is required.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "futureMilitaryRetiredPayExplanation": {
                                 "description": "Explains why future pay will be received.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "example": "Will be retiring soon.",
                                 "nullable": true,
                                 "maxLength": 1000
                               },
                               "militaryRetiredPay": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "nullable": true,
                                     "maxLength": 1000,
                                     "example": "Air Force"
                                   },
                                   "monthlyAmount": {
                                     "description": "Amount being received.",
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
+                                    "type": "integer",
                                     "nullable": true,
                                     "example": 100
                                   }
                                 }
                               },
                               "retiredStatus": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "description": "",
                                 "enum": [
                                   "RETIRED",
                                   "TEMPORARY_DISABILITY_RETIRED_LIST",
-                                  "PERMANENT_DISABILITY_RETIRED_LIST",
-                                  null
+                                  "PERMANENT_DISABILITY_RETIRED_LIST"
                                 ]
                               },
                               "favorMilitaryRetiredPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain military retired pay? See item 26 on form 21-526EZ for more details.",
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "example": true,
                                 "default": false
                               },
                               "receivedSeparationOrSeverancePay": {
                                 "description": "Has the Veteran ever received separation pay, disability severance pay, or any other lump sum payment from their branch of service?",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "enum": [
                                   "YES",
-                                  "NO",
-                                  null
+                                  "NO"
                                 ],
                                 "example": "YES",
                                 "nullable": true
                               },
                               "separationSeverancePay": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ],
+                                "type": "object",
                                 "nullable": true,
                                 "description": "",
                                 "properties": {
                                   "datePaymentReceived": {
                                     "description": "Approximate date separation pay was received. \n Format can be either YYYY-MM-DD or YYYY-MM or YYYY",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$|(?:[0-9]{4})$|(?:[0-9]{4})-(?:0[1-9]|1[0-2])$",
                                     "example": "2018-03-02 or 2018-03 or 2018"
                                   },
                                   "branchOfService": {
                                     "description": "Branch of service. The /service-branches endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) may be used to retrieve list of possible service branches.",
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ],
+                                    "type": "string",
                                     "maxLength": 1000,
                                     "nullable": true,
                                     "example": "Air Force"
                                   },
                                   "preTaxAmountReceived": {
                                     "description": "Amount being received.",
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
+                                    "type": "integer",
                                     "nullable": true,
                                     "example": 100
                                   }
@@ -8774,10 +7415,7 @@
                               },
                               "favorTrainingPay": {
                                 "description": "Is the Veteran waiving VA benefits to retain training pay? See item 28 on form 21-526EZ for more details. ",
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "example": true,
                                 "default": false
@@ -8785,63 +7423,44 @@
                             }
                           },
                           "directDeposit": {
-                            "type": [
-                              "object",
-                              "null"
-                            ],
+                            "type": "object",
                             "nullable": true,
                             "additionalProperties": false,
                             "description": "If direct deposit information is included, the following attributes are required: accountType, accountNumber, routingNumber.",
                             "properties": {
                               "noAccount": {
-                                "type": [
-                                  "boolean",
-                                  "null"
-                                ],
+                                "type": "boolean",
                                 "nullable": true,
                                 "description": "Claimant certifies that they do not have an account with a financial institution or certified payment agent.",
                                 "default": false
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "maxLength": 14,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
                               "accountType": {
                                 "description": "Account type for the direct deposit.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "example": "CHECKING",
                                 "enum": [
                                   "CHECKING",
-                                  "SAVINGS",
-                                  null
+                                  "SAVINGS"
                                 ]
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
                                 "maxLength": 1000,
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
                               },
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ],
+                                "type": "string",
                                 "nullable": true,
                                 "maxLength": 9,
                                 "example": "123123123"
@@ -9537,8 +8156,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-04-23",
-                      "expirationDate": "2025-04-23",
+                      "creationDate": "2024-04-24",
+                      "expirationDate": "2025-04-24",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -10355,16 +8974,15 @@
             "content": {
               "application/json": {
                 "example": {
-                  "errors": [
-                    {
-                      "title": "Resource not found",
-                      "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
-                      "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
-                      }
+                  "data": {
+                    "id": "867b7baa-8dbe-4053-823f-788218fa6984",
+                    "type": "individual",
+                    "attributes": {
+                      "code": "083",
+                      "name": "Firstname Lastname",
+                      "phoneNumber": "555-555-5555"
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10623,10 +9241,7 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      [
-                        "veteran",
-                        "representative"
-                      ]
+                      null
                     ],
                     "properties": {
                       "attributes": {
@@ -11055,16 +9670,15 @@
             "content": {
               "application/json": {
                 "example": {
-                  "errors": [
-                    {
-                      "title": "Resource not found",
-                      "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
-                      "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
-                      }
+                  "data": {
+                    "id": "c54cfb3e-8ec8-48ce-bb19-52847bdd9bde",
+                    "type": "organization",
+                    "attributes": {
+                      "code": "083",
+                      "name": "083 - DISABLED AMERICAN VETERANS",
+                      "phoneNumber": "555-555-5555"
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -11331,10 +9945,7 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      [
-                        "veteran",
-                        "serviceOrganization"
-                      ]
+                      null
                     ],
                     "properties": {
                       "attributes": {
@@ -11695,16 +10306,12 @@
             "content": {
               "application/json": {
                 "example": {
-                  "errors": [
-                    {
-                      "title": "Resource not found",
-                      "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
-                      "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
-                      }
+                  "data": {
+                    "type": "form/21-22a/validation",
+                    "attributes": {
+                      "status": "valid"
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -11957,10 +10564,7 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      [
-                        "veteran",
-                        "representative"
-                      ]
+                      null
                     ],
                     "properties": {
                       "attributes": {
@@ -12389,16 +10993,12 @@
             "content": {
               "application/json": {
                 "example": {
-                  "errors": [
-                    {
-                      "title": "Resource not found",
-                      "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
-                      "source": {
-                        "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
-                      }
+                  "data": {
+                    "type": "form/21-22/validation",
+                    "attributes": {
+                      "status": "valid"
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -12659,10 +11259,7 @@
                     "type": "object",
                     "required": [
                       "attributes",
-                      [
-                        "veteran",
-                        "serviceOrganization"
-                      ]
+                      null
                     ],
                     "properties": {
                       "attributes": {
@@ -13034,11 +11631,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "c4a6f2e4-2fb4-4dac-aa81-dbf56b1b4f55",
+                    "id": "af367b07-5484-4eb7-8a2b-3d4bf1ba447c",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "status": "submitted",
-                      "dateRequestAccepted": "2024-04-23",
+                      "dateRequestAccepted": "2024-04-24",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -5789,7 +5789,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "cfe5b467-a176-4987-80a9-4350ba73f350",
+                    "id": "05d0b0a5-f2c6-40fb-a88a-7f8fb6888649",
                     "type": "forms/526",
                     "attributes": {
                       "veteran": {
@@ -7873,8 +7873,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-04-23",
-                      "expirationDate": "2025-04-23",
+                      "creationDate": "2024-04-24",
+                      "expirationDate": "2025-04-24",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -8692,7 +8692,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "74658dd8-0176-4bd4-ac22-beedcef627df",
+                    "id": "6f744006-a5d4-4df8-8869-735a7a011c2b",
                     "type": "individual",
                     "attributes": {
                       "code": "083",
@@ -8892,7 +8892,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -9320,7 +9320,7 @@
                       },
                       "representative": {
                         "poaCode": "083",
-                        "registrationNumber": "67890",
+                        "registrationNumber": "999999999999",
                         "type": "ATTORNEY",
                         "address": {
                           "addressLine1": "123",
@@ -9388,7 +9388,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "f8eefcaa-020f-473e-9382-11dbd36f32ff",
+                    "id": "3a617b31-b98c-408a-844c-9bf3eef46b10",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -9596,7 +9596,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -9966,7 +9966,7 @@
                       },
                       "serviceOrganization": {
                         "poaCode": "083",
-                        "registrationNumber": "67890"
+                        "registrationNumber": "999999999999"
                       }
                     }
                   }
@@ -10215,7 +10215,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -10643,7 +10643,7 @@
                       },
                       "representative": {
                         "poaCode": "083",
-                        "registrationNumber": "67890",
+                        "registrationNumber": "999999999999",
                         "type": "ATTORNEY",
                         "address": {
                           "addressLine1": "123",
@@ -10910,7 +10910,7 @@
                     {
                       "title": "Resource not found",
                       "status": "404",
-                      "detail": "Could not find an Accredited Representative with registration number: 67890 and poa code: 083",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 083",
                       "source": {
                         "pointer": "/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb:70:in `validate_registration_number!'"
                       }
@@ -11280,7 +11280,7 @@
                       },
                       "serviceOrganization": {
                         "poaCode": "083",
-                        "registrationNumber": "67890"
+                        "registrationNumber": "999999999999"
                       }
                     }
                   }
@@ -11348,11 +11348,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "c08567c4-6f1d-49bb-8416-01b91642b301",
+                    "id": "475c01f3-1705-4639-a793-7a80074884ea",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "status": "submitted",
-                      "dateRequestAccepted": "2024-04-23",
+                      "dateRequestAccepted": "2024-04-24",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/invalid_poa.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/invalid_poa.json
@@ -12,7 +12,7 @@
       },
       "serviceOrganization": {
         "poaCode": "aaa",
-        "registrationNumber": "67890"
+        "registrationNumber": "999999999999"
       }
     }
   }

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/valid.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122/valid.json
@@ -12,7 +12,7 @@
       },
       "serviceOrganization": {
         "poaCode": "083",
-        "registrationNumber": "67890"
+        "registrationNumber": "999999999999"
       }
     }
   }

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/invalid_poa.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/invalid_poa.json
@@ -12,7 +12,7 @@
       },
       "representative": {
         "poaCode": "aaa",
-        "registrationNumber": "67890",
+        "registrationNumber": "999999999999",
         "type": "ATTORNEY",
         "address": {
           "addressLine1":  "123",

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/valid.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/2122a/valid.json
@@ -14,7 +14,7 @@
       },
       "representative": {
         "poaCode": "083",
-        "registrationNumber": "67890",
+        "registrationNumber": "999999999999",
         "type": "ATTORNEY",
         "address": {
           "addressLine1":  "123",

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_ind_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_ind_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
     before do
       Veteran::Service::Representative.create!(representative_id: '12345', poa_codes: [individual_poa_code],
                                                first_name: 'Abraham', last_name: 'Lincoln')
-      Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+      Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                first_name: 'George', last_name: 'Washington')
     end
 
@@ -346,7 +346,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
                     it 'returns a meaningful 404' do
                       mock_ccg(%w[claim.write claim.read]) do |auth_header|
-                        detail = 'Could not find an Accredited Representative with registration number: 67890 ' \
+                        detail = 'Could not find an Accredited Representative with registration number: 999999999999 ' \
                                  'and poa code: aaa'
 
                         post validate2122a_path, params: request_body, headers: auth_header

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
   describe 'PowerOfAttorney' do
     before do
-      Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+      Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                first_name: 'George', last_name: 'Washington')
       Veteran::Service::Organization.create!(poa: organization_poa_code,
                                              name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
@@ -39,7 +39,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
               },
               serviceOrganization: {
                 poaCode: organization_poa_code.to_s,
-                registrationNumber: '67890'
+                registrationNumber: '999999999999'
               }
             }
           }
@@ -103,7 +103,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
       context 'multiple reps with same poa code and registration number' do
         let(:rep_id) do
-          Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+          Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                    first_name: 'George', last_name: 'Washington-test').id
         end
 
@@ -181,7 +181,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
                 it 'returns a meaningful 404' do
                   mock_ccg(%w[claim.write claim.read]) do |auth_header|
-                    detail = 'Could not find an Accredited Representative with registration number: 67890 ' \
+                    detail = 'Could not find an Accredited Representative with registration number: 999999999999 ' \
                              'and poa code: aaa'
 
                     post validate2122_path, params: request_body, headers: auth_header

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_org_request_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
   describe 'PowerOfAttorney' do
     before do
-      Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
+      Veteran::Service::Representative.create!(representative_id: '999999999999',
+                                               poa_codes: [organization_poa_code],
                                                first_name: 'George', last_name: 'Washington')
       Veteran::Service::Organization.create!(poa: organization_poa_code,
                                              name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
@@ -103,7 +104,8 @@ RSpec.describe 'Power Of Attorney', type: :request do
 
       context 'multiple reps with same poa code and registration number' do
         let(:rep_id) do
-          Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
+          Veteran::Service::Representative.create!(representative_id: '999999999999',
+                                                   poa_codes: [organization_poa_code],
                                                    first_name: 'George', last_name: 'Washington-test').id
         end
 

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -184,7 +184,7 @@ describe 'PowerOfAttorney',
             expect_any_instance_of(local_bgs).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
             allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
               .and_return({ person_poa_history: nil })
-            Veteran::Service::Representative.new(representative_id: '67890',
+            Veteran::Service::Representative.new(representative_id: '999999999999',
                                                  poa_codes: [poa_code],
                                                  first_name: 'Firstname',
                                                  last_name: 'Lastname',
@@ -352,7 +352,7 @@ describe 'PowerOfAttorney',
             Veteran::Service::Organization.create!(poa: organization_poa_code,
                                                    name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS",
                                                    phone: '555-555-5555')
-            Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [organization_poa_code],
+            Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                      first_name: 'Firstname', last_name: 'Lastname',
                                                      phone: '555-555-5555')
 
@@ -510,7 +510,7 @@ describe 'PowerOfAttorney',
           end
 
           before do |example|
-            Veteran::Service::Representative.new(representative_id: '67890',
+            Veteran::Service::Representative.new(representative_id: '999999999999',
                                                  poa_codes: [poa_code],
                                                  first_name: 'Firstname',
                                                  last_name: 'Lastname',
@@ -679,7 +679,7 @@ describe 'PowerOfAttorney',
 
           before do |example|
             Veteran::Service::Organization.create!(poa: poa_code)
-            Veteran::Service::Representative.create!(representative_id: '67890', poa_codes: [poa_code],
+            Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [poa_code],
                                                      first_name: 'Firstname', last_name: 'Lastname',
                                                      phone: '555-555-5555')
 

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -352,7 +352,8 @@ describe 'PowerOfAttorney',
             Veteran::Service::Organization.create!(poa: organization_poa_code,
                                                    name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS",
                                                    phone: '555-555-5555')
-            Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
+            Veteran::Service::Representative.create!(representative_id: '999999999999',
+                                                     poa_codes: [organization_poa_code],
                                                      first_name: 'Firstname', last_name: 'Lastname',
                                                      phone: '555-555-5555')
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates documentation examples to use a value of "999999999999" for registrationNumber attribute of 2122 and 2122a submissions, as well as corresponding validate calls.
- Updates tests where appropriate to accommodate value change.

## Related issue(s)

-[API-35595](https://jira.devops.va.gov/browse/API-35595)

## Testing done

- [x] *New code is covered by unit tests*
- Confirmed locally that documentation examples for affected endpoints reflect the update value for registrationNumber

## Screenshots
![Screenshot 2024-04-23 at 3 48 13 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/95487885/b4605a85-e13a-4250-804b-4688318e1f71)

## What areas of the site does it impact?
526 documentation.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

