### PR TITLE
update-rx-breakers

### DIFF
--- a/lib/rx/configuration.rb
+++ b/lib/rx/configuration.rb
@@ -97,5 +97,9 @@ module Rx
         conn.adapter :typhoeus
       end
     end
+
+    def breakers_error_threshold
+      80 # breakers will be tripped if error rate reaches 80% over a two minute period.
+    end
   end
 end

--- a/spec/requests/breakers_integration_spec.rb
+++ b/spec/requests/breakers_integration_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe 'breakers', type: :request do
 
       stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', '{"message":"ack"}', status_code: 500)
       stub_varx_request(:get, 'mhv-api/patient/v1/prescription/getactiverx', '{"message":"ack"}', status_code: 500)
-      20.times do
+      80.times do
         response = get '/v0/prescriptions'
+        puts response
         expect(response).to eq(400)
       end
 
@@ -58,6 +59,7 @@ RSpec.describe 'breakers', type: :request do
       end.to trigger_statsd_increment('api.external_http_request.Rx.skipped', times: 1, value: 1)
 
       response = get '/v0/prescriptions'
+      puts response
       expect(response).to eq(503)
 
       Timecop.freeze(now)

--- a/spec/requests/breakers_integration_spec.rb
+++ b/spec/requests/breakers_integration_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe 'breakers', type: :request do
       stub_varx_request(:get, 'mhv-api/patient/v1/prescription/getactiverx', '{"message":"ack"}', status_code: 500)
       80.times do
         response = get '/v0/prescriptions'
-        puts response
         expect(response).to eq(400)
       end
 
@@ -59,7 +58,6 @@ RSpec.describe 'breakers', type: :request do
       end.to trigger_statsd_increment('api.external_http_request.Rx.skipped', times: 1, value: 1)
 
       response = get '/v0/prescriptions'
-      puts response
       expect(response).to eq(503)
 
       Timecop.freeze(now)


### PR DESCRIPTION
## Summary

This PR is to address issues we've seen where breakers are being tripped too often for the Rx API.

## Related issue(s)

No tickets created, this was a result of continuous alerts from datadog monitors.

## Testing done

- Updated spec tests
- Unable to test without tripping the breakers

## Screenshots
None

## What areas of the site does it impact?
VA.gov Rx and Rx mobile teams

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
