### PR TITLE
Update ri docker-compose web volumes 

### DIFF
--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -20,8 +20,8 @@ x-app: &common
   restart: unless-stopped
   volumes:
     - "../vets-api-mockdata:/cache"
-    - ../.secret:/app/secret:cached
-    - ../.pki:/app/pki:cached
+    - ../.secret:/srv/vets-api/secret:cached
+    - ../.pki:/srv/vets-api/pki:cached
     - shared-vol:/tmp
   working_dir: /app
   depends_on:


### PR DESCRIPTION
## Summary

- Switch back RI volume map to srv/vets-api
- This was causing errors with the settings from the devops repo [link](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/roles/review-instance-configure/vars/settings.local.yml)
- This was prevent log in via id.me on RIs

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82033

## Testing done

- [ ] Testing on RI

## Acceptance Criteria 

- [x] Users can log in via id.me option 