### PR TITLE
Dash/oren/api 34441/poa request.representation refinements

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client.rb
@@ -72,15 +72,15 @@ module ClaimsApi
       end
     end
 
-    ExternalId =
+    class ExternalId <
       Data.define(
         :external_uid,
         :external_key
-      ) do
-        self::DEFAULT = new(
-          external_uid: Settings.bgs.external_uid,
-          external_key: Settings.bgs.external_key
-        )
-      end
+      )
+      DEFAULT = new(
+        external_uid: Settings.bgs.external_uid,
+        external_key: Settings.bgs.external_key
+      )
+    end
   end
 end

--- a/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_request_blueprint.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_request_blueprint.rb
@@ -25,6 +25,22 @@ module ClaimsApi
           )
         end
 
+        class Decision < Blueprinter::Base
+          transform Transformers::LowerCamelTransformer
+
+          fields(
+            :status,
+            :declined_reason
+          )
+
+          field(
+            :updated_at,
+            datetime_format: :iso8601.to_proc
+          )
+
+          association :representative, blueprint: Representative
+        end
+
         class Claimant < Blueprinter::Base
           transform Transformers::LowerCamelTransformer
 
@@ -50,18 +66,11 @@ module ClaimsApi
           transform Transformers::LowerCamelTransformer
 
           fields(
-            :status,
-            :declined_reason,
             :power_of_attorney_code
           )
 
           field(
-            :submitted_at,
-            datetime_format: :iso8601.to_proc
-          )
-
-          field(
-            :accepted_or_declined_at,
+            :created_at,
             datetime_format: :iso8601.to_proc
           )
 
@@ -76,10 +85,10 @@ module ClaimsApi
           )
 
           association :veteran, blueprint: Veteran
-          association :representative, blueprint: Representative
           # E.g., we can remove the key but what are the right semantics?
           #   `if: -> (field, object, *) { object.claimant }`
           association :claimant, blueprint: Claimant
+          association :decision, blueprint: Decision
           association :claimant_address, blueprint: Address
         end
 

--- a/modules/claims_api/app/controllers/claims_api/v2/power_of_attorney_request/decisions_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/power_of_attorney_request/decisions_controller.rb
@@ -21,7 +21,7 @@ module ClaimsApi
         def declined?
           decision_params[:status] ==
             PowerOfAttorneyRequestService::
-              PoaRequest::Statuses::
+              PoaRequest::Decision::Statuses::
               DECLINED
         end
 

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/decide.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/decide.rb
@@ -5,6 +5,8 @@ module ClaimsApi
     module Decide
       class << self
         def perform(id, decision)
+          id = id.split('_').last
+
           action =
             BGSClient::Definitions::
               ManageRepresentativeService::

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/search.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/search.rb
@@ -96,7 +96,7 @@ module ClaimsApi
         }.freeze
 
         FIELDS = {
-          Query::Sort::Fields::SUBMITTED_AT => 'DATE_RECEIVED'
+          Query::Sort::Fields::CREATED_AT => 'DATE_RECEIVED'
         }.freeze
       end
     end

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/search/query.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/search/query.rb
@@ -16,7 +16,7 @@ module ClaimsApi
         module Sort
           module Fields
             ALL = [
-              SUBMITTED_AT = 'submittedAt'
+              CREATED_AT = 'createdAt'
             ].freeze
           end
 
@@ -33,13 +33,16 @@ module ClaimsApi
             # defaults which is why this is a method.
             def get_default
               {
-                field: Fields::SUBMITTED_AT,
+                field: Fields::CREATED_AT,
                 order: Orders::DESCENDING
               }
             end
           end
         end
 
+        # TODO: If keeping `dry-schema`, consider a good point to load
+        # extensions.
+        #
         # These have to load before our `Schema` definition, otherwise at least
         # the `hints` extension won't do its thing.
         Dry::Schema.load_extensions(:json_schema)
@@ -51,7 +54,7 @@ module ClaimsApi
             required(:filter).hash do
               required(:poaCodes).filled(:array).each(:string)
               optional(:statuses).filled(:array).each(
-                :string, included_in?: PoaRequest::Statuses::ALL
+                :string, included_in?: PoaRequest::Decision::Statuses::ALL
               )
             end
 
@@ -90,7 +93,7 @@ module ClaimsApi
           private
 
           def apply_defaults(query)
-            query[:filter][:statuses] ||= PoaRequest::Statuses::ALL
+            query[:filter][:statuses] ||= PoaRequest::Decision::Statuses::ALL
             query[:sort] ||= Sort.get_default
 
             page = query[:page] ||= {}

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -65,9 +65,9 @@ ClaimsApi::Engine.routes.draw do
     end
 
     resources :power_of_attorney_requests, path: 'power-of-attorney-requests', only: [:index] do
-      scope module: :power_of_attorney_request do
+      scope module: :power_of_attorney_request, param: :id do
         member do
-          resource :decision, only: [:update], param: :id
+          resource :decision, only: [:update]
         end
       end
     end

--- a/modules/claims_api/spec/requests/v2/power_of_attorney_requests/decline/request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/power_of_attorney_requests/decline/request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Power Of Attorney Requests: decline', :bgs, type: :request do
   end
 
   describe 'with a valid decline with reason' do
-    let(:id) { 3_854_887 }
+    let(:id) { '600082088_3854887' }
 
     let(:params) do
       {

--- a/modules/claims_api/spec/requests/v2/power_of_attorney_requests/index/request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/power_of_attorney_requests/index/request_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Power Of Attorney Requests: index', :bgs, type: :request do
                 'sort' => {
                   'field' => [
                     'must be a string',
-                    'must be one of: submittedAt'
+                    'must be one of: createdAt'
                   ],
                   'order' => [
                     'must be a string',
@@ -187,7 +187,7 @@ RSpec.describe 'Power Of Attorney Requests: index', :bgs, type: :request do
             'number' => 1
           },
           'sort' => {
-            'field' => 'submittedAt',
+            'field' => 'createdAt',
             'order' => 'desc'
           }
         }
@@ -214,7 +214,7 @@ RSpec.describe 'Power Of Attorney Requests: index', :bgs, type: :request do
           'size' => 5
         },
         'sort' => {
-          'field' => 'submittedAt',
+          'field' => 'createdAt',
           'order' => 'asc'
         }
       }
@@ -236,28 +236,30 @@ RSpec.describe 'Power Of Attorney Requests: index', :bgs, type: :request do
       )
 
       expect(subject.body['data'].first).to eq(
-        'id' => 3_854_197,
+        'id' => '600061742_3854197',
         'type' => 'powerOfAttorneyRequest',
         'attributes' => {
-          'status' => 'Accepted',
-          'declinedReason' => nil,
           'powerOfAttorneyCode' => '074',
-          'submittedAt' => '2024-03-08T13:56:37Z',
-          'acceptedOrDeclinedAt' => '2024-03-08T14:10:41Z',
+          'createdAt' => '2024-03-08T13:56:37Z',
           'isAddressChangingAuthorized' => true,
           'isTreatmentDisclosureAuthorized' => true,
           'veteran' => {
             'firstName' => 'WESLEY',
             'middleName' => 'WATSON',
             'lastName' => 'FORD',
-            'participantId' => 600_061_742
-          },
-          'representative' => {
-            'firstName' => 'BEATRICE',
-            'lastName' => 'STROUD',
-            'email' => 'Beatrice.Stroud44@va.gov'
+            'participantId' => '600061742'
           },
           'claimant' => nil,
+          'decision' => {
+            'status' => 'Accepted',
+            'declinedReason' => nil,
+            'updatedAt' => '2024-03-08T14:10:41Z',
+            'representative' => {
+              'firstName' => 'BEATRICE',
+              'lastName' => 'STROUD',
+              'email' => 'Beatrice.Stroud44@va.gov'
+            }
+          },
           'claimantAddress' => {
             'city' => 'WASHINGTON',
             'state' => 'DC',
@@ -347,7 +349,7 @@ RSpec.describe 'Power Of Attorney Requests: index', :bgs, type: :request do
               'number' => 1
             },
             'sort' => {
-              'field' => 'submittedAt',
+              'field' => 'createdAt',
               'order' => 'desc'
             }
           }
@@ -407,7 +409,7 @@ RSpec.describe 'Power Of Attorney Requests: index', :bgs, type: :request do
               'number' => 100
             },
             'sort' => {
-              'field' => 'submittedAt',
+              'field' => 'createdAt',
               'order' => 'desc'
             }
           }
@@ -461,7 +463,7 @@ RSpec.describe 'Power Of Attorney Requests: index', :bgs, type: :request do
               'number' => 1
             },
             'sort' => {
-              'field' => 'submittedAt',
+              'field' => 'createdAt',
               'order' => 'desc'
             }
           }


### PR DESCRIPTION
- Redundant composite ID `<participant_id>_<proc_id>` to adapt to BGS API
- `decision` as sub-resource of POA request in response body, mirroring our resourceful routes