### PR TITLE
Updgrade sidekiq and super_diff

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -753,7 +753,7 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     racc (1.7.3-java)
-    rack (2.2.8.1)
+    rack (2.2.9)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-cors (2.0.2)
@@ -962,7 +962,7 @@ GEM
     shrine (3.5.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
-    sidekiq (7.2.2)
+    sidekiq (7.2.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
@@ -998,7 +998,7 @@ GEM
     stringio (3.1.0)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
-    super_diff (0.12.0)
+    super_diff (0.12.1)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION
## Summary

- `sidekiq` 7.2.2 has a vulnerability and needed to be upgraded to 7.2.4
- `super_diff` 0.12.0 got yanked and needed to be upgraded to 0.12.1

## Related Issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81784

## Acceptance Criteria 

- [x] sidekiq is 7.2.4
- [x] super_diff is 0.12.1

