### PR TITLE
[78745] - Drop unused accredited_individuals_accredited_organizations join table

### DIFF
--- a/db/migrate/20240520191416_drop_accredited_individuals_accredited_organizations.rb
+++ b/db/migrate/20240520191416_drop_accredited_individuals_accredited_organizations.rb
@@ -1,0 +1,5 @@
+class DropAccreditedIndividualsAccreditedOrganizations < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :accredited_individuals_accredited_organizations
+  end
+end

--- a/db/migrate/20240520191416_drop_accredited_individuals_accredited_organizations.rb
+++ b/db/migrate/20240520191416_drop_accredited_individuals_accredited_organizations.rb
@@ -1,5 +1,5 @@
 class DropAccreditedIndividualsAccreditedOrganizations < ActiveRecord::Migration[7.1]
   def change
-    drop_table :accredited_individuals_accredited_organizations
+    drop_table :accredited_individuals_accredited_organizations, if_exists: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_15_192926) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_20_191416) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -99,14 +99,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_15_192926) do
     t.index ["location"], name: "index_accredited_individuals_on_location", using: :gist
     t.index ["poa_code"], name: "index_accredited_individuals_on_poa_code"
     t.index ["registration_number", "individual_type"], name: "index_on_reg_num_and_type_for_accredited_individuals", unique: true
-  end
-
-  create_table "accredited_individuals_accredited_organizations", force: :cascade do |t|
-    t.uuid "accredited_individual_id", null: false
-    t.uuid "accredited_organization_id", null: false
-    t.index ["accredited_individual_id", "accredited_organization_id"], name: "index_accredited_on_indi_and_org_ids", unique: true
-    t.index ["accredited_individual_id"], name: "idx_on_accredited_individual_id_94f42eefad"
-    t.index ["accredited_organization_id"], name: "idx_on_accredited_organization_id_a394d1de51"
   end
 
   create_table "accredited_organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1556,8 +1548,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_15_192926) do
   add_foreign_key "account_login_stats", "accounts"
   add_foreign_key "accreditations", "accredited_individuals"
   add_foreign_key "accreditations", "accredited_organizations"
-  add_foreign_key "accredited_individuals_accredited_organizations", "accredited_individuals"
-  add_foreign_key "accredited_individuals_accredited_organizations", "accredited_organizations"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "appeal_submissions", "user_accounts"


### PR DESCRIPTION
## Summary

- This is pr drops a join table that is no longer in use. The table should have no data in it and code does not reference it anymore.

## Related issue(s)

- [78745](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78745)

## Testing done

- Not much to test other than the migration succeeding and the test suite passing

## What areas of the site does it impact?
No impact as the table was never used. If there was impact, it would be limited to ARM and ARF teams.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature