### PR TITLE
My VA - add feature flag for enabling use of new SiP configuration on My VA

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -902,6 +902,9 @@ features:
   my_va_enable_mhv_link:
     actor_type: user
     description: Enables the "Visit MHV" CTA link under Health care section
+  my_va_enable_new_sip_config:
+    actor_type: user
+    description: Enables use of the new SiP configuration
   my_va_update_errors_warnings:
     actor_type: user
     description: Update all errors and warnings on My VA for consistency (will remove when va-notification component is released)


### PR DESCRIPTION
## Summary
This PR adds a `my_va_enable_new_sip_config` feature flag

## Related issue(s)
**Frontend**
- implementation issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/80036
- implementation PR (wip): https://github.com/department-of-veterans-affairs/vets-website/pull/29641