### PR TITLE
82585 Log some non-pii copay statement metadata

### DIFF
--- a/app/services/medical_copays/vbs/service.rb
+++ b/app/services/medical_copays/vbs/service.rb
@@ -92,8 +92,7 @@ module MedicalCopays
       end
 
       def send_statement_notifications(statements_json_byte)
-        # pausing until further notice
-        # CopayNotifications::ParseNewStatementsJob.perform_async(statements_json_byte)
+        CopayNotifications::ParseNewStatementsJob.perform_async(statements_json_byte)
       end
 
       def settings

--- a/app/sidekiq/copay_notifications/new_statement_notification_job.rb
+++ b/app/sidekiq/copay_notifications/new_statement_notification_job.rb
@@ -30,6 +30,7 @@ module CopayNotifications
     STATSD_KEY_PREFIX = 'api.copay_notifications.new_statement'
 
     def perform(statement)
+      # rubocop:disable Lint/UselessAssignment
       StatsD.increment("#{STATSD_KEY_PREFIX}.total")
       statement_service = DebtManagementCenter::StatementIdentifierService.new(statement)
       user_data = statement_service.get_mpi_data
@@ -41,7 +42,7 @@ module CopayNotifications
       statement_date = statement['statementDate']
       account_balance = statement['accountBalance']
       Rails.logger.info("Notification Data: date-#{statement_date}, balance-#{account_balance}")
-
+      # rubocop:enable Lint/UselessAssignment
       # pausing until further notice
       # DebtManagementCenter::VANotifyEmailJob.perform_async(icn, MCP_NOTIFICATION_TEMPLATE, personalization, 'icn')
     end

--- a/app/sidekiq/copay_notifications/new_statement_notification_job.rb
+++ b/app/sidekiq/copay_notifications/new_statement_notification_job.rb
@@ -38,7 +38,12 @@ module CopayNotifications
         'name' => user_data[:first_name],
         'date' => Time.zone.today.strftime('%B %d, %Y')
       }
-      DebtManagementCenter::VANotifyEmailJob.perform_async(icn, MCP_NOTIFICATION_TEMPLATE, personalization, 'icn')
+      statement_date = statement['statementDate']
+      account_balance = statement['accountBalance']
+      Rails.logger.info("Notification Data: date-#{statement_date}, balance-#{account_balance}")
+
+      # pausing until further notice
+      # DebtManagementCenter::VANotifyEmailJob.perform_async(icn, MCP_NOTIFICATION_TEMPLATE, personalization, 'icn')
     end
   end
 end

--- a/spec/sidekiq/copay_notifications/new_statement_notification_job_spec.rb
+++ b/spec/sidekiq/copay_notifications/new_statement_notification_job_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe CopayNotifications::NewStatementNotificationJob, type: :worker do
 
     it 'sends a new mcp notification email job frome edipi' do
       job = described_class.new
-      
+
       # pausing until further notice
       expect { job.perform(statement) }
-      .not_to change{ DebtManagementCenter::VANotifyEmailJob.jobs.size }
-      .from(0)
+        .not_to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
+        .from(0)
       # expect { job.perform(statement) }
       #   .to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
       #   .from(0)
@@ -58,11 +58,11 @@ RSpec.describe CopayNotifications::NewStatementNotificationJob, type: :worker do
 
       it 'sends a new mcp notification email job frome facility and vista id' do
         job = described_class.new
-      
+
         # pausing until further notice
         expect { job.perform(statement) }
-        .not_to change{ DebtManagementCenter::VANotifyEmailJob.jobs.size }
-        .from(0)
+          .not_to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
+          .from(0)
         # expect { job.perform(statement) }
         #   .to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
         #   .from(0)

--- a/spec/sidekiq/copay_notifications/new_statement_notification_job_spec.rb
+++ b/spec/sidekiq/copay_notifications/new_statement_notification_job_spec.rb
@@ -33,10 +33,15 @@ RSpec.describe CopayNotifications::NewStatementNotificationJob, type: :worker do
 
     it 'sends a new mcp notification email job frome edipi' do
       job = described_class.new
+      
+      # pausing until further notice
       expect { job.perform(statement) }
-        .to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
-        .from(0)
-        .to(1)
+      .not_to change{ DebtManagementCenter::VANotifyEmailJob.jobs.size }
+      .from(0)
+      # expect { job.perform(statement) }
+      #   .to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
+      #   .from(0)
+      #   .to(1)
     end
 
     context 'veteran identifier is a vista id' do
@@ -53,10 +58,15 @@ RSpec.describe CopayNotifications::NewStatementNotificationJob, type: :worker do
 
       it 'sends a new mcp notification email job frome facility and vista id' do
         job = described_class.new
+      
+        # pausing until further notice
         expect { job.perform(statement) }
-          .to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
-          .from(0)
-          .to(1)
+        .not_to change{ DebtManagementCenter::VANotifyEmailJob.jobs.size }
+        .from(0)
+        # expect { job.perform(statement) }
+        #   .to change { DebtManagementCenter::VANotifyEmailJob.jobs.size }
+        #   .from(0)
+        #   .to(1)
       end
     end
 


### PR DESCRIPTION
## Summary
We're expecting a new attribute to be included in the body of the POST requests sent to our `/v0/medical_copays/send_statement_notifications` endpoint.

This PR intends to confirm that this attribute is coming through as expected.

## Related issue(s)
[82585](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/82585)

## Testing done
Specs green

## What areas of the site does it impact?
Copay notifications. `/v0/medical_copays/send_statement_notifications`

## Acceptance criteria
vets-api will log some of the non-PII statement metadata sent to `/v0/medical_copays/send_statement_notifications`
