### PR TITLE
Add `VeteranOnboarding` model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,17 +132,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (7.2.2)
-      einhorn (~> 1.0)
-      gserver
-      sidekiq (>= 7.2.0, < 8)
-      sidekiq-pro (>= 7.2.0, < 8)
-    sidekiq-pro (7.2.0)
-      sidekiq (>= 7.2.0, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -406,7 +395,6 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -1244,8 +1232,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq (~> 7.2.0)
-  sidekiq-ent!
-  sidekiq-pro!
   sidekiq_alive
   simple_forms_api!
   simplecov

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -375,6 +375,16 @@ class User < Common::RedisStore
     @identity ||= UserIdentity.find(uuid)
   end
 
+  def onboarding
+    if Flipper.enabled?(:veteran_onboarding_beta_flow, self)
+      @onboarding ||= VeteranOnboarding.find_or_create_by(icn: icn)
+    end
+  end
+
+  # VeteranOnboarding attributes & methods
+  delegate :show_onboarding_flow_on_login, to: :onboarding, allow_nil: true
+
+
   def vet360_contact_info
     return nil unless VAProfile::Configuration::SETTINGS.contact_information.enabled && vet360_id.present?
 

--- a/app/models/veteran_onboarding.rb
+++ b/app/models/veteran_onboarding.rb
@@ -1,0 +1,25 @@
+# The VeteranOnboarding model represents the onboarding status of a veteran.
+# Each instance corresponds to a veteran who is in the process of onboarding.
+#
+# == Schema Information
+#
+# Table name: veteran_onboardings
+#
+#  id                      :bigint           not null, primary key
+#  icn                     :integer          not null, unique
+#  display_onboarding_flow :boolean          default(TRUE)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+class VeteranOnboarding < ApplicationRecord
+  # Ensures that ICN is present and unique for each veteran onboarding record
+  validates :icn, presence: true, uniqueness: true
+
+  # Determines whether the onboarding flow should be displayed for a veteran.
+  # Currently, this is based solely on the value of the `display_onboarding_flow` attribute.
+  # In the future, additional information (like MPI info) might be taken into account.
+  def show_onboarding_flow_on_login
+    display_onboarding_flow
+  end
+
+end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1166,6 +1166,9 @@ features:
   va_burial_v2:
     actor_type: user
     description: Allows us to toggle between 21-P530 and 21-P530V2
+  veteran_onboarding_beta_flow:
+    actor_type: user
+    description: Conditionally display the new veteran onboarding flow to user
   show_edu_benefits_1990EZ_Wizard:
     actor_type: user
     description: Navigates user to 1990EZ or 1990 depending on form questions.

--- a/db/migrate/20240430194448_create_veteran_onboardings.rb
+++ b/db/migrate/20240430194448_create_veteran_onboardings.rb
@@ -1,0 +1,12 @@
+class CreateVeteranOnboardings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :veteran_onboardings do |t|
+      t.string :icn
+      t.boolean :display_onboarding_flow, default: true
+
+      t.timestamps
+    end
+
+    add_index :veteran_onboardings, :icn, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_17_130647) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_30_194448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -1268,6 +1268,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_130647) do
     t.datetime "updated_at", null: false
     t.index ["device_id"], name: "index_veteran_device_records_on_device_id"
     t.index ["icn", "device_id"], name: "index_veteran_device_records_on_icn_and_device_id", unique: true
+  end
+
+  create_table "veteran_onboardings", force: :cascade do |t|
+    t.string "icn"
+    t.boolean "display_onboarding_flow", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["icn"], name: "index_veteran_onboardings_on_icn", unique: true
   end
 
   create_table "veteran_organizations", id: false, force: :cascade do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1226,4 +1226,36 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#onboarding - feature toggle enabled' do
+    let(:user) { create(:user, icn: identity_icn) }
+    let(:identity_icn) { 'some_identity_icn' }
+
+    before do
+        Flipper.enable(:veteran_onboarding_beta_flow, user)
+    end
+
+    it 'show_onboarding_flow_on_login returns true when feature flag is enabled and display_onboarding_flow is true' do
+      expect(user.show_onboarding_flow_on_login).to be true
+    end
+
+    it 'show_onboarding_flow_on_login returns false when feature flag is enabled but display_onboarding_flow is false' do
+      user.onboarding.display_onboarding_flow = false
+      expect(user.show_onboarding_flow_on_login).to be false
+    end
+  end
+
+  describe '#onboarding - feature toggle disabled' do
+    let(:user) { create(:user, icn: identity_icn) }
+    let(:identity_icn) { 'some_identity_icn' }
+
+    before do
+        Flipper.disable(:veteran_onboarding_beta_flow)
+    end
+
+    it 'show_onboarding_flow_on_login returns false when feature flag is disabled, even if display_onboarding_flow is true' do
+      expect(user.show_onboarding_flow_on_login).to be_falsey
+    end
+
+  end
 end


### PR DESCRIPTION
## Summary

Following [16573](https://github.com/department-of-veterans-affairs/vets-api/pull/16573), adding a feature toggle, this PR adds a new ActiveRecord model called `VeteranOnboarding` and links it to the `User` model.

The purpose of this model and it's accompanying database migration is to provide us with a place to store the state of a Veteran's Onboarding.  Currently this model is very bare:

|Field Name|Type|Notes|
|-----------|-----|------|
|ID|Integer (primary key)||
|icn|Integer| Refers to a User's ICN|
|display_onboarding_flow|boolean (default `true`)|allow user to dismiss the onboarding flow|

In the future, it is likely that we will add more columns, for example to hold a veteran's place in an onboarding "wizard" when they switch devices, for example.

This work is behind the feature toggle `veteran_onboarding_beta_flow`, and adds an associated `onboarding` attribute to the `User` model.  This will be a long-lived feature toggle as we iterate through the creation of a new Veteran Onboarding process, as well as to A/B test it with user populations in production.

## Related issue(s)

Additional tickets related to this project are located [here](https://github.com/department-of-veterans-affairs/va-iir/labels/Veteran%20Onboarding)

## Testing done

New code is covered by unit tests, both with the flipper on and off.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

With the feature toggle enabled, an `onboarding` attribute is added to the `User` model

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
