### PR TITLE
API-34961 Remove Flipper flag for new PII removal rules in appeals APIs

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -328,9 +328,6 @@ features:
   decision_review_delay_evidence:
     actor_type: user
     description: Ensures that NOD and SC evidence is not received in Central Mail before the appeal itself
-  decision_review_updated_pii_rules:
-    actor_type: user
-    description: Uses udpated rules for when to clear PII from appeals_api records
   dependency_verification:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/pdf_downloads.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/pdf_downloads.rb
@@ -79,7 +79,7 @@ module AppealsApi
     end
 
     def expired?(appeal)
-      appeal.class.pii_expunge_policy.exists?(appeal.id) || appeal.form_data.blank?
+      appeal.class.with_expired_pii.exists?(appeal.id) || appeal.form_data.blank?
     end
 
     def render_pdf_download_not_ready(appeal)

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -21,12 +21,6 @@ module AppealsApi
 
     before_create :assign_metadata, :assign_veteran_icn
 
-    scope :pii_expunge_policy, lambda {
-      timeframe = 7.days.ago
-      v1.where('updated_at < ? AND status IN (?)', timeframe, COMPLETE_STATUSES + ['success'])
-        .or(v2_or_v0.where('updated_at < ? AND status IN (?)', timeframe, COMPLETE_STATUSES))
-    }
-
     scope :stuck_unsubmitted, lambda {
       where('created_at < ? AND status IN (?)', 2.hours.ago, %w[pending submitting])
     }

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -22,15 +22,6 @@ module AppealsApi
     before_create :assign_metadata, :assign_veteran_icn
     before_update :submit_evidence_to_central_mail!, if: -> { status_changed_to_success? && delay_evidence_enabled? }
 
-    scope :pii_expunge_policy, lambda {
-      where(
-        status: COMPLETE_STATUSES
-      ).and(
-        where('updated_at < ? AND board_review_option IN (?)', 1.week.ago, %w[hearing direct_review])
-        .or(where('updated_at < ? AND board_review_option IN (?)', 91.days.ago, 'evidence_submission'))
-      )
-    }
-
     scope :stuck_unsubmitted, lambda {
       where('created_at < ? AND status IN (?)', 2.hours.ago, %w[pending submitting])
     }

--- a/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
+++ b/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
@@ -27,10 +27,6 @@ module AppealsApi
       nil
     end
 
-    scope :pii_expunge_policy, lambda {
-      where('updated_at < ? AND status IN (?)', 7.days.ago, COMPLETE_STATUSES)
-    }
-
     scope :stuck_unsubmitted, lambda {
       where('created_at < ? AND status IN (?)', 2.hours.ago, %w[pending submitting])
     }

--- a/modules/appeals_api/app/services/appeals_api/remove_pii.rb
+++ b/modules/appeals_api/app/services/appeals_api/remove_pii.rb
@@ -50,13 +50,7 @@ module AppealsApi
     end
 
     def records_to_be_expunged
-      @records_to_be_expunged ||= if Flipper.enabled?(:decision_review_updated_pii_rules)
-                                    form_type.with_expired_pii
-                                  else
-                                    form_type.where.not(form_data_ciphertext: nil)
-                                             .or(form_type.where.not(auth_headers_ciphertext: nil))
-                                             .pii_expunge_policy
-                                  end
+      @records_to_be_expunged ||= form_type.with_expired_pii
     end
   end
 end

--- a/modules/appeals_api/spec/services/appeals_api/remove_pii_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/remove_pii_spec.rb
@@ -125,175 +125,56 @@ shared_examples 'removes expired PII' do
 end
 
 describe AppealsApi::RemovePii do
-  describe '#run! with new PII rules' do
-    context 'with Higher-Level Review' do
-      let(:v2_factory) { :higher_level_review_v2 }
-      let(:v0_factory) { :higher_level_review_v0 }
-      let(:form_type) { AppealsApi::HigherLevelReview }
+  context 'with Higher-Level Review' do
+    let(:v2_factory) { :higher_level_review_v2 }
+    let(:v0_factory) { :higher_level_review_v0 }
+    let(:form_type) { AppealsApi::HigherLevelReview }
 
-      include_examples 'removes expired PII'
-    end
-
-    context 'with Supplemental Claim' do
-      let(:v2_factory) { :supplemental_claim }
-      let(:v0_factory) { :supplemental_claim_v0 }
-      let(:form_type) { AppealsApi::SupplementalClaim }
-
-      include_examples 'removes expired PII'
-    end
-
-    context 'with Notice of Disagreement' do
-      let(:v2_factory) { :notice_of_disagreement_v2 }
-      let(:v0_factory) { :notice_of_disagreement_v0 }
-      let(:form_type) { AppealsApi::NoticeOfDisagreement }
-
-      include_examples 'removes expired PII'
-    end
+    include_examples 'removes expired PII'
   end
 
-  describe '#run!' do
-    before { Flipper.disable :decision_review_updated_pii_rules }
+  context 'with Supplemental Claim' do
+    let(:v2_factory) { :supplemental_claim }
+    let(:v0_factory) { :supplemental_claim_v0 }
+    let(:form_type) { AppealsApi::SupplementalClaim }
 
-    it 'raises an ArgumentError if an invalid form type is supplied' do
-      expect { AppealsApi::RemovePii.new(form_type: 'Invalid').run! }.to raise_error(ArgumentError)
-    end
+    include_examples 'removes expired PII'
+  end
 
-    context 'when the removal fails' do
-      let!(:appeals) do
-        Timecop.freeze(100.days.ago) do
-          status = 'complete'
-          [create(:supplemental_claim, status:), create(:supplemental_claim_v0, status:)]
-        end
-      end
+  context 'with Notice of Disagreement' do
+    let(:v2_factory) { :notice_of_disagreement_v2 }
+    let(:v0_factory) { :notice_of_disagreement_v0 }
+    let(:form_type) { AppealsApi::NoticeOfDisagreement }
 
-      before do
-        instance = AppealsApi::RemovePii.new(form_type: AppealsApi::SupplementalClaim)
-        msg = 'Failed to remove expired AppealsApi::SupplementalClaim PII from records'
-        expect(Rails.logger).to receive(:error).with(msg, appeals.map(&:id))
-        expect_any_instance_of(AppealsApi::Slack::Messager).to receive(:notify!)
-        allow(instance).to receive(:remove_pii!).and_return []
-        instance.run!
-      end
+    include_examples 'removes expired PII'
+  end
 
-      it 'logs an error and the IDs of records whose PII failed to be removed' do
-        appeals.each do |appeal|
-          appeal.reload
-          expect(appeal.auth_headers).to be_present
-          expect(appeal.form_data).to be_present
-        end
+  it 'raises an ArgumentError if an invalid form type is supplied' do
+    expect { AppealsApi::RemovePii.new(form_type: 'Invalid').run! }.to raise_error(ArgumentError)
+  end
+
+  context 'when the removal fails' do
+    let!(:appeals) do
+      Timecop.freeze(100.days.ago) do
+        status = 'complete'
+        [create(:supplemental_claim, status:), create(:supplemental_claim_v0, status:)]
       end
     end
 
-    it 'removes PII from HLR records needing PII removal' do
-      day_old_has_pii_v2 = create :higher_level_review_v2, status: 'complete'
-      day_old_has_pii_v2.update updated_at: 1.day.ago
-
-      week_old_has_pii_v2 = create :higher_level_review_v2, status: 'complete'
-      week_old_has_pii_v2_incomplete = create :higher_level_review_v2, status: 'success' # Former V1 final status
-      week_old_has_pii_v2_error = create :higher_level_review_v2, status: 'error'
-
-      week_old_has_pii_v2.update updated_at: 8.days.ago
-      week_old_has_pii_v2_incomplete.update updated_at: 8.days.ago
-      week_old_has_pii_v2_error.update updated_at: 8.days.ago
-
-      expect(day_old_has_pii_v2.form_data_ciphertext).to be_present
-      expect(week_old_has_pii_v2.form_data_ciphertext).to be_present
-      expect(week_old_has_pii_v2_incomplete.form_data_ciphertext).to be_present
-      expect(week_old_has_pii_v2_error.form_data_ciphertext).to be_present
-
-      AppealsApi::RemovePii.new(form_type: AppealsApi::HigherLevelReview).run!
-
-      expect(day_old_has_pii_v2.reload.form_data_ciphertext).to be_present
-      expect(week_old_has_pii_v2.reload.form_data_ciphertext).to be_nil
-      expect(week_old_has_pii_v2_incomplete.reload.form_data_ciphertext).to be_present
-      expect(week_old_has_pii_v2_error.reload.form_data_ciphertext).to be_present
+    before do
+      instance = AppealsApi::RemovePii.new(form_type: AppealsApi::SupplementalClaim)
+      msg = 'Failed to remove expired AppealsApi::SupplementalClaim PII from records'
+      expect(Rails.logger).to receive(:error).with(msg, appeals.map(&:id))
+      expect_any_instance_of(AppealsApi::Slack::Messager).to receive(:notify!)
+      allow(instance).to receive(:remove_pii!).and_return []
+      instance.run!
     end
 
-    it 'removes PII from SC records needing PII removal' do
-      day_old_has_pii = create :supplemental_claim, status: 'complete'
-      day_old_has_pii.update updated_at: 1.day.ago
-
-      week_old_has_pii = create :supplemental_claim, status: 'complete'
-      week_old_has_pii.update updated_at: 8.days.ago
-
-      week_old_has_pii_error = create :supplemental_claim, status: 'error'
-      week_old_has_pii_error.update updated_at: 8.days.ago
-
-      expect(day_old_has_pii.form_data_ciphertext).to be_present
-      expect(week_old_has_pii.form_data_ciphertext).to be_present
-      expect(week_old_has_pii_error.form_data_ciphertext).to be_present
-
-      AppealsApi::RemovePii.new(form_type: AppealsApi::SupplementalClaim).run!
-
-      expect(day_old_has_pii.reload.form_data_ciphertext).to be_present
-      expect(week_old_has_pii.reload.form_data_ciphertext).to be_nil
-      expect(week_old_has_pii_error.reload.form_data_ciphertext).to be_present
-    end
-
-    describe 'removes PII from NODs at the correct times for the different lanes' do
-      it 'evidence_submission' do
-        week_old_has_pii = create :notice_of_disagreement, status: 'complete',
-                                                           board_review_option: 'evidence_submission'
-        ninety_day_old_has_pii = create :notice_of_disagreement, status: 'complete',
-                                                                 board_review_option: 'evidence_submission'
-        ninety_two_day_old_has_pii = create :notice_of_disagreement, status: 'complete',
-                                                                     board_review_option: 'evidence_submission'
-        ninety_two_day_old_has_pii_error = create :notice_of_disagreement, status: 'error',
-                                                                           board_review_option: 'evidence_submission'
-        week_old_has_pii.update(updated_at: 7.days.ago)
-        ninety_day_old_has_pii.update(updated_at: 90.days.ago)
-        ninety_two_day_old_has_pii.update(updated_at: 92.days.ago)
-        ninety_two_day_old_has_pii_error.update(updated_at: 92.days.ago)
-
-        expect(week_old_has_pii.form_data_ciphertext).to be_present
-        expect(ninety_day_old_has_pii.form_data_ciphertext).to be_present
-        expect(ninety_two_day_old_has_pii.form_data_ciphertext).to be_present
-        expect(ninety_two_day_old_has_pii_error.form_data_ciphertext).to be_present
-
-        AppealsApi::RemovePii.new(form_type: AppealsApi::NoticeOfDisagreement).run!
-
-        expect(week_old_has_pii.reload.form_data_ciphertext).to be_present
-        expect(ninety_day_old_has_pii.reload.form_data_ciphertext).to be_present
-        expect(ninety_two_day_old_has_pii.reload.form_data_ciphertext).to be_nil
-        expect(ninety_two_day_old_has_pii_error.reload.form_data_ciphertext).to be_present
-      end
-
-      it 'direct_review' do
-        one_day_old = create :notice_of_disagreement, status: 'complete', board_review_option: 'direct_review'
-        week_old_has_pii = create :notice_of_disagreement, status: 'complete', board_review_option: 'direct_review'
-        week_old_has_pii_error = create :notice_of_disagreement, status: 'error', board_review_option: 'direct_review'
-        one_day_old.update(updated_at: 1.day.ago)
-        week_old_has_pii.update(updated_at: 8.days.ago)
-        week_old_has_pii_error.update(updated_at: 8.days.ago)
-
-        expect(one_day_old.form_data_ciphertext).to be_present
-        expect(week_old_has_pii.form_data_ciphertext).to be_present
-        expect(week_old_has_pii_error.form_data_ciphertext).to be_present
-
-        AppealsApi::RemovePii.new(form_type: AppealsApi::NoticeOfDisagreement).run!
-
-        expect(one_day_old.reload.form_data_ciphertext).to be_present
-        expect(week_old_has_pii.reload.form_data_ciphertext).to be_nil
-        expect(week_old_has_pii_error.reload.form_data_ciphertext).to be_present
-      end
-
-      it 'hearing' do
-        one_day_old = create :notice_of_disagreement, status: 'complete', board_review_option: 'hearing'
-        week_old_has_pii = create :notice_of_disagreement, status: 'complete', board_review_option: 'hearing'
-        week_old_has_pii_error = create :notice_of_disagreement, status: 'error', board_review_option: 'hearing'
-        one_day_old.update(updated_at: 1.day.ago)
-        week_old_has_pii.update(updated_at: 8.days.ago)
-        week_old_has_pii_error.update(updated_at: 8.days.ago)
-
-        expect(one_day_old.form_data_ciphertext).to be_present
-        expect(week_old_has_pii.form_data_ciphertext).to be_present
-        expect(week_old_has_pii_error.form_data_ciphertext).to be_present
-
-        AppealsApi::RemovePii.new(form_type: AppealsApi::NoticeOfDisagreement).run!
-
-        expect(one_day_old.reload.form_data_ciphertext).to be_present
-        expect(week_old_has_pii.reload.form_data_ciphertext).to be_nil
-        expect(week_old_has_pii_error.reload.form_data_ciphertext).to be_present
+    it 'logs an error and the IDs of records whose PII failed to be removed' do
+      appeals.each do |appeal|
+        appeal.reload
+        expect(appeal.auth_headers).to be_present
+        expect(appeal.form_data).to be_present
       end
     end
   end


### PR DESCRIPTION
## Summary

- Removes the `decision_review_updated_pii_rules` flag, and instead usees the new rules all the time
- These rules have been in use for several weeks, and records in production look like they're being cleared correctly
- This also allows for the removal of the old `pii_expunge_policy` scopes on appeal models
- I'll be making one more PR to remove the `decision_review_*_pii_expunge_enabled` flags so that PII is always expunged, but I skipped it in this PR for two reasons:
  1. This may be enough to review on its own, and
  2. Once we remove those last flags, it's questionable whether the appeal-specific sidekiq jobs need to exist anymore - their whole functionality was to check those appeal-specific flags and call `RemovePii.run` with the appropriate arguments. IMO we should consolidate them into a single job, but there are valid arguments against that, too - I'll bring it up in standup.

## Related issue(s)

- [API-34961](https://jira.devops.va.gov/browse/API-34961)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
- Decision Reviews v2, plus unreleased APIs for Higher-Level Reviews, Notice of Disagreements, and Supplemental Claims

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


