### PR TITLE
Avoid pulling from all remote manifest branches

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -70,6 +70,7 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           fetch-depth: 1
           path: vsp-infra-application-manifests
+          ref: refs/heads/main
 
       - name: Update vets-api image and version name in Manifest repo for parent helm
         env:


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Avoid pulling from all remote manifest branches.