### PR TITLE
#83383: Add a new feature flag for CC direct scheduling implementation.

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1197,6 +1197,10 @@ features:
     actor_type: user
     description: Enables datadog Real User Monitoring.
     enable_in_development: true
+  va_online_scheduling_cc_direct_scheduling:
+    actor_type: user
+    description: Enables CC direct scheduling.
+    enable_in_development: true
   va_online_scheduling_use_vpg:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
Added `va_online_scheduling_cc_direct_scheduling` feature toggle.

Ticket link: https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/83383