### PR TITLE
DBEX: explicitly load Form526Submission submit_endpoint data migration module

### DIFF
--- a/lib/data_migrations/form526_submission_submit_endpoint_update.rb
+++ b/lib/data_migrations/form526_submission_submit_endpoint_update.rb
@@ -6,9 +6,7 @@ module DataMigrations
 
     def run
       Form526Submission.where(submit_endpoint: nil).in_batches do |batch|
-        # rubocop:disable Rails/SkipsModelValidations
-        batch.update_all(submit_endpoint: :evss)
-        # rubocop:enable Rails/SkipsModelValidations
+        batch.update_all(submit_endpoint: :evss) # rubocop:disable Rails/SkipsModelValidations
       end
     end
   end

--- a/rakelib/form526_submission_submit_endpoint_update.rake
+++ b/rakelib/form526_submission_submit_endpoint_update.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../lib/data_migrations/form526_submission_submit_endpoint_update'
+
 namespace :form526 do
   desc 'Update submit_endpoint for all records to evss'
   task submit_endpoint_update: :environment do


### PR DESCRIPTION
Modified Rake task to explicitly load module to migrate historic `Form526Submission` data, setting all `submit_endpoint` values to `evss`, corresponding to the service API used for past and current claim submissions. Resolves an error encountered when executing the task in staging environment.

## Summary

- *This work is behind a feature toggle (flipper): ~YES~/NO*
  - not directly, but it will be leveraged in conjunction with the `disability_526_toxic_exposure` Flipper
- Modifies https://github.com/department-of-veterans-affairs/vets-api/pull/16693
- Data migration files will be removed following confirmation of deployment to production per [VA Platform guidance](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-database-migrations#vets-apidatabasemigrations-DataMigrations)
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81830
- https://github.com/department-of-veterans-affairs/vets-api/pull/16693
- https://github.com/department-of-veterans-affairs/vets-api/pull/16689

## Testing done

- Reconfirmed Rake task successfully executed locally against a set of `Form526Submission` records
- *What is the testing plan for rolling out the feature?*
  - Verify via the console that the `submit_endpoint` value of all `Form526Submission` records has been updated to `evss` after running the Rake task

## What areas of the site does it impact?

- Form 526EZ

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
