### PR TITLE
[82120] Return device_secret when device_sso scope is given for SiS authentication

### DIFF
--- a/app/models/sign_in/access_token.rb
+++ b/app/models/sign_in/access_token.rb
@@ -17,7 +17,8 @@ module SignIn
       :version,
       :expiration_time,
       :created_time,
-      :user_attributes
+      :user_attributes,
+      :device_secret_hash
     )
 
     validates(
@@ -50,7 +51,8 @@ module SignIn
                    version: nil,
                    expiration_time: nil,
                    created_time: nil,
-                   user_attributes: nil)
+                   user_attributes: nil,
+                   device_secret_hash: nil)
       @uuid = uuid || create_uuid
       @session_handle = session_handle
       @client_id = client_id
@@ -64,6 +66,7 @@ module SignIn
       @expiration_time = expiration_time || set_expiration_time
       @created_time = created_time || set_created_time
       @user_attributes = filter_user_attributes(user_attributes:)
+      @device_secret_hash = device_secret_hash
 
       validate!
     end

--- a/app/models/sign_in/code_container.rb
+++ b/app/models/sign_in/code_container.rb
@@ -12,6 +12,7 @@ module SignIn
     attribute :user_verification_id, Integer
     attribute :credential_email, String
     attribute :user_attributes, Hash
+    attribute :device_sso, Boolean
 
     validates(:code, :user_verification_id, presence: true)
 

--- a/app/models/sign_in/session_container.rb
+++ b/app/models/sign_in/session_container.rb
@@ -9,7 +9,8 @@ module SignIn
       :refresh_token,
       :access_token,
       :anti_csrf_token,
-      :client_config
+      :client_config,
+      :device_secret
     )
 
     validates(
@@ -21,16 +22,18 @@ module SignIn
       presence: true
     )
 
-    def initialize(session:,
+    def initialize(session:, # rubocop:disable Metrics/ParameterLists
                    refresh_token:,
                    access_token:,
                    anti_csrf_token:,
-                   client_config:)
+                   client_config:,
+                   device_secret: nil)
       @session = session
       @refresh_token = refresh_token
       @access_token = access_token
       @anti_csrf_token = anti_csrf_token
       @client_config = client_config
+      @device_secret = device_secret
 
       validate!
     end

--- a/app/models/sign_in/validated_credential.rb
+++ b/app/models/sign_in/validated_credential.rb
@@ -8,7 +8,8 @@ module SignIn
       :user_verification,
       :credential_email,
       :client_config,
-      :user_attributes
+      :user_attributes,
+      :device_sso
     )
 
     validates(
@@ -20,11 +21,13 @@ module SignIn
     def initialize(user_verification:,
                    client_config:,
                    credential_email:,
-                   user_attributes:)
+                   user_attributes:,
+                   device_sso:)
       @user_verification = user_verification
       @client_config = client_config
       @credential_email = credential_email
       @user_attributes = user_attributes
+      @device_sso = device_sso
 
       validate!
     end

--- a/app/services/sign_in/code_validator.rb
+++ b/app/services/sign_in/code_validator.rb
@@ -65,7 +65,8 @@ module SignIn
       @validated_credential ||= ValidatedCredential.new(user_verification:,
                                                         credential_email: code_container.credential_email,
                                                         client_config:,
-                                                        user_attributes: code_container.user_attributes)
+                                                        user_attributes: code_container.user_attributes,
+                                                        device_sso: code_container.device_sso)
     end
 
     def client_config

--- a/app/services/sign_in/session_creator.rb
+++ b/app/services/sign_in/session_creator.rb
@@ -10,12 +10,13 @@ module SignIn
 
     def perform
       validate_credential_lock
-      validate_terms_of_use if client_config.enforced_terms.present?
-      SessionContainer.new(session:,
+      validate_terms_of_use
+      SessionContainer.new(session: create_new_session,
                            refresh_token:,
-                           access_token:,
+                           access_token: create_new_access_token,
                            anti_csrf_token:,
-                           client_config:)
+                           client_config:,
+                           device_secret:)
     end
 
     private
@@ -25,7 +26,7 @@ module SignIn
     end
 
     def validate_terms_of_use
-      if user_account.needs_accepted_terms_of_use?
+      if client_config.enforced_terms.present? && user_verification.user_account.needs_accepted_terms_of_use?
         raise Errors::TermsOfUseNotAcceptedError.new message: 'Terms of Use has not been accepted'
       end
     end
@@ -36,14 +37,6 @@ module SignIn
 
     def refresh_token
       @refresh_token ||= create_new_refresh_token(parent_refresh_token_hash:)
-    end
-
-    def access_token
-      @access_token ||= create_new_access_token
-    end
-
-    def session
-      @session ||= create_new_session
     end
 
     def double_parent_refresh_token_hash
@@ -58,17 +51,24 @@ module SignIn
       @parent_refresh_token_hash ||= get_hash(create_new_refresh_token.to_json)
     end
 
+    def hashed_device_secret
+      return unless validated_credential.device_sso
+
+      @hashed_device_secret ||= get_hash(device_secret)
+    end
+
     def create_new_access_token
       AccessToken.new(
         session_handle: handle,
-        client_id:,
+        client_id: client_config.client_id,
         user_uuid:,
-        audience:,
+        audience: AccessTokenAudienceGenerator.new(client_config:).perform,
         refresh_token_hash:,
         parent_refresh_token_hash:,
         anti_csrf_token:,
         last_regeneration_time: refresh_created_time,
-        user_attributes:
+        user_attributes:,
+        device_secret_hash: hashed_device_secret
       )
     end
 
@@ -82,43 +82,38 @@ module SignIn
     end
 
     def create_new_session
-      OAuthSession.create!(user_account:,
+      OAuthSession.create!(user_account: user_verification.user_account,
                            user_verification:,
-                           client_id:,
-                           credential_email:,
+                           client_id: client_config.client_id,
+                           credential_email: validated_credential.credential_email,
                            handle:,
                            hashed_refresh_token: double_parent_refresh_token_hash,
                            refresh_expiration: refresh_expiration_time,
                            refresh_creation: refresh_created_time,
-                           user_attributes: user_attributes.to_json)
+                           user_attributes: user_attributes.to_json,
+                           hashed_device_secret:)
     end
 
     def refresh_created_time
-      @created_at ||= Time.zone.now
+      @refresh_created_time ||= Time.zone.now
     end
 
     def refresh_expiration_time
-      @expiration_at ||= Time.zone.now + validity_length
+      @refresh_expiration_time ||= refresh_created_time + client_config.refresh_token_duration
     end
 
     def get_hash(object)
       Digest::SHA256.hexdigest(object)
     end
 
-    def client_id
-      @client_id ||= client_config.client_id
+    def device_secret
+      return unless validated_credential.device_sso
+
+      @device_secret ||= SecureRandom.hex
     end
 
     def user_verification
       @user_verification ||= validated_credential.user_verification
-    end
-
-    def credential_email
-      @credential_email ||= validated_credential.credential_email
-    end
-
-    def user_account
-      @user_account ||= user_verification.user_account
     end
 
     def user_attributes
@@ -133,16 +128,8 @@ module SignIn
       @handle ||= SecureRandom.uuid
     end
 
-    def audience
-      @audience ||= AccessTokenAudienceGenerator.new(client_config:).perform
-    end
-
     def client_config
       @client_config ||= validated_credential.client_config
-    end
-
-    def validity_length
-      client_config.refresh_token_duration
     end
   end
 end

--- a/app/services/sign_in/token_serializer.rb
+++ b/app/services/sign_in/token_serializer.rb
@@ -73,7 +73,12 @@ module SignIn
       payload[:refresh_token] = encrypted_refresh_token
       payload[:access_token] = encoded_access_token
       payload[:anti_csrf_token] = anti_csrf_token if anti_csrf_enabled_client?
+      payload[:device_secret] = device_secret if device_secret_enabled_client?
       payload
+    end
+
+    def device_secret_enabled_client?
+      api_authentication_client? && client_config.shared_sessions && device_secret
     end
 
     def cookie_authentication_client?
@@ -90,6 +95,10 @@ module SignIn
 
     def anti_csrf_enabled_client?
       client_config.anti_csrf
+    end
+
+    def device_secret
+      @device_secret ||= session_container.device_secret
     end
 
     def session_expiration

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -55,7 +55,12 @@ module SignIn
                         code_challenge: state_payload.code_challenge,
                         user_verification_id: user_verification.id,
                         credential_email:,
-                        user_attributes: access_token_attributes).save!
+                        user_attributes: access_token_attributes,
+                        device_sso:).save!
+    end
+
+    def device_sso
+      state_payload.scope == Constants::Auth::DEVICE_SSO
     end
 
     def user_verifier_object

--- a/spec/factories/sign_in/access_tokens.rb
+++ b/spec/factories/sign_in/access_tokens.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     version { SignIn::Constants::AccessToken::CURRENT_VERSION }
     expiration_time { Time.zone.now + SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
     created_time { Time.zone.now }
+    device_secret_hash { SecureRandom.hex }
     user_attributes do
       { 'first_name' => Faker::Name.first_name,
         'last_name' => Faker::Name.last_name,
@@ -33,7 +34,8 @@ FactoryBot.define do
           version:,
           expiration_time:,
           created_time:,
-          user_attributes:)
+          user_attributes:,
+          device_secret_hash:)
     end
   end
 end

--- a/spec/factories/sign_in/code_containers.rb
+++ b/spec/factories/sign_in/code_containers.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     code { SecureRandom.hex }
     client_id { create(:client_config).client_id }
     user_verification_id { create(:user_verification).id }
+    device_sso { false }
     user_attributes do
       { first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name,

--- a/spec/factories/sign_in/session_containers.rb
+++ b/spec/factories/sign_in/session_containers.rb
@@ -9,13 +9,15 @@ FactoryBot.define do
     access_token { create(:access_token) }
     anti_csrf_token { SecureRandom.hex }
     client_config { create(:client_config) }
+    device_secret { SecureRandom.hex }
 
     initialize_with do
       new(session:,
           refresh_token:,
           access_token:,
           anti_csrf_token:,
-          client_config:)
+          client_config:,
+          device_secret:)
     end
   end
 end

--- a/spec/factories/sign_in/validated_credentials.rb
+++ b/spec/factories/sign_in/validated_credentials.rb
@@ -12,12 +12,14 @@ FactoryBot.define do
         last_name: Faker::Name.last_name,
         email: Faker::Internet.email }
     end
+    device_sso { false }
 
     initialize_with do
       new(user_verification:,
           client_config:,
           credential_email:,
-          user_attributes:)
+          user_attributes:,
+          device_sso:)
     end
   end
 end

--- a/spec/models/sign_in/access_token_spec.rb
+++ b/spec/models/sign_in/access_token_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe SignIn::AccessToken, type: :model do
            expiration_time:,
            version:,
            created_time:,
-           user_attributes:)
+           user_attributes:,
+           device_secret_hash:)
   end
 
   let(:session_handle) { create(:oauth_session).handle }
@@ -40,6 +41,7 @@ RSpec.describe SignIn::AccessToken, type: :model do
   let(:first_name) { Faker::Name.first_name }
   let(:last_name) { Faker::Name.last_name }
   let(:email) { Faker::Internet.email }
+  let(:device_secret_hash) { SecureRandom.hex }
   let(:user_attributes) { { 'first_name' => first_name, 'last_name' => last_name, 'email' => email } }
 
   describe 'validations' do

--- a/spec/models/sign_in/code_container_spec.rb
+++ b/spec/models/sign_in/code_container_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe SignIn::CodeContainer, type: :model do
            client_id:,
            code:,
            user_verification_id:,
-           user_attributes:)
+           user_attributes:,
+           device_sso:)
   end
 
   let(:code_challenge) { Base64.urlsafe_encode64(SecureRandom.hex) }
@@ -22,6 +23,7 @@ RSpec.describe SignIn::CodeContainer, type: :model do
       last_name: Faker::Name.last_name,
       email: Faker::Internet.email }
   end
+  let(:device_sso) { false }
 
   describe 'validations' do
     describe '#code' do

--- a/spec/models/sign_in/session_container_spec.rb
+++ b/spec/models/sign_in/session_container_spec.rb
@@ -9,13 +9,15 @@ RSpec.describe SignIn::SessionContainer, type: :model do
            refresh_token:,
            access_token:,
            anti_csrf_token:,
-           client_config:)
+           client_config:,
+           device_secret:)
   end
 
   let(:session) { create(:oauth_session) }
   let(:refresh_token) { create(:refresh_token) }
   let(:access_token) { create(:access_token) }
   let(:anti_csrf_token) { SecureRandom.hex }
+  let(:device_secret) { SecureRandom.hex }
   let(:client_config) { create(:client_config) }
 
   describe 'validations' do

--- a/spec/models/sign_in/validated_credential_spec.rb
+++ b/spec/models/sign_in/validated_credential_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe SignIn::ValidatedCredential, type: :model do
            user_verification:,
            credential_email:,
            client_config:,
-           user_attributes:)
+           user_attributes:,
+           device_sso:)
   end
 
   let(:user_verification) { create(:user_verification) }
@@ -19,6 +20,7 @@ RSpec.describe SignIn::ValidatedCredential, type: :model do
       last_name: Faker::Name.last_name,
       email: Faker::Internet.email }
   end
+  let(:device_sso) { false }
 
   describe 'validations' do
     describe '#user_verification' do

--- a/spec/services/sign_in/session_creator_spec.rb
+++ b/spec/services/sign_in/session_creator_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe SignIn::SessionCreator do
     subject { session_creator.perform }
 
     context 'when input object is a ValidatedCredential' do
-      let(:validated_credential) { create(:validated_credential, client_config:) }
+      let(:validated_credential) { create(:validated_credential, client_config:, device_sso:) }
       let(:user_uuid) { validated_credential.user_verification.backing_credential_identifier }
       let(:client_id) { client_config.client_id }
       let(:client_config) { create(:client_config, refresh_token_duration:, access_token_attributes:, enforced_terms:) }
       let(:refresh_token_duration) { SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES }
       let(:access_token_attributes) { %w[first_name last_name email] }
       let(:enforced_terms) { nil }
+      let(:device_sso) { false }
 
       context 'expected credential_lock validation' do
         let(:validated_credential) { create(:validated_credential, client_config:, user_verification:) }
@@ -112,6 +113,25 @@ RSpec.describe SignIn::SessionCreator do
           allow(SecureRandom).to receive(:hex).and_return(stubbed_random_number)
           allow(SecureRandom).to receive(:uuid).and_return(expected_handle)
           allow(Time.zone).to receive(:now).and_return(expected_created_time)
+        end
+
+        context 'when validated credential is set up to enable device_sso' do
+          let(:device_sso) { true }
+          let(:expected_device_secret) { 'some-expected-device-secret' }
+
+          before { allow(Digest::SHA256).to receive(:hexdigest).and_return(expected_device_secret) }
+
+          it 'returns expected device_secret field on access token' do
+            expect(subject.session.hashed_device_secret).to eq(expected_device_secret)
+          end
+        end
+
+        context 'when validated credential is not set up to enable device_sso' do
+          let(:device_sso) { false }
+
+          it 'returns nil for device_secret field on access token' do
+            expect(subject.session.hashed_device_secret).to eq(nil)
+          end
         end
 
         it 'returns a Session Container with expected OAuth Session and fields' do
@@ -216,6 +236,25 @@ RSpec.describe SignIn::SessionCreator do
           allow(Time.zone).to receive(:now).and_return(expected_last_regeneration_time)
         end
 
+        context 'when validated credential is set up to enable device_sso' do
+          let(:device_sso) { true }
+          let(:expected_device_secret) { 'some-expected-device-secret' }
+
+          before { allow(Digest::SHA256).to receive(:hexdigest).and_return(expected_device_secret) }
+
+          it 'returns expected device_secret field on access token' do
+            expect(subject.access_token.device_secret_hash).to eq(expected_device_secret)
+          end
+        end
+
+        context 'when validated credential is not set up to enable device_sso' do
+          let(:device_sso) { false }
+
+          it 'returns nil for device_secret field on access token' do
+            expect(subject.access_token.device_secret_hash).to eq(nil)
+          end
+        end
+
         it 'returns a Session Container with expected Access Token and fields' do
           access_token = subject.access_token
           expect(access_token.session_handle).to eq(expected_handle)
@@ -256,6 +295,14 @@ RSpec.describe SignIn::SessionCreator do
             end
           end
         end
+      end
+
+      context 'when validated credential is set up to enable device_sso' do
+        let(:device_sso) { true }
+      end
+
+      context 'when validated credential is not set up to enable device_sso' do
+        let(:device_sso) { false }
       end
     end
   end

--- a/spec/services/sign_in/user_code_map_creator_spec.rb
+++ b/spec/services/sign_in/user_code_map_creator_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe SignIn::UserCodeMapCreator do
              client_state:,
              client_id:,
              code_challenge:,
-             type:)
+             type:,
+             scope:)
     end
     let(:client_state) { SecureRandom.alphanumeric(SignIn::Constants::Auth::CLIENT_STATE_MINIMUM_LENGTH) }
     let(:client_id) { client_config.client_id }
@@ -46,6 +47,8 @@ RSpec.describe SignIn::UserCodeMapCreator do
     let(:first_name) { Faker::Name.first_name }
     let(:last_name) { Faker::Name.last_name }
     let(:enforced_terms) { SignIn::Constants::Auth::VA_TERMS }
+    let(:device_sso) { true }
+    let(:scope) { SignIn::Constants::Auth::DEVICE_SSO }
     let(:expected_user_attributes) { { first_name:, last_name:, email: csp_email } }
 
     before do
@@ -107,6 +110,28 @@ RSpec.describe SignIn::UserCodeMapCreator do
       end
     end
 
+    context 'if state payload scope is set to device sso' do
+      let(:scope) { SignIn::Constants::Auth::DEVICE_SSO }
+      let(:expected_device_sso) { true }
+
+      it 'creates a code container with device_sso attribute set to false' do
+        user_code_map = subject
+        code_container = SignIn::CodeContainer.find(user_code_map.login_code)
+        expect(code_container.device_sso).to eq(expected_device_sso)
+      end
+    end
+
+    context 'if state payload scope is not set to device sso' do
+      let(:scope) { 'some-scope' }
+      let(:expected_device_sso) { false }
+
+      it 'creates a code container with device_sso attribute set to false' do
+        user_code_map = subject
+        code_container = SignIn::CodeContainer.find(user_code_map.login_code)
+        expect(code_container.device_sso).to eq(expected_device_sso)
+      end
+    end
+
     it 'creates a code container mapped to expected login code' do
       user_code_map = subject
       code_container = SignIn::CodeContainer.find(user_code_map.login_code)
@@ -115,6 +140,7 @@ RSpec.describe SignIn::UserCodeMapCreator do
       expect(code_container.credential_email).to eq(csp_email)
       expect(code_container.client_id).to eq(client_id)
       expect(code_container.user_attributes).to eq(expected_user_attributes)
+      expect(code_container.device_sso).to eq(device_sso)
     end
   end
 end


### PR DESCRIPTION
## Summary

- This PR returns a `device_secret` token when a Sign in Service authentication is performed with a `scope=device_sso` param

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82120

## Testing done

- [ ] Made an authentication with `scope=device_sso`
- [ ] Confirmed that resulting set of tokens from `/token` endpoint included `device_secret` token

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] For an API based SiS client with `shared_sessions` enabled, authenticate with `scope=device_sso` and confirm resulting tokens include `device_secret`
- [ ] For non API based SiS client with `shared_sessions` enabled, authenticate with `scope=device_sso` and confirm resulting tokens do not include `device_secret`
- [ ] For an API based SiS client with `shared_sessions` disabled, authenticate with `scope=device_sso` and confirm resulting tokens do not include `device_secret`
- [ ] For an API based SiS client with `shared_sessions` enabled, authenticate without a scope parameter and confirm resulting tokens do not include `device_secret`
