### PR TITLE
83215 - Create sign_in_certificates table

### DIFF
--- a/db/migrate/20240517145354_create_sign_in_certificates.rb
+++ b/db/migrate/20240517145354_create_sign_in_certificates.rb
@@ -1,0 +1,16 @@
+class CreateSignInCertificates < ActiveRecord::Migration[7.1]
+  def change
+    create_table :sign_in_certificates do |t|
+      t.string :issuer, null: false
+      t.string :subject, null: false
+      t.string :serial, null: false
+      t.datetime :not_before, null: false
+      t.datetime :not_after, null: false
+      t.text :plaintext, null: false
+      t.references :client_config, foreign_key: true, null: true, index: true
+      t.references :service_account_config, foreign_key: true, null: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_15_192926) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_17_145354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -1047,6 +1047,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_15_192926) do
     t.index ["service_account_id"], name: "index_service_account_configs_on_service_account_id", unique: true
   end
 
+  create_table "sign_in_certificates", force: :cascade do |t|
+    t.string "issuer", null: false
+    t.string "subject", null: false
+    t.string "serial", null: false
+    t.datetime "not_before", null: false
+    t.datetime "not_after", null: false
+    t.text "plaintext", null: false
+    t.bigint "client_config_id"
+    t.bigint "service_account_config_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_config_id"], name: "index_sign_in_certificates_on_client_config_id"
+    t.index ["service_account_config_id"], name: "index_sign_in_certificates_on_service_account_config_id"
+  end
+
   create_table "spool_file_events", force: :cascade do |t|
     t.integer "rpo"
     t.integer "number_of_submissions"
@@ -1579,6 +1594,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_15_192926) do
   add_foreign_key "mhv_opt_in_flags", "user_accounts"
   add_foreign_key "oauth_sessions", "user_accounts"
   add_foreign_key "oauth_sessions", "user_verifications"
+  add_foreign_key "sign_in_certificates", "client_configs"
+  add_foreign_key "sign_in_certificates", "service_account_configs"
   add_foreign_key "terms_of_use_agreements", "user_accounts"
   add_foreign_key "user_acceptable_verified_credentials", "user_accounts"
   add_foreign_key "user_credential_emails", "user_verifications"


### PR DESCRIPTION
## Summary

This PR creates the `sign_in_certificates` table. Currently, certificates for SiS configurations are stored in directly within the configuration as an array.

The draft PR to create the model can be found here: https://github.com/department-of-veterans-affairs/vets-api/pull/16797

## Related issue(s)

https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/83215

## Testing done

Migration succeeds and creates table with specified columns.

## Screenshots

Not relevant.

## What areas of the site does it impact?
Sign-in Service

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Any other fields needed?
