### PR TITLE
8473 nil response errors

### DIFF
--- a/lib/lighthouse/direct_deposit/client.rb
+++ b/lib/lighthouse/direct_deposit/client.rb
@@ -20,6 +20,8 @@ module DirectDeposit
     def get_payment_info
       response = config.get("?icn=#{@icn}")
       handle_response(response)
+    rescue Timeout::Error, Faraday::TimeoutError => e
+      raise Common::Exceptions::GatewayTimeout, e.class.name
     rescue Faraday::ClientError, Faraday::ServerError => e
       handle_error(e, config.settings.client_id, config.base_path)
     end
@@ -29,6 +31,8 @@ module DirectDeposit
 
       response = config.put("?icn=#{@icn}", body)
       handle_response(response)
+    rescue Timeout::Error, Faraday::TimeoutError => e
+      raise Common::Exceptions::GatewayTimeout, e.class.name
     rescue Faraday::ClientError, Faraday::ServerError => e
       handle_error(e, config.settings.client_id, config.base_path)
     end

--- a/lib/lighthouse/direct_deposit/client.rb
+++ b/lib/lighthouse/direct_deposit/client.rb
@@ -27,8 +27,6 @@ module DirectDeposit
     def update_payment_info(params)
       body = build_request_body(params)
 
-      raise Faraday::TimeoutError
-
       response = config.put("?icn=#{@icn}", body)
       handle_response(response)
     rescue Faraday::ClientError, Faraday::ServerError => e

--- a/lib/lighthouse/direct_deposit/client.rb
+++ b/lib/lighthouse/direct_deposit/client.rb
@@ -27,6 +27,8 @@ module DirectDeposit
     def update_payment_info(params)
       body = build_request_body(params)
 
+      raise Faraday::TimeoutError
+
       response = config.put("?icn=#{@icn}", body)
       handle_response(response)
     rescue Faraday::ClientError, Faraday::ServerError => e

--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -46,7 +46,7 @@ module Lighthouse
     # extracts and transforms Lighthouse errors into the evss_errors schema for the
     # controller ExceptionHandling class
     def self.get_errors_from_response(error, status_code)
-      errors = error.response[:body]['errors']
+      errors = error.response.try(:dig, :body, 'errors')
 
       if errors&.any?
         errors.map do |e|
@@ -89,15 +89,15 @@ module Lighthouse
     # log errors
     def self.send_error_logs(error, service_name, lighthouse_client_id, url)
       # Faraday error may contain request data
-      error.response.delete(:request)
+      error.response.try(:delete, :request)
 
       Rails.logger.error(
         service_name,
         {
           url:,
           lighthouse_client_id:,
-          status: error.response[:status],
-          body: error.response[:body]
+          status: error.response.try(:[], :status),
+          body: error.response.try(:[], :body)
         }
       )
 

--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -55,7 +55,7 @@ module Lighthouse
           transform_error_keys(e, status, title, detail, code)
         end
       else
-        error_body = error.response[:body]
+        error_body = error.response.try(:[], :body)
 
         status, title, detail, code = error_object_details(error_body, status_code)
 

--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -46,7 +46,7 @@ module Lighthouse
     # extracts and transforms Lighthouse errors into the evss_errors schema for the
     # controller ExceptionHandling class
     def self.get_errors_from_response(error, status_code)
-      errors = error.response.try(:dig, :body, 'errors')
+      errors = error.response[:body]['errors']
 
       if errors&.any?
         errors.map do |e|
@@ -55,7 +55,7 @@ module Lighthouse
           transform_error_keys(e, status, title, detail, code)
         end
       else
-        error_body = error.response.try(:[], :body)
+        error_body = error.response[:body]
 
         status, title, detail, code = error_object_details(error_body, status_code)
 
@@ -89,15 +89,15 @@ module Lighthouse
     # log errors
     def self.send_error_logs(error, service_name, lighthouse_client_id, url)
       # Faraday error may contain request data
-      error.response.try(:delete, :request)
+      error.response.delete(:request)
 
       Rails.logger.error(
         service_name,
         {
           url:,
           lighthouse_client_id:,
-          status: error.response.try(:[], :status),
-          body: error.response.try(:[], :body)
+          status: error.response[:status],
+          body: error.response[:body]
         }
       )
 

--- a/modules/mobile/spec/request/payment_information_request_spec.rb
+++ b/modules/mobile/spec/request/payment_information_request_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe 'payment information', type: :request do
         user.all_emails.each do |email|
           expect(VANotifyDdEmailJob).to receive(:perform_async).with(email, 'comp_and_pen')
         end
+
         subject
       end
     end

--- a/modules/mobile/spec/request/payment_information_request_spec.rb
+++ b/modules/mobile/spec/request/payment_information_request_spec.rb
@@ -196,11 +196,13 @@ RSpec.describe 'payment information', type: :request do
       end
 
       it 'calls VA Notify background job to send an email' do
-        user.all_emails.each do |email|
-          expect(VANotifyDdEmailJob).to receive(:perform_async).with(email, 'comp_and_pen')
-        end
+        # user.all_emails.each do |email|
+        #   expect(VANotifyDdEmailJob).to receive(:perform_async).with(email, 'comp_and_pen')
+        # end
 
         subject
+        binding.pry
+        puts "hi"
       end
     end
 

--- a/modules/mobile/spec/request/payment_information_request_spec.rb
+++ b/modules/mobile/spec/request/payment_information_request_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe 'payment information', type: :request do
         # user.all_emails.each do |email|
         #   expect(VANotifyDdEmailJob).to receive(:perform_async).with(email, 'comp_and_pen')
         # end
-
+        allow_any_instance_of(Faraday::Connection).to receive(:put).and_raise(Faraday::TimeoutError)
         subject
         binding.pry
         puts "hi"


### PR DESCRIPTION
## Summary

Fixes [this error](https://vagov.ddog-gov.com/apm/error-tracking/issue/a80368e8-f4d2-11ee-ab20-da7ad0900007?query=pod_name%3Avets-api-mobile-%2A&refresh_mode=paused&view=spans&from_ts=1712976884686&to_ts=1713066884686&live=false). I believe the underlying issue is that the lighthouse occasionally experiences timeouts and the lighthouse service exception class isn't really set up to handle timeout requests. `Farady::TimeoutError` has a nil `response`. The exception handler works makes a number of assumptions about how the error is structured that don't work with timeout errors. 

This is not the ideal fix. This is patch in one of the lighthouse clients. The correct approach is to change the lighthouse service exception class to handle all errors in a more robust fashion. I'm reluctant to do that in this PR because it would impact numerous controllers and is beyond the scope of my current ticket. I'm working with @tpharrison to ensure that that gets done in the coming sprints.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8473

## Testing done

Specs. Very difficult to force this to happen on live environments.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Direct deposit gets and puts.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
