### PR TITLE
Skip Pending Tests 

### DIFF
--- a/docs/setup/running_docker.md
+++ b/docs/setup/running_docker.md
@@ -35,6 +35,12 @@ but the following tasks have been aliased to speed development:
 - `make spec_parallel_setup` - This sets up the parallel tests databases. First the existing test database is dropped and reset, then the rest of the test databases are cloned off the standard one
 - `make spec_parallel` - Run the entire test suite in parallel. A spec folder path can optionally be given as an argument to run just the spec folder in parallel
 
+### Running pending tests
+
+Pending or skipped tests are ignored by default, to run the test suite _with_ pending tests in the output, simply add the PENDING=true environment variable to the test command
+
+`PENDING=true make spec_parallel`
+
 ### Running linters
 
 - `make lint` - Run the full suite of linters on the codebase.

--- a/docs/setup/running_natively.md
+++ b/docs/setup/running_natively.md
@@ -23,6 +23,12 @@ they would be when running rails directly.
 - `RAILS_ENV=test bundle exec rake parallel:setup` - This prepares all of the test databases. It will create a test database for each processor on your computer.
 - `RAILS_ENV=test NOCOVERAGE=true bundle exec parallel_rspec spec modules` - This runs the entire test suite. Optionally, a folder path can be given as a parameter. Each file is assigned a processor, so it probably doesn't make sense to pass an individual file to run it in parallel. It is currently suggested to forgo the coverage testing by adding `NOCOVERAGE=true` flag (currently the coverage check will fail, even if the test suite passes). If you would like to check coverage for the test run, remove that flag.
 
+#### Running pending tests
+
+Pending or skipped tests are ignored by default, to run the test suite _with_ pending tests in the output, simply add the PENDING=true environment variable to the test command
+
+`RAILS_ENV=test PENDING=true NOCOVERAGE=true bundle exec parallel_rspec spec modules`
+
 ### Running linters
 
 - `rake lint` - Run the full suite of linters on the codebase and autocorrect.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,6 +120,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.filter_run focus: true
+  config.filter_run_excluding skip: true if ENV['NO_PENDING'] == 'true'
   config.run_all_when_everything_filtered = true
   config.example_status_persistence_file_path = 'tmp/specs.txt'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,7 +120,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.filter_run focus: true
-  config.filter_run_excluding skip: true if ENV['NO_PENDING'] == 'true'
+  config.filter_run_excluding skip: true unless ENV['PENDING'] == 'true'
   config.run_all_when_everything_filtered = true
   config.example_status_persistence_file_path = 'tmp/specs.txt'
 


### PR DESCRIPTION
## Summary

The purpose of the PR is to reduce the noise in the CI Run Specs job.   

- By default ignores skipped/pending tests 
- add PENDING environment variable to show skipped/pending tets 
- Allow the CI to skip pending tests
    - Pending tests don't prevent PR approval, so they could be skipped to save time. 
- Update documentation to reflect PENDING environment variable changes

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83150

## Testing done

- [x] Manual local testing 

## Acceptance criteria

- [x] Skipped/pending tests are ignored by default
- [x] When the PENDING flag is true, pending tests are NOT ignored. 
- [x] Documentation is updated
