### PR TITLE
stub AWS responses for ivc_champva uploads_spec

### DIFF
--- a/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe 'Forms uploader', type: :request do
     'vha_10_7959c.json'
   ]
 
+  before do
+    Aws.config.update(stub_responses: true)
+  end
+
   describe '#submit' do
     forms.each do |form|
       fixture_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', form)

--- a/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
@@ -11,7 +11,12 @@ RSpec.describe 'Forms uploader', type: :request do
   ]
 
   before do
+    @original_aws_config = Aws.config.dup
     Aws.config.update(stub_responses: true)
+  end
+
+  after do
+    Aws.config = @original_aws_config
   end
 
   describe '#submit' do


### PR DESCRIPTION
## Summary

- stub aws responses for uploads_spec.rb in ivc_champva 
   - the aws s3 client was looking for credentials that don't exist and reporting a warning 
   - this warning added significant log lines in the Code Check > Run Specs log 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83563

## Testing done

- [x] Manual local testing

## Acceptance criteria

- [x]  modules/ivc_champva/spec/requests/v1/uploads_spec.rb doesn't product the below warning during testing

## Reviewer Notes

There's another test causing an additional warning: `Error retrieving instance profile credentials`, that will be addressed in a different PR 

### Further Info

Using `Aws.config.update(stub_responses: true)` in `rspec_helper.rb` caused some failures with a `VCR::Errors::UnusedHTTPInteractionError`

### Example Log

```
Error retrieving instance profile credentials: 

================================================================================
An HTTP request has been made that VCR does not know how to handle:
  PUT http://169.254.169.254/latest/api/token

There is currently no cassette in use. There are a few ways
you can configure VCR to handle this request:

  * If you're surprised VCR is raising this error
    and want insight about how VCR attempted to handle the request,
    you can use the debug_logger configuration option to log more details [1].
  * If you want VCR to record this request and play it back during future test
    runs, you should wrap your test (or this portion of your test) in a
    `VCR.use_cassette` block [2].
  * If you only want VCR to handle requests made while a cassette is in use,
    configure `allow_http_connections_when_no_cassette = true`. VCR will
    ignore this request since it is made when there is no cassette [3].
  * If you want VCR to ignore this request (and others like it), you can
    set an `ignore_request` callback [4].

[1] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/configuration/debug-logging
[2] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/getting-started
[3] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/configuration/allow-http-connections-when-no-cassette
[4] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/configuration/ignore-request
================================================================================
```