### PR TITLE
Added monitoring to VRO Client endpoints.

### DIFF
--- a/lib/virtual_regional_office/client.rb
+++ b/lib/virtual_regional_office/client.rb
@@ -7,18 +7,26 @@ module VirtualRegionalOffice
     include Common::Client::Concerns::Monitoring
     configuration VirtualRegionalOffice::Configuration
 
+    STATSD_KEY_PREFIX = 'api.vro'
+
     def classify_single_contention(params)
-      perform(:post, Settings.virtual_regional_office.ctn_classification_path, params.to_json.to_s, headers_hash)
+      with_monitoring do
+        perform(:post, Settings.virtual_regional_office.ctn_classification_path, params.to_json.to_s, headers_hash)
+      end
     end
 
     def get_max_rating_for_diagnostic_codes(diagnostic_codes_array)
-      params = { diagnostic_codes: diagnostic_codes_array }
-      perform(:post, Settings.virtual_regional_office.max_cfi_path, params.to_json.to_s, headers_hash)
+      with_monitoring do
+        params = { diagnostic_codes: diagnostic_codes_array }
+        perform(:post, Settings.virtual_regional_office.max_cfi_path, params.to_json.to_s, headers_hash)
+      end
     end
 
     def merge_end_products(pending_claim_id:, ep400_id:)
-      params = { pending_claim_id: pending_claim_id.to_i, ep400_claim_id: ep400_id.to_i }
-      perform(:post, Settings.virtual_regional_office.ep_merge_path, params.to_json.to_s, headers_hash)
+      with_monitoring do
+        params = { pending_claim_id: pending_claim_id.to_i, ep400_claim_id: ep400_id.to_i }
+        perform(:post, Settings.virtual_regional_office.ep_merge_path, params.to_json.to_s, headers_hash)
+      end
     end
 
     def generate_summary(claim_submission_id:, diagnostic_code:, veteran_info:, evidence:)

--- a/spec/lib/virtual_regional_office/integration/client_spec.rb
+++ b/spec/lib/virtual_regional_office/integration/client_spec.rb
@@ -6,6 +6,10 @@ require 'virtual_regional_office/client'
 RSpec.describe VirtualRegionalOffice::Client, :vcr do
   let(:client) { described_class.new }
 
+  before do
+    allow(StatsD).to receive(:increment)
+  end
+
   describe '#classify_single_contention' do
     context 'with a contention classification request' do
       subject do
@@ -16,22 +20,53 @@ RSpec.describe VirtualRegionalOffice::Client, :vcr do
         )
       end
 
-      it 'returns a classification' do
+      it 'returns a classification and logs monitor metric' do
         VCR.use_cassette('virtual_regional_office/contention_classification') do
           expect(subject.body['classification_name']).to eq('asthma')
+          expect(StatsD).not_to have_received(:increment).with('api.vro.classify_single_contention.fail', anything)
+          expect(StatsD).to have_received(:increment).with('api.vro.classify_single_contention.total')
+        end
+      end
+
+      it 'fails to returns a classification and logs monitor metric' do
+        VCR.use_cassette('virtual_regional_office/contention_classification_failure') do
+          expect { subject }.to raise_error(Common::Client::Errors::ClientError)
+
+          expected_failure_tags = ['error:CommonClientErrorsClientError', 'status:500']
+          expect(StatsD).to have_received(:increment).with('api.vro.classify_single_contention.fail',
+                                                           { tags: expected_failure_tags })
+          expect(StatsD).to have_received(:increment).with('api.vro.classify_single_contention.total')
         end
       end
     end
   end
 
   describe '#get_max_rating_for_diagnostic_codes' do
-    context 'with a max ratings request' do
+    context 'whe the request is successful' do
       subject { client.get_max_rating_for_diagnostic_codes(diagnostic_codes: [6260]) }
 
-      it 'returns max ratings' do
+      it 'returns max ratings and logs monitor metrics' do
         VCR.use_cassette('virtual_regional_office/max_ratings') do
           expect(subject.body['ratings'].first['diagnostic_code']).to eq(6260)
           expect(subject.body['ratings'].first['max_rating']).to eq(10)
+          expect(StatsD).not_to have_received(:increment).with('api.vro.get_max_rating_for_diagnostic_codes.fail',
+                                                               anything)
+          expect(StatsD).to have_received(:increment).with('api.vro.get_max_rating_for_diagnostic_codes.total')
+        end
+      end
+    end
+
+    context 'whe the request is unsuccessful' do
+      subject { client.get_max_rating_for_diagnostic_codes(diagnostic_codes: [6260]) }
+
+      it 'fails to return max ratings and logs monitor metrics' do
+        VCR.use_cassette('virtual_regional_office/max_ratings_failure') do
+          expect { subject }.to raise_error(Common::Client::Errors::ClientError)
+
+          expected_failure_tags = ['error:CommonClientErrorsClientError', 'status:500']
+          expect(StatsD).to have_received(:increment).with('api.vro.get_max_rating_for_diagnostic_codes.fail',
+                                                           { tags: expected_failure_tags })
+          expect(StatsD).to have_received(:increment).with('api.vro.get_max_rating_for_diagnostic_codes.total')
         end
       end
     end
@@ -41,17 +76,24 @@ RSpec.describe VirtualRegionalOffice::Client, :vcr do
     subject { client.merge_end_products(pending_claim_id: '12345', ep400_id: '12346') }
 
     context 'when the request is successful' do
-      it 'returns a successful job' do
+      it 'returns a accepted job and logs monitor metrics' do
         VCR.use_cassette('virtual_regional_office/ep_merge') do
           expect(subject.body['job']).to have_key('job_id')
+          expect(StatsD).not_to have_received(:increment).with('api.vro.merge_end_products.fail', anything)
+          expect(StatsD).to have_received(:increment).with('api.vro.merge_end_products.total')
         end
       end
     end
 
     context 'when the request is unsuccessful' do
-      it 'raises an exception' do
+      it 'raises an exception and log metrics' do
         VCR.use_cassette('virtual_regional_office/ep_merge_failure') do
           expect { subject }.to raise_error(Common::Client::Errors::ClientError)
+
+          expected_failure_tags = ['error:CommonClientErrorsClientError', 'status:500']
+          expect(StatsD).to have_received(:increment).with('api.vro.merge_end_products.fail',
+                                                           { tags: expected_failure_tags })
+          expect(StatsD).to have_received(:increment).with('api.vro.merge_end_products.total')
         end
       end
     end

--- a/spec/support/vcr_cassettes/virtual_regional_office/contention_classification_failure.yml
+++ b/spec/support/vcr_cassettes/virtual_regional_office/contention_classification_failure.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/v3/contention-classification/classifier
+    uri: http://localhost:8120/classifier
     body:
       encoding: UTF-8
       string: '{"diagnostic_code":5235,"claim_id":190,"form526_submission_id":179}'


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Added the `with_monitoring` feature to provide datadog metrics for fails/total requests made to those endpoints. This will provide Employee Experience team the ability to track requests made and failed to our services hosted in the VRO platform via LHDI. 
- I am part of the Claims Fast-Tracking crew's Employee Experience team. We work closely with the Disability Experience team which owns this code.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/abd-vro/issues/2960

## Testing done

- New code is covered by unit tests
- Old unit tests still passing
- Previous Behavior: Calls made to using the VRO client did not generate monitor metrics to datadog
- New Behavior: VRO client requests are wrapped in `with_monitoring` allowing fail / total metric increments. Any exceptions raised by the calls previously will still be bubbled up by the implementation of `with_monitoring`. The following metrics will now be generated with the common prefix `api.vro.`:
  - `classify_single_contention.fail` and `classify_single_contention.total`
  - `get_max_rating_for_diagnostic_codes.fail` and `get_max_rating_for_diagnostic_codes.total`
  - `merge_end_products.fail` and `merge_end_products.total`


## What areas of the site does it impact?
Calls made on backend upon 526 prefill and submission for populating maximum rating on rated disabilities, requests to populate contention classifications, and requests to Merge Pending EPs upon submission of an EP400. 

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

