### PR TITLE
[81760] Adding special error case to ToU provisioner response when user cannot be provisioned

### DIFF
--- a/app/services/terms_of_use/provisioner.rb
+++ b/app/services/terms_of_use/provisioner.rb
@@ -29,8 +29,10 @@ module TermsOfUse
         Rails.logger.error('[TermsOfUse] [Provisioner] update_provisioning error', { icn:, response: })
         raise(Errors::ProvisionerError, 'Agreement not accepted')
       end
-
-      ActiveModel::Type::Boolean.new.cast(response[:agreement_signed])
+      if response[:cerner_provisioned].blank?
+        Rails.logger.error('[TermsOfUse] [Provisioner] update_provisioning error', { icn:, response: })
+        raise(Errors::ProvisionerError, 'Account not Provisioned')
+      end
     rescue Common::Client::Errors::ClientError => e
       log_provisioner_error(e)
       raise Errors::ProvisionerError, e.message

--- a/lib/map/sign_up/service.rb
+++ b/lib/map/sign_up/service.rb
@@ -75,7 +75,9 @@ module MAP
 
       def successful_update_provisioning_response(response, icn)
         parsed_response = parse_response(response.body, icn, 'update provisioning')
-        Rails.logger.info("#{config.logging_prefix} update provisioning success, icn: #{icn}")
+
+        Rails.logger.info("#{config.logging_prefix} update provisioning success," \
+                          " icn: #{icn}, parsed_response: #{parsed_response}")
 
         parsed_response
       end

--- a/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
+++ b/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe V0::TermsOfUseAgreementsController, type: :controller do
     shared_examples 'unsuccessful acceptance and provisioning' do
       let(:expected_status) { :unprocessable_entity }
       let(:expected_log) do
-        '[TermsOfUseAgreementsController] accept_and_provision error: TermsOfUse::Errors::AcceptorError'
+        "[TermsOfUseAgreementsController] accept_and_provision error: #{expected_error}"
       end
 
       before do
@@ -355,9 +355,21 @@ RSpec.describe V0::TermsOfUseAgreementsController, type: :controller do
         it_behaves_like 'successful acceptance and provisioning'
       end
 
-      context 'when the acceptance and provisioning is not successful' do
+      context 'when the acceptance is not successful' do
+        let(:expected_error) { TermsOfUse::Errors::AcceptorError }
+
         before do
-          allow(acceptor).to receive(:perform!).and_raise(TermsOfUse::Errors::AcceptorError)
+          allow(acceptor).to receive(:perform!).and_raise(expected_error)
+        end
+
+        it_behaves_like 'unsuccessful acceptance and provisioning'
+      end
+
+      context 'when the provisioning is not successful' do
+        let(:expected_error) { TermsOfUse::Errors::ProvisionerError }
+
+        before do
+          allow(provisioner).to receive(:perform).and_raise(expected_error)
         end
 
         it_behaves_like 'unsuccessful acceptance and provisioning'
@@ -429,14 +441,6 @@ RSpec.describe V0::TermsOfUseAgreementsController, type: :controller do
 
       context 'when the provisioning is successful' do
         it_behaves_like 'successful provisioning'
-      end
-
-      context 'when the provisioning is not successful' do
-        let(:expected_status) { :unprocessable_entity }
-        let(:provisioned) { false }
-        let(:expected_log) { '[TermsOfUseAgreementsController] update_provisioning error: Failed to provision' }
-
-        it_behaves_like 'unsuccessful provisioning'
       end
 
       context 'when the provisioning raises an error' do

--- a/spec/lib/map/sign_up/service_spec.rb
+++ b/spec/lib/map/sign_up/service_spec.rb
@@ -187,7 +187,9 @@ describe MAP::SignUp::Service do
     end
 
     context 'when response is successful' do
-      let(:expected_log_message) { "#{log_prefix} update provisioning success, icn: #{icn}" }
+      let(:expected_log_message) do
+        "#{log_prefix} update provisioning success, icn: #{icn}, parsed_response: #{expected_response_hash}"
+      end
       let(:expected_response_hash) do
         {
           agreement_signed: true,
@@ -210,7 +212,9 @@ describe MAP::SignUp::Service do
     end
 
     context 'when response is successful with 406' do
-      let(:expected_log_message) { "#{log_prefix} update provisioning success, icn: #{icn}" }
+      let(:expected_log_message) do
+        "#{log_prefix} update provisioning success, icn: #{icn}, parsed_response: #{expected_response_hash}"
+      end
       let(:expected_response_hash) do
         {
           agreement_signed: true,
@@ -233,7 +237,9 @@ describe MAP::SignUp::Service do
     end
 
     context 'when response is successful with 412' do
-      let(:expected_log_message) { "#{log_prefix} update provisioning success, icn: #{icn}" }
+      let(:expected_log_message) do
+        "#{log_prefix} update provisioning success, icn: #{icn}, parsed_response: #{expected_response_hash}"
+      end
       let(:expected_response_hash) do
         {
           agreement_signed: true,


### PR DESCRIPTION


## Summary

- This PR adds an error case to the Provisioner class for Terms of User Controller that raises an error when the user cannot be provisioned

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81760

## Testing done

- [ ] Forced response from update provisioning to ensure that cerner_provisioning was false in response, and then ensured that ToU Controller `update_provisioning` and `accept_and_provision` returned an error with the message `Account not Provisioned`

## What areas of the site does it impact?
- Terms of Use, Authentication

## Acceptance criteria

- [ ] Default `update_provisioning` mock should have the `CernerProvisioned: false` field to create this error
- [ ] Call `terms_of_use_agreements/update_provisioning` and `terms_of_use_agreements/:version/accept_and_provision`
- [ ] Confirm error with the message `Account not provisioned`