### PR TITLE
[82599] prevents new user verification creation for locked CSPs

### DIFF
--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -139,10 +139,10 @@ module Login
     end
 
     def linked_user_verification_is_locked?
-      return false unless existing_user_account
-
-      lock = UserVerification.where(user_account: existing_user_account).any? { |v| v.send(type).present? && v.locked }
-      return false unless lock
+      return false unless existing_user_account &&
+                          UserVerification.where(user_account: existing_user_account).any? do |v|
+                            v.send(type).present? && v.locked
+                          end
 
       Rails.logger.info('[Login::UserVerifier] Locked UserVerification created ' \
                         "type=#{login_type} identifier=#{identifier}")

--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -140,7 +140,9 @@ module Login
     end
 
     def locked
-      @locked ||= existing_user_account&.user_verifications&.send(login_type)&.where(locked: true).present?
+      return false unless existing_user_account
+
+      @locked ||= existing_user_account.user_verifications.send(login_type)&.where(locked: true).present?
     end
 
     def existing_user_account

--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -102,7 +102,7 @@ module Login
                                user_account: existing_user_account || UserAccount.new(icn:),
                                backing_idme_uuid:,
                                verified_at:,
-                               locked: linked_user_verification_is_locked?)
+                               locked:)
     end
 
     def user_verification_needs_to_be_updated?
@@ -114,7 +114,8 @@ module Login
     end
 
     def set_new_user_log
-      @new_user_log = "[Login::UserVerifier] New VA.gov user, type=#{login_type}, broker=#{auth_broker}"
+      @new_user_log = '[Login::UserVerifier] New VA.gov user, ' \
+                      "type=#{login_type}, broker=#{auth_broker}, identifier=#{identifier}, locked=#{locked}"
     end
 
     def post_transaction_message_logs
@@ -135,18 +136,11 @@ module Login
       @identifier = idme_uuid
       raise Errors::UserVerificationNotCreatedError if identifier.nil?
 
-      Rails.logger.info("[Login::UserVerifier] Attempting alternate type=#{type}  identifier=#{identifier}")
+      Rails.logger.info("[Login::UserVerifier] Attempting alternate type=#{type} identifier=#{identifier}")
     end
 
-    def linked_user_verification_is_locked?
-      return false unless existing_user_account &&
-                          UserVerification.where(user_account: existing_user_account).any? do |v|
-                            v.send(type).present? && v.locked
-                          end
-
-      Rails.logger.info('[Login::UserVerifier] Locked UserVerification created ' \
-                        "type=#{login_type} identifier=#{identifier}")
-      true
+    def locked
+      @locked ||= existing_user_account&.user_verifications&.send(login_type)&.where(locked: true).present?
     end
 
     def existing_user_account

--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -142,7 +142,7 @@ module Login
     def locked
       return false unless existing_user_account
 
-      @locked ||= existing_user_account.user_verifications.send(login_type)&.where(locked: true).present?
+      @locked ||= existing_user_account.user_verifications.send(login_type).where(locked: true).present?
     end
 
     def existing_user_account

--- a/spec/services/login/user_verifier_spec.rb
+++ b/spec/services/login/user_verifier_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe Login::UserVerifier do
           end
 
           context 'and user_account matching icn already exists' do
-            let!(:existing_user_account) { UserAccount.create!(icn:) }
+            let!(:existing_user_account) { UserAccount.create(icn:) }
 
             context 'and a linked user verification with the same CSP type exists' do
               let!(:linked_user_verification) do
@@ -305,8 +305,8 @@ RSpec.describe Login::UserVerifier do
               end
 
               context 'and the linked user verification is not locked' do
-                it 'does not raise credential locked error' do
-                  expect { subject }.not_to raise_exception(SignIn::Errors::CredentialLockedError)
+                it 'creates an unlocked UserVerification object' do
+                  expect(subject.locked).to eq(false)
                 end
               end
             end

--- a/spec/services/login/user_verifier_spec.rb
+++ b/spec/services/login/user_verifier_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Login::UserVerifier do
       context 'and there is an alternate idme credential identifier' do
         let(:type) { :idme_uuid }
         let(:expected_log_idme) do
-          "[Login::UserVerifier] Attempting alternate type=#{type}  identifier=#{idme_uuid_identifier}"
+          "[Login::UserVerifier] Attempting alternate type=#{type} identifier=#{idme_uuid_identifier}"
         end
         let(:idme_uuid_identifier) { 'some-idme-uuid-identifier' }
         let!(:user_verification) do
@@ -84,7 +84,10 @@ RSpec.describe Login::UserVerifier do
     shared_examples 'user_verification with defined credential identifier' do
       context 'and current user is verified, with an ICN value' do
         let(:icn) { 'some-icn' }
-        let(:expected_log) { "[Login::UserVerifier] New VA.gov user, type=#{login_value}, broker=#{auth_broker}" }
+        let(:expected_log) do
+          '[Login::UserVerifier] New VA.gov user, ' \
+            "type=#{login_value}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
+        end
 
         context 'and user_verification for user credential already exists' do
           let(:user_account) { UserAccount.new(icn: user_identity.icn) }
@@ -244,7 +247,10 @@ RSpec.describe Login::UserVerifier do
 
         context 'and user_verification for user credential does not already exist' do
           let(:expected_verified_at_time) { Time.zone.now }
-          let(:expected_log) { "[Login::UserVerifier] New VA.gov user, type=#{login_value}, broker=#{auth_broker}" }
+          let(:expected_log) do
+            '[Login::UserVerifier] New VA.gov user, ' \
+              "type=#{login_value}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
+          end
 
           it 'makes a new user log to rails logger' do
             expect(Rails.logger).to receive(:info).with(expected_log, { icn: })
@@ -288,15 +294,10 @@ RSpec.describe Login::UserVerifier do
               end
 
               context 'and the linked user verification is locked' do
-                let(:locked_verification_log) do
-                  '[Login::UserVerifier] Locked UserVerification created ' \
-                    "type=#{login_value} identifier=#{authn_identifier}"
-                end
                 let(:locked) { true }
 
                 it 'creates a locked UserVerification object and logs the event' do
                   expect(Rails.logger).to receive(:info).with(expected_log, { icn: })
-                  expect(Rails.logger).to receive(:info).with(locked_verification_log)
                   expect(subject.locked).to eq(true)
                 end
               end
@@ -327,7 +328,10 @@ RSpec.describe Login::UserVerifier do
 
       context 'and current user is not verified, without an ICN value' do
         let(:icn) { nil }
-        let(:expected_log) { "[Login::UserVerifier] New VA.gov user, type=#{login_value}, broker=#{auth_broker}" }
+        let(:expected_log) do
+          '[Login::UserVerifier] New VA.gov user, ' \
+            "type=#{login_value}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
+        end
 
         context 'and user_verification for user credential already exists' do
           let!(:user_verification) do

--- a/spec/services/login/user_verifier_spec.rb
+++ b/spec/services/login/user_verifier_spec.rb
@@ -299,9 +299,8 @@ RSpec.describe Login::UserVerifier do
               context 'and the linked user verification is locked' do
                 let(:locked) { true }
 
-                it 'raises credential locked error and does not create a new user verification' do
-                  expect { subject }.to raise_exception(SignIn::Errors::CredentialLockedError)
-                  expect(UserVerification.where(authn_identifier_type => authn_identifier).count).to eq 0
+                it 'creates a locked UserVerification object and logs the event' do
+                  expect(subject.locked).to eq(true)
                 end
               end
 


### PR DESCRIPTION
## Summary

- Runs validation on new UserVerification creation, checking for an existing UserVerification with the same CSP type that is locked
- If a locked UserVerification is found the new UserVerification will still be created, but locked as well to prevent successful authentication.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82599

## Testing done

- [x] *New code is covered by unit tests*

To test, select the (Login.gov) user you wish to use and locate its corresponding UserAccount. Then delete the existing UserVerification if it exists and create a linked UserVerification that is locked.

```rails
UserCredentialEmail.delete_all
UserVerification.delete_all
UserVerification.new(user_account_id: <account id>, logingov_uuid: SecureRandom.hex, verified_at: Time.now, locked:true).save
```

- During SiS callback the user_verifier class will detect the linked UserVerification of the same CSP type & `locked` status and will set `locked` to true for the new UserVerification, as well as log the event.
    `Rails -- [Login::UserVerifier] Locked UserVerification created for type=logingov_uuid identifier=e444837a-e88b-4f59-87da-10d3c74c787b`
- Attempt to authenticate via `/token` with the selected user - login should be prevented by the existing credential lock behavior and Rails will throw an error:
`[SignInService] [V0::SignInController] token error -- { :errors => "Credential is locked" }`

## What areas of the site does it impact?
Authentication, new user creation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
