### PR TITLE
DBEX: add toxic_exposure boolean to form526_submissions

### DIFF
--- a/db/migrate/20240507174646_add_toxic_exposure_to_form526_submissions.rb
+++ b/db/migrate/20240507174646_add_toxic_exposure_to_form526_submissions.rb
@@ -1,0 +1,5 @@
+class AddToxicExposureToForm526Submissions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :form526_submissions, :toxic_exposure, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_06_214134) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_07_174646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -695,6 +695,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_06_214134) do
     t.uuid "user_account_id"
     t.string "backup_submitted_claim_id", comment: "*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.This column will be nil for all submissions where a backup submission is not generated.It will have the central mail id for submissions where a backup submission is submitted."
     t.string "aasm_state", default: "unprocessed"
+    t.boolean "toxic_exposure", default: false
     t.index ["saved_claim_id"], name: "index_form526_submissions_on_saved_claim_id", unique: true
     t.index ["submitted_claim_id"], name: "index_form526_submissions_on_submitted_claim_id", unique: true
     t.index ["user_account_id"], name: "index_form526_submissions_on_user_account_id"


### PR DESCRIPTION
Adds a `toxic_exposure` column to the `form526_submissions` table, with boolean data type and default value of false. Select Veterans will be provided with the opportunity to claim conditions related to toxic exposure when completing a new version of the form. This attribute will be used to indicate whether a disability compensation claim contains the Toxic Exposure section, which will aid in determining how the claim should be submitted.

## Summary

- *This work is behind a feature toggle (flipper): ~YES~/NO*
  - but it will be leveraged in conjunction with the `disability_526_toxic_exposure` Flipper
- A subsequent PR will set the value of the `toxic_exposure` attribute when a`Form526Submission` record is created, based on an indicator in the metadata of an `InProgressForm` that signifies that form includes a Toxic Exposure section.
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- [81830](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/81830)

## Testing done

- Nothing to test

## What areas of the site does it impact?

- Form 526EZ

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
