### PR TITLE
Update vpg cancellation request body

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -583,7 +583,7 @@ module VAOS
 
       def update_appointment_vpg(appt_id, status)
         url_path = "/vpg/v1/patients/#{user.icn}/appointments/#{appt_id}"
-        body = JSON.generate([VAOS::V2::UpdateAppointmentForm.new(status:).json_patch_op])
+        body = [VAOS::V2::UpdateAppointmentForm.new(status:).json_patch_op]
         perform(:patch, url_path, body, headers)
       end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -552,7 +552,7 @@ describe VAOS::V2::AppointmentsService do
 
           it 'returns a cancelled status and the cancelled appointment information' do
             VCR.use_cassette('vaos/v2/appointments/cancel_appointments_vpg_200',
-                             match_requests_on: %i[method path query]) do
+                             match_requests_on: %i[method path query body_as_json]) do
               VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_200',
                                match_requests_on: %i[method path query]) do
                 response = subject.update_appointment('70060', 'cancelled')


### PR DESCRIPTION
## Summary

- Appointment cancellations using VPG are current behind `va_online_scheduling_enable_OH_cancellations `and `va_online_scheduling_use_vpg`

PATCH requests to VPG to cancel appointments weren't including the body. The body content was apparently being dropped within Faraday due to a type mismatch.

The solution was to remove the explicit JSON serialization in `appointments_service.rb`. Tests were updated to also match the VCR file using the body to ensure that the valid body content is in the request.

This can be reproduced by attempting to cancel an appointment with feature flags turned on.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/82750

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Appointment cancellations

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
