### PR TITLE
[DBX-82100] patch logging and cleanup on 4142 job

### DIFF
--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -123,22 +123,24 @@ module CentralMail
       CentralMail::Service.new.upload(processor.request_body)
     end
 
-    def upload_to_lighthouse
-      @lighthouse_service = BenefitsIntakeService::Service.new(with_upload_location: true)
+    def lighthouse_service
+      @lighthouse_service ||= BenefitsIntakeService::Service.new(with_upload_location: true)
+    end
 
+    def upload_to_lighthouse
       Rails.logger.info(
         'Successful Form4142 Submission to Lighthouse',
-        { benefits_intake_uuid: @lighthouse_service.uuid, submission_id: submission.id }
+        { benefits_intake_uuid: lighthouse_service.uuid, submission_id: @submission_id }
       )
 
       payload = {
-        upload_url: @lighthouse_service.location,
+        upload_url: lighthouse_service.location,
         file: { file: @pdf_path, file_name: @pdf_path.split('/').last },
         metadata: generate_metadata.to_json,
         attachments: []
       }
 
-      @lighthouse_service.upload_doc(**payload)
+      lighthouse_service.upload_doc(**payload)
     end
 
     def generate_metadata

--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -102,7 +102,7 @@ module CentralMail
       retryable_error_handler(e)
       raise e
     ensure
-      File.delete(@pdf_path) if @pdf_path.present?
+      File.delete(@pdf_path) if File.exist?(@pdf_path.to_s)
     end
 
     private
@@ -126,14 +126,20 @@ module CentralMail
     def upload_to_lighthouse
       @lighthouse_service = BenefitsIntakeService::Service.new(with_upload_location: true)
 
+      metadata = generate_metadata
       payload = {
         upload_url: @lighthouse_service.location,
         file: { file: @pdf_path, file_name: @pdf_path.split('/').last },
-        metadata: generate_metadata.to_json,
-        attachments: [] # [ wipn8923 ] TODO: is this better than nil?
+        metadata: metadata.to_json,
+        attachments: []
       }
 
-      @lighthouse_service.upload_doc(**payload)
+      response = @lighthouse_service.upload_doc(**payload)
+      Rails.logger.info(
+        'Successful Form4142 Submission to Lighthouse',
+        { benefits_intake_uuid: @lighthouse_service.uuid, submission_id: submission.id }
+      )
+      response
     end
 
     def generate_metadata
@@ -147,7 +153,7 @@ module CentralMail
         'source' => 'Form526Submission va.gov',
         'docType' => '4142',
         'businessLine' => '',
-        'fileNumber' => filenumber # wipn8923 TODO: validate that this is correct
+        'fileNumber' => filenumber
       }
 
       SimpleFormsApiSubmission::MetadataValidator

--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -126,11 +126,10 @@ module CentralMail
     def upload_to_lighthouse
       @lighthouse_service = BenefitsIntakeService::Service.new(with_upload_location: true)
 
-      metadata = generate_metadata
       payload = {
         upload_url: @lighthouse_service.location,
         file: { file: @pdf_path, file_name: @pdf_path.split('/').last },
-        metadata: metadata.to_json,
+        metadata: generate_metadata.to_json,
         attachments: []
       }
 

--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -126,6 +126,11 @@ module CentralMail
     def upload_to_lighthouse
       @lighthouse_service = BenefitsIntakeService::Service.new(with_upload_location: true)
 
+      Rails.logger.info(
+        'Successful Form4142 Submission to Lighthouse',
+        { benefits_intake_uuid: @lighthouse_service.uuid, submission_id: submission.id }
+      )
+
       payload = {
         upload_url: @lighthouse_service.location,
         file: { file: @pdf_path, file_name: @pdf_path.split('/').last },
@@ -133,12 +138,7 @@ module CentralMail
         attachments: []
       }
 
-      response = @lighthouse_service.upload_doc(**payload)
-      Rails.logger.info(
-        'Successful Form4142 Submission to Lighthouse',
-        { benefits_intake_uuid: @lighthouse_service.uuid, submission_id: submission.id }
-      )
-      response
+      @lighthouse_service.upload_doc(**payload)
     end
 
     def generate_metadata


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Fix a logical bug with file deletion in the legacy 4142 job
- Add logging of the filenumber for visibility

## Related issue(s)

- [Ticket for the original implementation](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/74810)
- [Ticket for this follow up work](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/82100)

## Testing done

- [x] *New code is covered by unit tests*
- `File.delete(@pdf_path) if @pdf_path.present?` fails when the the `@pdf_path` string is present, but the file has already been deleted (the new Lighthouse implementation handles the deletion of this file).  The new logic checks for file presence
- The new code has been tested line by line in a console
- Not a new flipper, but the logging exists behind a existing flipper
- testing plan is to roll out an monitor logs and check for file delivery (using the new filenumber log) 

## What areas of the site does it impact?
Form 4142 submission (as ancillary to 526)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation) N/a
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature N/a
