### PR TITLE
Pension 83847 Sidekiq Exhaustion - PDF Size Validation

### DIFF
--- a/lib/lighthouse/benefits_intake/service.rb
+++ b/lib/lighthouse/benefits_intake/service.rb
@@ -123,7 +123,7 @@ module BenefitsIntake
     # @returns [String] path to file
     #
     def valid_document?(document:)
-      result = PDFUtilities::PDFValidator::Validator.new(document, options: PDF_VALIDATOR_OPTIONS).validate
+      result = PDFUtilities::PDFValidator::Validator.new(document, PDF_VALIDATOR_OPTIONS).validate
       raise InvalidDocumentError, "Invalid Document: #{result.errors}" unless result.valid_pdf?
 
       doc = File.read(document, mode: 'rb')


### PR DESCRIPTION
## Summary

correct options set on PDF Validator

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/83487

## Testing done

- [x] *New code is covered by unit tests*
- invalid options applied to pdf validation
- changed service to correctly send options
- loaded validator in rails console, passing options as in service, viewed validator option attribute

## What areas of the site does it impact?

Pension

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
