### PR TITLE
Appointment search using VPG

### DIFF
--- a/modules/mobile/spec/request/appointments_vaos_v2_list_request_spec.rb
+++ b/modules/mobile/spec/request/appointments_vaos_v2_list_request_spec.rb
@@ -7,42 +7,63 @@ RSpec.describe 'vaos v2 appointments', type: :request do
 
   let!(:user) { sis_user(icn: '1012846043V576341') }
 
-  describe 'GET /mobile/v0/appointments' do
+  context 'with VAOS' do
     before do
-      allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
-      allow(Rails.logger).to receive(:info)
-      Timecop.freeze(Time.zone.parse('2022-01-01T19:25:00Z'))
+      Flipper.disable(:va_online_scheduling_enable_OH_reads)
+      Flipper.disable(:va_online_scheduling_use_vpg)
     end
 
-    after do
-      Timecop.return
-    end
+    describe 'GET /mobile/v0/appointments' do
+      before do
+        allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
+        allow(Rails.logger).to receive(:info)
+        Timecop.freeze(Time.zone.parse('2022-01-01T19:25:00Z'))
+      end
 
-    let(:start_date) { Time.zone.parse('2021-01-01T00:00:00Z').iso8601 }
-    let(:end_date) { Time.zone.parse('2023-01-01T00:00:00Z').iso8601 }
-    let(:params) { { startDate: start_date, endDate: end_date, include: ['pending'] } }
+      after do
+        Timecop.return
+      end
 
-    describe 'authorization' do
-      context 'when feature flag is off' do
-        before { Flipper.disable('va_online_scheduling') }
+      let(:start_date) { Time.zone.parse('2021-01-01T00:00:00Z').iso8601 }
+      let(:end_date) { Time.zone.parse('2023-01-01T00:00:00Z').iso8601 }
+      let(:params) { { startDate: start_date, endDate: end_date, include: ['pending'] } }
 
-        it 'returns forbidden' do
-          get('/mobile/v0/appointments', headers: sis_headers, params:)
-          expect(response).to have_http_status(:forbidden)
+      describe 'authorization' do
+        context 'when feature flag is off' do
+          before { Flipper.disable('va_online_scheduling') }
+
+          it 'returns forbidden' do
+            get('/mobile/v0/appointments', headers: sis_headers, params:)
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+        context 'when user does not have access' do
+          let!(:user) { sis_user(:api_auth, :loa1, icn: nil) }
+
+          it 'returns forbidden' do
+            get('/mobile/v0/appointments', headers: sis_headers, params:)
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+        context 'when feature flag is on and user has access' do
+          it 'returns ok' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200',
+                                 match_requests_on: %i[method uri]) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+            expect(response).to have_http_status(:ok)
+          end
         end
       end
 
-      context 'when user does not have access' do
-        let!(:user) { sis_user(:api_auth, :loa1, icn: nil) }
-
-        it 'returns forbidden' do
-          get('/mobile/v0/appointments', headers: sis_headers, params:)
-          expect(response).to have_http_status(:forbidden)
-        end
-      end
-
-      context 'when feature flag is on and user has access' do
-        it 'returns ok' do
+      context 'backfill facility service returns data' do
+        it 'location is populated' do
           VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
             VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
               VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200', match_requests_on: %i[method uri]) do
@@ -51,135 +72,72 @@ RSpec.describe 'vaos v2 appointments', type: :request do
             end
           end
           expect(response).to have_http_status(:ok)
+          location = response.parsed_body.dig('data', 0, 'attributes', 'location')
+          physical_location = response.parsed_body.dig('data', 0, 'attributes', 'physicalLocation')
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+          expect(location).to eq({ 'id' => '983',
+                                   'name' => 'Cheyenne VA Medical Center',
+                                   'address' =>
+                                     { 'street' => '2360 East Pershing Boulevard',
+                                       'city' => 'Cheyenne',
+                                       'state' => 'WY',
+                                       'zipCode' => '82001-5356' },
+                                   'lat' => 41.148026,
+                                   'long' => -104.786255,
+                                   'phone' =>
+                                     { 'areaCode' => '307', 'number' => '778-7550',
+                                       'extension' => nil },
+                                   'url' => nil,
+                                   'code' => nil })
+          expect(physical_location).to eq('MTZ OPC, LAB')
+          expect(response.parsed_body['meta']).to eq({
+                                                       'pagination' => { 'currentPage' => 1,
+                                                                         'perPage' => 10,
+                                                                         'totalPages' => 1,
+                                                                         'totalEntries' => 1 },
+                                                       'upcomingAppointmentsCount' => 0,
+                                                       'upcomingDaysLimit' => 7
+                                                     })
         end
       end
-    end
 
-    context 'backfill facility service returns data' do
-      it 'location is populated' do
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200', match_requests_on: %i[method uri]) do
-              get '/mobile/v0/appointments', headers: sis_headers, params:
+      context 'backfill facility service returns in error' do
+        it 'location is nil' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_500', match_requests_on: %i[method uri],
+                                                                             allow_playback_repeats: true) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200', match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
             end
           end
+          expect(response).to have_http_status(:ok)
+          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                            errors: [{ missing_facilities: ['983'] }])
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+          location = response.parsed_body.dig('data', 0, 'attributes', 'location')
+          expect(location).to eq({ 'id' => nil,
+                                   'name' => nil,
+                                   'address' =>
+                                     { 'street' => nil,
+                                       'city' => nil,
+                                       'state' => nil,
+                                       'zipCode' => nil },
+                                   'lat' => nil,
+                                   'long' => nil,
+                                   'phone' =>
+                                     { 'areaCode' => nil,
+                                       'number' => nil,
+                                       'extension' => nil },
+                                   'url' => nil,
+                                   'code' => nil })
         end
-        expect(response).to have_http_status(:ok)
-        location = response.parsed_body.dig('data', 0, 'attributes', 'location')
-        physical_location = response.parsed_body.dig('data', 0, 'attributes', 'physicalLocation')
-        expect(response.body).to match_json_schema('VAOS_v2_appointments')
-        expect(location).to eq({ 'id' => '983',
-                                 'name' => 'Cheyenne VA Medical Center',
-                                 'address' =>
-                                   { 'street' => '2360 East Pershing Boulevard',
-                                     'city' => 'Cheyenne',
-                                     'state' => 'WY',
-                                     'zipCode' => '82001-5356' },
-                                 'lat' => 41.148026,
-                                 'long' => -104.786255,
-                                 'phone' =>
-                                   { 'areaCode' => '307', 'number' => '778-7550',
-                                     'extension' => nil },
-                                 'url' => nil,
-                                 'code' => nil })
-        expect(physical_location).to eq('MTZ OPC, LAB')
-        expect(response.parsed_body['meta']).to eq({
-                                                     'pagination' => { 'currentPage' => 1,
-                                                                       'perPage' => 10,
-                                                                       'totalPages' => 1,
-                                                                       'totalEntries' => 1 },
-                                                     'upcomingAppointmentsCount' => 0,
-                                                     'upcomingDaysLimit' => 7
-                                                   })
-      end
-    end
 
-    context 'backfill facility service returns in error' do
-      it 'location is nil' do
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+        it 'does not attempt to fetch facility more than once' do
+          expect_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_facility).with('983').once
+
           VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_500', match_requests_on: %i[method uri],
                                                                            allow_playback_repeats: true) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200', match_requests_on: %i[method uri]) do
-              get '/mobile/v0/appointments', headers: sis_headers, params:
-            end
-          end
-        end
-        expect(response).to have_http_status(:ok)
-        expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
-                                                          errors: [{ missing_facilities: ['983'] }])
-        expect(response.body).to match_json_schema('VAOS_v2_appointments')
-        location = response.parsed_body.dig('data', 0, 'attributes', 'location')
-        expect(location).to eq({ 'id' => nil,
-                                 'name' => nil,
-                                 'address' =>
-                                   { 'street' => nil,
-                                     'city' => nil,
-                                     'state' => nil,
-                                     'zipCode' => nil },
-                                 'lat' => nil,
-                                 'long' => nil,
-                                 'phone' =>
-                                   { 'areaCode' => nil,
-                                     'number' => nil,
-                                     'extension' => nil },
-                                 'url' => nil,
-                                 'code' => nil })
-      end
-
-      it 'does not attempt to fetch facility more than once' do
-        expect_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_facility).with('983').once
-
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_500', match_requests_on: %i[method uri],
-                                                                         allow_playback_repeats: true) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_bad_facility_200',
-                           match_requests_on: %i[method uri]) do
-            get '/mobile/v0/appointments', headers: sis_headers, params:
-          end
-        end
-      end
-    end
-
-    context 'backfill clinic service returns data' do
-      it 'vetextId is correct' do
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200', match_requests_on: %i[method uri]) do
-              get '/mobile/v0/appointments', headers: sis_headers, params:
-            end
-          end
-        end
-        expect(response.body).to match_json_schema('VAOS_v2_appointments')
-        expect(response.parsed_body.dig('data', 0, 'attributes', 'vetextId')).to eq('442;3220827.043')
-      end
-    end
-
-    context 'backfill clinic service uses facility id that does not exist' do
-      it 'healthcareService is nil' do
-        allow_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).and_return(nil)
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_404', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinic_bad_facility_id_500',
-                           match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_bad_facility_id',
-                             match_requests_on: %i[method uri]) do
-              get '/mobile/v0/appointments', headers: sis_headers, params:
-            end
-          end
-        end
-        expect(response).to have_http_status(:ok)
-        expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
-                                                          errors: [{ missing_facilities: ['999AA'] },
-                                                                   { missing_clinics: ['999'] }])
-        expect(response.body).to match_json_schema('VAOS_v2_appointments')
-        expect(response.parsed_body.dig('data', 0, 'attributes', 'healthcareService')).to be_nil
-      end
-
-      it 'attempts to fetch clinic once' do
-        allow_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).and_return(nil)
-        expect_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).once
-
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinic_bad_facility_id_500',
-                           match_requests_on: %i[method uri]) do
             VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_bad_facility_200',
                              match_requests_on: %i[method uri]) do
               get '/mobile/v0/appointments', headers: sis_headers, params:
@@ -187,180 +145,9 @@ RSpec.describe 'vaos v2 appointments', type: :request do
           end
         end
       end
-    end
 
-    context 'when partial appointments data is received' do
-      it 'has access and returned va appointments having partial errors' do
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_partial_error',
-                             match_requests_on: %i[method uri]) do
-              get '/mobile/v0/appointments', headers: sis_headers, params:
-            end
-          end
-        end
-
-        expect(response).to have_http_status(:multi_status)
-        appointment_error = { errors: [{ appointment_errors: [{ system: 'the system',
-                                                                id: 'id-string',
-                                                                status: 'status-string',
-                                                                code: 0,
-                                                                trace_id: 'traceId-string',
-                                                                message: 'msg-string',
-                                                                detail: 'detail-string' }] }] }
-        expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error', appointment_error)
-        expect(response.parsed_body['data'].count).to eq(1)
-        expect(response.parsed_body['meta']).to include(
-          {
-            'errors' => [{ 'source' => 'VA Service' }]
-          }
-        )
-      end
-    end
-
-    context 'request telehealth onsite appointment' do
-      let(:start_date) { Time.zone.parse('1991-01-01T00:00:00Z').iso8601 }
-      let(:end_date) { Time.zone.parse('2023-01-01T00:00:00Z').iso8601 }
-      let(:params) do
-        { page: { number: 1, size: 9999 }, startDate: start_date, endDate: end_date }
-      end
-
-      it 'processes appointments without error' do
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_telehealth_onsite',
-                             match_requests_on: %i[method uri]) do
-              VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
-                                                                    tag: :force_utf8) do
-                get '/mobile/v0/appointments', headers: sis_headers, params:
-              end
-            end
-          end
-        end
-        attributes = response.parsed_body.dig('data', 0, 'attributes')
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to match_json_schema('VAOS_v2_appointments')
-
-        expect(attributes['appointmentType']).to eq('VA_VIDEO_CONNECT_ONSITE')
-        expect(attributes['location']).to eq({ 'id' => '983',
-                                               'name' => 'Cheyenne VA Medical Center',
-                                               'address' =>
-                                                { 'street' => '2360 East Pershing Boulevard',
-                                                  'city' => 'Cheyenne',
-                                                  'state' => 'WY',
-                                                  'zipCode' => '82001-5356' },
-                                               'lat' => 41.148026,
-                                               'long' => -104.786255,
-                                               'phone' =>
-                                                { 'areaCode' => '307',
-                                                  'number' => '778-7550',
-                                                  'extension' => nil },
-                                               'url' => nil,
-                                               'code' => nil })
-      end
-    end
-
-    describe 'healthcare provider names' do
-      let(:erb_template_params) { { start_date: '2021-01-01T00:00:00Z', end_date: '2023-01-26T23:59:59Z' } }
-
-      def fetch_appointments
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
-                             erb: erb_template_params,
-                             match_requests_on: %i[method uri]) do
-              VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
-                                                                    tag: :force_utf8) do
-                get '/mobile/v0/appointments', headers: sis_headers
-              end
-            end
-          end
-        end
-      end
-
-      context 'when upstream appointments index returns provider names' do
-        it 'adds names to healthcareProvider field' do
-          fetch_appointments
-          appointment = response.parsed_body['data'].find { |appt| appt['id'] == '76133' }
-          expect(appointment['attributes']['healthcareProvider']).to eq('MATTHEW ENGHAUSER')
-        end
-      end
-
-      context 'when the upstream appointments index returns provider id but no name' do
-        let(:appointment) { response.parsed_body['data'].find { |appt| appt['id'] == '76132' } }
-
-        it 'backfills that data by calling the provider service' do
-          fetch_appointments
-          expect(appointment['attributes']['healthcareProvider']).to eq('DEHGHAN, AMIR')
-        end
-
-        it 'falls back to nil when provider does not return provider data' do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
-                               erb: erb_template_params,
-                               match_requests_on: %i[method uri]) do
-                VCR.use_cassette('mobile/providers/get_provider_400', match_requests_on: %i[method uri],
-                                                                      tag: :force_utf8) do
-                  get '/mobile/v0/appointments', headers: sis_headers
-                end
-              end
-            end
-          end
-          expect(response).to have_http_status(:ok)
-          expect(appointment['attributes']['healthcareProvider']).to be_nil
-          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
-                                                            errors: [{ missing_providers: ['1407938061'] }])
-        end
-
-        it 'falls back to nil when provider service returns 500' do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
-                               erb: erb_template_params,
-                               match_requests_on: %i[method uri]) do
-                VCR.use_cassette('mobile/providers/get_provider_500', match_requests_on: %i[method uri],
-                                                                      tag: :force_utf8) do
-                  get '/mobile/v0/appointments', headers: sis_headers
-                end
-              end
-            end
-          end
-          expect(response).to have_http_status(:ok)
-          expect(appointment['attributes']['healthcareProvider']).to be_nil
-          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
-                                                            errors: [{ missing_providers: ['1407938061'] }])
-        end
-      end
-
-      context 'when upstream appointments index provides neither provider name nor id' do
-        it 'sets provider name to nil' do
-          fetch_appointments
-          appointment = response.parsed_body['data'].find { |appt| appt['id'] == '76131' }
-          expect(appointment['attributes']['healthcareProvider']).to be_nil
-        end
-      end
-    end
-
-    describe 'appointment IEN' do
-      context 'when appointment identifier with the system VistADefinedTerms/409_84 is found' do
-        it 'finds an appointment ien' do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_with_ien_200',
-                               match_requests_on: %i[method uri]) do
-                get '/mobile/v0/appointments', headers: sis_headers, params:
-              end
-            end
-          end
-          appt_ien = response.parsed_body.dig('data', 0, 'attributes', 'appointmentIen')
-          expect(response.body).to match_json_schema('VAOS_v2_appointments')
-          expect(appt_ien).to eq('11461')
-        end
-      end
-
-      context 'when appointment identifier with the system VistADefinedTerms/409_84 is not found' do
-        it 'sets appointment ien to nil' do
+      context 'backfill clinic service returns data' do
+        it 'vetextId is correct' do
           VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
             VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
               VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200', match_requests_on: %i[method uri]) do
@@ -368,38 +155,669 @@ RSpec.describe 'vaos v2 appointments', type: :request do
               end
             end
           end
-          appt_ien = response.parsed_body.dig('data', 0, 'attributes', 'appointmentIen')
           expect(response.body).to match_json_schema('VAOS_v2_appointments')
-          expect(appt_ien).to be_nil
+          expect(response.parsed_body.dig('data', 0, 'attributes', 'vetextId')).to eq('442;3220827.043')
         end
       end
-    end
 
-    describe 'upcoming_appointments_count and upcoming_days_limit' do
-      before { Timecop.freeze(Time.zone.parse('2022-01-24T00:00:00Z')) }
-
-      it 'includes the upcoming_days_limit and a count of booked appointments within that limit in the meta' do
-        VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
-          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
-                             erb: { start_date: '2021-01-01T00:00:00Z', end_date: '2023-02-18T23:59:59Z' },
+      context 'backfill clinic service uses facility id that does not exist' do
+        it 'healthcareService is nil' do
+          allow_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).and_return(nil)
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_404', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinic_bad_facility_id_500',
                              match_requests_on: %i[method uri]) do
-              VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
-                                                                    tag: :force_utf8) do
-                get '/mobile/v0/appointments', headers: sis_headers
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_bad_facility_id',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+          expect(response).to have_http_status(:ok)
+          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                            errors: [{ missing_facilities: ['999AA'] },
+                                                                     { missing_clinics: ['999'] }])
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+          expect(response.parsed_body.dig('data', 0, 'attributes', 'healthcareService')).to be_nil
+        end
+
+        it 'attempts to fetch clinic once' do
+          allow_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).and_return(nil)
+          expect_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).once
+
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinic_bad_facility_id_500',
+                             match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_bad_facility_200',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+        end
+      end
+
+      context 'when partial appointments data is received' do
+        it 'has access and returned va appointments having partial errors' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_partial_error',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+
+          expect(response).to have_http_status(:multi_status)
+          appointment_error = { errors: [{ appointment_errors: [{ system: 'the system',
+                                                                  id: 'id-string',
+                                                                  status: 'status-string',
+                                                                  code: 0,
+                                                                  trace_id: 'traceId-string',
+                                                                  message: 'msg-string',
+                                                                  detail: 'detail-string' }] }] }
+          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error', appointment_error)
+          expect(response.parsed_body['data'].count).to eq(1)
+          expect(response.parsed_body['meta']).to include(
+            {
+              'errors' => [{ 'source' => 'VA Service' }]
+            }
+          )
+        end
+      end
+
+      context 'request telehealth onsite appointment' do
+        let(:start_date) { Time.zone.parse('1991-01-01T00:00:00Z').iso8601 }
+        let(:end_date) { Time.zone.parse('2023-01-01T00:00:00Z').iso8601 }
+        let(:params) do
+          { page: { number: 1, size: 9999 }, startDate: start_date, endDate: end_date }
+        end
+
+        it 'processes appointments without error' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_telehealth_onsite',
+                               match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
+                                                                      tag: :force_utf8) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+          end
+          attributes = response.parsed_body.dig('data', 0, 'attributes')
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+
+          expect(attributes['appointmentType']).to eq('VA_VIDEO_CONNECT_ONSITE')
+          expect(attributes['location']).to eq({ 'id' => '983',
+                                                 'name' => 'Cheyenne VA Medical Center',
+                                                 'address' =>
+                                                   { 'street' => '2360 East Pershing Boulevard',
+                                                     'city' => 'Cheyenne',
+                                                     'state' => 'WY',
+                                                     'zipCode' => '82001-5356' },
+                                                 'lat' => 41.148026,
+                                                 'long' => -104.786255,
+                                                 'phone' =>
+                                                   { 'areaCode' => '307',
+                                                     'number' => '778-7550',
+                                                     'extension' => nil },
+                                                 'url' => nil,
+                                                 'code' => nil })
+        end
+      end
+
+      describe 'healthcare provider names' do
+        let(:erb_template_params) { { start_date: '2021-01-01T00:00:00Z', end_date: '2023-01-26T23:59:59Z' } }
+
+        def fetch_appointments
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
+                               erb: erb_template_params,
+                               match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
+                                                                      tag: :force_utf8) do
+                  get '/mobile/v0/appointments', headers: sis_headers
+                end
               end
             end
           end
         end
 
-        expected_upcoming_pending_count = response.parsed_body['data'].count do |appt|
-          appt_start_time = DateTime.parse(appt['attributes']['startDateUtc'])
-          appt['attributes']['isPending'] == false && appt['attributes']['status'] == 'BOOKED' &&
-            appt_start_time > Time.now.utc && appt_start_time <= 2.weeks.from_now.end_of_day.utc
+        context 'when upstream appointments index returns provider names' do
+          it 'adds names to healthcareProvider field' do
+            fetch_appointments
+            appointment = response.parsed_body['data'].find { |appt| appt['id'] == '76133' }
+            expect(appointment['attributes']['healthcareProvider']).to eq('MATTHEW ENGHAUSER')
+          end
         end
-        expect(expected_upcoming_pending_count).to eq(2)
-        expect(response.parsed_body['meta']['upcomingAppointmentsCount']).to eq(2)
-        expect(response.parsed_body['meta']['upcomingDaysLimit']).to eq(7)
+
+        context 'when the upstream appointments index returns provider id but no name' do
+          let(:appointment) { response.parsed_body['data'].find { |appt| appt['id'] == '76132' } }
+
+          it 'backfills that data by calling the provider service' do
+            fetch_appointments
+            expect(appointment['attributes']['healthcareProvider']).to eq('DEHGHAN, AMIR')
+          end
+
+          it 'falls back to nil when provider does not return provider data' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
+                                 erb: erb_template_params,
+                                 match_requests_on: %i[method uri]) do
+                  VCR.use_cassette('mobile/providers/get_provider_400', match_requests_on: %i[method uri],
+                                                                        tag: :force_utf8) do
+                    get '/mobile/v0/appointments', headers: sis_headers
+                  end
+                end
+              end
+            end
+            expect(response).to have_http_status(:ok)
+            expect(appointment['attributes']['healthcareProvider']).to be_nil
+            expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                              errors: [{ missing_providers: ['1407938061'] }])
+          end
+
+          it 'falls back to nil when provider service returns 500' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
+                                 erb: erb_template_params,
+                                 match_requests_on: %i[method uri]) do
+                  VCR.use_cassette('mobile/providers/get_provider_500', match_requests_on: %i[method uri],
+                                                                        tag: :force_utf8) do
+                    get '/mobile/v0/appointments', headers: sis_headers
+                  end
+                end
+              end
+            end
+            expect(response).to have_http_status(:ok)
+            expect(appointment['attributes']['healthcareProvider']).to be_nil
+            expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                              errors: [{ missing_providers: ['1407938061'] }])
+          end
+        end
+
+        context 'when upstream appointments index provides neither provider name nor id' do
+          it 'sets provider name to nil' do
+            fetch_appointments
+            appointment = response.parsed_body['data'].find { |appt| appt['id'] == '76131' }
+            expect(appointment['attributes']['healthcareProvider']).to be_nil
+          end
+        end
+      end
+
+      describe 'appointment IEN' do
+        context 'when appointment identifier with the system VistADefinedTerms/409_84 is found' do
+          it 'finds an appointment ien' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_with_ien_200',
+                                 match_requests_on: %i[method uri]) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+            appt_ien = response.parsed_body.dig('data', 0, 'attributes', 'appointmentIen')
+            expect(response.body).to match_json_schema('VAOS_v2_appointments')
+            expect(appt_ien).to eq('11461')
+          end
+        end
+
+        context 'when appointment identifier with the system VistADefinedTerms/409_84 is not found' do
+          it 'sets appointment ien to nil' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200',
+                                 match_requests_on: %i[method uri]) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+            appt_ien = response.parsed_body.dig('data', 0, 'attributes', 'appointmentIen')
+            expect(response.body).to match_json_schema('VAOS_v2_appointments')
+            expect(appt_ien).to be_nil
+          end
+        end
+      end
+
+      describe 'upcoming_appointments_count and upcoming_days_limit' do
+        before { Timecop.freeze(Time.zone.parse('2022-01-24T00:00:00Z')) }
+
+        it 'includes the upcoming_days_limit and a count of booked appointments within that limit in the meta' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types',
+                               erb: { start_date: '2021-01-01T00:00:00Z', end_date: '2023-02-18T23:59:59Z' },
+                               match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
+                                                                      tag: :force_utf8) do
+                  get '/mobile/v0/appointments', headers: sis_headers
+                end
+              end
+            end
+          end
+
+          expected_upcoming_pending_count = response.parsed_body['data'].count do |appt|
+            appt_start_time = DateTime.parse(appt['attributes']['startDateUtc'])
+            appt['attributes']['isPending'] == false && appt['attributes']['status'] == 'BOOKED' &&
+              appt_start_time > Time.now.utc && appt_start_time <= 2.weeks.from_now.end_of_day.utc
+          end
+          expect(expected_upcoming_pending_count).to eq(2)
+          expect(response.parsed_body['meta']['upcomingAppointmentsCount']).to eq(2)
+          expect(response.parsed_body['meta']['upcomingDaysLimit']).to eq(7)
+        end
+      end
+    end
+  end
+
+  context 'with VPG' do
+    before do
+      Flipper.enable(:va_online_scheduling_enable_OH_reads)
+      Flipper.enable(:va_online_scheduling_use_vpg)
+    end
+
+    describe 'GET /mobile/v0/appointments' do
+      before do
+        allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
+        allow(Rails.logger).to receive(:info)
+        Timecop.freeze(Time.zone.parse('2022-01-01T19:25:00Z'))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      let(:start_date) { Time.zone.parse('2021-01-01T00:00:00Z').iso8601 }
+      let(:end_date) { Time.zone.parse('2023-01-01T00:00:00Z').iso8601 }
+      let(:params) { { startDate: start_date, endDate: end_date, include: ['pending'] } }
+
+      describe 'authorization' do
+        context 'when feature flag is off' do
+          before { Flipper.disable('va_online_scheduling') }
+
+          it 'returns forbidden' do
+            get('/mobile/v0/appointments', headers: sis_headers, params:)
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+        context 'when user does not have access' do
+          let!(:user) { sis_user(:api_auth, :loa1, icn: nil) }
+
+          it 'returns forbidden' do
+            get('/mobile/v0/appointments', headers: sis_headers, params:)
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+        context 'when feature flag is on and user has access' do
+          it 'returns ok' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_vpg',
+                                 match_requests_on: %i[method uri]) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+            expect(response).to have_http_status(:ok)
+          end
+        end
+      end
+
+      context 'backfill facility service returns data' do
+        it 'location is populated' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_vpg',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+          expect(response).to have_http_status(:ok)
+          location = response.parsed_body.dig('data', 0, 'attributes', 'location')
+          physical_location = response.parsed_body.dig('data', 0, 'attributes', 'physicalLocation')
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+          expect(location).to eq({ 'id' => '983',
+                                   'name' => 'Cheyenne VA Medical Center',
+                                   'address' =>
+                                     { 'street' => '2360 East Pershing Boulevard',
+                                       'city' => 'Cheyenne',
+                                       'state' => 'WY',
+                                       'zipCode' => '82001-5356' },
+                                   'lat' => 41.148026,
+                                   'long' => -104.786255,
+                                   'phone' =>
+                                     { 'areaCode' => '307', 'number' => '778-7550',
+                                       'extension' => nil },
+                                   'url' => nil,
+                                   'code' => nil })
+          expect(physical_location).to eq('MTZ OPC, LAB')
+          expect(response.parsed_body['meta']).to eq({
+                                                       'pagination' => { 'currentPage' => 1,
+                                                                         'perPage' => 10,
+                                                                         'totalPages' => 1,
+                                                                         'totalEntries' => 1 },
+                                                       'upcomingAppointmentsCount' => 0,
+                                                       'upcomingDaysLimit' => 7
+                                                     })
+        end
+      end
+
+      context 'backfill facility service returns in error' do
+        it 'location is nil' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_500', match_requests_on: %i[method uri],
+                                                                             allow_playback_repeats: true) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_vpg',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+          expect(response).to have_http_status(:ok)
+          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                            errors: [{ missing_facilities: ['983'] }])
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+          location = response.parsed_body.dig('data', 0, 'attributes', 'location')
+          expect(location).to eq({ 'id' => nil,
+                                   'name' => nil,
+                                   'address' =>
+                                     { 'street' => nil,
+                                       'city' => nil,
+                                       'state' => nil,
+                                       'zipCode' => nil },
+                                   'lat' => nil,
+                                   'long' => nil,
+                                   'phone' =>
+                                     { 'areaCode' => nil,
+                                       'number' => nil,
+                                       'extension' => nil },
+                                   'url' => nil,
+                                   'code' => nil })
+        end
+
+        it 'does not attempt to fetch facility more than once' do
+          expect_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_facility).with('983').once
+
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_500', match_requests_on: %i[method uri],
+                                                                           allow_playback_repeats: true) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_bad_facility_200_vpg',
+                             match_requests_on: %i[method uri]) do
+              get '/mobile/v0/appointments', headers: sis_headers, params:
+            end
+          end
+        end
+      end
+
+      context 'backfill clinic service returns data' do
+        it 'vetextId is correct' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_vpg',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+          expect(response.parsed_body.dig('data', 0, 'attributes', 'vetextId')).to eq('442;3220827.043')
+        end
+      end
+
+      context 'backfill clinic service uses facility id that does not exist' do
+        it 'healthcareService is nil' do
+          allow_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).and_return(nil)
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facility_404', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinic_bad_facility_id_500',
+                             match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_bad_facility_id_vpg',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+          expect(response).to have_http_status(:ok)
+          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                            errors: [{ missing_facilities: ['999AA'] },
+                                                                     { missing_clinics: ['999'] }])
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+          expect(response.parsed_body.dig('data', 0, 'attributes', 'healthcareService')).to be_nil
+        end
+
+        it 'attempts to fetch clinic once' do
+          allow_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).and_return(nil)
+          expect_any_instance_of(Mobile::AppointmentsHelper).to receive(:get_clinic).once
+
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinic_bad_facility_id_500',
+                             match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_bad_facility_200_vpg',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+        end
+      end
+
+      context 'when partial appointments data is received' do
+        it 'has access and returned va appointments having partial errors' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_partial_error_vpg',
+                               match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: sis_headers, params:
+              end
+            end
+          end
+
+          expect(response).to have_http_status(:multi_status)
+          appointment_error = { errors: [{ appointment_errors: [{ system: 'the system',
+                                                                  id: 'id-string',
+                                                                  status: 'status-string',
+                                                                  code: 0,
+                                                                  trace_id: 'traceId-string',
+                                                                  message: 'msg-string',
+                                                                  detail: 'detail-string' }] }] }
+          expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error', appointment_error)
+          expect(response.parsed_body['data'].count).to eq(1)
+          expect(response.parsed_body['meta']).to include(
+            {
+              'errors' => [{ 'source' => 'VA Service' }]
+            }
+          )
+        end
+      end
+
+      context 'request telehealth onsite appointment' do
+        let(:start_date) { Time.zone.parse('1991-01-01T00:00:00Z').iso8601 }
+        let(:end_date) { Time.zone.parse('2023-01-01T00:00:00Z').iso8601 }
+        let(:params) do
+          { page: { number: 1, size: 9999 }, startDate: start_date, endDate: end_date }
+        end
+
+        it 'processes appointments without error' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_telehealth_onsite_vpg',
+                               match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
+                                                                      tag: :force_utf8) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+          end
+          attributes = response.parsed_body.dig('data', 0, 'attributes')
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to match_json_schema('VAOS_v2_appointments')
+
+          expect(attributes['appointmentType']).to eq('VA_VIDEO_CONNECT_ONSITE')
+          expect(attributes['location']).to eq({ 'id' => '983',
+                                                 'name' => 'Cheyenne VA Medical Center',
+                                                 'address' =>
+                                                   { 'street' => '2360 East Pershing Boulevard',
+                                                     'city' => 'Cheyenne',
+                                                     'state' => 'WY',
+                                                     'zipCode' => '82001-5356' },
+                                                 'lat' => 41.148026,
+                                                 'long' => -104.786255,
+                                                 'phone' =>
+                                                   { 'areaCode' => '307',
+                                                     'number' => '778-7550',
+                                                     'extension' => nil },
+                                                 'url' => nil,
+                                                 'code' => nil })
+        end
+      end
+
+      describe 'healthcare provider names' do
+        let(:erb_template_params) { { start_date: '2021-01-01T00:00:00Z', end_date: '2023-01-26T23:59:59Z' } }
+
+        def fetch_appointments
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types_vpg',
+                               erb: erb_template_params,
+                               match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
+                                                                      tag: :force_utf8) do
+                  get '/mobile/v0/appointments', headers: sis_headers
+                end
+              end
+            end
+          end
+        end
+
+        context 'when upstream appointments index returns provider names' do
+          it 'adds names to healthcareProvider field' do
+            fetch_appointments
+            appointment = response.parsed_body['data'].find { |appt| appt['id'] == '76133' }
+            expect(appointment['attributes']['healthcareProvider']).to eq('MATTHEW ENGHAUSER')
+          end
+        end
+
+        context 'when the upstream appointments index returns provider id but no name' do
+          let(:appointment) { response.parsed_body['data'].find { |appt| appt['id'] == '76132' } }
+
+          it 'backfills that data by calling the provider service' do
+            fetch_appointments
+            expect(appointment['attributes']['healthcareProvider']).to eq('DEHGHAN, AMIR')
+          end
+
+          it 'falls back to nil when provider does not return provider data' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types_vpg',
+                                 erb: erb_template_params,
+                                 match_requests_on: %i[method uri]) do
+                  VCR.use_cassette('mobile/providers/get_provider_400', match_requests_on: %i[method uri],
+                                                                        tag: :force_utf8) do
+                    get '/mobile/v0/appointments', headers: sis_headers
+                  end
+                end
+              end
+            end
+            expect(response).to have_http_status(:ok)
+            expect(appointment['attributes']['healthcareProvider']).to be_nil
+            expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                              errors: [{ missing_providers: ['1407938061'] }])
+          end
+
+          it 'falls back to nil when provider service returns 500' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types_vpg',
+                                 erb: erb_template_params,
+                                 match_requests_on: %i[method uri]) do
+                  VCR.use_cassette('mobile/providers/get_provider_500', match_requests_on: %i[method uri],
+                                                                        tag: :force_utf8) do
+                    get '/mobile/v0/appointments', headers: sis_headers
+                  end
+                end
+              end
+            end
+            expect(response).to have_http_status(:ok)
+            expect(appointment['attributes']['healthcareProvider']).to be_nil
+            expect(Rails.logger).to have_received(:info).with('Mobile Appointment Partial Error',
+                                                              errors: [{ missing_providers: ['1407938061'] }])
+          end
+        end
+
+        context 'when upstream appointments index provides neither provider name nor id' do
+          it 'sets provider name to nil' do
+            fetch_appointments
+            appointment = response.parsed_body['data'].find { |appt| appt['id'] == '76131' }
+            expect(appointment['attributes']['healthcareProvider']).to be_nil
+          end
+        end
+      end
+
+      describe 'appointment IEN' do
+        context 'when appointment identifier with the system VistADefinedTerms/409_84 is found' do
+          it 'finds an appointment ien' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_with_ien_200_vpg',
+                                 match_requests_on: %i[method uri]) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+            appt_ien = response.parsed_body.dig('data', 0, 'attributes', 'appointmentIen')
+            expect(response.body).to match_json_schema('VAOS_v2_appointments')
+            expect(appt_ien).to eq('11461')
+          end
+        end
+
+        context 'when appointment identifier with the system VistADefinedTerms/409_84 is not found' do
+          it 'sets appointment ien to nil' do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_200_vpg',
+                                 match_requests_on: %i[method uri]) do
+                  get '/mobile/v0/appointments', headers: sis_headers, params:
+                end
+              end
+            end
+            appt_ien = response.parsed_body.dig('data', 0, 'attributes', 'appointmentIen')
+            expect(response.body).to match_json_schema('VAOS_v2_appointments')
+            expect(appt_ien).to be_nil
+          end
+        end
+      end
+
+      describe 'upcoming_appointments_count and upcoming_days_limit' do
+        before { Timecop.freeze(Time.zone.parse('2022-01-24T00:00:00Z')) }
+
+        it 'includes the upcoming_days_limit and a count of booked appointments within that limit in the meta' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types_vpg',
+                               erb: { start_date: '2021-01-01T00:00:00Z', end_date: '2023-02-18T23:59:59Z' },
+                               match_requests_on: %i[method uri]) do
+                VCR.use_cassette('mobile/providers/get_provider_200', match_requests_on: %i[method uri],
+                                                                      tag: :force_utf8) do
+                  get '/mobile/v0/appointments', headers: sis_headers
+                end
+              end
+            end
+          end
+
+          expected_upcoming_pending_count = response.parsed_body['data'].count do |appt|
+            appt_start_time = DateTime.parse(appt['attributes']['startDateUtc'])
+            appt['attributes']['isPending'] == false && appt['attributes']['status'] == 'BOOKED' &&
+              appt_start_time > Time.now.utc && appt_start_time <= 2.weeks.from_now.end_of_day.utc
+          end
+          expect(expected_upcoming_pending_count).to eq(2)
+          expect(response.parsed_body['meta']['upcomingAppointmentsCount']).to eq(2)
+          expect(response.parsed_body['meta']['upcomingDaysLimit']).to eq(7)
+        end
       end
     end
   end

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -21,6 +21,7 @@ module VAOS
       ORACLE_HEALTH_CANCELLATIONS = :va_online_scheduling_enable_OH_cancellations
       APPOINTMENTS_USE_VPG = :va_online_scheduling_use_vpg
       APPOINTMENTS_ENABLE_OH_REQUESTS = :va_online_scheduling_enable_OH_requests
+      APPOINTMENTS_ENABLE_OH_READS = :va_online_scheduling_enable_OH_reads
 
       # rubocop:disable Metrics/MethodLength
       def get_appointments(start_date, end_date, statuses = nil, pagination_params = {})
@@ -32,7 +33,13 @@ module VAOS
         cnp_count = 0
 
         with_monitoring do
-          response = perform(:get, appointments_base_path, params, headers)
+          response = if Flipper.enabled?(APPOINTMENTS_USE_VPG, user) &&
+                        Flipper.enabled?(APPOINTMENTS_ENABLE_OH_READS)
+                       perform(:get, appointments_base_path_vpg, params, headers)
+                     else
+                       perform(:get, appointments_base_path_vaos, params, headers)
+                     end
+
           validate_response_schema(response, 'appointments_index')
           response.body[:data].each do |appt|
             # for CnP and covid appointments set cancellable to false per GH#57824, GH#58690
@@ -96,9 +103,9 @@ module VAOS
         with_monitoring do
           response = if Flipper.enabled?(APPOINTMENTS_USE_VPG, user) &&
                         Flipper.enabled?(APPOINTMENTS_ENABLE_OH_REQUESTS)
-                       perform(:post, "/vpg/v1/patients/#{user.icn}/appointments", params, headers)
+                       perform(:post, appointments_base_path_vpg, params, headers)
                      else
-                       perform(:post, appointments_base_path, params, headers)
+                       perform(:post, appointments_base_path_vaos, params, headers)
                      end
           convert_appointment_time(response.body)
           OpenStruct.new(response.body)
@@ -549,8 +556,12 @@ module VAOS
         )
       end
 
-      def appointments_base_path
+      def appointments_base_path_vaos
         "/vaos/v1/patients/#{user.icn}/appointments"
+      end
+
+      def appointments_base_path_vpg
+        "/vpg/v1/patients/#{user.icn}/appointments"
       end
 
       def avs_path(sid)
@@ -558,7 +569,12 @@ module VAOS
       end
 
       def get_appointment_base_path(appointment_id)
-        "/vaos/v1/patients/#{user.icn}/appointments/#{appointment_id}"
+        if Flipper.enabled?(APPOINTMENTS_USE_VPG, user) &&
+           Flipper.enabled?(APPOINTMENTS_ENABLE_OH_READS)
+          "/vpg/v1/patients/#{user.icn}/appointments/#{appointment_id}"
+        else
+          "/vaos/v1/patients/#{user.icn}/appointments/#{appointment_id}"
+        end
       end
 
       def date_params(start_date, end_date)

--- a/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_bad_facility_id_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_bad_facility_id_vpg.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2023-01-26T23:59:59Z&pageSize=0&start=2021-01-01T00:00:00Z&statuses=proposed,cancelled,booked,fulfilled,arrived
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - eyJhbGciOiJSUzUxMiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJsYXN0TmFtZSI6Ik1vcmdhbiIsInN1YiI6IjEwMTI4NDYwNDNWNTc2MzQxIiwiYXV0aGVudGljYXRpb25BdXRob3JpdHkiOiJnb3YudmEudmFvcyIsImdlbmRlciI6IkZFTUFMRSIsImlzcyI6Imdvdi52YS52YW1mLnVzZXJzZXJ2aWNlLnYyIiwidmFtZi5hdXRoLnJlc291cmNlcyI6WyJeLiooXC8pP3BhdGllbnRbc10_XC8oSUNOXC8pPzEwMTI4NDYwNDNWNTc2MzQxKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_OTgzXC9wYXRpZW50W3NdP1wvNzIxNjY4NVwvYXBwb2ludG1lbnRzKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_NjY4XC9wYXRpZW50W3NdP1wvMTYxNzM3XC9hcHBvaW50bWVudHMoXC8uKik_JCIsIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNDRcL2FwcG9pbnRtZW50cyhcLy4qKT8kIl0sInNzbiI6Ijc5NjA2MTk3NiIsInNzdCI6MTYzOTQzODEwNSwicGF0aWVudCI6eyJmaXJzdE5hbWUiOiJKYWNxdWVsaW5lIiwibGFzdE5hbWUiOiJNb3JnYW4iLCJnZW5kZXIiOiJGRU1BTEUiLCJpY24iOiIxMDEyODQ2MDQzVjU3NjM0MSIsImRvYiI6IjE5NjItMDItMDciLCJkYXRlT2ZCaXJ0aCI6IjE5NjItMDItMDciLCJzc24iOiI3OTYwNjE5NzYifSwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2Mzk0MzkwMDYsImp0aSI6IjVjNmFmYzUyLWJkZDctNGVhMi04OTM0LTI5NTk2YWUyZjUzMCIsImlkVHlwZSI6IklDTiIsImRhdGVPZkJpcnRoIjoiMTk2MjAyMDciLCJ2ZXJzaW9uIjoyLjYsImVkaXBpZCI6IjEwMTM1OTk3MzAiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNzIxNjY4NSIsInNpdGVJZCI6Ijk4MyJ9LHsicGF0aWVudElkIjoiMTYxNzM3Iiwic2l0ZUlkIjoiNjY4In0seyJwYXRpZW50SWQiOiI1NTIxNjEwNDQiLCJzaXRlSWQiOiI5ODQifV0sImZpcnN0TmFtZSI6IkphY3F1ZWxpbmUiLCJzdGFmZkRpc2NsYWltZXJBY2NlcHRlZCI6dHJ1ZSwibmJmIjoxNjM5NDM3OTI2LCJkb2IiOiIxOTYyMDIwNyIsImxvYSI6Mn0.rrz0bmrUqXf9NZZtShsP0Ub5ZRiI2LUqgqncs-M9rtBTUyDyW8qUBO7MhYvmJEhA40S66eOh0-JZyDJYKUVg4Hl-1ZRiVc5uX-0I1MhxoQ0DYR886bH373Eybuh3AU30gyohkBun0M3NQV2C3bxs-f0_wkAuyNIR-Rxm6nysei5ZmnQvzJChHg1YKtQKNUUUIVOPDCro_q6pTw_QQA7ZdIVxmT4f18xHODxs9aUXnHOFJPzUK32VbPQVtVYRQWK_SFisG42-Rhxg3O_rDiUeFSxfV-Uhjo2RBh9W0utGuMW9qDbRx1AqQrIsbBM7YeaNhno-BBsfQyeX3--GlXq1YA
+        X-Request-Id:
+          - ''
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Mon, 13 Dec 2021 23:28:26 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '653'
+        Server:
+          - openresty
+        X-Vamf-Version:
+          - 1.14.1
+        B3:
+          - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        X-Vamf-Build:
+          - 20a82ca
+        X-Vamf-Timestamp:
+          - '2021-11-26T16:29:10+0000'
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+        X-Envoy-Upstream-Service-Time:
+          - '424'
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: '{"data":[
+      {
+   "id":"121133",
+   "identifier":[
+      {
+         "system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
+         "value":"999;20220827.094500"
+      }
+   ],
+   "kind":"clinic",
+   "status":"cancelled",
+   "service_type":"optometry",
+   "patient_icn":"1012846043V576341",
+   "location_id":"999AA",
+   "clinic":"999",
+   "start":"2022-08-27T15:45:00Z",
+   "cancelation_reason":{
+      "coding":[
+         {
+            "system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+            "code":"pat",
+            "display":"The appointment was cancelled by the patient"
+         }
+      ]
+   },
+   "cancellable":false,
+   "extension":{
+      "cc_location":{
+         "address":{
+            
+         }
+      },
+      "vista_status":[
+         "CANCELLED BY PATIENT",
+         "FUTURE"
+      ]
+   }
+}
+      ]}'
+    recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_partial_error_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_partial_error_vpg.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2023-01-26T23:59:59Z&pageSize=0&start=2021-01-01T00:00:00Z&statuses=proposed,cancelled,booked,fulfilled,arrived
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - eyJhbGciOiJSUzUxMiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJsYXN0TmFtZSI6Ik1vcmdhbiIsInN1YiI6IjEwMTI4NDYwNDNWNTc2MzQxIiwiYXV0aGVudGljYXRpb25BdXRob3JpdHkiOiJnb3YudmEudmFvcyIsImdlbmRlciI6IkZFTUFMRSIsImlzcyI6Imdvdi52YS52YW1mLnVzZXJzZXJ2aWNlLnYyIiwidmFtZi5hdXRoLnJlc291cmNlcyI6WyJeLiooXC8pP3BhdGllbnRbc10_XC8oSUNOXC8pPzEwMTI4NDYwNDNWNTc2MzQxKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_OTgzXC9wYXRpZW50W3NdP1wvNzIxNjY4NVwvYXBwb2ludG1lbnRzKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_NjY4XC9wYXRpZW50W3NdP1wvMTYxNzM3XC9hcHBvaW50bWVudHMoXC8uKik_JCIsIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNDRcL2FwcG9pbnRtZW50cyhcLy4qKT8kIl0sInNzbiI6Ijc5NjA2MTk3NiIsInNzdCI6MTYzOTQzODEwNSwicGF0aWVudCI6eyJmaXJzdE5hbWUiOiJKYWNxdWVsaW5lIiwibGFzdE5hbWUiOiJNb3JnYW4iLCJnZW5kZXIiOiJGRU1BTEUiLCJpY24iOiIxMDEyODQ2MDQzVjU3NjM0MSIsImRvYiI6IjE5NjItMDItMDciLCJkYXRlT2ZCaXJ0aCI6IjE5NjItMDItMDciLCJzc24iOiI3OTYwNjE5NzYifSwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2Mzk0MzkwMDYsImp0aSI6IjVjNmFmYzUyLWJkZDctNGVhMi04OTM0LTI5NTk2YWUyZjUzMCIsImlkVHlwZSI6IklDTiIsImRhdGVPZkJpcnRoIjoiMTk2MjAyMDciLCJ2ZXJzaW9uIjoyLjYsImVkaXBpZCI6IjEwMTM1OTk3MzAiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNzIxNjY4NSIsInNpdGVJZCI6Ijk4MyJ9LHsicGF0aWVudElkIjoiMTYxNzM3Iiwic2l0ZUlkIjoiNjY4In0seyJwYXRpZW50SWQiOiI1NTIxNjEwNDQiLCJzaXRlSWQiOiI5ODQifV0sImZpcnN0TmFtZSI6IkphY3F1ZWxpbmUiLCJzdGFmZkRpc2NsYWltZXJBY2NlcHRlZCI6dHJ1ZSwibmJmIjoxNjM5NDM3OTI2LCJkb2IiOiIxOTYyMDIwNyIsImxvYSI6Mn0.rrz0bmrUqXf9NZZtShsP0Ub5ZRiI2LUqgqncs-M9rtBTUyDyW8qUBO7MhYvmJEhA40S66eOh0-JZyDJYKUVg4Hl-1ZRiVc5uX-0I1MhxoQ0DYR886bH373Eybuh3AU30gyohkBun0M3NQV2C3bxs-f0_wkAuyNIR-Rxm6nysei5ZmnQvzJChHg1YKtQKNUUUIVOPDCro_q6pTw_QQA7ZdIVxmT4f18xHODxs9aUXnHOFJPzUK32VbPQVtVYRQWK_SFisG42-Rhxg3O_rDiUeFSxfV-Uhjo2RBh9W0utGuMW9qDbRx1AqQrIsbBM7YeaNhno-BBsfQyeX3--GlXq1YA
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Dec 2021 23:28:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.14.1
+      B3:
+      - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 20a82ca
+      X-Vamf-Timestamp:
+      - '2021-11-26T16:29:10+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      X-Envoy-Upstream-Service-Time:
+      - '424'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[
+      {
+   "id":"121133",
+   "identifier":[
+      {
+         "system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
+         "value":"999;20220827.094500"
+      }
+   ],
+   "kind":"clinic",
+   "status":"cancelled",
+   "service_type":"optometry",
+   "patient_icn":"1012846043V576341",
+   "location_id":"983",
+   "clinic":"455",
+   "start":"2022-08-27T15:45:00Z",
+   "cancelation_reason":{
+      "coding":[
+         {
+            "system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+            "code":"pat",
+            "display":"The appointment was cancelled by the patient"
+         }
+      ]
+   },
+   "cancellable":false,
+   "extension":{
+      "cc_location":{
+         "address":{
+            
+         }
+      },
+      "vista_status":[
+         "CANCELLED BY PATIENT",
+         "FUTURE"
+      ]
+   }
+}
+      ],
+      "failures":[
+   {
+      "system":"the system",
+      "id":"id-string",
+      "status":"status-string",
+      "code":0,
+      "traceId":"traceId-string",
+      "message":"msg-string",
+      "detail":"detail-string"
+   }
+]}'
+  recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_telehealth_onsite_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_telehealth_onsite_vpg.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2023-01-26T23:59:59Z&pageSize=0&start=1991-01-01T00:00:00Z&statuses=proposed,cancelled,booked,fulfilled,arrived
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - eyJhbGciOiJSUzUxMiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJsYXN0TmFtZSI6Ik1vcmdhbiIsInN1YiI6IjEwMTI4NDYwNDNWNTc2MzQxIiwiYXV0aGVudGljYXRpb25BdXRob3JpdHkiOiJnb3YudmEudmFvcyIsImdlbmRlciI6IkZFTUFMRSIsImlzcyI6Imdvdi52YS52YW1mLnVzZXJzZXJ2aWNlLnYyIiwidmFtZi5hdXRoLnJlc291cmNlcyI6WyJeLiooXC8pP3BhdGllbnRbc10_XC8oSUNOXC8pPzEwMTI4NDYwNDNWNTc2MzQxKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_OTgzXC9wYXRpZW50W3NdP1wvNzIxNjY4NVwvYXBwb2ludG1lbnRzKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_NjY4XC9wYXRpZW50W3NdP1wvMTYxNzM3XC9hcHBvaW50bWVudHMoXC8uKik_JCIsIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNDRcL2FwcG9pbnRtZW50cyhcLy4qKT8kIl0sInNzbiI6Ijc5NjA2MTk3NiIsInNzdCI6MTYzOTQzODEwNSwicGF0aWVudCI6eyJmaXJzdE5hbWUiOiJKYWNxdWVsaW5lIiwibGFzdE5hbWUiOiJNb3JnYW4iLCJnZW5kZXIiOiJGRU1BTEUiLCJpY24iOiIxMDEyODQ2MDQzVjU3NjM0MSIsImRvYiI6IjE5NjItMDItMDciLCJkYXRlT2ZCaXJ0aCI6IjE5NjItMDItMDciLCJzc24iOiI3OTYwNjE5NzYifSwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2Mzk0MzkwMDYsImp0aSI6IjVjNmFmYzUyLWJkZDctNGVhMi04OTM0LTI5NTk2YWUyZjUzMCIsImlkVHlwZSI6IklDTiIsImRhdGVPZkJpcnRoIjoiMTk2MjAyMDciLCJ2ZXJzaW9uIjoyLjYsImVkaXBpZCI6IjEwMTM1OTk3MzAiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNzIxNjY4NSIsInNpdGVJZCI6Ijk4MyJ9LHsicGF0aWVudElkIjoiMTYxNzM3Iiwic2l0ZUlkIjoiNjY4In0seyJwYXRpZW50SWQiOiI1NTIxNjEwNDQiLCJzaXRlSWQiOiI5ODQifV0sImZpcnN0TmFtZSI6IkphY3F1ZWxpbmUiLCJzdGFmZkRpc2NsYWltZXJBY2NlcHRlZCI6dHJ1ZSwibmJmIjoxNjM5NDM3OTI2LCJkb2IiOiIxOTYyMDIwNyIsImxvYSI6Mn0.rrz0bmrUqXf9NZZtShsP0Ub5ZRiI2LUqgqncs-M9rtBTUyDyW8qUBO7MhYvmJEhA40S66eOh0-JZyDJYKUVg4Hl-1ZRiVc5uX-0I1MhxoQ0DYR886bH373Eybuh3AU30gyohkBun0M3NQV2C3bxs-f0_wkAuyNIR-Rxm6nysei5ZmnQvzJChHg1YKtQKNUUUIVOPDCro_q6pTw_QQA7ZdIVxmT4f18xHODxs9aUXnHOFJPzUK32VbPQVtVYRQWK_SFisG42-Rhxg3O_rDiUeFSxfV-Uhjo2RBh9W0utGuMW9qDbRx1AqQrIsbBM7YeaNhno-BBsfQyeX3--GlXq1YA
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Dec 2021 23:28:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.14.1
+      B3:
+      - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 20a82ca
+      X-Vamf-Timestamp:
+      - '2021-11-26T16:29:10+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      X-Envoy-Upstream-Service-Time:
+      - '424'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[{
+      "id": "167462",
+      "identifier": [
+          {
+              "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+              "value": "a8766c10-e3ce-42d9-a1cb-c43d539ed7d9"
+          }
+      ],
+      "kind": "telehealth",
+      "status": "booked",
+      "patientIcn": "1012845331V153043",
+      "locationId": "983",
+      "practitioners": [
+          {
+              "identifier": [
+                  {
+                      "system": "dfn-984",
+                      "value": "36016"
+                  }
+              ],
+              "name": {
+                  "family": "NADEAU",
+                  "given": [
+                      "MARCY"
+                  ]
+              },
+              "practiceName": "Dayton OH VAMC"
+          }
+      ],
+      "start": "2022-03-28T17:25:00Z",
+      "end": "2022-03-28T17:45:00Z",
+      "minutesDuration": 20,
+      "cancellable": true,
+      "patientInstruction": "Medication Review\n\n- As part of your video visit, your provider wants to review all the medications, vitamins, herbs, and supplements you are taking. Your provider will want to know about these items even if you get them from a local store, another provider, or another VA clinic.\n - Please have available during the visit information about all the medications, vitamins, herbs and supplements you are taking to your video visit.\n - Informing your provider about all these will help you get the best and safest care possible.\n\nRemember, it is your medications, your life, so play it safe by reviewing all your medications with your health care team.",
+      "telehealth": {
+          "url": "https://pexip.mapsandbox.net/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000423688@pexip.mapsandbox.net&pin=449814&aid=a8766c10-e3ce-42d9-a1cb-c43d539ed7d9#",
+          "group": false,
+          "vvsKind": "CLINIC_BASED"
+      },
+      "extension": {
+          "ccLocation": {
+              "address": {}
+          },
+          "patientHasMobileGfe": false
+      },
+      "localStartTime": "2024-03-28T13:25:00.000-04:00",
+      "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+              "id": "983",
+              "vistaSite": "983",
+              "vastParent": "983",
+              "type": "va_health_facility",
+              "name": "Dayton VA Medical Center",
+              "classification": "VA Medical Center (VAMC)",
+              "timezone": {
+                  "timeZoneId": "America/New_York"
+              },
+              "lat": 39.74935,
+              "long": -84.2532,
+              "website": "https://www.dayton.va.gov/locations/directions.asp",
+              "phone": {
+                  "main": "937-268-6511"
+              },
+              "physicalAddress": {
+                  "type": "physical",
+                  "line": [
+                      "4100 West Third Street"
+                  ],
+                  "city": "Dayton",
+                  "state": "OH",
+                  "postalCode": "45428-9000"
+              },
+              "healthService": [
+                  "Audiology",
+                  "Cardiology",
+                  "DentalServices",
+                  "Dermatology",
+                  "Gastroenterology",
+                  "Gynecology",
+                  "MentalHealthCare",
+                  "Nutrition",
+                  "Ophthalmology",
+                  "Optometry",
+                  "Orthopedics",
+                  "Podiatry",
+                  "PrimaryCare",
+                  "SpecialtyCare",
+                  "Urology",
+                  "WomensHealth"
+              ]
+          }
+      }
+  }
+      ]}'
+  recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_200_vpg.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2023-01-26T23:59:59Z&pageSize=0&start=2021-01-01T00:00:00Z&statuses=proposed,cancelled,booked,fulfilled,arrived
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - eyJhbGciOiJSUzUxMiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJsYXN0TmFtZSI6Ik1vcmdhbiIsInN1YiI6IjEwMTI4NDYwNDNWNTc2MzQxIiwiYXV0aGVudGljYXRpb25BdXRob3JpdHkiOiJnb3YudmEudmFvcyIsImdlbmRlciI6IkZFTUFMRSIsImlzcyI6Imdvdi52YS52YW1mLnVzZXJzZXJ2aWNlLnYyIiwidmFtZi5hdXRoLnJlc291cmNlcyI6WyJeLiooXC8pP3BhdGllbnRbc10_XC8oSUNOXC8pPzEwMTI4NDYwNDNWNTc2MzQxKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_OTgzXC9wYXRpZW50W3NdP1wvNzIxNjY4NVwvYXBwb2ludG1lbnRzKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_NjY4XC9wYXRpZW50W3NdP1wvMTYxNzM3XC9hcHBvaW50bWVudHMoXC8uKik_JCIsIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNDRcL2FwcG9pbnRtZW50cyhcLy4qKT8kIl0sInNzbiI6Ijc5NjA2MTk3NiIsInNzdCI6MTYzOTQzODEwNSwicGF0aWVudCI6eyJmaXJzdE5hbWUiOiJKYWNxdWVsaW5lIiwibGFzdE5hbWUiOiJNb3JnYW4iLCJnZW5kZXIiOiJGRU1BTEUiLCJpY24iOiIxMDEyODQ2MDQzVjU3NjM0MSIsImRvYiI6IjE5NjItMDItMDciLCJkYXRlT2ZCaXJ0aCI6IjE5NjItMDItMDciLCJzc24iOiI3OTYwNjE5NzYifSwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2Mzk0MzkwMDYsImp0aSI6IjVjNmFmYzUyLWJkZDctNGVhMi04OTM0LTI5NTk2YWUyZjUzMCIsImlkVHlwZSI6IklDTiIsImRhdGVPZkJpcnRoIjoiMTk2MjAyMDciLCJ2ZXJzaW9uIjoyLjYsImVkaXBpZCI6IjEwMTM1OTk3MzAiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNzIxNjY4NSIsInNpdGVJZCI6Ijk4MyJ9LHsicGF0aWVudElkIjoiMTYxNzM3Iiwic2l0ZUlkIjoiNjY4In0seyJwYXRpZW50SWQiOiI1NTIxNjEwNDQiLCJzaXRlSWQiOiI5ODQifV0sImZpcnN0TmFtZSI6IkphY3F1ZWxpbmUiLCJzdGFmZkRpc2NsYWltZXJBY2NlcHRlZCI6dHJ1ZSwibmJmIjoxNjM5NDM3OTI2LCJkb2IiOiIxOTYyMDIwNyIsImxvYSI6Mn0.rrz0bmrUqXf9NZZtShsP0Ub5ZRiI2LUqgqncs-M9rtBTUyDyW8qUBO7MhYvmJEhA40S66eOh0-JZyDJYKUVg4Hl-1ZRiVc5uX-0I1MhxoQ0DYR886bH373Eybuh3AU30gyohkBun0M3NQV2C3bxs-f0_wkAuyNIR-Rxm6nysei5ZmnQvzJChHg1YKtQKNUUUIVOPDCro_q6pTw_QQA7ZdIVxmT4f18xHODxs9aUXnHOFJPzUK32VbPQVtVYRQWK_SFisG42-Rhxg3O_rDiUeFSxfV-Uhjo2RBh9W0utGuMW9qDbRx1AqQrIsbBM7YeaNhno-BBsfQyeX3--GlXq1YA
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Dec 2021 23:28:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.14.1
+      B3:
+      - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 20a82ca
+      X-Vamf-Timestamp:
+      - '2021-11-26T16:29:10+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      X-Envoy-Upstream-Service-Time:
+      - '424'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[
+      {
+   "id":"121133",
+   "identifier":[
+      {
+         "system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
+         "value":"999;20220827.094500"
+      }
+   ],
+   "kind":"clinic",
+   "status":"cancelled",
+   "service_type":"optometry",
+   "patient_icn":"1012846043V576341",
+   "location_id":"983",
+   "clinic":"455",
+   "start":"2022-08-27T10:30:00Z",
+   "cancelation_reason":{
+      "coding":[
+         {
+            "system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+            "code":"pat",
+            "display":"The appointment was cancelled by the patient"
+         }
+      ]
+   },
+   "cancellable":false,
+   "extension":{
+      "cc_location":{
+         "address":{
+            
+         }
+      },
+      "vista_status":[
+         "CANCELLED BY PATIENT",
+         "FUTURE"
+      ]
+   }
+}
+      ]}'
+  recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_with_ien_200_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointment_with_ien_200_vpg.yml
@@ -1,0 +1,123 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2023-01-26T23:59:59Z&pageSize=0&start=2021-01-01T00:00:00Z&statuses=proposed,cancelled,booked,fulfilled,arrived
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - eyJhbGciOiJSUzUxMiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJsYXN0TmFtZSI6Ik1vcmdhbiIsInN1YiI6IjEwMTI4NDYwNDNWNTc2MzQxIiwiYXV0aGVudGljYXRpb25BdXRob3JpdHkiOiJnb3YudmEudmFvcyIsImdlbmRlciI6IkZFTUFMRSIsImlzcyI6Imdvdi52YS52YW1mLnVzZXJzZXJ2aWNlLnYyIiwidmFtZi5hdXRoLnJlc291cmNlcyI6WyJeLiooXC8pP3BhdGllbnRbc10_XC8oSUNOXC8pPzEwMTI4NDYwNDNWNTc2MzQxKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_OTgzXC9wYXRpZW50W3NdP1wvNzIxNjY4NVwvYXBwb2ludG1lbnRzKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_NjY4XC9wYXRpZW50W3NdP1wvMTYxNzM3XC9hcHBvaW50bWVudHMoXC8uKik_JCIsIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNDRcL2FwcG9pbnRtZW50cyhcLy4qKT8kIl0sInNzbiI6Ijc5NjA2MTk3NiIsInNzdCI6MTYzOTQzODEwNSwicGF0aWVudCI6eyJmaXJzdE5hbWUiOiJKYWNxdWVsaW5lIiwibGFzdE5hbWUiOiJNb3JnYW4iLCJnZW5kZXIiOiJGRU1BTEUiLCJpY24iOiIxMDEyODQ2MDQzVjU3NjM0MSIsImRvYiI6IjE5NjItMDItMDciLCJkYXRlT2ZCaXJ0aCI6IjE5NjItMDItMDciLCJzc24iOiI3OTYwNjE5NzYifSwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2Mzk0MzkwMDYsImp0aSI6IjVjNmFmYzUyLWJkZDctNGVhMi04OTM0LTI5NTk2YWUyZjUzMCIsImlkVHlwZSI6IklDTiIsImRhdGVPZkJpcnRoIjoiMTk2MjAyMDciLCJ2ZXJzaW9uIjoyLjYsImVkaXBpZCI6IjEwMTM1OTk3MzAiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNzIxNjY4NSIsInNpdGVJZCI6Ijk4MyJ9LHsicGF0aWVudElkIjoiMTYxNzM3Iiwic2l0ZUlkIjoiNjY4In0seyJwYXRpZW50SWQiOiI1NTIxNjEwNDQiLCJzaXRlSWQiOiI5ODQifV0sImZpcnN0TmFtZSI6IkphY3F1ZWxpbmUiLCJzdGFmZkRpc2NsYWltZXJBY2NlcHRlZCI6dHJ1ZSwibmJmIjoxNjM5NDM3OTI2LCJkb2IiOiIxOTYyMDIwNyIsImxvYSI6Mn0.rrz0bmrUqXf9NZZtShsP0Ub5ZRiI2LUqgqncs-M9rtBTUyDyW8qUBO7MhYvmJEhA40S66eOh0-JZyDJYKUVg4Hl-1ZRiVc5uX-0I1MhxoQ0DYR886bH373Eybuh3AU30gyohkBun0M3NQV2C3bxs-f0_wkAuyNIR-Rxm6nysei5ZmnQvzJChHg1YKtQKNUUUIVOPDCro_q6pTw_QQA7ZdIVxmT4f18xHODxs9aUXnHOFJPzUK32VbPQVtVYRQWK_SFisG42-Rhxg3O_rDiUeFSxfV-Uhjo2RBh9W0utGuMW9qDbRx1AqQrIsbBM7YeaNhno-BBsfQyeX3--GlXq1YA
+        X-Request-Id:
+          - ''
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Mon, 13 Dec 2021 23:28:26 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '653'
+        Server:
+          - openresty
+        X-Vamf-Version:
+          - 1.14.1
+        B3:
+          - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        X-Vamf-Build:
+          - 20a82ca
+        X-Vamf-Timestamp:
+          - '2021-11-26T16:29:10+0000'
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+        X-Envoy-Upstream-Service-Time:
+          - '424'
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: '{"data": [{
+    "id": "188453",
+    "identifier": [
+      {
+        "system": "Appointment/",
+        "value": "413938333131343631"
+      },
+      {
+        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+        "value": "983:11461"
+      }
+    ],
+    "kind": "clinic",
+    "status": "booked",
+    "service_type": "covid",
+    "service_types": [
+      {
+        "coding": [
+          {
+            "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+            "code": "covid"
+          }
+        ]
+      }
+    ],
+    "service_category": [
+      {
+        "coding": [
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+            "code": "REGULAR",
+            "display": "REGULAR"
+          }
+        ],
+        "text": "REGULAR"
+      }
+    ],
+    "patient_icn": "1012845331V153043",
+    "location_id": "983",
+    "clinic": "1038",
+    "start": "2022-10-03T17:15:00Z",
+    "end": "2022-10-03T17:30:00Z",
+    "minutes_duration": 15,
+    "slot": {
+      "id": "3230323331303033313731353A323032333130303331373330",
+      "start": "2023-10-03T17:15:00Z",
+      "end": "2023-10-03T17:30:00Z"
+    },
+    "created": "2023-10-02T00:00:00Z",
+    "cancellable": false,
+    "extension": {
+      "cc_location": {
+        "address": {}
+      },
+      "vista_status": [
+        "NO ACTION TAKEN"
+      ],
+      "pre_checkin_allowed": true,
+      "e_checkin_allowed": true
+    },
+    "local_start_time": "2023-10-03T11:15:00.000-06:00"
+  }]
+}'
+    recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointments_bad_facility_200_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointments_bad_facility_200_vpg.yml
@@ -1,0 +1,136 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2023-01-26T23:59:59Z&pageSize=0&start=2021-01-01T00:00:00Z&statuses=proposed,cancelled,booked,fulfilled,arrived
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - eyJhbGciOiJSUzUxMiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJsYXN0TmFtZSI6Ik1vcmdhbiIsInN1YiI6IjEwMTI4NDYwNDNWNTc2MzQxIiwiYXV0aGVudGljYXRpb25BdXRob3JpdHkiOiJnb3YudmEudmFvcyIsImdlbmRlciI6IkZFTUFMRSIsImlzcyI6Imdvdi52YS52YW1mLnVzZXJzZXJ2aWNlLnYyIiwidmFtZi5hdXRoLnJlc291cmNlcyI6WyJeLiooXC8pP3BhdGllbnRbc10_XC8oSUNOXC8pPzEwMTI4NDYwNDNWNTc2MzQxKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_OTgzXC9wYXRpZW50W3NdP1wvNzIxNjY4NVwvYXBwb2ludG1lbnRzKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_NjY4XC9wYXRpZW50W3NdP1wvMTYxNzM3XC9hcHBvaW50bWVudHMoXC8uKik_JCIsIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNDRcL2FwcG9pbnRtZW50cyhcLy4qKT8kIl0sInNzbiI6Ijc5NjA2MTk3NiIsInNzdCI6MTYzOTQzODEwNSwicGF0aWVudCI6eyJmaXJzdE5hbWUiOiJKYWNxdWVsaW5lIiwibGFzdE5hbWUiOiJNb3JnYW4iLCJnZW5kZXIiOiJGRU1BTEUiLCJpY24iOiIxMDEyODQ2MDQzVjU3NjM0MSIsImRvYiI6IjE5NjItMDItMDciLCJkYXRlT2ZCaXJ0aCI6IjE5NjItMDItMDciLCJzc24iOiI3OTYwNjE5NzYifSwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2Mzk0MzkwMDYsImp0aSI6IjVjNmFmYzUyLWJkZDctNGVhMi04OTM0LTI5NTk2YWUyZjUzMCIsImlkVHlwZSI6IklDTiIsImRhdGVPZkJpcnRoIjoiMTk2MjAyMDciLCJ2ZXJzaW9uIjoyLjYsImVkaXBpZCI6IjEwMTM1OTk3MzAiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNzIxNjY4NSIsInNpdGVJZCI6Ijk4MyJ9LHsicGF0aWVudElkIjoiMTYxNzM3Iiwic2l0ZUlkIjoiNjY4In0seyJwYXRpZW50SWQiOiI1NTIxNjEwNDQiLCJzaXRlSWQiOiI5ODQifV0sImZpcnN0TmFtZSI6IkphY3F1ZWxpbmUiLCJzdGFmZkRpc2NsYWltZXJBY2NlcHRlZCI6dHJ1ZSwibmJmIjoxNjM5NDM3OTI2LCJkb2IiOiIxOTYyMDIwNyIsImxvYSI6Mn0.rrz0bmrUqXf9NZZtShsP0Ub5ZRiI2LUqgqncs-M9rtBTUyDyW8qUBO7MhYvmJEhA40S66eOh0-JZyDJYKUVg4Hl-1ZRiVc5uX-0I1MhxoQ0DYR886bH373Eybuh3AU30gyohkBun0M3NQV2C3bxs-f0_wkAuyNIR-Rxm6nysei5ZmnQvzJChHg1YKtQKNUUUIVOPDCro_q6pTw_QQA7ZdIVxmT4f18xHODxs9aUXnHOFJPzUK32VbPQVtVYRQWK_SFisG42-Rhxg3O_rDiUeFSxfV-Uhjo2RBh9W0utGuMW9qDbRx1AqQrIsbBM7YeaNhno-BBsfQyeX3--GlXq1YA
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Dec 2021 23:28:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.14.1
+      B3:
+      - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 20a82ca
+      X-Vamf-Timestamp:
+      - '2021-11-26T16:29:10+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      X-Envoy-Upstream-Service-Time:
+      - '424'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[
+      {
+   "id":"121133",
+   "identifier":[
+      {
+         "system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
+         "value":"999;20220827.094500"
+      }
+   ],
+   "kind":"clinic",
+   "status":"cancelled",
+   "service_type":"optometry",
+   "patient_icn":"1012846043V576341",
+   "location_id":"983",
+   "clinic":"455",
+   "start":"2022-08-27T15:45:00Z",
+   "cancelation_reason":{
+      "coding":[
+         {
+            "system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+            "code":"pat",
+            "display":"The appointment was cancelled by the patient"
+         }
+      ]
+   },
+   "cancellable":false,
+   "extension":{
+      "cc_location":{
+         "address":{
+            
+         }
+      },
+      "vista_status":[
+         "CANCELLED BY PATIENT",
+         "FUTURE"
+      ]
+   }
+},
+      {
+   "id":"121134",
+   "identifier":[
+      {
+         "system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
+         "value":"999;20220827.094500"
+      }
+   ],
+   "kind":"clinic",
+   "status":"cancelled",
+   "service_type":"optometry",
+   "patient_icn":"1012846043V576341",
+   "location_id":"983",
+   "clinic":"455",
+   "start":"2022-08-27T15:45:00Z",
+   "cancelation_reason":{
+      "coding":[
+         {
+            "system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+            "code":"pat",
+            "display":"The appointment was cancelled by the patient"
+         }
+      ]
+   },
+   "cancellable":false,
+   "extension":{
+      "cc_location":{
+         "address":{
+            
+         }
+      },
+      "vista_status":[
+         "CANCELLED BY PATIENT",
+         "FUTURE"
+      ]
+   }
+}
+      ]}'
+  recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types_vpg.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=<%= end_date || "2023-01-26T23:59:59Z" %>&pageSize=0&start=<%= start_date || "2021-01-01T00:00:00Z" %>&statuses=proposed,cancelled,booked,fulfilled,arrived
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - eyJhbGciOiJSUzUxMiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJsYXN0TmFtZSI6Ik1vcmdhbiIsInN1YiI6IjEwMTI4NDYwNDNWNTc2MzQxIiwiYXV0aGVudGljYXRpb25BdXRob3JpdHkiOiJnb3YudmEudmFvcyIsImdlbmRlciI6IkZFTUFMRSIsImlzcyI6Imdvdi52YS52YW1mLnVzZXJzZXJ2aWNlLnYyIiwidmFtZi5hdXRoLnJlc291cmNlcyI6WyJeLiooXC8pP3BhdGllbnRbc10_XC8oSUNOXC8pPzEwMTI4NDYwNDNWNTc2MzQxKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_OTgzXC9wYXRpZW50W3NdP1wvNzIxNjY4NVwvYXBwb2ludG1lbnRzKFwvLiopPyQiLCJeLiooXC8pP3NpdGVbc10_XC8oZGZuLSk_NjY4XC9wYXRpZW50W3NdP1wvMTYxNzM3XC9hcHBvaW50bWVudHMoXC8uKik_JCIsIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNDRcL2FwcG9pbnRtZW50cyhcLy4qKT8kIl0sInNzbiI6Ijc5NjA2MTk3NiIsInNzdCI6MTYzOTQzODEwNSwicGF0aWVudCI6eyJmaXJzdE5hbWUiOiJKYWNxdWVsaW5lIiwibGFzdE5hbWUiOiJNb3JnYW4iLCJnZW5kZXIiOiJGRU1BTEUiLCJpY24iOiIxMDEyODQ2MDQzVjU3NjM0MSIsImRvYiI6IjE5NjItMDItMDciLCJkYXRlT2ZCaXJ0aCI6IjE5NjItMDItMDciLCJzc24iOiI3OTYwNjE5NzYifSwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2Mzk0MzkwMDYsImp0aSI6IjVjNmFmYzUyLWJkZDctNGVhMi04OTM0LTI5NTk2YWUyZjUzMCIsImlkVHlwZSI6IklDTiIsImRhdGVPZkJpcnRoIjoiMTk2MjAyMDciLCJ2ZXJzaW9uIjoyLjYsImVkaXBpZCI6IjEwMTM1OTk3MzAiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNzIxNjY4NSIsInNpdGVJZCI6Ijk4MyJ9LHsicGF0aWVudElkIjoiMTYxNzM3Iiwic2l0ZUlkIjoiNjY4In0seyJwYXRpZW50SWQiOiI1NTIxNjEwNDQiLCJzaXRlSWQiOiI5ODQifV0sImZpcnN0TmFtZSI6IkphY3F1ZWxpbmUiLCJzdGFmZkRpc2NsYWltZXJBY2NlcHRlZCI6dHJ1ZSwibmJmIjoxNjM5NDM3OTI2LCJkb2IiOiIxOTYyMDIwNyIsImxvYSI6Mn0.rrz0bmrUqXf9NZZtShsP0Ub5ZRiI2LUqgqncs-M9rtBTUyDyW8qUBO7MhYvmJEhA40S66eOh0-JZyDJYKUVg4Hl-1ZRiVc5uX-0I1MhxoQ0DYR886bH373Eybuh3AU30gyohkBun0M3NQV2C3bxs-f0_wkAuyNIR-Rxm6nysei5ZmnQvzJChHg1YKtQKNUUUIVOPDCro_q6pTw_QQA7ZdIVxmT4f18xHODxs9aUXnHOFJPzUK32VbPQVtVYRQWK_SFisG42-Rhxg3O_rDiUeFSxfV-Uhjo2RBh9W0utGuMW9qDbRx1AqQrIsbBM7YeaNhno-BBsfQyeX3--GlXq1YA
+        X-Request-Id:
+          - ''
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Mon, 13 Dec 2021 23:28:26 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '653'
+        Server:
+          - openresty
+        X-Vamf-Version:
+          - 1.14.1
+        B3:
+          - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        X-Vamf-Build:
+          - 20a82ca
+        X-Vamf-Timestamp:
+          - '2021-11-26T16:29:10+0000'
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+        X-Envoy-Upstream-Service-Time:
+          - '424'
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: '{"data": [
+          {
+            "id":"76131",
+            "identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vvs/id", "value":"28b565a0-64ef-4e13-82c5-aec4c41071c5"}],
+            "kind":"clinic",
+            "status":"booked",
+             "location_id":"438",
+             "clinic":"16",
+             "start":"2022-01-23T21:03:00Z",
+             "end":"2022-01-23T21:23:00Z",
+             "minutes_duration":20,
+             "comment":"Test2 - 1/23/2022 - CLINIC_BASED - Farid",
+             "cancellable":true,
+             "patient_instruction":"this is a test of instruction",
+             "telehealth":{"group":false, "vvs_kind":"CLINIC_BASED"},
+             "extension":{"cc_location":{"address":{}}}
+            },
+            {
+              "id":"76132",
+              "identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vvs/id", "value":"deda8593-5500-4a7c-ab75-ad266d6af8e8"}],
+              "kind":"clinic",
+              "status":"booked",
+              "patient_icn":"1012853802V084487",
+              "location_id":"442",
+              "clinic":"5079",
+              "practitioners":[{"identifier":[{"system":"dfn-983", "value":"1407938061"}]}],
+              "start":"2022-01-24T21:03:00Z",
+              "end":"2022-01-24T21:23:00Z",
+              "minutes_duration":20,
+              "comment":"Test3 - 1/23/2022 - CLINIC_BASED - Farid", "cancellable":true, "patient_instruction":"this is a test of instruction",
+              "telehealth":{"group":false, "vvs_kind":"CLINIC_BASED"},
+              "extension":{"cc_location":{"address":{}}}
+            },
+            {
+              "id":"76133",
+              "identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vvs/id", "value":"ed1c8182-c92f-403f-8eac-104f9eb79963"}],
+              "kind":"clinic",
+              "status":"booked",
+              "service_type":"optometry",
+              "patient_icn":"1012853802V084487",
+              "location_id":"984",
+              "clinic":"1184",
+              "practitioners":[{"identifier":[{"system":"dfn-983", "value":"520647609"}], "name":{"family":"ENGHAUSER", "given":["MATTHEW"]}, "practice_name":"Site #983"}],
+              "start":"2022-01-25T21:03:00Z",
+              "end":"2022-01-25T21:23:00Z",
+              "minutes_duration":20,
+              "comment":"Test4 - 1/23/2022 - CLINIC_BASED - Farid",
+              "cancellable":true,
+              "patient_instruction":"this is a test of instruction",
+              "telehealth":{"group":false, "vvs_kind":"CLINIC_BASED"},
+              "extension":{"cc_location":{"address":{}}}
+            }
+        ]}'
+    recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_CnP_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_CnP_vpg.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012845331V153043/appointments/159472
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 May 2023 17:16:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '842'
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      X-Envoy-Upstream-Service-Time:
+      - '332'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"159472","identifier":[{"system":"http://vista-scheduling-provider-v1.sqa/vistasp/v1/Appointment/","value":"523938333130383130"}],"kind":"phone","status":"proposed","serviceType":"socialWork","serviceTypes":[{"coding":[{"system":"http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type","code":"socialWork"}]}],"serviceCategory":[{"coding":[{"system":"http://www.va.gov/Terminology/VistADefinedTerms/409_1","code":"COMPENSATION
+        & PENSION","display":"COMPENSATION & PENSION"}],"text":"COMPENSATION & PENSION"}],"reasonCode":{"text":"call
+        from iss"},"patientIcn":"1012845331V153043","locationId":"983","start":"2023-02-04T00:00:00Z","created":"2023-02-03T00:00:00Z","requestedPeriods":[{"start":"2023-02-04T00:00:00Z","end":"2023-02-04T00:00:00Z"}],"cancellable":true,"extension":{"ccLocation":{"address":{}}}}}'
+  recorded_at: Wed, 17 May 2023 17:16:41 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/facilities/v2/facilities/983
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Aug 2021 17:48:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1114'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 2.8.0
+      B3:
+      - 531af1d2054d758c-b79b44f980a35120-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - '6026315'
+      X-Vamf-Timestamp:
+      - '2021-07-06T17:59:37+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id" : "983",
+          "vistaSite" : "983",
+          "vastParent" : "983",
+          "type" : "va_facilities",
+          "name" : "Cheyenne VA Medical Center",
+          "classification" : "VA Medical Center (VAMC)",
+          "timezone": {
+              "zoneId": "America/New_York",
+              "abbreviation": "EDT"
+          },
+          "lat" : 39.744507,
+          "long" : -104.830956,
+          "website" : "https://www.denver.va.gov/locations/directions.asp",
+          "phone" : {
+            "main" : "307-778-7550",
+            "fax" : "307-778-7381",
+            "pharmacy" : "866-420-6337",
+            "afterHours" : "307-778-7550",
+            "patientAdvocate" : "307-778-7550 x7517",
+            "mentalHealthClinic" : "307-778-7349",
+            "enrollmentCoordinator" : "307-778-7550 x7579"
+          },
+          "physicalAddress" : {
+            "type" : "physical",
+            "line" : [ "2360 East Pershing Boulevard" ],
+            "city" : "Cheyenne",
+            "state" : "WY",
+            "postalCode" : "82001-5356"
+          },
+          "mobile" : false,
+          "healthService" : [ "Audiology", "Cardiology", "DentalServices", "EmergencyCare", "Gastroenterology", "Gynecology", "MentalHealthCare", "Nutrition", "Ophthalmology", "Optometry", "Orthopedics", "Podiatry", "PrimaryCare", "SpecialtyCare", "UrgentCare", "Urology", "WomensHealth" ],
+          "operatingStatus" : {
+            "code" : "NORMAL"
+          }
+        }
+  recorded_at: Mon, 09 Aug 2021 17:48:58 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_booked_cerner_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_booked_cerner_vpg.yml
@@ -1,0 +1,154 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://veterans.va.gov/vpg/v1/patients/1012845331V153043/appointments/180402
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - stubbed_token
+        X-Request-Id:
+          - ''
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Tue, 08 Aug 2023 20:19:59 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '938'
+        Server:
+          - openresty
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+        X-Envoy-Upstream-Service-Time:
+          - '956'
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+      body:
+        encoding: UTF-8
+        string: '{"data":{"id":"180402","identifier":[{"system":"urn:va.gov:masv2:cerner:appointment","value":"Appointment/52499028"}],"kind":"clinic","status":"booked","serviceTypes":[{"coding":[{"system":"https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249","code":"381456583"}]}],"description":"PC
+        Established Patient","patientIcn":"1012845331V153043","locationId":"757","practitioners":[{"name":{"family":"Everett","given":["Matthew","DO"]}}],"start":"2024-07-19T12:00:00Z","end":"2024-07-19T12:30:00Z","minutesDuration":30,"requestedPeriods":[{"start":"2024-07-19T12:00:00Z","end":"2024-07-19T12:30:00Z"}],"cancellable":false,"patientInstruction":"Preparations:\n-
+        If you have any new non-VA medical records since your last visit, please bring
+        them.\r\nIf you need to cancel or reschedule your appointment, please call
+        our Contact Center at 614-257-5200 or visit the patient portal.","extension":{"ccLocation":{"address":{}}}}}'
+    recorded_at: Tue, 08 Aug 2023 20:19:59 GMT
+  - request:
+      method: get
+      uri: https://veterans.va.gov/facilities/v2/facilities/757
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - stubbed_token
+        X-Request-Id:
+          - ''
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Tue, 08 Aug 2023 20:19:59 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '1319'
+        Server:
+          - openresty
+        X-Vamf-Version:
+          - 2.21.2
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        X-Vamf-Build:
+          - e6edae5
+        X-Vamf-Timestamp:
+          - '2023-07-03T20:22:49+0000'
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+        X-Envoy-Upstream-Service-Time:
+          - '1'
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "id" : "757",
+            "facilitiesApiId" : "vha_757",
+            "vistaSite" : "757",
+            "vastParent" : "757",
+            "type" : "va_health_facility",
+            "name" : "Chalmers P. Wylie Veterans Outpatient Clinic",
+            "classification" : "Health Care Center (HCC)",
+            "timezone" : {
+              "timeZoneId" : "America/New_York"
+            },
+            "lat" : 39.98048,
+            "long" : -82.9123,
+            "website" : "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+            "phone" : {
+              "main" : "614-257-5200",
+              "fax" : "614-257-5460",
+              "pharmacy" : "614-257-5230",
+              "afterHours" : "614-257-5512",
+              "patientAdvocate" : "614-257-5290",
+              "mentalHealthClinic" : "614-257-5631",
+              "enrollmentCoordinator" : "614-257-5628"
+            },
+            "mailingAddress" : {
+              "type" : "postal",
+              "line" : [ null, null, null ]
+            },
+            "physicalAddress" : {
+              "type" : "physical",
+              "line" : [ "420 North James Road", null, null ],
+              "city" : "Columbus",
+              "state" : "OH",
+              "postalCode" : "43219-1834"
+            },
+            "mobile" : false,
+            "healthService" : [ "Audiology", "Cardiology", "CaregiverSupport", "Covid19Vaccine", "Dermatology", "Gastroenterology", "Gynecology", "Nutrition", "Orthopedics", "Podiatry", "PrimaryCare", "UrgentCare", "Urology", "WomensHealth" ],
+            "operatingStatus" : {
+              "code" : "NORMAL"
+            },
+            "visn" : "10"
+          }
+    recorded_at: Tue, 08 Aug 2023 20:19:59 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_non_med_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_non_med_vpg.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012845331V153043/appointments/159472
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 May 2023 17:16:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '842'
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      X-Envoy-Upstream-Service-Time:
+      - '332'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"159472","identifier":[{"system":"http://vista-scheduling-provider-v1.sqa/vistasp/v1/Appointment/","value":"523938333130383130"}],"kind":"phone","status":"proposed","serviceType":"socialWork","serviceTypes":[{"coding":[{"system":"http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type","code":"socialWork"}]}],"serviceCategory":[{"coding":[{"system":"http://www.va.gov/Terminology/VistADefinedTerms/409_1","code":"SERVICE
+        CONNECTED","display":"SERVICE CONNECTED"}],"text":"SERVICE CONNECTED"}],"reasonCode":{"text":"call
+        from iss"},"patientIcn":"1012845331V153043","locationId":"983","start":"2023-02-04T00:00:00Z","created":"2023-02-03T00:00:00Z","requestedPeriods":[{"start":"2023-02-04T00:00:00Z","end":"2023-02-04T00:00:00Z"}],"cancellable":true,"extension":{"ccLocation":{"address":{}}}}}'
+  recorded_at: Wed, 17 May 2023 17:16:41 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/facilities/v2/facilities/983
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Aug 2021 17:48:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1114'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 2.8.0
+      B3:
+      - 531af1d2054d758c-b79b44f980a35120-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - '6026315'
+      X-Vamf-Timestamp:
+      - '2021-07-06T17:59:37+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id" : "983",
+          "vistaSite" : "983",
+          "vastParent" : "983",
+          "type" : "va_facilities",
+          "name" : "Cheyenne VA Medical Center",
+          "classification" : "VA Medical Center (VAMC)",
+          "timezone": {
+              "zoneId": "America/New_York",
+              "abbreviation": "EDT"
+          },
+          "lat" : 39.744507,
+          "long" : -104.830956,
+          "website" : "https://www.denver.va.gov/locations/directions.asp",
+          "phone" : {
+            "main" : "307-778-7550",
+            "fax" : "307-778-7381",
+            "pharmacy" : "866-420-6337",
+            "afterHours" : "307-778-7550",
+            "patientAdvocate" : "307-778-7550 x7517",
+            "mentalHealthClinic" : "307-778-7349",
+            "enrollmentCoordinator" : "307-778-7550 x7579"
+          },
+          "physicalAddress" : {
+            "type" : "physical",
+            "line" : [ "2360 East Pershing Boulevard" ],
+            "city" : "Cheyenne",
+            "state" : "WY",
+            "postalCode" : "82001-5356"
+          },
+          "mobile" : false,
+          "healthService" : [ "Audiology", "Cardiology", "DentalServices", "EmergencyCare", "Gastroenterology", "Gynecology", "MentalHealthCare", "Nutrition", "Ophthalmology", "Optometry", "Orthopedics", "Podiatry", "PrimaryCare", "SpecialtyCare", "UrgentCare", "Urology", "WomensHealth" ],
+          "operatingStatus" : {
+            "code" : "NORMAL"
+          }
+        }
+  recorded_at: Mon, 09 Aug 2021 17:48:58 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_with_facility_200_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_200_with_facility_200_vpg.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments/70060
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Dec 2021 23:28:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.14.1
+      B3:
+      - 8c17e441da8d346f6934d442b0a0ac7c-e1581452019f7fc4-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 20a82ca
+      X-Vamf-Timestamp:
+      - '2021-11-26T16:29:10+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      X-Envoy-Upstream-Service-Time:
+      - '424'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"70060","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a4890c47da65e2b017db59b20500000"}],"kind":"clinic","status":"proposed","serviceType":"socialWork","reasonCode":{"text":"text"},"patientIcn":"1012846043V576341","locationId":"983GB","created":"2021-12-13T14:03:02Z","requestedPeriods":[{"start":"2021-12-20T00:00:00Z","end":"2021-12-20T11:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"C_Natalie.Yun@cerner.com"},{"type":"phone","value":"2566832029"}]},"preferredTimesForPhoneCall":["Morning"],"cancellationReason":{"code":"other"},"cancellable":true,"extension":{"ccLocation":{"address":{}}}}}'
+  recorded_at: Mon, 13 Dec 2021 23:28:26 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/facilities/v2/facilities/983GB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Aug 2021 17:48:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1114'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 2.8.0
+      B3:
+      - 531af1d2054d758c-b79b44f980a35120-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - '6026315'
+      X-Vamf-Timestamp:
+      - '2021-07-06T17:59:37+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id" : "983GB",
+          "vistaSite" : "983",
+          "vastParent" : "983",
+          "type" : "va_facilities",
+          "name" : "Cheyenne VA Medical Center",
+          "classification" : "VA Medical Center (VAMC)",
+          "timezone": {
+              "zoneId": "America/New_York",
+              "abbreviation": "EDT"
+          },
+          "lat" : 39.744507,
+          "long" : -104.830956,
+          "website" : "https://www.denver.va.gov/locations/directions.asp",
+          "phone" : {
+            "main" : "307-778-7550",
+            "fax" : "307-778-7381",
+            "pharmacy" : "866-420-6337",
+            "afterHours" : "307-778-7550",
+            "patientAdvocate" : "307-778-7550 x7517",
+            "mentalHealthClinic" : "307-778-7349",
+            "enrollmentCoordinator" : "307-778-7550 x7579"
+          },
+          "physicalAddress" : {
+            "type" : "physical",
+            "line" : [ "2360 East Pershing Boulevard" ],
+            "city" : "Cheyenne",
+            "state" : "WY",
+            "postalCode" : "82001-5356"
+          },
+          "mobile" : false,
+          "healthService" : [ "Audiology", "Cardiology", "DentalServices", "EmergencyCare", "Gastroenterology", "Gynecology", "MentalHealthCare", "Nutrition", "Ophthalmology", "Optometry", "Orthopedics", "Podiatry", "PrimaryCare", "SpecialtyCare", "UrgentCare", "Urology", "WomensHealth" ],
+          "operatingStatus" : {
+            "code" : "NORMAL"
+          }
+        }
+  recorded_at: Mon, 09 Aug 2021 17:48:58 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_500_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointment_500_vpg.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments/00000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed-token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Wed, 26 May 2021 22:47:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '260'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.5.0
+      B3:
+      - edb650c5fed99511-10c51619b9c07470-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - d8af5ed
+      X-Vamf-Timestamp:
+      - '2021-05-24T22:00:44+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+    body:
+      encoding: UTF-8
+      string: '{"id":"6d0c8a60-5eff-44bc-b734-a65dcfdc6ca7","code":500,"errorCode":7003,"traceId":"edb650c5fed99511","message":"failed
+        to fetch appointments","meta":{"upstreamErrorSource":"mobile-appointment-service","upstreamErrorId":"1768c311-b339-4826-b014-822df0bb76bd"}}'
+  recorded_at: Wed, 26 May 2021 22:47:08 GMT

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointments_200_with_facilities_200_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointments_200_with_facilities_200_vpg.yml
@@ -1,0 +1,248 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2022-12-01T19:45:00Z&pageSize=0&start=2022-01-01T19:25:00Z
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Nov 2021 19:56:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.12.1
+      B3:
+      - fb5e01cb7d2f4995-d9e83a83cc4e7326-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 661c259
+      X-Vamf-Timestamp:
+      - '2021-11-01T15:35:46+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"37060","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vista/984/appointment/id","value":"3583;20210902.100000"}],"kind":"clinic","status":"cancelled","serviceType":"audiology","patientIcn":"1012845331V153043","locationId":"984","clinic":"3583","start":"2021-09-02T14:00:00Z","cancellationReason":{"code":"other"},"cancelationReason":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason","code":"pat","display":"The
+        appointment was cancelled by the patient"}]},"cancellable":false},{"id":"32237","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id","value":"707;20210903.094500"}],"kind":"clinic","status":"cancelled","serviceType":"foodAndNutrition","patientIcn":"1012845331V153043","locationId":"983","clinic":"707","start":"2021-09-03T15:45:00Z","cancellationReason":{"code":"other"},"cancelationReason":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason","code":"pat","display":"The
+        appointment was cancelled by the patient"}]},"cancellable":false},{"id":"50059","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id","value":"308;20210903.140000"}],"kind":"clinic","status":"cancelled","serviceType":"primaryCare","patientIcn":"1012845331V153043","locationId":"983","clinic":"308","start":"2021-09-03T20:00:00Z","cancellationReason":{"code":"other"},"cancelationReason":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason","code":"pat","display":"The
+        appointment was cancelled by the patient"}]},"cancellable":false},{"id":"41121","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id","value":"923;20210906.100000"}],"kind":"clinic","status":"cancelled","patientIcn":"1012845331V153043","locationId":"983","clinic":"923","start":"2021-09-06T16:00:00Z","cancellationReason":{"code":"other"},"cancelationReason":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason","code":"pat","display":"The
+        appointment was cancelled by the patient"}]},"cancellable":false},{"id":"50096","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id","value":"308;20210907.140000"}],"kind":"clinic","serviceType":"primaryCare","patientIcn":"1012845331V153043","locationId":"983","clinic":"308","start":"2021-09-07T20:00:00Z","end":"2021-09-07T20:20:00Z","minutesDuration":20,"slot":{"id":"3230323130393037323030303A323032313039303732303230","start":"2021-09-07T20:00:00Z","end":"2021-09-07T20:20:00Z"},"cancellationReason":{"code":"other"},"cancellable":true},{"id":"43956","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id","value":"848;20210915.080000"}],"kind":"clinic","status":"cancelled","serviceType":"primaryCare","patientIcn":"1012845331V153043","locationId":"983","clinic":"848","start":"2021-09-15T14:00:00Z","cancellationReason":{"code":"other"},"cancelationReason":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason","code":"prov","display":"The
+        appointment was cancelled by the provider"}]},"cancellable":false},{"id":"50094","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a487fd67ba6a62d017bc0cc86d80002"}],"kind":"telehealth","status":"proposed","serviceType":"Primary
+        Care ","patientIcn":"1012845331V153043","locationId":"983","reason":"Test_SM
+        test (tele)","requestedPeriods":[{"start":"2021-09-08T12:00:00Z","end":"2021-09-08T23:59:59.999Z"}],"contact":{"telecom":[{"type":"phone","value":"9999999992"}]},"cancellationReason":{"code":"other"},"cancellable":true},{"id":"53351","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a48f8687be6a735017bea5ab97a0007"}],"kind":"clinic","status":"cancelled","serviceType":"primaryCare","patientIcn":"1012845331V153043","locationId":"983","reason":"Medication
+        Concern","requestedPeriods":[{"start":"2022-01-13T00:00:00Z","end":"2022-01-13T11:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"Aarathi.poldass@va.gov"},{"type":"phone","value":"7175555555"}]},"preferredTimesForPhoneCall":["Morning"],"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50962","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a48d8a47ba18356017bc5fb7d7d002c"}],"kind":"telehealth","status":"cancelled","serviceType":"audiology","patientIcn":"1012845331V153043","locationId":"983","reason":"Medication
+        Concern","requestedPeriods":[{"start":"2021-09-13T00:00:00Z","end":"2021-09-13T11:59:59.999Z"},{"start":"2021-09-13T12:00:00Z","end":"2021-09-13T23:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"mightykc70@gmail.com"},{"type":"phone","value":"7175555555"}]},"preferredTimesForPhoneCall":["Afternoon"],"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50077","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a48b4ef7ba184d5017ba77f4ab20017"}],"kind":"clinic","status":"cancelled","serviceType":"primaryCare","patientIcn":"1012845331V153043","locationId":"983","reason":"Routine
+        Follow-up","requestedPeriods":[{"start":"2021-09-07T00:00:00Z","end":"2021-09-07T11:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"marcy.nadeau@va.gov"},{"type":"phone","value":"7175555555"}]},"preferredTimesForPhoneCall":["Morning"],"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50093","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a487fd67ba6a62d017bc0c8f6730001"}],"kind":"clinic","status":"cancelled","serviceType":"primary
+        care","patientIcn":"1012845331V153043","locationId":"983","reason":"Test_SM
+        test","requestedPeriods":[{"start":"2021-09-07T12:00:00Z","end":"2021-09-07T23:59:59.999Z"}],"contact":{"telecom":[{"type":"phone","value":"9999999991"}]},"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50960","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a48ebfe7ba184d4017bc5ffbb6e0033"}],"kind":"telehealth","status":"cancelled","serviceType":"audiology","patientIcn":"1012845331V153043","locationId":"983","reason":"Routine
+        Follow-up","requestedPeriods":[{"start":"2021-09-13T00:00:00Z","end":"2021-09-13T11:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"marcy.nadeau@va.gov"},{"type":"phone","value":"7175555555"}]},"preferredTimesForPhoneCall":["Afternoon"],"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50957","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a48ebfe7ba184d4017ba7e00d270026"}],"kind":"clinic","status":"cancelled","serviceType":"audiology","patientIcn":"1012845331V153043","locationId":"983","reason":"Routine
+        Follow-up","requestedPeriods":[{"start":"2021-09-22T00:00:00Z","end":"2021-09-22T11:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"Aarathi.poldass@va.gov"},{"type":"phone","value":"7175555555"}]},"preferredTimesForPhoneCall":["Morning"],"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50101","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a487fd67ba6a62d017bc101fd390007"}],"kind":"clinic","status":"cancelled","serviceType":"mental
+        health","patientIcn":"1012845331V153043","locationId":"983","reason":"Test///-SM(clinic_prop)","requestedPeriods":[{"start":"2021-09-07T12:00:00Z","end":"2021-09-07T23:59:59.999Z"}],"contact":{"telecom":[{"type":"phone","value":"9999999998"}]},"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50066","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a487fcd7ba1835c017ba6bb1eaf0010"}],"kind":"phone","status":"cancelled","serviceType":"primaryCare","patientIcn":"1012845331V153043","locationId":"983","reason":"New
+        Issue","requestedPeriods":[{"start":"2021-09-13T00:00:00Z","end":"2021-09-13T11:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"marcy.nadeau@va.gov"},{"type":"phone","value":"7175555555"}]},"preferredTimesForPhoneCall":["Afternoon"],"cancellationReason":{"code":"other"},"cancellable":false},{"id":"50067","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/ars/id","value":"8a48b4ef7ba184d5017ba68a3bd70010"}],"kind":"phone","status":"cancelled","serviceType":"primaryCare","patientIcn":"1012845331V153043","locationId":"983","reason":"New
+        Issue","requestedPeriods":[{"start":"2021-09-07T00:00:00Z","end":"2021-09-07T11:59:59.999Z"}],"contact":{"telecom":[{"type":"email","value":"marcy.nadeau@va.gov"},{"type":"phone","value":"7175555555"}]},"preferredTimesForPhoneCall":["Afternoon"],"cancellationReason":{"code":"other"},"cancellable":false}]}'
+  recorded_at: Thu, 04 Nov 2021 19:56:46 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/facilities/v2/facilities/983
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Aug 2021 17:48:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1114'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 2.8.0
+      B3:
+      - 531af1d2054d758c-b79b44f980a35120-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - '6026315'
+      X-Vamf-Timestamp:
+      - '2021-07-06T17:59:37+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id" : "983",
+          "vistaSite" : "983",
+          "vastParent" : "983",
+          "type" : "va_facilities",
+          "name" : "Cheyenne VA Medical Center",
+          "classification" : "VA Medical Center (VAMC)",
+          "timezone": {
+              "zoneId": "America/New_York",
+              "abbreviation": "EDT"
+          },
+          "lat" : 39.744507,
+          "long" : -104.830956,
+          "website" : "https://www.denver.va.gov/locations/directions.asp",
+          "phone" : {
+            "main" : "307-778-7550",
+            "fax" : "307-778-7381",
+            "pharmacy" : "866-420-6337",
+            "afterHours" : "307-778-7550",
+            "patientAdvocate" : "307-778-7550 x7517",
+            "mentalHealthClinic" : "307-778-7349",
+            "enrollmentCoordinator" : "307-778-7550 x7579"
+          },
+          "physicalAddress" : {
+            "type" : "physical",
+            "line" : [ "2360 East Pershing Boulevard" ],
+            "city" : "Cheyenne",
+            "state" : "WY",
+            "postalCode" : "82001-5356"
+          },
+          "mobile" : false,
+          "healthService" : [ "Audiology", "Cardiology", "DentalServices", "EmergencyCare", "Gastroenterology", "Gynecology", "MentalHealthCare", "Nutrition", "Ophthalmology", "Optometry", "Orthopedics", "Podiatry", "PrimaryCare", "SpecialtyCare", "UrgentCare", "Urology", "WomensHealth" ],
+          "operatingStatus" : {
+            "code" : "NORMAL"
+          }
+        }
+  recorded_at: Mon, 09 Aug 2021 17:48:58 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/facilities/v2/facilities/984
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Aug 2021 17:48:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1114'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 2.8.0
+      B3:
+      - 531af1d2054d758c-b79b44f980a35120-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - '6026315'
+      X-Vamf-Timestamp:
+      - '2021-07-06T17:59:37+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "id" : "984",
+            "vistaSite" : "984",
+            "vastParent" : "984",
+            "type" : "va_health_facility",
+            "name" : "Dayton VA Medical Center",
+            "classification" : "VA Medical Center (VAMC)",
+            "timezone": {
+              "zoneId": "America/New_York",
+              "abbreviation": "EDT"
+            },
+            "website" : "https://www.dayton.va.gov/locations/directions.asp",
+            "phone" : {
+              "main" : "937-268-6511"
+            },
+            "physicalAddress" : {
+              "type" : "physical",
+              "line" : [ "4100 West Third Street" ],
+              "city" : "Dayton",
+              "state" : "OH",
+              "postalCode" : "45428-9000"
+            },
+            "healthService" : [ "Audiology", "Cardiology", "DentalServices", "Dermatology", "Gastroenterology", "Gynecology", "MentalHealthCare", "Nutrition", "Ophthalmology", "Optometry", "Orthopedics", "Podiatry", "PrimaryCare", "SpecialtyCare", "Urology", "WomensHealth" ]
+          }
+  recorded_at: Mon, 09 Aug 2021 17:48:58 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Summary
- Changes are behind `va_online_scheduling_enable_OH_reads` feature flag
- Appointment search requests are now sent to the `vpg` endpoint instead of `vaos`

## Related issue(s)
https://app.zenhub.com/workspaces/appointments-oracle-health-integration-65a6e99ea522640e4d09393b/issues/gh/department-of-veterans-affairs/va.gov-team/83349

## Testing done
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
These changes impact health appointment creation.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution

