### PR TITLE
DBEX: assign toxic exposure submit endpoint & metadata

### DIFF
--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -85,7 +85,8 @@ class FormProfiles::VA526ez < FormProfile
     {
       version: 0,
       prefill: true,
-      returnUrl: '/veteran-information'
+      returnUrl: '/veteran-information',
+      includeToxicExposure: Flipper.enabled?(:disability_526_toxic_exposure, user)
     }
   end
 

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -105,7 +105,7 @@ module EVSS
 
           user = OpenStruct.new({ user_account_uuid: user_account.id, flipper_id: user_account.id })
           begin
-            submit_to_claims_api = submssion.submit_endpoint == 'claims_api'
+            submit_to_claims_api = submission.claims_api?
             # send submission data to either EVSS or Lighthouse (LH)
             response = if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration, user) ||
                           submit_to_claims_api # right operand evaluation not needed once fully migrated to LH
@@ -115,9 +115,9 @@ module EVSS
                          # 2. transform submission data to LH format
                          transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
                          body = transform_service.transform(submission.form['form526'])
-                         # 3. send transformed submission data to LH endpoint,
-                         # conditionally setting options argument based on toxic exposure Flipper state for user
+                         # 3. send transformed submission data to LH endpoint
                          service = BenefitsClaims::Service.new(icn)
+                         # conditionally set options argument based on toxic exposure Flipper state for user
                          options = generate_options_hash(submit_to_claims_api, user)
                          raw_response = service.submit526(body, options)
                          # 4. convert LH raw response to a FormSubmitResponse for further processing (claim_id, status)

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -77,8 +77,7 @@ module EVSS
       #
       # @param submission_id [Integer] The {Form526Submission} id
       #
-      # rubocop:disable Metrics/MethodLength
-      def perform(submission_id)
+      def perform(submission_id) # rubocop:disable Metrics/MethodLength
         send_notifications = true
         @submission_id = submission_id
 
@@ -106,19 +105,21 @@ module EVSS
 
           user = OpenStruct.new({ user_account_uuid: user_account.id, flipper_id: user_account.id })
           begin
+            submit_to_claims_api = submssion.submit_endpoint == 'claims_api'
             # send submission data to either EVSS or Lighthouse (LH)
-            response = if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration, user)
+            response = if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration, user) ||
+                          submit_to_claims_api # right operand evaluation not needed once fully migrated to LH
                          # submit 526 through LH API
                          # 1. get user's ICN
-                         user_account = UserAccount.find_by(id: submission.user_account_id) ||
-                                        Account.find_by(idme_uuid: submission.user_uuid)
                          icn = user_account.icn
                          # 2. transform submission data to LH format
                          transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
                          body = transform_service.transform(submission.form['form526'])
-                         # 3. send transformed submission data to LH endpoint
+                         # 3. send transformed submission data to LH endpoint,
+                         # conditionally setting options argument based on toxic exposure Flipper state for user
                          service = BenefitsClaims::Service.new(icn)
-                         raw_response = service.submit526(body)
+                         options = generate_options_hash(submit_to_claims_api, user)
+                         raw_response = service.submit526(body, options)
                          # 4. convert LH raw response to a FormSubmitResponse for further processing (claim_id, status)
                          # JSON.parse when it matters to get the claim id
                          # something like response_json = JSON.parse(raw_response.body)
@@ -145,12 +146,16 @@ module EVSS
           send_post_evss_notifications(submission) if send_notifications
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
       private
 
       def submit_complete_form
         service.submit_form526(submission.form_to_json(Form526Submission::FORM_526))
+      end
+
+      def generate_options_hash(submit_to_claims_api, user)
+        te_flipper_disabled_for_user = !Flipper.enabled?(:disability_526_toxic_exposure, user)
+        submit_to_claims_api && te_flipper_disabled_for_user ? { generate_pdf: true } : {}
       end
 
       def response_handler(response)

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -73,7 +73,7 @@ module Sidekiq
         return unless Settings.form526_backup.enabled
 
         submission = Form526Submission.find(form526_submission_id)
-        submission.update(submit_endpoint: 'benefits_intake_api')
+        submission.benefits_intake_api!
         job_status = Form526JobStatus.find_or_initialize_by(job_id: jid)
         job_status.assign_attributes(form526_submission_id:,
                                      job_class: 'BackupSubmission',

--- a/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
+++ b/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
@@ -25,6 +25,7 @@ module Sidekiq
                                  submission_obj.submitted_claim_id.nil?
 
         if send_backup_submission
+          submission_obj.update(submit_endpoint: 'benefits_intake_api')
           backup_job_jid = Sidekiq::Form526BackupSubmissionProcess::Submit.perform_async(form526_submission_id)
         end
         vagov_id = JSON.parse(submission_obj.auth_headers_json)['va_eauth_service_transaction_id']

--- a/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
+++ b/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
@@ -25,7 +25,6 @@ module Sidekiq
                                  submission_obj.submitted_claim_id.nil?
 
         if send_backup_submission
-          submission_obj.update(submit_endpoint: 'benefits_intake_api')
           backup_job_jid = Sidekiq::Form526BackupSubmissionProcess::Submit.perform_async(form526_submission_id)
         end
         vagov_id = JSON.parse(submission_obj.auth_headers_json)['va_eauth_service_transaction_id']

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
     Flipper.disable(:disability_526_classifier_new_claims)
     Flipper.disable(:disability_compensation_lighthouse_submit_migration)
     Flipper.disable(:disability_compensation_lighthouse_claims_service_provider)
+    Flipper.disable(:disability_526_toxic_exposure)
   end
 
   let(:user) { FactoryBot.create(:user, :loa3) }
@@ -414,6 +415,34 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           expect(Form526JobStatus.last.status).to eq Form526JobStatus::STATUS[:success]
           submission.reload
           # TODO: re-visit when using lighthouse synchronous response endpoint
+          expect(submission.submitted_claim_id).to eq(Form526JobStatus.last.submission.submitted_claim_id)
+        end
+      end
+
+      context 'with toxic exposure Fipper enabled for user' do
+        let(:submission) do
+          create(:form526_submission,
+                 :with_everything,
+                 user_uuid: user.uuid,
+                 auth_headers_json: auth_headers.to_json,
+                 saved_claim_id: saved_claim.id,
+                 submit_endpoint: 'claims_api')
+        end
+
+        before do
+          Flipper.enable(:disability_526_toxic_exposure, user)
+          allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
+        end
+
+        after do
+          Flipper.disable(:disability_526_toxic_exposure, user)
+        end
+
+        it 'performs a successful submission' do
+          subject.perform_async(submission.id)
+          expect { described_class.drain }.not_to change(backup_klass.jobs, :size)
+          expect(Form526JobStatus.last.status).to eq Form526JobStatus::STATUS[:success]
+          submission.reload
           expect(submission.submitted_claim_id).to eq(Form526JobStatus.last.submission.submitted_claim_id)
         end
       end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
         end
       end
 
-      context 'with toxic exposure Fipper enabled for user' do
+      context 'with toxic exposure Flipper enabled for user' do
         let(:submission) do
           create(:form526_submission,
                  :with_everything,


### PR DESCRIPTION
- Follow-on to https://github.com/department-of-veterans-affairs/vets-api/pull/16693

## Summary

- *This work is behind a feature toggle (flipper): **YES**/~NO~*: `disability_526_toxic_exposure`
- Evaluates Flipper set for current user, assigning boolean value of a `includeToxicExposure` metadata attribute for a newly created in progress form, to be utilized on the frontend in tracking and reporting the inclusion of the toxic exposure section for the form
- A submission whose `submit_endpoint` attribute is set to `'claims_api'` (implemented in [previous PR update](https://github.com/department-of-veterans-affairs/vets-api/pull/16693/files#:~:text=def%20includes_toxic_exposure%3F,end)) is handled similarly to that of a user whose `disability_compensation_lighthouse_submit_migration` Flipper is enabled
- Conditionally sets `options` argument based on `disability_526_toxic_exposure` Flipper state for the current user, determining ultimate Lighthouse API submit endpoint (`'/526'` or `'/526/generatePDF'`)
- **Responsible team:** Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81830
- https://github.com/department-of-veterans-affairs/vets-api/pull/16689
- https://github.com/department-of-veterans-affairs/vets-api/pull/16693

## Testing done

- unit test enablement of toxic exposure feature flag
- local data manipulated to confirm expected results
- plan to target staging users for additional verification

## What areas of the site does it impact?

- Form 526EZ

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [X]  Neither error nor warning in the console
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [X]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
