### PR TITLE
Mobile: Protect against calling `.any?` on a non-array

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -99,7 +99,7 @@ module Mobile
       end
 
       def appointment_errors?(failures)
-        failures.any? { |failure| failure[:appointment_errors].present? }
+        Array.wrap(failures).any? { |failure| failure[:appointment_errors].present? }
       end
 
       def filter_by_date_range(appointments)


### PR DESCRIPTION
Summary
A recent change unintentionally caused a lot of errors on prod due to calling `.any?` on a non-array. This pr ensures we always are calling it on an array

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8488

## Testing done
None added

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
