### PR TITLE
Api 36643 remove fault message

### DIFF
--- a/modules/claims_api/lib/claims_api/error/soap_error_handler.rb
+++ b/modules/claims_api/lib/claims_api/error/soap_error_handler.rb
@@ -67,8 +67,7 @@ module ClaimsApi
     def soap_logging(status_code)
       ClaimsApi::Logger.log('soap_error_handler',
                             detail: "Returning #{status_code} via local_bgs & soap_error_handler, " \
-                                    "fault_string: #{@fault_string}, with message: #{@fault_message}, " \
-                                    "and fault_code: #{@fault_code}.")
+                                    "fault_string: #{@fault_string}, fault_code: #{@fault_code}.")
     end
   end
 end


### PR DESCRIPTION
## Summary
- Change a log line that has potential to log PII if an upstream returns it.

## Related issue(s)
- [API-36643](https://jira.devops.va.gov/browse/API-36643)

## Testing done
- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
Mostly claims v1, but some v2 also (just logging, nothing public facing)

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
