### PR TITLE
Change Sidekiq::AttrPackage key to random value

### DIFF
--- a/app/controllers/v0/terms_of_use_agreements_controller.rb
+++ b/app/controllers/v0/terms_of_use_agreements_controller.rb
@@ -24,7 +24,7 @@ module V0
     end
 
     def accept_and_provision
-      terms_of_use_agreement = acceptor(async: false).perform!
+      terms_of_use_agreement = acceptor(sync: true).perform!
       if terms_of_use_agreement.accepted? && provisioner.perform
         create_cerner_cookie
         recache_user unless terms_code_temporary_auth?
@@ -58,12 +58,12 @@ module V0
 
     private
 
-    def acceptor(async: true)
+    def acceptor(sync: false)
       TermsOfUse::Acceptor.new(
         user_account: @user_account,
         common_name:,
         version: params[:version],
-        async:
+        sync:
       )
     end
 

--- a/app/services/terms_of_use/acceptor.rb
+++ b/app/services/terms_of_use/acceptor.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 require 'terms_of_use/exceptions'
+require 'sidekiq/attr_package'
 
 module TermsOfUse
   class Acceptor
     include ActiveModel::Validations
 
-    attr_reader :user_account, :icn, :common_name, :version, :async
+    attr_reader :user_account, :icn, :common_name, :version, :sync
 
     validates :user_account, :icn, :common_name, :version, presence: true
 
-    def initialize(user_account:, common_name:, version:, async: true)
+    def initialize(user_account:, common_name:, version:, sync: false)
       @user_account = user_account
       @common_name = common_name
       @version = version
-      @async = async
+      @sync = sync
       @icn = user_account&.icn
 
       validate!
@@ -23,11 +24,8 @@ module TermsOfUse
     end
 
     def perform!
-      if async
-        asynchronous_update
-      else
-        synchronous_update
-      end
+      terms_of_use_agreement.accepted!
+      update_sign_up_service
 
       Logger.new(terms_of_use_agreement:).perform
 
@@ -42,14 +40,9 @@ module TermsOfUse
       @terms_of_use_agreement ||= user_account.terms_of_use_agreements.new(agreement_version: version)
     end
 
-    def asynchronous_update
-      terms_of_use_agreement.accepted!
-      SignUpServiceUpdaterJob.perform_async(attr_package_key)
-    end
-
-    def synchronous_update
-      terms_of_use_agreement.accepted!
-      SignUpServiceUpdaterJob.new.perform(attr_package_key)
+    def update_sign_up_service
+      Rails.logger.info('[TermsOfUse] [Acceptor] attr_package key', { icn:, attr_package_key: })
+      SignUpServiceUpdaterJob.set(sync:).perform_async(attr_package_key)
     end
 
     def log_and_raise_acceptor_error(error)
@@ -58,7 +51,7 @@ module TermsOfUse
     end
 
     def attr_package_key
-      Sidekiq::AttrPackage.create(icn:, signature_name: common_name, version:, expires_in: 2.days)
+      @attr_package_key ||= Sidekiq::AttrPackage.create(icn:, signature_name: common_name, version:, expires_in: 2.days)
     end
   end
 end

--- a/app/services/terms_of_use/decliner.rb
+++ b/app/services/terms_of_use/decliner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'terms_of_use/exceptions'
+require 'sidekiq/attr_package'
 
 module TermsOfUse
   class Decliner
@@ -38,6 +39,7 @@ module TermsOfUse
     end
 
     def update_sign_up_service
+      Rails.logger.info('[TermsOfUse] [Decliner] attr_package key', { icn:, attr_package_key: })
       SignUpServiceUpdaterJob.perform_async(attr_package_key)
     end
 
@@ -47,7 +49,7 @@ module TermsOfUse
     end
 
     def attr_package_key
-      Sidekiq::AttrPackage.create(icn:, signature_name: common_name, version:, expires_in: 2.days)
+      @attr_package_key ||= Sidekiq::AttrPackage.create(icn:, signature_name: common_name, version:, expires_in: 2.days)
     end
   end
 end

--- a/lib/sidekiq/attr_package.rb
+++ b/lib/sidekiq/attr_package.rb
@@ -11,7 +11,7 @@ module Sidekiq
       # @return [String] the key of the stored attributes
       def create(expires_in: 7.days, **attrs)
         json_attrs = attrs.to_json
-        key = Digest::SHA256.hexdigest(json_attrs)
+        key = SecureRandom.hex(32)
 
         redis.set(key, json_attrs, ex: expires_in)
 

--- a/spec/lib/sidekiq/attr_package_spec.rb
+++ b/spec/lib/sidekiq/attr_package_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe Sidekiq::AttrPackage do
 
   describe '.create' do
     let(:attrs) { { foo: 'bar' } }
-    let(:expected_key) { Digest::SHA256.hexdigest(attrs.to_json) }
+    let(:expected_key) { SecureRandom.hex(32) }
 
     before do
       allow(redis_double).to receive(:set)
+      allow(SecureRandom).to receive(:hex).and_return(expected_key)
     end
 
     context 'when no expiration is provided' do

--- a/spec/services/terms_of_use/decliner_spec.rb
+++ b/spec/services/terms_of_use/decliner_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe TermsOfUse::Decliner, type: :service do
     end
 
     describe '#perform!' do
-      let(:expected_attr_key) do
-        Digest::SHA256.hexdigest({ icn:, signature_name: common_name, version: }.to_json)
-      end
+      let(:expected_attr_key) { SecureRandom.hex(32) }
 
       before do
         allow(TermsOfUse::SignUpServiceUpdaterJob).to receive(:perform_async)
+        allow(SecureRandom).to receive(:hex).and_return(expected_attr_key)
+        allow(Rails.logger).to receive(:info)
       end
 
       it 'creates a new terms of use agreement with the given version' do
@@ -90,6 +90,12 @@ RSpec.describe TermsOfUse::Decliner, type: :service do
       it 'enqueues the SignUpServiceUpdaterJob with expected parameters' do
         decliner.perform!
         expect(TermsOfUse::SignUpServiceUpdaterJob).to have_received(:perform_async).with(expected_attr_key)
+      end
+
+      it 'logs the attr_package key' do
+        decliner.perform!
+        expect(Rails.logger).to have_received(:info).with('[TermsOfUse] [Decliner] attr_package key',
+                                                          { icn:, attr_package_key: expected_attr_key })
       end
     end
   end


### PR DESCRIPTION
## Summary
- Change `Sidekiq::AttrPackage` key to random value to avoid race conditions where 2 jobs from the same user may be running at the same time

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81819

## Testing 
### UpdaterJob
- Accept or decline terms for a user - `localhost:3001/terms-of-use`
- Check sidekiq for enqueued job with hex key as argument - http://localhost:3000/sidekiq/queues/default
- Grab the argument and find the package in rails console
   ```ruby
    Sidekiq::AttrPackage.find(<key>)
   ```
   you should get a hash back with user information


### Sidekiq::AttrPackage
- Open rails console - `rails c`
- Create a package and retrieve the key
   ```ruby
    require 'sidekiq/attr_package'

   Sidekiq::AttrPackage.create(icn: '123498767V234859', signature_name: 'John Doe', version: '1.0.0')
   ```
- Find the package with key
   ```ruby
   Sidekiq::AttrPackage.find("key")
   ```
- The packackeg should still be in redis:
    ```ruby
   Sidekiq::AttrPackage.find("key")
   ```
- Delete the packjage
   ```ruby
   Sidekiq::AttrPackage.delete("key")
   ```

## What areas of the site does it impact?
Sidekiq::AttrPackage

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

