### PR TITLE
Suppress Logs from GovDelivery in CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -642,6 +642,7 @@ app/sidekiq/structured_data/process_data_job.rb @department-of-veterans-affairs/
 app/sidekiq/terms_of_use/ @department-of-veterans-affairs/octo-identity
 app/sidekiq/test_user_dashboard @department-of-veterans-affairs/octo-identity @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/backend-review-group
 app/sidekiq/test_user_dashboard/daily_maintenance.rb @department-of-veterans-affairs/octo-identity @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/backend-review-group
+app/sidekiq/transactional_email_analytics_job.rb @department-of-veterans-affairs/backend-review-group
 app/sidekiq/va_notify_dd_email_job.rb @department-of-veterans-affairs/va-notify-write @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/va_notify_email_job.rb @department-of-veterans-affairs/va-notify-write @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/vbms @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/sidekiq/transactional_email_analytics_job.rb
+++ b/app/sidekiq/transactional_email_analytics_job.rb
@@ -80,7 +80,7 @@ class TransactionalEmailAnalyticsJob
     @govdelivery_client ||= GovDelivery::TMS::Client.new(
       Settings.govdelivery.token,
       api_root: "https://#{Settings.govdelivery.server}",
-      logger:
+      logger: ENV['CI'] == 'true' ? nil : self.logger
     )
   end
 

--- a/app/sidekiq/transactional_email_analytics_job.rb
+++ b/app/sidekiq/transactional_email_analytics_job.rb
@@ -80,7 +80,7 @@ class TransactionalEmailAnalyticsJob
     @govdelivery_client ||= GovDelivery::TMS::Client.new(
       Settings.govdelivery.token,
       api_root: "https://#{Settings.govdelivery.server}",
-      logger: ENV['CI'] == 'true' ? nil : self.logger
+      logger: ENV['CI'] == 'true' ? nil : logger
     )
   end
 


### PR DESCRIPTION
## Summary

GovDelivery logs a unnecessary messages from the request and response for the CI. Causing hundreds of lines useless log messages. If there is an error the test will fail so there's no need for info logs. 

In order to reduce the log output in CI the request/response messages are suppressed. 

```
I, [2018-05-30T18:18:56.000000 #20]  INFO -- response: Status 200
I, [2018-05-30T18:18:56.000000 #20]  INFO -- response: date: "Wed, 30 May 2018 18:17:56 GMT"
server: "Apache/2.2.15 (CentOS)"
x-frame-options: "SAMEORIGIN"
x-xss-protection: "1; mode=block"
x-content-type-options: "nosniff"
etag: "W/\"6112d22f31b736a3002f590517cb2e81\""
cache-control: "max-age=0, private, must-revalidate"
x-request-id: "82b2f861-4370-4db2-955c-aa0dd56ad102"
x-runtime: "0.026356"
x-served-by: "stg-xactweb3.ep.gdi"
connection: "close"
transfer-encoding: "chunked"
content-type: "application/json;charset=utf-8"
strict-transport-security: "max-age=31536000"
```

## Tasks
- [x] If ENV['CI'] is true, suppress GovDelivery log.  

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82835

## Testing done

- [x] manual testing of `app/sidekiq/transactional_email_analytics_job` and related spec

## What areas of the site does it impact?
- `app/sidekiq/transactional_email_analytics_job`

## Acceptance Criteria 

- [x] GovDelivery::TMS::Client doesn't logs if CI=true
- [x] GovDelivery::TMS::Client logs if CI=false or not present
