### PR TITLE
Add ScannedFormUploadsController

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -3,8 +3,6 @@
 module SimpleFormsApi
   module V1
     class ScannedFormUploadsController < ApplicationController
-      # skip_before_action :authenticate
-
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
 

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SimpleFormsApi
+  module V1
+    class ScannedFormUploadsController < ApplicationController
+      # skip_before_action :authenticate
+
+      def submit
+        Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
+
+        confirmation_code = params[:confirmation_code]
+        attachment = PersistentAttachment.find_by(guid: confirmation_code)
+        file_path = attachment.to_pdf.to_s
+        raw_metadata = {
+          'veteranFirstName' => @current_user.first_name,
+          'veteranLastName' => @current_user.last_name,
+          'fileNumber' => @current_user.ssn,
+          'zipCode' => @current_user.address[:postal_code],
+          'source' => 'VA Platform Digital Forms',
+          'docType' => params[:form_number],
+          'businessLine' => 'CMP'
+        }
+        metadata = SimpleFormsApiSubmission::MetadataValidator.validate(raw_metadata)
+
+        status, confirmation_number = SimpleFormsApi::PdfUploader.new(file_path, metadata,
+                                                                      params[:form_number]).upload_to_benefits_intake(params)
+
+        render json: { confirmation_number:, status: }
+      end
+
+      def upload_scanned_form
+        attachment = PersistentAttachments::MilitaryRecords.new(form_id: params['formId'])
+        attachment.file = params['file']
+        raise Common::Exceptions::ValidationErrors, attachment unless attachment.valid?
+
+        attachment.save
+        render json: attachment
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -22,8 +22,11 @@ module SimpleFormsApi
         }
         metadata = SimpleFormsApiSubmission::MetadataValidator.validate(raw_metadata)
 
-        status, confirmation_number = SimpleFormsApi::PdfUploader.new(file_path, metadata,
-                                                                      params[:form_number]).upload_to_benefits_intake(params)
+        status, confirmation_number = SimpleFormsApi::PdfUploader.new(
+          file_path,
+          metadata,
+          params[:form_number]
+        ).upload_to_benefits_intake(params)
 
         render json: { confirmation_number:, status: }
       end

--- a/modules/simple_forms_api/config/routes.rb
+++ b/modules/simple_forms_api/config/routes.rb
@@ -5,5 +5,8 @@ SimpleFormsApi::Engine.routes.draw do
     post '/simple_forms', to: 'uploads#submit'
     post '/simple_forms/submit_supporting_documents', to: 'uploads#submit_supporting_documents'
     get '/simple_forms/get_intents_to_file', to: 'uploads#get_intents_to_file'
+
+    post '/submit_scanned_form', to: 'scanned_form_uploads#submit'
+    post '/scanned_form_upload', to: 'scanned_form_uploads#upload_scanned_form'
   end
 end

--- a/modules/simple_forms_api/spec/requests/v1/scanned_form_uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/scanned_form_uploads_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'simple_forms_api_submission/metadata_validator'
+require 'common/file_helpers'
+
+RSpec.describe 'Scanned forms uploader', type: :request do
+  before do
+    sign_in
+  end
+
+  describe '#submit' do
+    let(:metadata_file) { "#{file_seed}.SimpleFormsApi.metadata.json" }
+    let(:file_seed) { 'tmp/some-unique-simple-forms-file-seed' }
+    let(:random_string) { 'some-unique-simple-forms-file-seed' }
+
+    before do
+      VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
+      VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
+      allow(Common::FileHelpers).to receive(:random_file_path).and_return(file_seed)
+      allow(Common::FileHelpers).to receive(:generate_temp_file).and_wrap_original do |original_method, *args|
+        original_method.call(args[0], random_string)
+      end
+    end
+
+    after do
+      VCR.eject_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
+      VCR.eject_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
+      Common::FileHelpers.delete_file_if_exists(metadata_file)
+    end
+
+    it 'makes the request' do
+      pdf_path = Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf')
+      confirmation_code = 'a-random-guid'
+      attachment = double
+      allow(attachment).to receive(:to_pdf).and_return(pdf_path)
+      expect(PersistentAttachment).to receive(:find_by).with(guid: confirmation_code).and_return(attachment)
+
+      post '/simple_forms_api/v1/submit_scanned_form', params: { form_number: '21-0779', confirmation_code: }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#upload_scanned_form' do
+    it 'renders the attachment as json' do
+      clamscan = double(safe?: true)
+      allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+      file = fixture_file_upload('doctors-note.gif')
+
+      params = { form_id: '21-0779', file: }
+
+      expect do
+        post '/simple_forms_api/v1/scanned_form_upload', params:
+      end.to change(PersistentAttachment, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      resp = JSON.parse(response.body)
+      expect(resp['data']['attributes'].keys.sort).to eq(%w[confirmation_code name size])
+      expect(PersistentAttachment.last).to be_a(PersistentAttachments::MilitaryRecords)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds a new controller to the Simple Forms API: the ScannedFormUploadsController. This controller is meant to handle Form Upload, where the user can directly upload a PDF and this controller will pass it along to the Benefits Intake API.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1277

## Testing done
Tests have been written for both actions.
