### PR TITLE
[82120] Adding hashed device secret to oauth sessions for sis token exchange flow

### DIFF
--- a/db/migrate/20240502210842_add_device_secret_hash_to_oauth_sessions.rb
+++ b/db/migrate/20240502210842_add_device_secret_hash_to_oauth_sessions.rb
@@ -1,0 +1,8 @@
+class AddDeviceSecretHashToOAuthSessions < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :oauth_sessions, :hashed_device_secret, :string, null: true
+    add_index :oauth_sessions, :hashed_device_secret, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -915,7 +915,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_06_214134) do
     t.string "client_id", null: false
     t.text "user_attributes_ciphertext"
     t.text "encrypted_kms_key"
+    t.string "hashed_device_secret"
     t.index ["handle"], name: "index_oauth_sessions_on_handle", unique: true
+    t.index ["hashed_device_secret"], name: "index_oauth_sessions_on_hashed_device_secret"
     t.index ["hashed_refresh_token"], name: "index_oauth_sessions_on_hashed_refresh_token", unique: true
     t.index ["refresh_creation"], name: "index_oauth_sessions_on_refresh_creation"
     t.index ["refresh_expiration"], name: "index_oauth_sessions_on_refresh_expiration"


### PR DESCRIPTION

## Summary

- This PR is the schema changes necessary to enable a device secret to be utilized in the Sign in Service authentication flows. This is specifically used for a token exchange functionality

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82120

## Testing done

- [ ] confirm migration runs
- [ ] confirm migration can be rolled back

## What areas of the site does it impact?
- Authentication