### PR TITLE
DBEX: add submit_endpoint to form526_submissions

### DIFF
--- a/db/migrate/20240508190041_add_submit_endpoint_to_form526_submissions.rb
+++ b/db/migrate/20240508190041_add_submit_endpoint_to_form526_submissions.rb
@@ -1,0 +1,5 @@
+class AddSubmitEndpointToForm526Submissions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :form526_submissions, :submit_endpoint, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_06_214134) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_08_190041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -695,6 +695,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_06_214134) do
     t.uuid "user_account_id"
     t.string "backup_submitted_claim_id", comment: "*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.This column will be nil for all submissions where a backup submission is not generated.It will have the central mail id for submissions where a backup submission is submitted."
     t.string "aasm_state", default: "unprocessed"
+    t.integer "submit_endpoint"
     t.index ["saved_claim_id"], name: "index_form526_submissions_on_saved_claim_id", unique: true
     t.index ["submitted_claim_id"], name: "index_form526_submissions_on_submitted_claim_id", unique: true
     t.index ["user_account_id"], name: "index_form526_submissions_on_user_account_id"


### PR DESCRIPTION
Adds a `submit_endpoint` column enum attribute to the `form526_submissions` table to be utilized in determining to which service endpoint a claim should be submitted. Currently, the primary submission of all claims is to EVSS. Those failing primary submission are routed to a different service. With the introduction of a new version of form 526, claims that include a new toxic exposure section will be submitted through Lighthouse. Select Veterans will be provided with the opportunity to claim conditions related to toxic exposure when completing a new version of the form. The value of the `submit_endpoint` will be set when a submission is created and based on a Veteran's claim containing the toxic exposure section. The decision to use an enum attribute should benefit potential future (and possibly current) efforts determining where a submission should be sent.

## Summary

- *This work is behind a feature toggle (flipper): ~YES~/NO*
  - but it will be leveraged in conjunction with the `disability_526_toxic_exposure` Flipper
- A subsequent PR will set the value of the `submit_endpoint` attribute when a`Form526Submission` record is created, based on an indicator in the metadata of an `InProgressForm` that signifies that the form includes a Toxic Exposure section.
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- [81830](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/81830)

## Testing done

- Nothing to test

## What areas of the site does it impact?

- Form 526EZ

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
