### PR TITLE
#82765 [10-10EZR]: Add/update a form submission's `veteranDateOfBirth` if it's missing or blank

### DIFF
--- a/lib/form1010_ezr/service.rb
+++ b/lib/form1010_ezr/service.rb
@@ -118,8 +118,24 @@ module Form1010Ezr
       parsed_form.merge!(required_fields)
     end
 
-    def configure_and_validate_form(parsed_form)
+    # Due to issues with receiving submissions without the Veteran's DOB, we'll
+    # try to add it in before we validate the form
+    def post_fill_veteran_date_of_birth(parsed_form)
+      return if parsed_form['veteranDateOfBirth'].present?
+
+      user_dob = @user.birth_date
+      parsed_form['veteranDateOfBirth'] = user_dob if user_dob.present?
+
+      parsed_form
+    end
+
+    def post_fill_fields(parsed_form)
       post_fill_required_fields(parsed_form)
+      post_fill_veteran_date_of_birth(parsed_form)
+    end
+
+    def configure_and_validate_form(parsed_form)
+      post_fill_fields(parsed_form)
       validate_form(parsed_form)
       # Due to overriding the JSON form schema, we need to do so after the form has been validated
       override_parsed_form(parsed_form)


### PR DESCRIPTION
## Summary

- Adds a method to "post-fill" the `veteranDateOfBirth` key in the form params if it's missing or blank. We'll utilize the `current_user`'s session by setting the form value to the `birth_date` value. This is to hopefully resolve the schema validation error related to `veteranDateOfBirth` we've been seeing on and off.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
