### PR TITLE
Fixing flaky pdf filler specs related to file names

### DIFF
--- a/modules/ivc_champva/spec/services/pdf_filler_spec.rb
+++ b/modules/ivc_champva/spec/services/pdf_filler_spec.rb
@@ -4,28 +4,23 @@ require 'rails_helper'
 require IvcChampva::Engine.root.join('spec', 'spec_helper.rb')
 
 describe IvcChampva::PdfFiller do
-  def self.test_pdf_fill(form_number, test_payload = form_number)
+  %w[vha_10_10d vha_10_7959f_1 vha_10_7959f_2].each do |form_number|
     form_name = form_number.split(Regexp.union(%w[vba_ vha_]))[1].gsub('_', '-')
-    context "when filling the pdf for form #{form_name} given template #{test_payload}" do
+    context "when filling the pdf for form #{form_name} given template #{form_number}" do
+      let(:expected_pdf_path) { "tmp/#{name}-tmp.pdf" }
+      let(:name) { SecureRandom.hex }
+      let(:data) { JSON.parse(File.read("modules/ivc_champva/spec/fixtures/form_json/#{form_number}.json")) }
+      let(:form) { "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
+
+      after { FileUtils.rm_f(expected_pdf_path) }
+
       it 'fills out a PDF from a templated JSON file' do
-        expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
-
-        # remove the pdf if it already exists
-        FileUtils.rm_f(expected_pdf_path)
-
-        # fill the PDF
-        data = JSON.parse(File.read("modules/ivc_champva/spec/fixtures/form_json/#{test_payload}.json"))
-        form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        filler = IvcChampva::PdfFiller.new(form_number:, form:)
-        filler.generate
-        expect(File.exist?(expected_pdf_path)).to eq(true)
+        expect do
+          IvcChampva::PdfFiller.new(form_number:, form:, name:).generate
+        end.to change { File.exist?(expected_pdf_path) }.from(false).to(true)
       end
     end
   end
-
-  test_pdf_fill 'vha_10_10d'
-  test_pdf_fill 'vha_10_7959f_1'
-  test_pdf_fill 'vha_10_7959f_2'
 
   def self.test_json_valid(mapping_file)
     it 'validates json is parseable' do

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -34,32 +34,23 @@ describe SimpleFormsApi::PdfFiller do
 
   describe '#generate' do
     forms.each do |file_name|
-      ActiveRecord::Base.transaction do
-        context "when mapping the pdf data given JSON file: #{file_name}" do
-          let(:expected_pdf_path) { map_pdf_data(file_name) }
+      context "when mapping the pdf data given JSON file: #{file_name}" do
+        let(:form_number) { file_name.gsub('-min', '') }
+        let(:expected_pdf_path) { "tmp/#{name}-tmp.pdf" }
+        let(:data) { JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{file_name}.json")) }
+        let(:form) { "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
+        let(:name) { SecureRandom.hex }
 
-          # remove the pdf if it already exists
-          after { FileUtils.rm_f(expected_pdf_path) }
+        after { FileUtils.rm_f(expected_pdf_path) }
 
-          context 'when a legitimate JSON payload is provided' do
-            it 'properly fills out the associated PDF' do
-              expect(File.exist?(expected_pdf_path)).to eq(true)
-            end
+        context 'when a legitimate JSON payload is provided' do
+          it 'properly fills out the associated PDF' do
+            expect do
+              described_class.new(form_number:, form:, name:).generate
+            end.to change { File.exist?(expected_pdf_path) }.from(false).to(true)
           end
         end
       end
-    end
-
-    def map_pdf_data(file_name)
-      form_number = file_name.gsub('-min', '')
-      expected_pdf_path = "tmp/#{form_number}-tmp.pdf"
-      data = JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{file_name}.json"))
-      form = "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-
-      instance = described_class.new(form_number:, form:)
-      instance.generate
-
-      expected_pdf_path
     end
   end
 


### PR DESCRIPTION
## Summary

- Flaky specs have been related to destroying and creating PDF files that interfere with each other. This properly gives random names to the specs and deletes them at the appropriate time