### PR TITLE
Log SignUpServiceUpdaterJob sidekiq package args

### DIFF
--- a/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
+++ b/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
@@ -7,13 +7,14 @@ module TermsOfUse
   class SignUpServiceUpdaterJob
     include Sidekiq::Job
 
-    sidekiq_options retry: 5 # ~17 mins
+    sidekiq_options retry_for: 47.hours
 
     sidekiq_retries_exhausted do |job, exception|
-      Rails.logger.warn(
-        "[TermsOfUse][SignUpServiceUpdaterJob] Retries exhausted for #{job['class']} " \
-        "with args #{job['args']}: #{exception.message}"
-      )
+      attr_package_key = job['args'].first
+      attrs = Sidekiq::AttrPackage.find(attr_package_key)
+
+      Rails.logger.warn('[TermsOfUse][SignUpServiceUpdaterJob] retries exhausted',
+                        { icn: attrs[:icn], exception_message: exception.message, attr_package_key: })
     end
 
     attr_reader :icn, :signature_name, :version


### PR DESCRIPTION
## Summary
- Clean up logging when job fails. 
  - log attributes from sidekiq attr_package since it expires 
  - move exception message to log payload
  - log package key for tracking purposes
  - remove job retry limit
  - bump `attr_package` expiration to match total possible job retry time (~21 days)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82978

## Testing
- Test the retries_exhausted block functionality:
- In rails console -`rails c`
```ruby
# 1. Create attr package

require 'sidekiq/attr_package'

attr_package_key = Sidekiq::AttrPackage.create( icn: 'some-icn', signature_name: 'some-name', version: 'some-version' )

# 2. create sidekiq job and exception

job = { args: [attr_package_key] }.as_json
exception = StandardError.new('some-error')

# 3. call retries_exhausted block

TermsOfUse::SignUpServiceUpdaterJob.sidekiq_retries_exhausted_block.call(job, exception)
```

You should see a log like:
```ruby
Rails -- [TermsOfUse][SignUpServiceUpdaterJob] retries exhausted -- { :icn => "some-icn", :exception_message => "some-error", :attr_package_key => "0c115b48be89fb8c5fc82c6ef4e10254e67274cab850b5a03ab6ec048e926b12" }
```

## What areas of the site does it impact?
Terms of use

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

