### PR TITLE
[CST] Updating EVSSClaim DB records to prevent 404s

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -77,6 +77,10 @@ module V0
             evss_id: claim['id'],
             data: {}
           )
+        else
+          # If there is a record, we want to set the updated_at field
+          # to Time.zone.now
+          record.touch # rubocop:disable Rails/SkipsModelValidations
         end
       end
     end

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
       it 'updates the ’updated_at’ field on existing EVSSClaim records' do
         Timecop.travel(10.minutes.from_now)
+
         VCR.use_cassette('lighthouse/benefits_claims/index/200_response') do
           get(:index)
         end

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
       end
     end
 
+    context 'it updates existing EVSSClaim records when visited' do
+      let(:evss_id) { 600_383_363 }
+      let(:claim) { create(:evss_claim, evss_id:, user_uuid: user.uuid) }
+      let(:t1) { claim.updated_at }
+
+      before do
+        p "TIMESTAMP #1: #{t1} #{t1.class}"
+      end
+
+      it 'updates the ’updated_at’ field on existing EVSSClaim records' do
+        Timecop.travel(10.minutes.from_now)
+        VCR.use_cassette('lighthouse/benefits_claims/index/200_response') do
+          get(:index)
+        end
+
+        expect(response).to have_http_status(:ok)
+
+        t2 = EVSSClaim.where(evss_id:).first.updated_at
+        expect(t2).to be > t1
+      end
+    end
+
     context 'when not authorized' do
       it 'returns a status of 401' do
         VCR.use_cassette('lighthouse/benefits_claims/index/401_response') do


### PR DESCRIPTION
## Summary
Updating the EVSSClaim records that are already in the DB and correspond to claims that are retrieved via the `#index` or `#show` methods to have their `updated_at` times reflect the time of the latest claim retrieval. This is to prevent 404s that occur whenever the `EVSS::DeleteOldClaims` job runs nightly

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/82790

## Testing done
Added a new spec to ensure that the `updated_at` field gets updated for records that existed before the controller was visited and that are related to claims that are passed to `tap_claims` (used by the #index and #show methods)

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
