### PR TITLE
[78745] Create accreditation model

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -192,6 +192,7 @@ app/mailers/views/veteran_readiness_employment_cmp.html.erb @department-of-veter
 app/mailers/views/veteran_readiness_employment.html.erb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/account_login_stat.rb @department-of-veterans-affairs/octo-identity
 app/models/account.rb @department-of-veterans-affairs/octo-identity
+app/models/accreditation.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 app/models/accredited_individual.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 app/models/accredited_organization.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 app/models/adapters/payment_history_adapter.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
@@ -1094,6 +1095,7 @@ spec/factories/686c/form_686c_674.rb @department-of-veterans-affairs/benefits-de
 spec/factories/686c/spouse.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/686c/step_child_lives_with_veteran.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/accounts.rb @department-of-veterans-affairs/octo-identity
+spec/factories/accreditations.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 spec/factories/accredited_individuals.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 spec/factories/accredited_organizations.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 spec/factories/appeal_submissions.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1462,6 +1464,7 @@ spec/mailers/transactional_email_mailer_spec.rb @department-of-veterans-affairs/
 spec/mailers/veteran_readiness_employment_mailer_spec.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/middleware @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/account_spec.rb @department-of-veterans-affairs/octo-identity
+spec/models/accreditation_spec.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 spec/models/accredited_individual_spec.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 spec/models/accredited_organization_spec.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-accredited-rep-facing
 spec/models/async_transaction/base_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/accreditation.rb
+++ b/app/models/accreditation.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Accreditation < ApplicationRecord
+  # Acts as the join between AccreditedIndividual and AccreditedOrganization and is meant to store information that
+  # lives at the grain between the two models. For example, can_accept_reject_poa is a permission that needs to be
+  # set for each organization a representative is accredited with.
+  #
+  # @note for can_accept_reject_poa that a slight change
+  # to implementation might be needed to support attorneys and claims agents since they do not have organization
+  # accreditations.
+
+  belongs_to :accredited_individual
+  belongs_to :accredited_organization
+
+  validates :accredited_organization_id, uniqueness: { scope: :accredited_individual_id }
+end

--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -12,7 +12,7 @@ class AccreditedIndividual < ApplicationRecord
   #   https://www.va.gov/ogc/apps/accreditation/ that Veteran::Service::Representative uses.
   # 2. The intent of raw_address is to store the address as supplied by OGC for diffing purposes to avoid excess API
   #   calls. Those addresses are not verified and do not contain latitude and longitude. The address information stored
-  #   on the record comes from the Lighthouse Address  Validation API so that geolocation searching is supported
+  #   on the record comes from the Lighthouse Address Validation API so that geolocation searching is supported
   #   for the Find A Representative feature.
   # 3. The representative type should not have a POA code assigned. Representatives should only be associated with the
   #   POA codes of the AccreditedOrganizations they are accredited with.

--- a/app/models/accredited_organization.rb
+++ b/app/models/accredited_organization.rb
@@ -11,7 +11,7 @@ class AccreditedOrganization < ApplicationRecord
   #   https://www.va.gov/ogc/apps/accreditation/ that Veteran::Service::Organization uses.
   # 2. The intent of raw_address is to store the address as supplied by OGC for diffing purposes to avoid excess API
   #   calls. Those addresses are not verified and do not contain latitude and longitude. The address information stored
-  #   on the record comes from the Lighthouse Address  Validation API so that geolocation searching is supported
+  #   on the record comes from the Lighthouse Address Validation API so that geolocation searching is supported
   #   for the Find A Representative feature.
   # 3. The ogc_id is the id from the source table within OGC. It can be used to interact with their show endpoints
   #   and may be nice to have for troubleshooting purposes.

--- a/app/models/accredited_organization.rb
+++ b/app/models/accredited_organization.rb
@@ -3,11 +3,21 @@
 require 'accredited_representation/constants'
 
 class AccreditedOrganization < ApplicationRecord
-  # rubocop:disable Rails/HasAndBelongsToMany
-  has_and_belongs_to_many :accredited_individuals,
-                          class: 'AccreditedIndividual',
-                          join_table: 'accredited_individuals_accredited_organizations'
-  # rubocop:enable Rails/HasAndBelongsToMany
+  # Represents an accredited organization as defined by he OGC accreditation APIs. Until a form of soft deletion is
+  # implemented, these records will only reflect organization with active accreditation.
+  #
+  # Key notes:
+  # 1. The core record attributes are populated from the OGC accreditation APIs, not the files found at
+  #   https://www.va.gov/ogc/apps/accreditation/ that Veteran::Service::Organization uses.
+  # 2. The intent of raw_address is to store the address as supplied by OGC for diffing purposes to avoid excess API
+  #   calls. Those addresses are not verified and do not contain latitude and longitude. The address information stored
+  #   on the record comes from the Lighthouse Address  Validation API so that geolocation searching is supported
+  #   for the Find A Representative feature.
+  # 3. The ogc_id is the id from the source table within OGC. It can be used to interact with their show endpoints
+  #   and may be nice to have for troubleshooting purposes.
+
+  has_many :accreditations, dependent: :destroy
+  has_many :accredited_individuals, through: :accreditations
 
   validates :ogc_id, :poa_code, presence: true
   validates :poa_code, length: { is: 3 }

--- a/spec/factories/accreditations.rb
+++ b/spec/factories/accreditations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :accreditation do
+    accredited_individual { create(:accredited_individual) }
+    accredited_organization { create(:accredited_organization) }
+    can_accept_reject_poa { true }
+  end
+end

--- a/spec/factories/accredited_individuals.rb
+++ b/spec/factories/accredited_individuals.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
 
     trait :with_organizations do
       after(:create) do |individual, evaluator|
-        create_list(:accredited_organization, evaluator.org_count, accredited_individuals: [individual])
+        individual.accredited_organizations << create_list(:accredited_organization, evaluator.org_count)
 
         individual.reload
       end

--- a/spec/factories/accredited_organizations.rb
+++ b/spec/factories/accredited_organizations.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
 
     trait :with_representatives do
       after(:create) do |organization, evaluator|
-        create_list(:accredited_individual, evaluator.rep_count, accredited_organizations: [organization])
+        organization.accredited_individuals << create_list(:accredited_individual, evaluator.rep_count)
 
         organization.reload
       end

--- a/spec/models/accreditation_spec.rb
+++ b/spec/models/accreditation_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Accreditation, type: :model do
+  describe 'validations' do
+    subject { build(:accreditation) }
+
+    it { is_expected.to belong_to(:accredited_individual) }
+    it { is_expected.to belong_to(:accredited_organization) }
+
+    it {
+      expect(subject).to validate_uniqueness_of(:accredited_organization_id)
+        .scoped_to(:accredited_individual_id)
+        .ignoring_case_sensitivity
+    }
+  end
+end

--- a/spec/models/accredited_individual_spec.rb
+++ b/spec/models/accredited_individual_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe AccreditedIndividual, type: :model do
   describe 'validations' do
     subject { build(:accredited_individual) }
 
+    it { is_expected.to have_many(:accredited_organizations).through(:accreditations) }
+
     it { expect(subject).to validate_presence_of(:ogc_id) }
     it { expect(subject).to validate_presence_of(:registration_number) }
     it { expect(subject).to validate_presence_of(:individual_type) }

--- a/spec/models/accredited_organization_spec.rb
+++ b/spec/models/accredited_organization_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe AccreditedOrganization, type: :model do
   describe 'validations' do
     subject { build(:accredited_organization) }
 
+    it { is_expected.to have_many(:accredited_individuals).through(:accreditations) }
+
     it { expect(subject).to validate_presence_of(:ogc_id) }
     it { expect(subject).to validate_presence_of(:poa_code) }
     it { expect(subject).to validate_length_of(:poa_code).is_equal_to(3) }


### PR DESCRIPTION
## Summary

- This pr adds a new `Accreditation` model that acts the join between `AccreditedIndividual` and `AccreditedOrganization`

## Related issue(s)

- [78745](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78745)

## Testing done

- [x] *New code is covered by unit tests*
- Tested creattion with factories in rails console
- Tested destroy with rails console

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature