### PR TITLE
VAOS Removed Masking of ICNs in Appointment Response Failure Details

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -534,7 +534,7 @@ module VAOS
       # @return [nil]
       #
       def log_partial_errors(response)
-        return unless response&.status == 200
+        return unless response.status == 200
 
         failures_dup = response.body[:failures].deep_dup
         failures_dup.each do |failure|

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -520,22 +520,33 @@ module VAOS
       def partial_errors(response)
         return { failures: [] } if response.body[:failures].blank?
 
-        response.body[:failures].each do |failure|
-          detail = failure[:detail]
-          failure[:detail] = VAOS::Anonymizers.anonymize_icns(detail) if detail.present?
-        end
-
-        if response.status == 200
-          log_message_to_sentry(
-            'VAOS::V2::AppointmentService#get_appointments has response errors.',
-            :info,
-            failures: response.body[:failures].to_json
-          )
-        end
+        log_partial_errors(response)
 
         {
           failures: response.body[:failures]
         }
+      end
+
+      # Logs partial errors from a response.
+      #
+      # @param response [Faraday::Env] The response object containing the status and body.
+      #
+      # @return [nil]
+      #
+      def log_partial_errors(response)
+        return unless response&.status == 200
+
+        failures_dup = response.body[:failures].deep_dup
+        failures_dup.each do |failure|
+          detail = failure[:detail]
+          failure[:detail] = VAOS::Anonymizers.anonymize_icns(detail) if detail.present?
+        end
+
+        log_message_to_sentry(
+          'VAOS::V2::AppointmentService#get_appointments has response errors.',
+          :info,
+          failures: failures_dup.to_json
+        )
       end
 
       def appointments_base_path

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -281,11 +281,28 @@ describe VAOS::V2::AppointmentsService do
     end
 
     context 'when partial success is returned and failures are returned with ICNs' do
-      it 'anonymizes the ICNs' do
+      it 'does not anonymizes the ICNs in the response' do
         VCR.use_cassette('vaos/v2/appointments/get_appointments_200_with_facilities_200_and_log_data',
                          match_requests_on: %i[method path query]) do
           response = subject.get_appointments(start_date3, end_date3)
-          expect(response.dig(:meta, :failures).to_json).not_to match(/\d{10}V\d{6}/)
+          expect(response.dig(:meta, :failures).to_json).to match(/\d{10}V\d{6}/)
+        end
+      end
+
+      it 'logs the failures and anonymizes the ICNs sent to the log' do
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_200_with_facilities_200_and_log_data',
+                         match_requests_on: %i[method path query]) do
+          expected_msg = 'VAOS::V2::AppointmentService#get_appointments has response errors. : ' \
+                         '{:failures=>"[{\\"system\\":\\"VSP\\",\\"status\\":\\"500\\",\\"code\\":10000,\\"' \
+                         'message\\":\\"Could not fetch appointments from Vista Scheduling Provider\\",\\"' \
+                         'detail\\":\\"icn=d12672eba61b7e9bc50bb6085a0697133a5fbadf195e6cade452ddaad7921c1d, ' \
+                         'startDate=2022-04-01T19:25Z, endDate=2023-03-01T19:45Z\\"}]"}'
+
+          allow(Rails.logger).to receive(:info)
+
+          subject.get_appointments(start_date3, end_date3)
+
+          expect(Rails.logger).to have_received(:info).with(expected_msg)
         end
       end
     end


### PR DESCRIPTION
## Summary

The code previously anonymized (masked) ICNs before sending the failure details, both in the response and logs. With this commit, ICNs are no longer anonymized in the response, but are still anonymized in the log entries for the failures. The partial failures are processed using a new method, log_partial_errors. The purpose of these changes is to provide complete failure details in ICNs response while maintaining the ICN anonymization within the logs

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/81903

## Testing done

- Modified existing tests and added new tests to check logging.

