### PR TITLE
Add form upload flow to FormProfile list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -704,6 +704,7 @@ config/form_profile_mappings/40-10007.yml @department-of-veterans-affairs/mbs-co
 config/form_profile_mappings/5655.yml @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/686C-674.yml @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/FEEDBACK-TOOL.yml @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group  @department-of-veterans-affairs/my-education-benefits
+config/form_profile_mappings/FORM-UPLOAD-FLOW.yml @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/MDOT.yml @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 config/form_profile_mappings/10-7959c.yml @department-of-veterans-affairs/champva-engineering @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/freshclam.conf @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -102,7 +102,8 @@ class FormProfile
     coe: ['26-1880'],
     adapted_housing: ['26-4555'],
     intent_to_file: ['21-0966'],
-    ivc_champva: %w[10-7959F-1 10-7959C]
+    ivc_champva: %w[10-7959F-1 10-7959C],
+    form_upload_flow: ['FORM-UPLOAD-FLOW']
   }.freeze
 
   FORM_ID_TO_CLASS = {
@@ -141,7 +142,8 @@ class FormProfile
     '26-1880' => ::FormProfiles::VA261880,
     '26-4555' => ::FormProfiles::VA264555,
     '21-0966' => ::FormProfiles::VA210966,
-    '10-7959F-1' => ::FormProfiles::VA107959f1
+    '10-7959F-1' => ::FormProfiles::VA107959f1,
+    'FORM-UPLOAD-FLOW' => ::FormProfiles::FormUploadFlow
   }.freeze
 
   APT_REGEX = /\S\s+((apt|apartment|unit|ste|suite).+)/i

--- a/app/models/form_profiles/form_upload_flow.rb
+++ b/app/models/form_profiles/form_upload_flow.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class FormProfiles::FormUploadFlow < FormProfile
+  def metadata
+    {
+      version: 0,
+      prefill: true,
+      returnUrl: '/personal-information-1'
+    }
+  end
+end

--- a/app/models/form_profiles/form_upload_flow.rb
+++ b/app/models/form_profiles/form_upload_flow.rb
@@ -4,8 +4,7 @@ class FormProfiles::FormUploadFlow < FormProfile
   def metadata
     {
       version: 0,
-      prefill: true,
-      returnUrl: '/personal-information-1'
+      prefill: true
     }
   end
 end

--- a/config/form_profile_mappings/FORM-UPLOAD-FLOW.yml
+++ b/config/form_profile_mappings/FORM-UPLOAD-FLOW.yml
@@ -1,0 +1,4 @@
+veteran:
+  fullName: [identity_information, full_name]
+  ssn: [identity_information, ssn]
+  address: [contact_information, address]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -414,6 +414,9 @@ intent_to_file:
 ivc_champva:
   prefill: true
 
+form_upload_flow:
+  prefill: true
+
 # Settings for Expiry Scanner
 expiry_scanner:
   slack:


### PR DESCRIPTION
## Summary
This PR allows the front end to consume veteran data on the form upload flow from FormProfile.

Associated to https://github.com/department-of-veterans-affairs/vets-website/pull/29878

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/83019
