### PR TITLE
API-35575: Drop `vba_documents_git_items` Table

### DIFF
--- a/db/migrate/20240502151751_drop_vba_documents_git_items.rb
+++ b/db/migrate/20240502151751_drop_vba_documents_git_items.rb
@@ -1,0 +1,5 @@
+class DropVBADocumentsGitItems < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :vba_documents_git_items, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_01_183550) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_02_151751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -1220,17 +1220,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_01_183550) do
     t.datetime "updated_at", null: false
     t.index ["user_account_id", "form_id"], name: "index_in_progress_reminders_sent_user_account_form_id", unique: true
     t.index ["user_account_id"], name: "index_va_notify_in_progress_reminders_sent_on_user_account_id"
-  end
-
-  create_table "vba_documents_git_items", force: :cascade do |t|
-    t.string "url", null: false
-    t.jsonb "git_item"
-    t.boolean "notified", default: false
-    t.string "label"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["notified", "label"], name: "index_vba_documents_git_items_on_notified_and_label"
-    t.index ["url"], name: "index_vba_documents_git_items_on_url", unique: true
   end
 
   create_table "vba_documents_monthly_stats", force: :cascade do |t|


### PR DESCRIPTION
## Summary
The `vba_documents_git_items` table was used from 4/15/2021 to 5/25/2022 to store information about PRs opened for the Benefits Intake API and Forms API. Once the data was entered into the table, it was used to notify the team who owned the Benefits Intake API and Forms API at the time about production deploys that included their changes.

The table and feature were originally added in #6557. The feature was later replaced by Slack integrations with GitHub, and all usages of the table were removed in #11141. The data itself provides no value anymore, and so the table can be safely removed in its entirety.

My team (Lighthouse Team Banana Peels) owns the `vba_documents` module.

## Related issue(s)
- [API-35575](https://jira.devops.va.gov/browse/API-35575)

## Testing done
Ensured that the data migration ran successfully locally and that the schema file was updated correctly.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `vba_documents` module only.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
