### PR TITLE
Remove Ruby version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source 'https://rubygems.org'
 
-ruby '~> 3.2.4'
-
 # Modules
 path 'modules' do
   gem 'accredited_representative_portal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1283,8 +1283,5 @@ DEPENDENCIES
   with_advisory_lock
   yard
 
-RUBY VERSION
-   ruby 3.2.4p170
-
 BUNDLED WITH
    2.4.9


### PR DESCRIPTION
Per https://github.com/rails/rails/issues/51089, I'm removing Ruby from the Gemfile as it's unnecessary. Our local versions of Ruby will read from `.ruby-version` and our deployed environments will build from our Dockerfile.
