### PR TITLE
VAOS Revert URL ICN Anonymization 

### DIFF
--- a/modules/vaos/app/exceptions/vaos/exceptions/backend_service_exception.rb
+++ b/modules/vaos/app/exceptions/vaos/exceptions/backend_service_exception.rb
@@ -35,8 +35,7 @@ module VAOS
       def response_values
         {
           detail: detail(@env.body),
-          source: { vamf_url: VAOS::Anonymizers.anonymize_uri_icn(@env.url), vamf_body: @env.body,
-                    vamf_status: @env.status }
+          source: { vamf_url: @env.url, vamf_body: @env.body, vamf_status: @env.status }
         }
       end
 

--- a/modules/vaos/app/helpers/vaos/anonymizers.rb
+++ b/modules/vaos/app/helpers/vaos/anonymizers.rb
@@ -2,27 +2,6 @@
 
 module VAOS
   module Anonymizers
-    # Anonymizes the ICN present in a given URI object by substituting a SHA256 digest for the ICN.
-    # If an ICN is not present in the URL,  it would simply return the original URI.
-    #
-    # @param url [URI] URI in which ICN needs to be anonymized.
-    #
-    # @return [URI] URI with anonymized ICN (If present), original URI otherwise.
-    #
-    def self.anonymize_uri_icn(uri)
-      return nil if uri.nil?
-
-      # Extract the patient ICN from the URL
-      url = uri.to_s
-      match = url[/(\d{10}V\d{6})/]
-
-      return uri unless match
-
-      digest = Digest::SHA256.hexdigest(match)
-      url.gsub!(match, digest)
-      URI(url)
-    end
-
     # Anonymizes the ICNs (Integration Control Number) in a given message. It scans the message for ICNs,
     # which are identified by a specific pattern (\d{10}V\d{6}), and replaces each ICN with
     # a SHA256 digest. If the message is nil, the method returns nil.

--- a/modules/vaos/app/services/vaos/middleware/response/errors.rb
+++ b/modules/vaos/app/services/vaos/middleware/response/errors.rb
@@ -7,8 +7,7 @@ module VAOS
         def on_complete(env)
           return if env.success?
 
-          Sentry.set_extras(vamf_status: env.status, vamf_body: env.response_body,
-                            vamf_url: VAOS::Anonymizers.anonymize_uri_icn(env.url))
+          Sentry.set_extras(vamf_status: env.status, vamf_body: env.response_body, vamf_url: env.url)
           raise VAOS::Exceptions::BackendServiceException, env
         end
       end

--- a/modules/vaos/app/services/vaos/middleware/vaos_logging.rb
+++ b/modules/vaos/app/services/vaos/middleware/vaos_logging.rb
@@ -44,13 +44,12 @@ module VAOS
       private
 
       def log_tags(env, start_time, response_env = nil)
-        anon_uri = VAOS::Anonymizers.anonymize_uri_icn(env.url)
         {
           jti: jti(env),
           status: response_env&.status,
           duration: Time.current - start_time,
           # service_name: service_name || 'VAOS Generic', # Need to figure out a clean way to do this with headers
-          url: "(#{env.method.upcase}) #{anon_uri}"
+          url: "(#{env.method.upcase}) #{env.url}"
         }
       end
 

--- a/modules/vaos/spec/helpers/anonymizers_spec.rb
+++ b/modules/vaos/spec/helpers/anonymizers_spec.rb
@@ -3,23 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe VAOS::Anonymizers do
-  describe '#anonymize_uri_icn' do
-    it 'returns nil if the URI is nil' do
-      expect(subject.anonymize_uri_icn(nil)).to be_nil
-    end
-
-    it 'returns the original URI if the URI does not contain an ICN' do
-      uri = URI.parse('http://example.com')
-      expect(subject.anonymize_uri_icn(uri)).to be(uri)
-    end
-
-    it 'returns a URI with the ICN hashed' do
-      uri = URI.parse('http://example.com/1234567890V123456')
-      anon_uri = URI.parse('http://example.com/441ab560b8fc574c6bf84d6c6105318b79455321a931ef701d39f4ff91894c64')
-      expect(subject.anonymize_uri_icn(uri)).to eql(anon_uri)
-    end
-  end
-
   describe '#anonymize_icns' do
     let(:icn1) { '1234567890V123456' }
     let(:icn2) { '0987654321V654321' }

--- a/modules/vaos/spec/request/v2/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/v2/appointments_request_spec.rb
@@ -679,13 +679,9 @@ RSpec.describe VAOS::V2::AppointmentsController, type: :request, skip_mvi: true 
       context 'when the VAOS service errors on retrieving an appointment' do
         it 'returns a 502 status code' do
           VCR.use_cassette('vaos/v2/appointments/get_appointment_500', match_requests_on: %i[method path query]) do
-            vamf_url = 'https://veteran.apps.va.gov/vaos/v1/patients/' \
-                       'd12672eba61b7e9bc50bb6085a0697133a5fbadf195e6cade452ddaad7921c1d/appointments/00000'
             get '/vaos/v2/appointments/00000'
-            body = JSON.parse(response.body)
             expect(response).to have_http_status(:bad_gateway)
-            expect(body.dig('errors', 0, 'code')).to eq('VAOS_502')
-            expect(body.dig('errors', 0, 'source', 'vamf_url')).to eq(vamf_url)
+            expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_502')
           end
         end
       end

--- a/modules/vaos/spec/services/middleware/vaos_errors_spec.rb
+++ b/modules/vaos/spec/services/middleware/vaos_errors_spec.rb
@@ -18,7 +18,6 @@ describe VAOS::Middleware::Response::Errors do
   }
 
   let(:url) { URI.parse('url') }
-  let(:url_w_icn) { URI.parse('https://veteran.apps.va.gov/id/1234567890V123456') }
   let(:success) { Faraday::Env.new(:get, nil, url, nil, nil, nil, nil, nil, nil, nil, 200, nil, 'response_body') }
   let(:env_400) { Faraday::Env.new(:get, nil, url, nil, nil, nil, nil, nil, nil, nil, 400, nil, 'response_body') }
   let(:env_403) { Faraday::Env.new(:get, nil, url, nil, nil, nil, nil, nil, nil, nil, 403, nil, 'response_body') }
@@ -28,7 +27,6 @@ describe VAOS::Middleware::Response::Errors do
   let(:env_other) { Faraday::Env.new(:get, nil, url, nil, nil, nil, nil, nil, nil, nil, 600, nil, 'response_body') }
   let(:env_with_error) { Faraday::Env.new(:get, nil, url, nil, nil, nil, nil, nil, nil, nil, 400, nil, JSON[error]) }
   let(:env_with_errors) { Faraday::Env.new(:get, nil, url, nil, nil, nil, nil, nil, nil, nil, 400, nil, JSON[errors]) }
-  let(:env_w_icn) { Faraday::Env.new(:get, nil, url_w_icn, nil, nil, nil, nil, nil, nil, nil, 400, nil, JSON[errors]) }
 
   describe 'on complete' do
     context 'with success' do
@@ -133,15 +131,6 @@ describe VAOS::Middleware::Response::Errors do
           expect(e.key).to equal('VAOS_400')
           expect(e.response_values[:detail]).to match('first')
           expect(e.response_values[:detail]).not_to match('second')
-        }
-      end
-
-      it 'hashes the icn in the uri' do
-        expected_uri = URI('https://veteran.apps.va.gov/id/441ab560b8fc574c6bf84d6c6105318b79455321a931ef701d39f4ff91894c64')
-        err = VAOS::Middleware::Response::Errors.new
-
-        expect { err.on_complete(env_w_icn) }.to raise_error(VAOS::Exceptions::BackendServiceException) { |e|
-          expect(e.response_values.dig(:source, :vamf_url)).to eql(expected_uri)
         }
       end
     end

--- a/modules/vaos/spec/services/middleware/vaos_logging_spec.rb
+++ b/modules/vaos/spec/services/middleware/vaos_logging_spec.rb
@@ -22,7 +22,6 @@ describe VAOS::Middleware::VAOSLogging do
   let(:all_other_uris) { 'https://veteran.apps.va.gov/whatever' }
   let(:user_service_refresh_uri) { 'https://veteran.apps.va.gov/user_service_refresh_uri' }
   let(:user_service_uri) { 'https://veteran.apps.va.gov/users/v2/session?processRules=true' }
-  let(:appt_uri) { 'https://veteran.apps.va.gov/vaos/v1/patients/1234567890V123456/appointments' }
 
   before do
     allow(Settings.va_mobile).to receive(:key_path).and_return(fixture_file_path('open_ssl_rsa_private.pem'))
@@ -122,23 +121,6 @@ describe VAOS::Middleware::VAOSLogging do
       expect { client.post(user_service_uri) }.to raise_error(Faraday::TimeoutError)
       expect(Rails.logger).to have_received(:warn).with(rails_log_msg, anything).once
       expect(StatsD).to have_received(:increment).with(statsd_msg, anything).once
-    end
-
-    it 'logs timeout error with hashed URI' do
-      expected_log_tags = {
-        duration: 0.0,
-        jti: 'unknown jti',
-        status: nil,
-        url: '(POST) https://veteran.apps.va.gov/vaos/v1/patients/' \
-             '441ab560b8fc574c6bf84d6c6105318b79455321a931ef701d39f4ff91894c64/appointments'
-      }
-      rails_log_msg = 'VAOS service call failed - timeout'                     
-
-      allow_any_instance_of(Faraday::Adapter).to receive(:call).and_raise(Faraday::TimeoutError)
-      allow(Rails.logger).to receive(:warn).with(rails_log_msg, anything).and_call_original
-
-      expect { client.post(appt_uri) }.to raise_error(Faraday::TimeoutError)
-      expect(Rails.logger).to have_received(:warn).with(rails_log_msg, expected_log_tags).once
     end
   end
 end


### PR DESCRIPTION


## Summary

This reverts [VAOS Mask ICN in URL being logged in DataDog](https://github.com/department-of-veterans-affairs/vets-api/pull/15749). During triage of appointment cancellation errors in staging, the masking of ICNs in URLs was questioned. To eliminate this as a cause, the masking is removed.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/81926

## Testing done

- code was removed along with applicable tests; all other tests still pass.

