### PR TITLE
81058 full transform, assets portion

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/asset_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/asset_calculator.rb
@@ -1,24 +1,68 @@
 # frozen_string_literal: true
 
+require 'debts_api/v0/fsr_form_transform/utils'
+include FsrFormTransform::Utils
+
 module DebtsApi
   module V0
     module FsrFormTransform
       class AssetCalculator
+
+        CASH_IN_BANK = 'Cash in a bank (savings and checkings)';
+        CASH_ON_HAND = 'Cash on hand (not in bank)';
+        US_BONDS = 'U.S. Savings Bonds'
+
         def initialize(form)
           @form = form
           @enhanced_fsr_active = @form['view:enhanced_financial_status_report']
           @assets = @form['assets']
+          
+          @monetary_assets = @assets['monetary_assets'] || []
+          @cash_on_hand = sum_values(@monetary_assets.select{|asset| asset['name'] == CASH_ON_HAND}, 'amount')
+          @cash_in_bank = sum_values(@monetary_assets.select{|asset| asset['name'] == CASH_IN_BANK}, 'amount')
+          @us_savings_bonds = @monetary_assets.select{|asset| asset['name'] == US_BONDS}
+          
+          @other_assets = @assets.dig('other_assets')
+          @automobiles = @assets.dig('automobiles')
+          @rec_vehicle_amount = @assets.dig('rec_vehicle_amount')
+          @real_estate_value = @assets['real_estate_value']&.gsub(/[^0-9.-]/, '')&.to_f || 0.0
           @real_estate_records = @form['real_estate_records']
           @questions = @form['questions']
         end
 
+        def default_output
+          {
+            'cashInBank' => '0.00',
+            'cashOnHand' => '0.00',
+            'automobiles' => [],
+            'trailersBoatsCampers' => '0.00',
+            'usSavingsBonds' => '0.00',
+            'stocksAndOtherBonds' => '0.00',
+            'realEstateOwned' => '0.00',
+            'otherAssets' => [],
+            'totalAssets' => '0.00' 
+          }
+        end
+
+        def transform_assets
+          output = default_output
+          output['cashInBank'] = dollars_cents(@cash_in_bank) if @cash_in_bank 
+          output['cashOnHand'] = dollars_cents(@cash_on_hand) if @cash_on_hand
+          output['automobiles'] = @automobiles if @automobiles
+          output['trailersBoatsCampers'] = @rec_vehicle_amount if @rec_vehicle_amount
+          output['usSavingsBonds'] = dollars_cents(sum_values(@us_savings_bonds, 'amount').to_f)
+          output['realEstateOwned'] = dollars_cents(@real_estate_value) if @real_estate_value
+          output['otherAssets'] = @other_assets if @other_assets
+          output['totalAssets'] = dollars_cents(get_total_assets)
+          re_camel(output)
+        end
+
         def get_total_assets
-          formatted_re_value = @assets['real_estate_value']&.gsub(/[^0-9.-]/, '')&.to_f || 0
           tot_other_assets = sum_values(@assets['other_assets'], 'amount')
           tot_rec_vehicles = @enhanced_fsr_active ? @assets['rec_vehicle_amount']&.gsub(/[^0-9.-]/, '')&.to_f || 0 : 0
           tot_vehicles = @questions['has_vehicle'] ? sum_values(@assets['automobiles'], 'resale_value') : 0
           real_estate = if @enhanced_fsr_active
-                          formatted_re_value
+                          @real_estate_value
                         else
                           sum_values(@real_estate_records,
                                      'real_estate_amount')
@@ -37,7 +81,7 @@ module DebtsApi
 
         def sum_values(collection, key)
           collection&.sum { |item| item[key]&.gsub(/[^0-9.-]/, '')&.to_f } || 0
-        end
+        end 
       end
     end
   end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/asset_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/asset_calculator.rb
@@ -1,31 +1,30 @@
 # frozen_string_literal: true
 
 require 'debts_api/v0/fsr_form_transform/utils'
-include FsrFormTransform::Utils
 
 module DebtsApi
   module V0
     module FsrFormTransform
       class AssetCalculator
-
-        CASH_IN_BANK = 'Cash in a bank (savings and checkings)';
-        CASH_ON_HAND = 'Cash on hand (not in bank)';
+        include ::FsrFormTransform::Utils
+        CASH_IN_BANK = 'Cash in a bank (savings and checkings)'
+        CASH_ON_HAND = 'Cash on hand (not in bank)'
         US_BONDS = 'U.S. Savings Bonds'
 
         def initialize(form)
           @form = form
           @enhanced_fsr_active = @form['view:enhanced_financial_status_report']
           @assets = @form['assets']
-          
+
           @monetary_assets = @assets['monetary_assets'] || []
-          @cash_on_hand = sum_values(@monetary_assets.select{|asset| asset['name'] == CASH_ON_HAND}, 'amount')
-          @cash_in_bank = sum_values(@monetary_assets.select{|asset| asset['name'] == CASH_IN_BANK}, 'amount')
-          @us_savings_bonds = @monetary_assets.select{|asset| asset['name'] == US_BONDS}
-          
-          @other_assets = @assets.dig('other_assets')
-          @automobiles = @assets.dig('automobiles')
-          @rec_vehicle_amount = @assets.dig('rec_vehicle_amount')
-          @real_estate_value = @assets['real_estate_value']&.gsub(/[^0-9.-]/, '')&.to_f || 0.0
+          @cash_on_hand = sum_values(@monetary_assets.select { |asset| asset['name'] == CASH_ON_HAND }, 'amount')
+          @cash_in_bank = sum_values(@monetary_assets.select { |asset| asset['name'] == CASH_IN_BANK }, 'amount')
+          @us_savings_bonds = @monetary_assets.select { |asset| asset['name'] == US_BONDS }
+
+          @other_assets = @assets['other_assets']
+          @automobiles = @assets['automobiles']
+          @rec_vehicle_amount = @assets['rec_vehicle_amount']
+          @real_estate_value = @assets['real_estate_value']&.gsub(/[^0-9.-]/, '').to_f
           @real_estate_records = @form['real_estate_records']
           @questions = @form['questions']
         end
@@ -40,13 +39,13 @@ module DebtsApi
             'stocksAndOtherBonds' => '0.00',
             'realEstateOwned' => '0.00',
             'otherAssets' => [],
-            'totalAssets' => '0.00' 
+            'totalAssets' => '0.00'
           }
         end
 
         def transform_assets
           output = default_output
-          output['cashInBank'] = dollars_cents(@cash_in_bank) if @cash_in_bank 
+          output['cashInBank'] = dollars_cents(@cash_in_bank) if @cash_in_bank
           output['cashOnHand'] = dollars_cents(@cash_on_hand) if @cash_on_hand
           output['automobiles'] = @automobiles if @automobiles
           output['trailersBoatsCampers'] = @rec_vehicle_amount if @rec_vehicle_amount
@@ -81,7 +80,7 @@ module DebtsApi
 
         def sum_values(collection, key)
           collection&.sum { |item| item[key]&.gsub(/[^0-9.-]/, '')&.to_f } || 0
-        end 
+        end
       end
     end
   end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/utils.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/utils.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module FsrFormTransform
+  module Utils
+    def dollars_cents(flt)
+      flt.round(2).to_s.gsub(/^\d+\.\d{1}$/, '\00')
+    end
+
+    def re_camel(x)
+      return re_camel_array(x) if x.class == Array
+      return re_camel_hash(x) if x.class == Hash
+    end
+
+    def re_camel_array(x)
+      result = []
+      x.each do |el|
+        if el.class == Hash || el.class == Array
+          result << re_camel(el)
+        else
+          result << el
+        end
+      end
+      return result
+    end
+
+    def re_camel_hash(x)
+      result = {}
+      x.each do |key, val|
+        if val.class == Hash || val.class == Array
+          result[key.camelcase(:lower)] = re_camel(val)
+        else
+          result[key.camelcase(:lower)] = val
+        end
+      end
+      return result
+    end
+  end
+end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/utils.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/utils.rb
@@ -7,32 +7,33 @@ module FsrFormTransform
     end
 
     def re_camel(x)
-      return re_camel_array(x) if x.class == Array
-      return re_camel_hash(x) if x.class == Hash
+      return re_camel_array(x) if x.instance_of?(Array)
+
+      re_camel_hash(x) if x.instance_of?(Hash)
     end
 
     def re_camel_array(x)
       result = []
       x.each do |el|
-        if el.class == Hash || el.class == Array
-          result << re_camel(el)
-        else
-          result << el
-        end
+        result << if el.instance_of?(Hash) || el.instance_of?(Array)
+                    re_camel(el)
+                  else
+                    el
+                  end
       end
-      return result
+      result
     end
 
     def re_camel_hash(x)
       result = {}
       x.each do |key, val|
-        if val.class == Hash || val.class == Array
-          result[key.camelcase(:lower)] = re_camel(val)
-        else
-          result[key.camelcase(:lower)] = val
-        end
+        result[key.camelcase(:lower)] = if val.instance_of?(Hash) || val.instance_of?(Array)
+                                          re_camel(val)
+                                        else
+                                          val
+                                        end
       end
-      return result
+      result
     end
   end
 end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/asset_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/asset_calculator_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::AssetCalculator, type: :service d
   let(:maximal_fsr_form_data) do
     get_fixture_absolute('modules/debts_api/spec/fixtures//pre_submission_fsr/fsr_assets_form')
   end
-
-  before do
-    calculate_total_assets
+  let(:pre_transform_fsr_form_data) do
+    get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/pre_transform')
+  end
+  let(:post_transform_fsr_form_data) do
+    get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform')
   end
 
   def calculate_total_assets
@@ -17,7 +19,16 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::AssetCalculator, type: :service d
     @total_assets = calculations_controller.get_total_assets
   end
 
+  def transform_assets
+    transformer = described_class.new(pre_transform_fsr_form_data)
+    @assets = transformer.transform_assets
+  end
+
   describe '#calculate_assets' do
+    before do
+      calculate_total_assets
+    end
+
     it 'calculates total assets' do
       expect(@total_assets).not_to be_nil
     end
@@ -25,5 +36,71 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::AssetCalculator, type: :service d
     it 'calculates total assets accurately' do
       expect(@total_assets).to eq(2120)
     end
+  end
+
+  describe '#transform_assets' do
+    before do
+      transform_assets
+    end
+
+    # it 'gets x right' do 
+    #   expected_x = post_transform_fsr_form_data['assets']['x']
+    #   actual_x = @assets['x']
+    #   expect(actual_x).to eq(expected_x)
+    # end
+
+    it 'gets cashInBank right' do
+      expected_cash_in_bank = post_transform_fsr_form_data['assets']['cashInBank']
+      actual_cash_in_bank = @assets['cashInBank']
+      expect(actual_cash_in_bank).to eq(expected_cash_in_bank)
+    end
+
+    it 'gets cashOnHand right' do
+      expected_cash_on_hand = post_transform_fsr_form_data['assets']['cashOnHand']
+      actual_cash_on_hand = @assets['cashOnHand']
+      expect(actual_cash_on_hand).to eq(expected_cash_on_hand)
+    end
+
+    it 'gets automobiles right' do 
+      expected_auto = post_transform_fsr_form_data['assets']['automobiles']
+      actual_auto = @assets['automobiles']
+      expect(actual_auto).to eq(expected_auto)
+    end
+
+    it 'gets trailersBoatsCampers right' do 
+      expected_toys = post_transform_fsr_form_data['assets']['trailersBoatsCampers']
+      actual_toys = @assets['trailersBoatsCampers']
+      expect(actual_toys).to eq(expected_toys)
+    end
+
+    it 'gets usSavingsBonds right' do 
+      expected_bonds = post_transform_fsr_form_data['assets']['usSavingsBonds']
+      actual_bonds = @assets['usSavingsBonds']
+      expect(actual_bonds).to eq(expected_bonds)
+    end
+
+    it 'gets stocksAndOtherBonds right' do 
+      expected_stocks = post_transform_fsr_form_data['assets']['stocksAndOtherBonds']
+      actual_stocks = @assets['stocksAndOtherBonds']
+      expect(actual_stocks).to eq(expected_stocks)
+    end
+    
+    it 'gets realEstateOwned right' do 
+      expected_realestate = post_transform_fsr_form_data['assets']['realEstateOwned']
+      actual_realestate = @assets['realEstateOwned']
+      expect(actual_realestate).to eq(expected_realestate)
+    end
+
+    it 'gets otherAssets right' do 
+      expected_other = post_transform_fsr_form_data['assets']['otherAssets']
+      actual_other = @assets['otherAssets']
+      expect(actual_other).to eq(expected_other)
+    end
+
+    it 'gets totalAssets right' do 
+      expected_total = post_transform_fsr_form_data['assets']['totalAssets']
+      actual_total = @assets['totalAssets']
+      expect(actual_total).to eq(expected_total)
+    end    
   end
 end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/asset_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/asset_calculator_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::AssetCalculator, type: :service d
       transform_assets
     end
 
-    # it 'gets x right' do 
+    # it 'gets x right' do
     #   expected_x = post_transform_fsr_form_data['assets']['x']
     #   actual_x = @assets['x']
     #   expect(actual_x).to eq(expected_x)
@@ -61,46 +61,46 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::AssetCalculator, type: :service d
       expect(actual_cash_on_hand).to eq(expected_cash_on_hand)
     end
 
-    it 'gets automobiles right' do 
+    it 'gets automobiles right' do
       expected_auto = post_transform_fsr_form_data['assets']['automobiles']
       actual_auto = @assets['automobiles']
       expect(actual_auto).to eq(expected_auto)
     end
 
-    it 'gets trailersBoatsCampers right' do 
+    it 'gets trailersBoatsCampers right' do
       expected_toys = post_transform_fsr_form_data['assets']['trailersBoatsCampers']
       actual_toys = @assets['trailersBoatsCampers']
       expect(actual_toys).to eq(expected_toys)
     end
 
-    it 'gets usSavingsBonds right' do 
+    it 'gets usSavingsBonds right' do
       expected_bonds = post_transform_fsr_form_data['assets']['usSavingsBonds']
       actual_bonds = @assets['usSavingsBonds']
       expect(actual_bonds).to eq(expected_bonds)
     end
 
-    it 'gets stocksAndOtherBonds right' do 
+    it 'gets stocksAndOtherBonds right' do
       expected_stocks = post_transform_fsr_form_data['assets']['stocksAndOtherBonds']
       actual_stocks = @assets['stocksAndOtherBonds']
       expect(actual_stocks).to eq(expected_stocks)
     end
-    
-    it 'gets realEstateOwned right' do 
+
+    it 'gets realEstateOwned right' do
       expected_realestate = post_transform_fsr_form_data['assets']['realEstateOwned']
       actual_realestate = @assets['realEstateOwned']
       expect(actual_realestate).to eq(expected_realestate)
     end
 
-    it 'gets otherAssets right' do 
+    it 'gets otherAssets right' do
       expected_other = post_transform_fsr_form_data['assets']['otherAssets']
       actual_other = @assets['otherAssets']
       expect(actual_other).to eq(expected_other)
     end
 
-    it 'gets totalAssets right' do 
+    it 'gets totalAssets right' do
       expected_total = post_transform_fsr_form_data['assets']['totalAssets']
       actual_total = @assets['totalAssets']
       expect(actual_total).to eq(expected_total)
-    end    
+    end
   end
 end


### PR DESCRIPTION
## Summary
This PR is part 2 of an effort to move the FSR transform logic from vets-website to vets-api. 

## Related issue(s)
[81058](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/81058)

## Testing done
Specs added

## What areas of the site does it impact?
Eventually it will impact the Financial status Report, currently it effects nothing.

## Acceptance criteria
`FsrFormTransform::AssetCalculator.new(...).transform_assets` should generate the `assets` portion of `modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform.json`
