### PR TITLE
change endpoint

### DIFF
--- a/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
+++ b/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
@@ -3,7 +3,7 @@
 class Swagger::V1::Requests::IvcChampvaForms
   include Swagger::Blocks
 
-  swagger_path '/v1/ivc_champva_forms/status_updates' do
+  swagger_path '/ivc_champva/v1/forms/status_updates' do
     operation :post do
       extend Swagger::Responses::AuthenticationError
 


### PR DESCRIPTION
## Summary
This PR changes the document endpoint in swagger  from   swagger_path '/v1/ivc_champva_forms/status_updates' to swagger_path '/ivc_champva/v1/forms/status_updates'

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-api/pull/16567
https://github.com/department-of-veterans-affairs/vets-api/pull/16387

<img width="1294" alt="Screenshot 2024-04-30 at 1 53 24 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/99479640/574d5c9a-ea42-4ded-ab78-5ed888d49e2d">

![Uploading Screenshot 2024-04-30 at 8.18.40 AM.png…]()

