### PR TITLE
sorting logger fix

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
@@ -133,7 +133,7 @@ module Mobile
           message.sent_date
         end
 
-        if bad_sort_flag || nil_counter.positive?
+        if bad_sort_flag || nil_sent_dates_count.positive?
           Rails.logger.info('Mobile Message Bad Sort', sent_dates:, bad_sort_flag:, nil_sent_dates_count:)
         end
       rescue => e

--- a/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
@@ -11,6 +11,7 @@ module Mobile
 
         resource = params[:filter].present? ? resource.find_by(filter_params) : resource
         resource = resource.sort(params[:sort])
+        log_bad_sort(resource)
         resource = resource.paginate(**pagination_params)
         resource.metadata.merge!(message_counts(resource))
 
@@ -114,6 +115,30 @@ module Mobile
       end
 
       private
+
+      def log_bad_sort(resource)
+        last_sent_date = Time.now.utc
+        bad_sort_flag = false
+        nil_sent_dates_count = 0
+        sent_dates = resource.attributes.map do |message|
+          unless message&.sent_date
+            nil_sent_dates_count += 1
+            next
+          end
+
+          bad_sort_flag ||= message.sent_date > last_sent_date
+
+          last_sent_date = message.sent_date
+
+          message.sent_date
+        end
+
+        if bad_sort_flag || nil_counter.positive?
+          Rails.logger.info('Mobile Message Bad Sort', sent_dates:, bad_sort_flag:, nil_sent_dates_count:)
+        end
+      rescue => e
+        Rails.logger.info('Mobile Message Log Bad Sort Failed', error: e)
+      end
 
       # When we get message parameters as part of a multipart payload (i.e. with attachments),
       # ActionController::Parameters leaves the message part as a string so we have to turn it into


### PR DESCRIPTION
## Summary
sorting logger fix for wrong variable name being called

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8536

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
