### PR TITLE
Send phone fields and email in payload for 26-4555

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -119,6 +119,9 @@ module SimpleFormsApi
           last: full_name['last']&.[](0..29),
           suffix: full_name['suffix']
         },
+        homePhone: data.dig('veteran', 'home_phone'),
+        mobilePhone: data.dig('veteran', 'mobile_phone'),
+        email: data.dig('veteran', 'email'),
         dateOfBirth: data.dig('veteran', 'date_of_birth')
       }
     end


### PR DESCRIPTION
## Summary
This PR adds a few fields that had been previously missing to the payload for 26-4555. We send this payload back to SAHSHA. I'll handle the `location` part of this separately (if at all) because we're already sending those fields along.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1290
