### PR TITLE
[FSR] 68302 - Adding expense feature flag api

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -452,6 +452,10 @@ features:
     actor_type: user
     description: Points to debts-api module routes
     enable_in_development: true
+  financial_status_report_expenses_update:
+    actor_type: user
+    description: Update expense lists in the Financial Status Report (FSR - 5655) form
+    enable_in_development: true
   financial_status_report_streamlined_waiver:
     actor_type: user
     description: Enables streamlined waiver flow for qualifying users completing the Financial Status Report (FSR) form


### PR DESCRIPTION
## Summary
Including feature toggle for new expense feature flag 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#68302

- [vets-api PR 29563](https://github.com/department-of-veterans-affairs/vets-website/pull/29563)

## Testing done

- [x] Feature is showing locally when running on `http://localhost:3000/flipper/features/financial_status_report_expenses_update`


## What areas of the site does it impact?
Feature flags
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
