### PR TITLE
API-34798: Add Veteran Impact Stats to Appeals API Stats Report

### DIFF
--- a/modules/appeals_api/lib/appeals_api/stats_report.rb
+++ b/modules/appeals_api/lib/appeals_api/stats_report.rb
@@ -186,7 +186,7 @@ module AppealsApi
         Higher Level Reviews: #{number_to_delimited(hlr_icns.count)}
         Notice of Disagreements: #{number_to_delimited(nod_icns.count)}
         Supplemental Claims: #{number_to_delimited(sc_icns.count)}
-        All Decision Reviews: #{(number_to_delimited(hlr_icns + nod_icns + sc_icns).uniq.count)}
+        All Decision Reviews: #{number_to_delimited((hlr_icns + nod_icns + sc_icns).uniq.count)}
       STATS
     end
 

--- a/modules/appeals_api/lib/appeals_api/stats_report.rb
+++ b/modules/appeals_api/lib/appeals_api/stats_report.rb
@@ -2,6 +2,8 @@
 
 module AppealsApi
   class StatsReport
+    include ActiveSupport::NumberHelper
+
     DATE_FORMAT = '%b%e, %Y'
 
     # [from, to] pairs to report transition times
@@ -181,10 +183,10 @@ module AppealsApi
       sc_icns = unique_icns(AppealsApi::SupplementalClaim)
 
       <<~STATS
-        Higher Level Reviews: #{hlr_icns.count}
-        Notice of Disagreements: #{nod_icns.count}
-        Supplemental Claims: #{sc_icns.count}
-        All Decision Reviews: #{(hlr_icns + nod_icns + sc_icns).uniq.count}
+        Higher Level Reviews: #{number_to_delimited(hlr_icns.count)}
+        Notice of Disagreements: #{number_to_delimited(nod_icns.count)}
+        Supplemental Claims: #{number_to_delimited(sc_icns.count)}
+        All Decision Reviews: #{(number_to_delimited(hlr_icns + nod_icns + sc_icns).uniq.count)}
       STATS
     end
 

--- a/modules/appeals_api/lib/appeals_api/stats_report.rb
+++ b/modules/appeals_api/lib/appeals_api/stats_report.rb
@@ -184,7 +184,7 @@ module AppealsApi
         Higher Level Reviews: #{hlr_icns.count}
         Notice of Disagreements: #{nod_icns.count}
         Supplemental Claims: #{sc_icns.count}
-        Combined: #{(hlr_icns + nod_icns + sc_icns).uniq.count}
+        All Decision Reviews: #{(hlr_icns + nod_icns + sc_icns).uniq.count}
       STATS
     end
 

--- a/modules/appeals_api/lib/appeals_api/stats_report.rb
+++ b/modules/appeals_api/lib/appeals_api/stats_report.rb
@@ -61,6 +61,11 @@ module AppealsApi
         ### Stalled records
 
         #{formatted_stalled_stats(AppealsApi::SupplementalClaim)}
+
+
+        Veterans Impacted (Unique ICNs)
+        ---
+        #{formatted_impact_stats}
       REPORT
     end
 
@@ -168,6 +173,23 @@ module AppealsApi
       end.compact
 
       parts.empty? ? '(none)' : parts.join("\n")
+    end
+
+    def formatted_impact_stats
+      hlr_icns = unique_icns(AppealsApi::HigherLevelReview)
+      nod_icns = unique_icns(AppealsApi::NoticeOfDisagreement)
+      sc_icns = unique_icns(AppealsApi::SupplementalClaim)
+
+      <<~STATS
+        Higher Level Reviews: #{hlr_icns.count}
+        Notice of Disagreements: #{nod_icns.count}
+        Supplemental Claims: #{sc_icns.count}
+        Combined: #{(hlr_icns + nod_icns + sc_icns).uniq.count}
+      STATS
+    end
+
+    def unique_icns(appeal_type)
+      appeal_type.where(created_at: date_from..date_to).pluck(:veteran_icn).uniq
     end
   end
 end

--- a/modules/appeals_api/spec/lib/stats_report_spec.rb
+++ b/modules/appeals_api/spec/lib/stats_report_spec.rb
@@ -155,6 +155,16 @@ describe AppealsApi::StatsReport do
       ]
     end
 
+    before do
+      # Records for testing Veterans Impacted stats
+      created_at = Date.new(2022, 3, 1).beginning_of_day
+      create(:higher_level_review_v2, veteran_icn: '1234567890V012345', created_at:)
+      create(:notice_of_disagreement_v2, veteran_icn: '1234567890V012345', created_at:)
+      create(:notice_of_disagreement_v2, veteran_icn: '1234567890V012345', created_at:)
+      create(:notice_of_disagreement_v2, veteran_icn: '9876543210V543210', created_at:)
+      create(:supplemental_claim, veteran_icn: '9876543210V543210', created_at:)
+    end
+
     it 'includes the start and end dates' do
       expect(text).to match(/Feb 4, 2022 to Mar 4, 2022/)
     end
@@ -176,6 +186,15 @@ describe AppealsApi::StatsReport do
       expect(text).to match(/Stalled in 'processing':\n\* 4-5 months: 1\n\* 5-6 months: 2\n\* > 6 months: 1/)
       expect(text).to match(/Stalled in 'submitted':\n\* 3-4 months: 1\n\* 4-5 months: 2\n\* 5-6 months: 1/)
       expect(text).to match(/Stalled in 'error':\n\* 3-4 months: 2\n\* 4-5 months: 1\n\* 5-6 months: 1/)
+    end
+
+    it 'includes the veteran impact header' do
+      expect(text).to match(/Veterans Impacted \(Unique ICNs\)\n---\n/)
+    end
+
+    it 'includes the veteran impact stats' do
+      expect(text)
+        .to match(/Higher Level Reviews: 1\nNotice of Disagreements: 2\nSupplemental Claims: 1\nCombined: 2\n/)
     end
 
     context 'when there is no data' do

--- a/modules/appeals_api/spec/lib/stats_report_spec.rb
+++ b/modules/appeals_api/spec/lib/stats_report_spec.rb
@@ -193,9 +193,8 @@ describe AppealsApi::StatsReport do
     end
 
     it 'includes the veteran impact stats' do
-      expect(text).to match(
-        /Higher Level Reviews: 1\nNotice of Disagreements: 2\nSupplemental Claims: 1\nAll Decision Reviews: 2\n/
-      )
+      expect(text).to match(/Higher Level Reviews: 1\nNotice of Disagreements: 2\n/)
+      expect(text).to match(/Supplemental Claims: 1\nAll Decision Reviews: 2\n/)
     end
 
     context 'when there is no data' do

--- a/modules/appeals_api/spec/lib/stats_report_spec.rb
+++ b/modules/appeals_api/spec/lib/stats_report_spec.rb
@@ -193,8 +193,9 @@ describe AppealsApi::StatsReport do
     end
 
     it 'includes the veteran impact stats' do
-      expect(text)
-        .to match(/Higher Level Reviews: 1\nNotice of Disagreements: 2\nSupplemental Claims: 1\nCombined: 2\n/)
+      expect(text).to match(
+        /Higher Level Reviews: 1\nNotice of Disagreements: 2\nSupplemental Claims: 1\nAll Decision Reviews: 2\n/
+      )
     end
 
     context 'when there is no data' do


### PR DESCRIPTION
## Summary
This PR adds a new "Veterans Impacted" section to the monthly Appeals API stats report that captures the unique Veteran ICNs that were associated with the previous month's appeal submissions. Stats are split out by appeal type (Higher Level Reviews, Notice of Disagreements, Supplemental Claims), and there is also a combined number.

My team (Lighthouse Team Banana Peels) owns the `appeals_api` module.

## Related issue(s)
[API-34798](https://jira.devops.va.gov/browse/API-34798)

## Testing done
Unit tests have been added to test the new section of the report. Also generated the stats report locally against my local appeal test data.

## Screenshots
<img width="250" alt="Screenshot 2024-05-09 at 12 58 50 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/11942904/a23700a8-1720-4253-a400-a842dbce66dc">

## What areas of the site does it impact?
This PR impacts the `appeals_api` module only, and specifically the monthly stats (email) report.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback
No specific feedback requested for this PR.
