### PR TITLE
[CST] Ensure that EVSS doc upload files have extensions that matches their contents

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1246,7 +1246,7 @@ spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb @departmen
 spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
+spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/benefits-management-tools-be  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/retrieve_claims_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/update_claim_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/export_breaker_status_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -222,9 +222,9 @@ app/models/education_benefits_claim.rb @department-of-veterans-affairs/my-educat
 app/models/education_benefits_submission.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/education_stem_automated_decision.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/eligible_data_class.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/evss_claim_document.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/evss_claim_document.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/evss_claim.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/evss_claims_sync_status_tracker.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/evss_claims_sync_status_tracker.rb @department-of-veterans-affairs/benefits-management-tools-be @depart@department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/expiry_scanner.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/external_services_redis/status.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/facilities @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1246,7 +1246,7 @@ spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb @departmen
 spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/retrieve_claims_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/update_claim_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/export_breaker_status_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1527,7 +1527,7 @@ spec/requests/csrf_request_spec.rb @department-of-veterans-affairs/octo-identity
 spec/requests/debts_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/requests/decision_review_evidences_request_spec.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/disability_compensation_form_request_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/requests/documents_spec.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/requests/documents_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/education_benefits_claims_request_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/evss_claims_async_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/evss_claims_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,7 +224,7 @@ app/models/education_stem_automated_decision.rb @department-of-veterans-affairs/
 app/models/eligible_data_class.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/evss_claim_document.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/evss_claim.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/evss_claims_sync_status_tracker.rb @department-of-veterans-affairs/benefits-management-tools-be @depart@department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/evss_claims_sync_status_tracker.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/expiry_scanner.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/external_services_redis/status.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/facilities @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1246,7 +1246,7 @@ spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb @departmen
 spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/sidekiq/evss/retrieve_claims_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/update_claim_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/export_breaker_status_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -83,6 +83,8 @@ class EVSSClaimDocument < Common::Base
   private
 
   def content_type_matches_extension?
+    return unless file_obj
+
     true_mime_type = MimeMagic.by_magic(File.open(file_obj.tempfile.path)).to_s
 
     # MimeMagic cannot always determine the mime_type and will sometimes

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -18,6 +18,7 @@ class EVSSClaimDocument < Common::Base
 
   validates(:file_name, presence: true)
   validate :known_document_type?
+  validate :content_type_matches_extension?
   validate :unencrypted_pdf?
   before_validation :normalize_text, :convert_to_unlocked_pdf, :normalize_file_name
 
@@ -80,6 +81,28 @@ class EVSSClaimDocument < Common::Base
   end
 
   private
+
+  def content_type_matches_extension?
+    true_mime_type = MimeMagic.by_magic(File.open(file_obj.tempfile.path)).to_s
+
+    # MimeMagic cannot always determine the mime_type and will sometimes
+    # return ''. In those cases it makes sense to fall back to the content_type
+    # as passed in when the request is made
+    true_mime_type = file_obj.content_type if true_mime_type.empty?
+
+    assumed_mime_type = MimeMagic.by_extension(extension).to_s
+
+    p "Assumed MIME Type: #{assumed_mime_type}"
+    p "True MIME Type: #{true_mime_type}"
+
+    errors.add(:base, I18n.t('errors.messages.uploads.content_type_mismatch')) if true_mime_type != assumed_mime_type
+  end
+
+  def extension
+    # Using file_name instead of file_path because the temp path doesn't include
+    # an extension
+    File.extname(file_name).downcase[1..] # Remove the leading dot
+  end
 
   def known_document_type?
     errors.add(:base, I18n.t('errors.messages.uploads.document_type_unknown')) unless description

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -92,9 +92,6 @@ class EVSSClaimDocument < Common::Base
 
     assumed_mime_type = MimeMagic.by_extension(extension).to_s
 
-    p "Assumed MIME Type: #{assumed_mime_type}"
-    p "True MIME Type: #{true_mime_type}"
-
     errors.add(:base, I18n.t('errors.messages.uploads.content_type_mismatch')) if true_mime_type != assumed_mime_type
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
       # end carrierwave messages
 
       uploads:
-        content_type_mismatch: "We couldn't upload your file because the content doesn’t match the extension."
+        content_type_mismatch: 'We couldn’t upload your file because the content doesn’t match the extension.'
         document_type_unknown: 'We couldn’t upload your file because it’s not a known document type.'
         encrypted: 'We couldn’t upload your PDF because it’s encrypted. Save your file without a password and try uploading it again'
         malformed_pdf: 'We couldn’t upload your PDF because the file is corrupted'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,8 @@ en:
       # end carrierwave messages
 
       uploads:
-        document_type_unknown:  'We couldn’t upload your file because it’s not a known document type.'
+        content_type_mismatch: "We couldn't upload your file because the content doesn’t match the extension."
+        document_type_unknown: 'We couldn’t upload your file because it’s not a known document type.'
         encrypted: 'We couldn’t upload your PDF because it’s encrypted. Save your file without a password and try uploading it again'
         malformed_pdf: 'We couldn’t upload your PDF because the file is corrupted'
         ascii_encoded: "We couldn’t upload your file because we can’t read its characters. Text files must be ASCII-encoded."

--- a/spec/fixtures/files/html.txt
+++ b/spec/fixtures/files/html.txt
@@ -1,0 +1,1 @@
+<html><head></head><body>Fake TXT file</body></html>

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Documents management', type: :request do
       params = { file: tempfile, tracked_item_id:, document_type: }
       post('/v0/evss_claims/189625/documents', params:)
       expect(response.status).to eq(422)
-      expect(JSON.parse(response.body)['errors'][0]['title']).to eq(I18n.t('errors.messages.uploads.malformed_pdf'))
+      expect(JSON.parse(response.body)['errors'].first['title']).to eq(I18n.t('errors.messages.uploads.malformed_pdf'))
     end
   end
 

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe 'Documents management', type: :request do
     expect(args['tracked_item_id']).to be_nil
   end
 
+  context 'when content type and file extension don’t match' do
+    let(:file) { fixture_file_upload('html.txt', 'text/plain') }
+
+    it 'rejects files when the content type and extension don’t match' do
+      params = { file:, tracked_item_id:, document_type: }
+      post('/v0/evss_claims/189625/documents', params:)
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)['errors'].first['title']).to eq(
+        I18n.t('errors.messages.uploads.content_type_mismatch')
+      )
+    end
+  end
+
   context 'with unaccepted file_type' do
     let(:file) { fixture_file_upload('invalid_idme_cert.crt', 'application/x-x509-ca-cert') }
 
@@ -70,7 +83,7 @@ RSpec.describe 'Documents management', type: :request do
       expect(JSON.parse(response.body)['job_id']).to eq(EVSS::DocumentUpload.jobs.first['jid'])
     end
 
-    it 'rejects locked PDFs with the incocorrect password' do
+    it 'rejects locked PDFs with the incorrect password' do
       params = { file: locked_file, tracked_item_id:, document_type:, password: 'bad' }
       post('/v0/evss_claims/189625/documents', params:)
 
@@ -93,7 +106,7 @@ RSpec.describe 'Documents management', type: :request do
       params = { file: tempfile, tracked_item_id:, document_type: }
       post('/v0/evss_claims/189625/documents', params:)
       expect(response.status).to eq(422)
-      expect(JSON.parse(response.body)['errors'].first['title']).to eq(I18n.t('errors.messages.uploads.malformed_pdf'))
+      expect(JSON.parse(response.body)['errors'][0]['title']).to eq(I18n.t('errors.messages.uploads.malformed_pdf'))
     end
   end
 


### PR DESCRIPTION
## Summary
EVSS rejects document uploads where the files extension does not match its contents. An example that we ran into in production was an HTML file that was uploaded with the TXT extension. We don't accept HTML files, so we have hypothesized that the user changed the extension to circumvent that restriction. Also added a new error message indicating that the extension of the file the user is attempting to upload does not match it's contents.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/81549

## Testing done
Added a new spec to test this use case. The fixture I added contains HTML but has the TXT extension, similar to the production case that caused issues originally

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
