### PR TITLE
Api 36152 remove empty confinements

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -608,7 +608,10 @@ module ClaimsApi
       end
 
       def confinements
-        return if @pdf_data[:data][:attributes][:serviceInformation][:confinements].blank?
+        if @pdf_data[:data][:attributes][:serviceInformation][:confinements].blank?
+          @pdf_data[:data][:attributes][:serviceInformation].delete(:confinements)
+          return
+        end
 
         si = []
         @pdf_data[:data][:attributes][:serviceInformation][:prisonerOfWarConfinement] = { confinementDates: [] }
@@ -618,9 +621,7 @@ module ClaimsApi
           end_date =
             make_date_object(confinement[:approximateEndDate], confinement[:approximateEndDate].length)
 
-          si.push({
-                    start: start_date, end: end_date
-                  })
+          si.push({ start: start_date, end: end_date })
           si
         end
         pow = si.present?

--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -609,8 +609,7 @@ module ClaimsApi
 
       def confinements
         if @pdf_data[:data][:attributes][:serviceInformation][:confinements].blank?
-          @pdf_data[:data][:attributes][:serviceInformation].delete(:confinements)
-          return
+          return @pdf_data[:data][:attributes][:serviceInformation].delete(:confinements)
         end
 
         si = []

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -102,6 +102,16 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
                                                            day: date.strftime('%d') })
         end
       end
+
+      context 'with empty confinements' do
+        it "doesn't send confinements" do
+          form_attributes['serviceInformation']['confinements'] = []
+          mapper.map_claim
+
+          service_information = pdf_data[:data][:attributes][:serviceInformation]
+          expect(service_information.keys).not_to include :confinements
+        end
+      end
     end
 
     context '526 section 1' do


### PR DESCRIPTION
## Summary
- Don't send contentions if there aren't any

## Related issue(s)
- [API-36152](https://jira.devops.va.gov/browse/API-36152)

## Testing done
- [x] *New code is covered by unit tests*
- Used to send an `[]` for empty contentions, now doesn't send contentions if there aren't any.

## What areas of the site does it impact?
v2 526

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
