### PR TITLE
API-35476-add-restricted-scope

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
@@ -28,6 +28,9 @@ module ClaimsApi
         before_action only: %i[generate_pdf] do
           permit_scopes(%w[system/526-pdf.override], actions: [:generate_pdf])
         end
+        before_action only: %i[synchronous] do
+          permit_scopes(%w[system/526.override], actions: [:synchronous])
+        end
 
         def submit
           auto_claim = ClaimsApi::AutoEstablishedClaim.create(

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -3984,7 +3984,7 @@ RSpec.describe 'Disability Claims', type: :request do
   describe 'POST #synchronous' do
     let(:veteran_id) { '1012832025V743496' }
     let(:synchronous_path) { "/services/claims/v2/veterans/#{veteran_id}/526/synchronous" }
-    let(:synchronous_scopes) { %w[system/526.override] }
+    let(:synchronous_scopes) { %w[system/526.override system/claim.write] }
     let(:invalid_scopes) { %w[system/526-pdf.override] }
 
     context 'submission to synchronous' do

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -3984,13 +3984,29 @@ RSpec.describe 'Disability Claims', type: :request do
   describe 'POST #synchronous' do
     let(:veteran_id) { '1012832025V743496' }
     let(:synchronous_path) { "/services/claims/v2/veterans/#{veteran_id}/526/synchronous" }
+    let(:synchronous_scopes) { %w[system/526.override] }
+    let(:invalid_scopes) { %w[system/526-pdf.override] }
 
-    context 'when the endpoint is hit' do
+    context 'submission to synchronous' do
       it 'returns an empty test object' do
-        mock_ccg(scopes) do |auth_header|
+        mock_ccg_for_fine_grained_scope(synchronous_scopes) do |auth_header|
           post synchronous_path, params: {}.to_json, headers: auth_header
 
           expect(JSON.parse(response.body)).to eq({})
+        end
+      end
+
+      it 'returns a 200 response when successful' do
+        mock_ccg_for_fine_grained_scope(synchronous_scopes) do |auth_header|
+          post synchronous_path, params: {}.to_json, headers: auth_header
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      it 'returns a 401 unauthorized with incorrect scopes' do
+        mock_ccg_for_fine_grained_scope(invalid_scopes) do |auth_header|
+          post synchronous_path, params: {}.to_json, headers: auth_header
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end


### PR DESCRIPTION
## Summary

- Adds fine grained scopes to synchronous endpoint. 
- Adds tests.

## Related issue(s)

- [API-35476](https://jira.devops.va.gov/browse/API-35476)

## Testing done

- [X] *New code is covered by unit tests*
- Postman
- rspec

*** Don't forget to add `system/526.override` to however you generate your ccg tokens

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
	modified:   modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature