### PR TITLE
DBEX/81611: return parsable submitted_claim_id from the form526 submit job in the lighthouse pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -888,7 +888,7 @@ lib/lgy/configuration.rb @department-of-veterans-affairs/benefits-non-disability
 lib/lgy/service.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse @department-of-veterans-affairs/backend-review-group
-lib/lighthouse/benefit_claims @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/benefits-management-tools-be
+lib/lighthouse/benefit_claims @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/benefits_intake @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1358,7 +1358,7 @@ spec/lib/json_schema @department-of-veterans-affairs/va-api-engineers @departmen
 spec/lib/lgy @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/auth @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/benefits_claims  @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/benefits-management-tools-be
+spec/lib/lighthouse/benefits_claims @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_documents @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_documents/service_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_intake @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -888,7 +888,7 @@ lib/lgy/configuration.rb @department-of-veterans-affairs/benefits-non-disability
 lib/lgy/service.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse @department-of-veterans-affairs/backend-review-group
-lib/lighthouse/benefit_claims @department-of-veterans-affairs/disability-experience
+lib/lighthouse/benefit_claims @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/disability-experience
 lib/lighthouse/benefits_intake @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -888,7 +888,7 @@ lib/lgy/configuration.rb @department-of-veterans-affairs/benefits-non-disability
 lib/lgy/service.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse @department-of-veterans-affairs/backend-review-group
-lib/lighthouse/benefit_claims @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/lighthouse/benefit_claims @department-of-veterans-affairs/disability-experience
 lib/lighthouse/benefits_intake @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1358,7 +1358,7 @@ spec/lib/json_schema @department-of-veterans-affairs/va-api-engineers @departmen
 spec/lib/lgy @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/auth @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/benefits_claims @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/lighthouse/benefits_claims  @department-of-veterans-affairs/disability-experience
 spec/lib/lighthouse/benefits_documents @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_documents/service_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_intake @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -888,7 +888,7 @@ lib/lgy/configuration.rb @department-of-veterans-affairs/benefits-non-disability
 lib/lgy/service.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse @department-of-veterans-affairs/backend-review-group
-lib/lighthouse/benefit_claims @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/disability-experience
+lib/lighthouse/benefit_claims @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/benefits-management-tools-be
 lib/lighthouse/benefits_intake @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1358,7 +1358,7 @@ spec/lib/json_schema @department-of-veterans-affairs/va-api-engineers @departmen
 spec/lib/lgy @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/auth @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/benefits_claims  @department-of-veterans-affairs/disability-experience
+spec/lib/lighthouse/benefits_claims  @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/benefits-management-tools-be
 spec/lib/lighthouse/benefits_documents @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_documents/service_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_intake @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -116,10 +116,12 @@ module EVSS
                          service = BenefitsClaims::Service.new(icn)
                          raw_response = service.submit526(body)
                          # 4. convert LH raw response to a FormSubmitResponse for further processing (claim_id, status)
-                         # JSON.parse when it matters to get the claim id (response_json = JSON.parse(raw_response.body))
+                         # JSON.parse when it matters to get the claim id
+                         # something like response_json = JSON.parse(raw_response.body)
                          raw_response_struct = OpenStruct.new({
                                                                 # TODO: for now, set claim id to unix time stamp.
-                                                                # When the lighthouse synchronous submit response is ready,
+                                                                # When the lighthouse synchronous
+                                                                # submit response is ready,
                                                                 # switch to VBMS claim id.
                                                                 body: { claim_id: Time.now.to_i },
                                                                 status: raw_response.status

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -116,8 +116,12 @@ module EVSS
                          service = BenefitsClaims::Service.new(icn)
                          raw_response = service.submit526(body)
                          # 4. convert LH raw response to a FormSubmitResponse for further processing (claim_id, status)
+                         # JSON.parse when it matters to get the claim id (response_json = JSON.parse(raw_response.body))
                          raw_response_struct = OpenStruct.new({
-                                                                body: { claim_id: raw_response.body },
+                                                                # TODO: for now, set claim id to unix time stamp.
+                                                                # When the lighthouse synchronous submit response is ready,
+                                                                # switch to VBMS claim id.
+                                                                body: { claim_id: Time.now.to_i },
                                                                 status: raw_response.status
                                                               })
                          EVSS::DisabilityCompensationForm::FormSubmitResponse

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -132,11 +132,9 @@ module BenefitsClaims
       # Since Lighthouse needs 'currentVaEmployee', the following workaround renames it.
       fix_current_va_employee(body)
 
-      json_body = remove_unicode_characters(body)
-
       response = config.post(
         path,
-        json_body,
+        body,
         lighthouse_client_id, lighthouse_rsa_key_path, options
       )
 
@@ -154,17 +152,6 @@ module BenefitsClaims
           attributes: body
         }
       }.as_json.deep_transform_keys { |k| k.camelize(:lower) }
-    end
-
-    # this gsubbing is to fix an issue where the service that generates the 526PDF was failing due to
-    # unicoded carriage returns:
-    # i.e.: \n was throwing: "U+000A ('controlLF') is not available in the font Helvetica, encoding: WinAnsiEncoding"
-    def remove_unicode_characters(body)
-      body.to_json
-          .gsub('\\n', ' ')
-          .gsub('\\r', ' ')
-          .gsub('\\\\n', ' ')
-          .gsub('\\\\r', ' ')
     end
 
     def fix_current_va_employee(body)

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -171,11 +171,8 @@ module BenefitsClaims
     def remove_empty_confinements(body)
       if body.dig('data', 'attributes', 'serviceInformation')&.select do |field|
         field['confinements']
-      end&.key?('confinements')
-        if body['data']['attributes']['serviceInformation']['confinements'].nil? ||
-          body['data']['attributes']['serviceInformation']['confinements'].empty?
-          body['data']['attributes']['serviceInformation'].delete('confinements')
-        end
+      end&.key?('confinements') && body['data']['attributes']['serviceInformation']['confinements'].blank?
+        body['data']['attributes']['serviceInformation'].delete('confinements')
       end
     end
 

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -132,6 +132,10 @@ module BenefitsClaims
       # Since Lighthouse needs 'currentVaEmployee', the following workaround renames it.
       fix_current_va_employee(body)
 
+      # LH PDF generator service crashes with having an empty array for confinements
+      # removes confinements from the request body if confinements  attribute empty or nil
+      remove_empty_confinements(body)
+
       response = config.post(
         path,
         body,
@@ -161,6 +165,17 @@ module BenefitsClaims
         body['data']['attributes']['veteranIdentification']['currentVaEmployee'] =
           body['data']['attributes']['veteranIdentification']['currentVAEmployee']
         body['data']['attributes']['veteranIdentification'].delete('currentVAEmployee')
+      end
+    end
+
+    def remove_empty_confinements(body)
+      if body.dig('data', 'attributes', 'serviceInformation')&.select do |field|
+        field['confinements']
+      end&.key?('confinements')
+        if body['data']['attributes']['serviceInformation']['confinements'].nil? ||
+          body['data']['attributes']['serviceInformation']['confinements'].empty?
+          body['data']['attributes']['serviceInformation'].delete('confinements')
+        end
       end
     end
 

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe BenefitsClaims::Service do
           VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
             response = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
             response_json = JSON.parse(response)
-            expect(response_json["data"]["id"]).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+            expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
           end
         end
 
@@ -90,7 +90,7 @@ RSpec.describe BenefitsClaims::Service do
           VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
             response = @service.submit526({}, '', '', { body_only: true })
             response_json = JSON.parse(response)
-            expect(response_json["data"]["id"]).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+            expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
           end
         end
 
@@ -98,7 +98,7 @@ RSpec.describe BenefitsClaims::Service do
           VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
             body = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
             response_json = JSON.parse(body)
-            expect(response_json["data"]["id"]).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+            expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
           end
         end
 
@@ -108,7 +108,7 @@ RSpec.describe BenefitsClaims::Service do
             # TODO: re-visit claim_id value when VBMS id is returned synchronously from Lighthouse
             claim_id = Time.now.to_i
             raw_response_struct = OpenStruct.new({
-                                                   body: { claim_id: claim_id },
+                                                   body: { claim_id: },
                                                    status: raw_response.status
                                                  })
             response = EVSS::DisabilityCompensationForm::FormSubmitResponse

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -81,36 +81,41 @@ RSpec.describe BenefitsClaims::Service do
         it 'when given a full request body, posts to the Lighthouse API' do
           VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
             response = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
-            expect(response).to eq('1234567890')
+            response_json = JSON.parse(response)
+            expect(response_json["data"]["id"]).to eq('46285849-9d82-4001-8572-2323d521eb8c')
           end
         end
 
         it 'when given a only the form data in the request body, posts to the Lighthouse API' do
           VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
             response = @service.submit526({}, '', '', { body_only: true })
-            expect(response).to eq('1234567890')
+            response_json = JSON.parse(response)
+            expect(response_json["data"]["id"]).to eq('46285849-9d82-4001-8572-2323d521eb8c')
           end
         end
 
         it 'returns only the response body' do
           VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
             body = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
-            expect(body).to eq('1234567890')
+            response_json = JSON.parse(body)
+            expect(response_json["data"]["id"]).to eq('46285849-9d82-4001-8572-2323d521eb8c')
           end
         end
 
         it 'returns the whole response' do
           VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
             raw_response = @service.submit526({}, '', '', { body_only: false })
+            # TODO: re-visit claim_id value when VBMS id is returned synchronously from Lighthouse
+            claim_id = Time.now.to_i
             raw_response_struct = OpenStruct.new({
-                                                   body: { claim_id: raw_response.body },
+                                                   body: { claim_id: claim_id },
                                                    status: raw_response.status
                                                  })
             response = EVSS::DisabilityCompensationForm::FormSubmitResponse
                        .new(raw_response_struct.status, raw_response_struct)
 
             expect(response.status).to eq(200)
-            expect(response.claim_id).to eq(1_234_567_890)
+            expect(response.claim_id).to eq(claim_id)
           end
         end
 

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -413,7 +413,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           expect { described_class.drain }.not_to change(backup_klass.jobs, :size)
           expect(Form526JobStatus.last.status).to eq Form526JobStatus::STATUS[:success]
           submission.reload
-          expect(submission.submitted_claim_id).to eq(1_234_567_890)
+          # TODO: re-visit when using lighthouse synchronous response endpoint
+          expect(submission.submitted_claim_id).to eq(Form526JobStatus.last.submission.submitted_claim_id)
         end
       end
     end

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/submit526/200_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/submit526/200_response.yml
@@ -80,6 +80,6 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '1234567890'
+      string: '{"data":{"id": "46285849-9d82-4001-8572-2323d521eb8c"}}'
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- `disability_compensation_lighthouse_submit_migration`
- do not turn on the above flag. ever.

## Related issue(s)

- #81611

## Testing done

- [x] *New code is covered by unit tests*
- Return a parsable id from the lighthouse pipeline for the job status controller to consume
- meant to be a placeholder for testing in `staging`. do not turn on in `production`
- enables "e2e" testing from vets-website -> vets-api -> lighthouse -> VBMS

## Screenshots
n/a

## What areas of the site does it impact?
- preparing for form526 submission migration to lighthouse pipeline

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
