### PR TITLE
Remove Health Enrollment TERA feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -63,9 +63,6 @@ features:
   hca_sigi_enabled:
     actor_type: user
     description: Enables Self-Identifying Gender Identity question for health care applicants.
-  hca_tera_enabled:
-    actor_type: user
-    description: Enables Toxic Exposure questions for health care applicants.
   hca_use_facilities_API:
     actor_type: user
     description: Allow list of medical care facilites to be fetched by way of the Facilities API.


### PR DESCRIPTION
## Summary

With the Toxic Exposure questions reaching a maturity of 60+ days in the Health Care Application, it is safe to remove the feature toggle that was activate these questions. This PR removes the reference to the feature flag, along with cleaning up a few extra remnants of the feature reference.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81972

## Acceptance criteria

- Application is free of logic that restricts access to the Toxic Exposure questions

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution