### PR TITLE
Simple Forms: Pull pdf upload out into a service

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require 'ddtrace'
-require 'simple_forms_api_submission/service'
 require 'simple_forms_api_submission/metadata_validator'
-require 'simple_forms_api_submission/s3'
 require 'lgy/service'
 
 module SimpleFormsApi
@@ -112,7 +110,8 @@ module SimpleFormsApi
         parsed_form_data = JSON.parse(params.to_json)
         file_path, metadata, form = get_file_paths_and_metadata(parsed_form_data)
 
-        status, confirmation_number = upload_pdf_to_benefits_intake(file_path, metadata, form_id)
+        status, confirmation_number = SimpleFormsApi::PdfUploader.new(file_path, metadata,
+                                                                      form_id).upload_to_benefits_intake(params)
         form.track_user_identity(confirmation_number)
 
         Rails.logger.info(
@@ -145,43 +144,6 @@ module SimpleFormsApi
         form.handle_attachments(file_path) if %w[vba_40_0247 vba_20_10207 vba_40_10007].include? form_id
 
         [file_path, metadata, form]
-      end
-
-      def get_upload_location_and_uuid(lighthouse_service, form_id)
-        upload_location = lighthouse_service.get_upload_location.body
-        if form_id == 'vba_40_10007'
-          uuid = upload_location.dig('data', 'id')
-          SimpleFormsApi::PdfStamper.stamp4010007_uuid(uuid)
-        end
-        {
-          uuid: upload_location.dig('data', 'id'),
-          location: upload_location.dig('data', 'attributes', 'location')
-        }
-      end
-
-      def upload_pdf_to_benefits_intake(file_path, metadata, form_id)
-        lighthouse_service = SimpleFormsApiSubmission::Service.new
-        uuid_and_location = get_upload_location_and_uuid(lighthouse_service, form_id)
-        form_submission = FormSubmission.create(
-          form_type: params[:form_number],
-          benefits_intake_uuid: uuid_and_location[:uuid],
-          form_data: params.to_json,
-          user_account: @current_user&.user_account
-        )
-        FormSubmissionAttempt.create(form_submission:)
-
-        Datadog::Tracing.active_trace&.set_tag('uuid', uuid_and_location[:uuid])
-        Rails.logger.info(
-          'Simple forms api - preparing to upload PDF to benefits intake',
-          { location: uuid_and_location[:location], uuid: uuid_and_location[:uuid] }
-        )
-        response = lighthouse_service.upload_doc(
-          upload_url: uuid_and_location[:location],
-          file: file_path,
-          metadata: metadata.to_json
-        )
-
-        [response.status, uuid_and_location[:uuid]]
       end
 
       def form_is210966

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simple_forms_api_submission/service'
 
 module SimpleFormsApi

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
@@ -1,0 +1,52 @@
+require 'simple_forms_api_submission/service'
+
+module SimpleFormsApi
+  class PdfUploader
+    attr_reader :file_path, :metadata, :form_id
+
+    def initialize(file_path, metadata, form_id)
+      @file_path = file_path
+      @metadata = metadata
+      @form_id = form_id
+    end
+
+    def upload_to_benefits_intake(params)
+      lighthouse_service = SimpleFormsApiSubmission::Service.new
+      uuid_and_location = get_upload_location_and_uuid(lighthouse_service, form_id)
+      form_submission = FormSubmission.create(
+        form_type: params[:form_number],
+        benefits_intake_uuid: uuid_and_location[:uuid],
+        form_data: params.to_json,
+        user_account: @current_user&.user_account
+      )
+      FormSubmissionAttempt.create(form_submission:)
+
+      Datadog::Tracing.active_trace&.set_tag('uuid', uuid_and_location[:uuid])
+      Rails.logger.info(
+        'Simple forms api - preparing to upload PDF to benefits intake',
+        { location: uuid_and_location[:location], uuid: uuid_and_location[:uuid] }
+      )
+      response = lighthouse_service.upload_doc(
+        upload_url: uuid_and_location[:location],
+        file: file_path,
+        metadata: metadata.to_json
+      )
+
+      [response.status, uuid_and_location[:uuid]]
+    end
+
+    private
+
+    def get_upload_location_and_uuid(lighthouse_service, form_id)
+      upload_location = lighthouse_service.get_upload_location.body
+      if form_id == 'vba_40_10007'
+        uuid = upload_location.dig('data', 'id')
+        SimpleFormsApi::PdfStamper.stamp4010007_uuid(uuid)
+      end
+      {
+        uuid: upload_location.dig('data', 'id'),
+        location: upload_location.dig('data', 'attributes', 'location')
+      }
+    end
+  end
+end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -516,8 +516,8 @@ RSpec.describe 'Forms uploader', type: :request do
 
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
-        allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf_to_benefits_intake).and_return([200, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([200, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -536,8 +536,8 @@ RSpec.describe 'Forms uploader', type: :request do
 
       it 'unsuccessful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
-        allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf_to_benefits_intake).and_return([500, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([500, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -557,8 +557,8 @@ RSpec.describe 'Forms uploader', type: :request do
 
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
-        allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf_to_benefits_intake).and_return([200, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([200, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -577,8 +577,8 @@ RSpec.describe 'Forms uploader', type: :request do
 
       it 'unsuccessful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
-        allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf_to_benefits_intake).and_return([500, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([500, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -604,11 +604,8 @@ RSpec.describe 'Forms uploader', type: :request do
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        allow_any_instance_of(
-          SimpleFormsApi::V1::UploadsController
-        ).to receive(
-          :upload_pdf_to_benefits_intake
-        ).and_return([200, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([200, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -628,11 +625,8 @@ RSpec.describe 'Forms uploader', type: :request do
       it 'unsuccessful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        allow_any_instance_of(
-          SimpleFormsApi::V1::UploadsController
-        ).to receive(
-          :upload_pdf_to_benefits_intake
-        ).and_return([500, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([500, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -652,8 +646,8 @@ RSpec.describe 'Forms uploader', type: :request do
 
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
-        allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf_to_benefits_intake).and_return([200, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([200, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -672,8 +666,8 @@ RSpec.describe 'Forms uploader', type: :request do
 
       it 'unsuccessful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
-        allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf_to_benefits_intake).and_return([500, confirmation_number])
+        allow_any_instance_of(SimpleFormsApi::PdfUploader)
+          .to receive(:upload_to_benefits_intake).and_return([500, confirmation_number])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 

--- a/modules/simple_forms_api/spec/services/pdf_uploader_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_uploader_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+require 'simple_forms_api_submission/service'
+
+describe SimpleFormsApi::PdfUploader do
+  describe '#upload_to_benefits_intake' do
+    it 'returns the status and uuid from Lighthouse' do
+      file_path = '/some-path'
+      metadata = { 'meta' => 'data' }
+      form_id = '12-3456'
+      expected_status = 200
+      expected_uuid = 'some-uuid'
+      lighthouse_service = double
+      upload_location = double
+      body = { 'data' => { 'id' => expected_uuid } }
+      params = { form_number: form_id }
+      expected_response = double(status: expected_status)
+      allow(upload_location).to receive(:body).and_return body
+      allow(lighthouse_service).to receive(:get_upload_location).and_return upload_location
+      allow(lighthouse_service).to receive(:upload_doc).and_return expected_response
+      allow(SimpleFormsApiSubmission::Service).to receive(:new).and_return lighthouse_service
+
+      pdf_uploader = SimpleFormsApi::PdfUploader.new(file_path, metadata, form_id)
+
+      expect(pdf_uploader.upload_to_benefits_intake(params)).to eq [expected_status, expected_uuid]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This refactor PR is in anticipation of needing to upload PDFs directly from the front end for the upcoming **Form Upload** functionality. For that functionality we'll want to bypass the PDF filling and stamping and submit directly to the Benefits Intake API.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1257

## Testing done
New test written and passing.
