### PR TITLE
updated super_diff: 0.12.0 => 0.12.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -998,7 +998,7 @@ GEM
     stringio (3.1.0)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
-    super_diff (0.12.0)
+    super_diff (0.12.1)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION
needed to bump to super_diff-0.12.1 after switching to new ruby version because super_diff-0.12.0 is no longer available.