### PR TITLE
fix array

### DIFF
--- a/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
+++ b/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
@@ -28,7 +28,7 @@ class Swagger::V1::Requests::IvcChampvaForms
               key :type, :string
               key :description, 'List of file names associated with the form'
             end
-            key :example, ['12345678-1234-5678-1234-567812345678_vha_7959F1.pdf', '12345678-1234-5678-1234-567812345678_vha_7959F2.pdf']
+            key :example, ['12345678-1234_vha_7959F1.pdf', '12345678-1234_vha_7959F2.pdf']
           end
           property :status do
             key :type, :string

--- a/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
+++ b/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
@@ -26,9 +26,9 @@ class Swagger::V1::Requests::IvcChampvaForms
             key :type, :array
             items do
               key :type, :string
-              key :example, ['12345678-1234-5678_vha_10_10d-tmp.pdf', '12345678-1234-5678_vha10_10d_2-tmp.pdf']
               key :description, 'List of file names associated with the form'
             end
+            key :example, ['12345678-1234-5678-1234-567812345678_vha_7959F1.pdf', '12345678-1234-5678-1234-567812345678_vha_7959F2.pdf']
           end
           property :status do
             key :type, :string


### PR DESCRIPTION

## Summary

This PR changes fixes the nest array issue for filenames.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-api/pull/16567
https://github.com/department-of-veterans-affairs/vets-api/pull/16387
https://github.com/department-of-veterans-affairs/vets-api/pull/16580


## Screenshots
<img width="1155" alt="Screenshot 2024-05-01 at 2 01 43 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/99479640/5beb85db-37ae-4142-83c5-30e1e5e448e7">

