### PR TITLE
[82117] Add device_sso field to SiS authorize endpoint

### DIFF
--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -15,6 +15,7 @@ module V0
       client_id = params[:client_id].presence
       acr = params[:acr].presence
       operation = params[:operation].presence || SignIn::Constants::Auth::AUTHORIZE
+      scope = params[:scope].presence
 
       validate_authorize_params(type, client_id, acr, operation)
 
@@ -26,7 +27,8 @@ module V0
                                                  acr:,
                                                  client_config: client_config(client_id),
                                                  type:,
-                                                 client_state:).perform
+                                                 client_state:,
+                                                 scope:).perform
       context = { type:, client_id:, acr:, operation: }
 
       sign_in_logger.info('authorize', context)

--- a/app/models/sign_in/client_config.rb
+++ b/app/models/sign_in/client_config.rb
@@ -60,6 +60,10 @@ module SignIn
       service_levels.include?(acr)
     end
 
+    def device_sso_enabled?
+      api_auth? && shared_sessions
+    end
+
     private
 
     def appropriate_mock_environment?

--- a/app/models/sign_in/state_payload.rb
+++ b/app/models/sign_in/state_payload.rb
@@ -11,6 +11,7 @@ module SignIn
       :code_challenge,
       :client_state,
       :code,
+      :scope,
       :created_at
     )
 
@@ -22,13 +23,21 @@ module SignIn
     validate :confirm_client_id
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(acr:, client_id:, type:, code:, code_challenge: nil, client_state: nil, created_at: nil)
+    def initialize(acr:,
+                   client_id:,
+                   type:,
+                   code:,
+                   scope: nil,
+                   code_challenge: nil,
+                   client_state: nil,
+                   created_at: nil)
       @acr = acr
       @client_id = client_id
       @type = type
       @code_challenge = code_challenge
       @client_state = client_state
       @code = code
+      @scope = scope
       @created_at = created_at || Time.zone.now.to_i
 
       validate!

--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -39,6 +39,7 @@ module SignIn
       REFRESH_ROUTE_PATH = '/v0/sign_in/refresh'
       REFRESH_TOKEN_COOKIE_NAME = 'vagov_refresh_token'
       SERVICE_ACCOUNT_ACCESS_TOKEN_COOKIE_NAME = 'service_account_access_token'
+      SCOPES = [DEVICE_SSO = 'device_sso'].freeze
       TOKEN_ROUTE_PATH = '/v0/sign_in/token'
     end
   end

--- a/app/services/sign_in/errors.rb
+++ b/app/services/sign_in/errors.rb
@@ -65,5 +65,6 @@ module SignIn
     class TermsOfUseNotAcceptedError < StandardError; end
     class CredentialLockedError < StandardError; end
     class InvalidAudienceError < StandardError; end
+    class InvalidScope < StandardError; end
   end
 end

--- a/app/services/sign_in/state_payload_jwt_decoder.rb
+++ b/app/services/sign_in/state_payload_jwt_decoder.rb
@@ -22,7 +22,8 @@ module SignIn
         code_challenge: decoded_jwt.code_challenge,
         client_state: decoded_jwt.client_state,
         code: decoded_jwt.code,
-        created_at: decoded_jwt.created_at
+        created_at: decoded_jwt.created_at,
+        scope: decoded_jwt.scope
       )
     end
 

--- a/app/services/sign_in/state_payload_jwt_encoder.rb
+++ b/app/services/sign_in/state_payload_jwt_encoder.rb
@@ -2,44 +2,50 @@
 
 module SignIn
   class StatePayloadJwtEncoder
-    attr_reader :acr, :client_config, :type, :code_challenge, :code_challenge_method, :client_state
+    attr_reader :acr, :client_config, :type, :code_challenge, :code_challenge_method, :client_state, :scope
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(code_challenge:, code_challenge_method:, acr:, client_config:, type:, client_state: nil)
+    def initialize(code_challenge:, code_challenge_method:, acr:, client_config:, type:, scope: nil, client_state: nil)
       @acr = acr
       @client_config = client_config
       @type = type
       @code_challenge = code_challenge
       @code_challenge_method = code_challenge_method
       @client_state = client_state
+      @scope = scope
     end
     # rubocop:enable Metrics/ParameterLists
 
     def perform
-      validate_pkce_params if client_config.pkce?
-      validate_state_payload
+      validate_pkce_params! if client_config.pkce?
+      validate_scope!
+      validate_state_payload!
       save_state_code
       jwt_encode_state_payload
     end
 
     private
 
-    def validate_pkce_params
-      validate_code_challenge_method
-      validate_code_challenge
+    def validate_pkce_params!
+      validate_code_challenge_method!
+      validate_code_challenge!
     end
 
-    def validate_code_challenge_method
+    def validate_scope!
+      raise Errors::InvalidScope.new message: 'Scope is not valid for Client' if sso_not_enabled_for_device_sso_scope?
+    end
+
+    def validate_code_challenge_method!
       if code_challenge_method != Constants::Auth::CODE_CHALLENGE_METHOD
         raise Errors::CodeChallengeMethodMismatchError.new message: 'Code Challenge Method is not valid'
       end
     end
 
-    def validate_code_challenge
+    def validate_code_challenge!
       raise Errors::CodeChallengeMalformedError.new message: 'Code Challenge is not valid' if code_challenge.blank?
     end
 
-    def validate_state_payload
+    def validate_state_payload!
       state_payload
     rescue ActiveModel::ValidationError
       raise Errors::StatePayloadError.new message: 'Attributes are not valid'
@@ -61,7 +67,8 @@ module SignIn
         code_challenge: state_payload.code_challenge,
         client_state: state_payload.client_state,
         code: state_payload.code,
-        created_at: state_payload.created_at
+        created_at: state_payload.created_at,
+        scope: state_payload.scope
       }
     end
 
@@ -71,11 +78,16 @@ module SignIn
                                           client_id: client_config.client_id,
                                           code_challenge: remove_base64_padding(code_challenge),
                                           code: state_code,
-                                          client_state:)
+                                          client_state:,
+                                          scope:)
     end
 
     def state_code
       @state_code ||= SecureRandom.hex
+    end
+
+    def sso_not_enabled_for_device_sso_scope?
+      scope == Constants::Auth::DEVICE_SSO && !client_config.device_sso_enabled?
     end
 
     def remove_base64_padding(data)

--- a/spec/factories/sign_in/client_configs.rb
+++ b/spec/factories/sign_in/client_configs.rb
@@ -16,5 +16,6 @@ FactoryBot.define do
     access_token_attributes { [] }
     enforced_terms { SignIn::Constants::Auth::VA_TERMS }
     terms_of_use_url { Faker::Internet.url }
+    shared_sessions { false }
   end
 end

--- a/spec/factories/sign_in/state_payloads.rb
+++ b/spec/factories/sign_in/state_payloads.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     client_state { SecureRandom.hex }
     code { SecureRandom.hex }
     created_at { Time.zone.now.to_i }
+    scope { SignIn::Constants::Auth::DEVICE_SSO }
 
     initialize_with do
       new(acr:,
@@ -19,7 +20,8 @@ FactoryBot.define do
           client_id:,
           type:,
           code:,
-          created_at:)
+          created_at:,
+          scope:)
     end
   end
 end

--- a/spec/models/sign_in/client_config_spec.rb
+++ b/spec/models/sign_in/client_config_spec.rb
@@ -539,4 +539,44 @@ RSpec.describe SignIn::ClientConfig, type: :model do
       end
     end
   end
+
+  describe '#device_sso_enabled?' do
+    subject { client_config.device_sso_enabled? }
+
+    context 'when authentication method is set to API' do
+      let(:authentication) { SignIn::Constants::Auth::API }
+
+      context 'and shared_sessions is set to true' do
+        let(:shared_sessions) { true }
+
+        it 'returns true' do
+          expect(subject).to be(true)
+        end
+      end
+
+      context 'and shared_sessions is set to false' do
+        let(:shared_sessions) { false }
+
+        it 'returns false' do
+          expect(subject).to be(false)
+        end
+      end
+    end
+
+    context 'when authentication method is set to COOKIE' do
+      let(:authentication) { SignIn::Constants::Auth::COOKIE }
+
+      it 'returns false' do
+        expect(subject).to be(false)
+      end
+    end
+
+    context 'when authentication method is set to MOCK' do
+      let(:authentication) { SignIn::Constants::Auth::MOCK }
+
+      it 'returns false' do
+        expect(subject).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/sign_in/state_payload_spec.rb
+++ b/spec/models/sign_in/state_payload_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe SignIn::StatePayload, type: :model do
            acr:,
            code:,
            client_state:,
-           created_at:)
+           created_at:,
+           scope:)
   end
 
   let(:code_challenge) { Base64.urlsafe_encode64(SecureRandom.hex) }
@@ -22,6 +23,7 @@ RSpec.describe SignIn::StatePayload, type: :model do
   let(:client_id) { client_config.client_id }
   let(:client_state) { SecureRandom.hex }
   let(:created_at) { Time.zone.now.to_i }
+  let(:scope) { SignIn::Constants::Auth::DEVICE_SSO }
 
   describe 'validations' do
     describe '#code' do

--- a/spec/services/sign_in/state_payload_jwt_decoder_spec.rb
+++ b/spec/services/sign_in/state_payload_jwt_decoder_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
                                          code_challenge_method:,
                                          type:,
                                          code_challenge:,
-                                         client_state:).perform
+                                         client_state:,
+                                         scope:).perform
     end
     let(:code_challenge) { Base64.urlsafe_encode64('some-safe-code-challenge') }
     let(:code_challenge_method) { SignIn::Constants::Auth::CODE_CHALLENGE_METHOD }
@@ -22,8 +23,10 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
     let(:acr) { SignIn::Constants::Auth::ACR_VALUES.first }
     let(:type) { SignIn::Constants::Auth::CSP_TYPES.first }
     let(:client_id) { client_config.client_id }
-    let(:client_config) { create(:client_config) }
+    let(:client_config) { create(:client_config, shared_sessions:) }
     let(:created_at) { Time.zone.now.to_i }
+    let(:shared_sessions) { true }
+    let(:scope) { SignIn::Constants::Auth::DEVICE_SSO }
 
     let(:client_state_minimum_length) { SignIn::Constants::Auth::CLIENT_STATE_MINIMUM_LENGTH }
 
@@ -43,7 +46,8 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
           acr:,
           type:,
           client_id:,
-          created_at:
+          created_at:,
+          scope:
         }
       end
       let(:expected_error) { SignIn::Errors::StatePayloadSignatureMismatchError }
@@ -73,6 +77,7 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
         expect(decoded_state_payload.type).to eq(type)
         expect(decoded_state_payload.client_id).to eq(client_id)
         expect(decoded_state_payload.created_at).to eq(created_at)
+        expect(decoded_state_payload.scope).to eq(scope)
       end
     end
   end


### PR DESCRIPTION
## Summary

- This PR adds the `scope=device_sso` field to the Sign in Service `/authorize` endpoint. When calling `/authorize` with this field, the expectation is that the `state` value included in the params to the CSP redirect will include an object with the given `scope`.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82117

## Testing done

- [ ] Called SiS `/authorize` with `scope=device_sso`
- [ ] Confirmed that state value that returned includes the scope value

Authentication

## Acceptance criteria

- [ ]  Make a Sign in Service `/authorize` call with `scope=device_sso`
- [ ] Inspect the `state` value that's returned in `/callback`
- [ ] Confirm `state` value has a `scope=device_sso` field
- [ ] Confirm any other `scope=` value returns an error
- [ ] Confirm a client that is not enabled for `device_sso` (for example, a Cookie-based client), returns an error
