### PR TITLE
#79804 [10-10EZR]: Add auth-only feature flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -77,6 +77,10 @@ features:
     actor_type: user
     description: Enables Toxic Exposure questions for 10-10EZR applicants.
     enable_in_development: true
+  ezr_auth_only_enabled:
+    actor_type: user
+    description: Enables the auth-only experience, allowing only authenticated users to view any part of the form.
+    enable_in_development: true
   cerner_override_653:
     actor_type: user
     description: This will show the Cerner facility 653 as `isCerner`.


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- Adds a feature toggle for the auth-only view of the 10-10EZR form.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79804

## What areas of the site does it impact?
- The 10-10EZR form

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
