### PR TITLE
Token exchange for device sso clients

### DIFF
--- a/app/controllers/concerns/sign_in/audience_validator.rb
+++ b/app/controllers/concerns/sign_in/audience_validator.rb
@@ -38,7 +38,7 @@ module SignIn
       return if valid_audience.blank?
       return if access_token.audience.any? { |aud| valid_audience.include?(aud) }
 
-      Rails.logger.error('[SignIn::AudienceValidator] Invalid audience',
+      Rails.logger.error('[SignIn][AudienceValidator] Invalid audience',
                          { invalid_audience: access_token.audience, valid_audience: })
       raise Errors::InvalidAudienceError.new(message: 'Invalid audience')
     end

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -248,7 +248,7 @@ module V0
 
     def token_params
       params.permit(:grant_type, :code, :code_verifier, :client_assertion, :client_assertion_type,
-                    :assertion, :subject_token, :actor_token, :actor_token_type, :client_id)
+                    :assertion, :subject_token, :subject_token_type, :actor_token, :actor_token_type, :client_id)
     end
 
     def handle_pre_login_error(error, client_id)

--- a/app/services/sign_in/client_assertion_validator.rb
+++ b/app/services/sign_in/client_assertion_validator.rb
@@ -20,7 +20,7 @@ module SignIn
     private
 
     def validate_client_assertion_type
-      if client_assertion_type != Constants::Auth::CLIENT_ASSERTION_TYPE
+      if client_assertion_type != Constants::Urn::JWT_BEARER_CLIENT_AUTHENTICATION
         raise Errors::ClientAssertionTypeInvalidError.new message: 'Client assertion type is not valid'
       end
     end

--- a/app/services/sign_in/constants/access_token.rb
+++ b/app/services/sign_in/constants/access_token.rb
@@ -12,7 +12,6 @@ module SignIn
 
       ISSUER = 'va.gov sign in'
       USER_ATTRIBUTES = %w[first_name last_name email].freeze
-      OAUTH_TOKEN_TYPE = 'urn.ietf:;params:oauth:token-type:access_token'
     end
   end
 end

--- a/app/services/sign_in/constants/access_token.rb
+++ b/app/services/sign_in/constants/access_token.rb
@@ -12,6 +12,7 @@ module SignIn
 
       ISSUER = 'va.gov sign in'
       USER_ATTRIBUTES = %w[first_name last_name email].freeze
+      OAUTH_TOKEN_TYPE = 'urn.ietf:;params:oauth:token-type:access_token'
     end
   end
 end

--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -28,7 +28,8 @@ module SignIn
       CSP_TYPES = [IDME = 'idme', LOGINGOV = 'logingov', DSLOGON = 'dslogon', MHV = 'mhv'].freeze
       OPERATION_TYPES = [SIGN_UP = 'sign_up', AUTHORIZE = 'authorize'].freeze
       GRANT_TYPES = [AUTH_CODE_GRANT = 'authorization_code',
-                     JWT_BEARER_GRANT = 'urn:ietf:params:oauth:grant-type:jwt-bearer'].freeze
+                     JWT_BEARER_GRANT = 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                     TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange'].freeze
       ENFORCED_TERMS = [VA_TERMS = 'VA'].freeze
       CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
       ASSERTION_ENCODE_ALGORITHM = 'RS256'

--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -28,10 +28,9 @@ module SignIn
       CSP_TYPES = [IDME = 'idme', LOGINGOV = 'logingov', DSLOGON = 'dslogon', MHV = 'mhv'].freeze
       OPERATION_TYPES = [SIGN_UP = 'sign_up', AUTHORIZE = 'authorize'].freeze
       GRANT_TYPES = [AUTH_CODE_GRANT = 'authorization_code',
-                     JWT_BEARER_GRANT = 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-                     TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange'].freeze
+                     JWT_BEARER_GRANT = Urn::JWT_BEARER_GRANT_TYPE,
+                     TOKEN_EXCHANGE_GRANT = Urn::TOKEN_EXCHANGE_GRANT_TYPE].freeze
       ENFORCED_TERMS = [VA_TERMS = 'VA'].freeze
-      CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
       ASSERTION_ENCODE_ALGORITHM = 'RS256'
       IAL = [IAL_ONE = 1, IAL_TWO = 2].freeze
       INFO_COOKIE_NAME = 'vagov_info_token'
@@ -42,7 +41,6 @@ module SignIn
       SERVICE_ACCOUNT_ACCESS_TOKEN_COOKIE_NAME = 'service_account_access_token'
       SCOPES = [DEVICE_SSO = 'device_sso'].freeze
       TOKEN_ROUTE_PATH = '/v0/sign_in/token'
-      DEVICE_SECRET_TOKEN_TYPE = 'urn:x-oath:params:oauth:token-type:device-secret'
     end
   end
 end

--- a/app/services/sign_in/constants/urn.rb
+++ b/app/services/sign_in/constants/urn.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SignIn
+  module Constants
+    module Urn
+      ACCESS_TOKEN = 'urn:ietf:params:oauth:token-type:access_token'
+      DEVICE_SECRET = 'urn:x-oath:params:oauth:token-type:device-secret'
+      JWT_BEARER_CLIENT_AUTHENTICATION = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+      JWT_BEARER_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+      TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange'
+    end
+  end
+end

--- a/app/services/sign_in/errors.rb
+++ b/app/services/sign_in/errors.rb
@@ -66,6 +66,9 @@ module SignIn
     class CredentialLockedError < StandardError; end
     class InvalidAudienceError < StandardError; end
     class InvalidScope < StandardError; end
-    class TokenExchangerError < StandardError; end
+    class InvalidTokenError < StandardError; end
+    class InvalidTokenTypeError < StandardError; end
+    class InvalidClientConfigError < StandardError; end
+    class InvalidSSORequestError < StandardError; end
   end
 end

--- a/app/services/sign_in/errors.rb
+++ b/app/services/sign_in/errors.rb
@@ -66,5 +66,6 @@ module SignIn
     class CredentialLockedError < StandardError; end
     class InvalidAudienceError < StandardError; end
     class InvalidScope < StandardError; end
+    class TokenExchangerError < StandardError; end
   end
 end

--- a/app/services/sign_in/session_spawner.rb
+++ b/app/services/sign_in/session_spawner.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module SignIn
+  class SessionSpawner
+    attr_reader :credential_email,
+                :user_verification,
+                :user_attributes,
+                :client_config,
+                :hashed_device_secret,
+                :refresh_creation
+
+    def initialize(current_session:, new_session_client_config:)
+      @credential_email = current_session.credential_email
+      @user_verification = current_session.user_verification
+      @user_attributes = current_session.user_attributes
+      @client_config = new_session_client_config
+      @hashed_device_secret = current_session.hashed_device_secret
+      @refresh_creation = current_session.refresh_creation
+    end
+
+    def perform
+      validate_credential_lock!
+      validate_terms_of_use!
+      SessionContainer.new(session: create_new_session,
+                           refresh_token:,
+                           access_token: create_new_access_token,
+                           anti_csrf_token:,
+                           client_config:)
+    end
+
+    private
+
+    def validate_credential_lock!
+      raise SignIn::Errors::CredentialLockedError.new(message: 'Credential is locked') if user_verification.locked
+    end
+
+    def validate_terms_of_use!
+      if client_config.enforced_terms.present? && user_verification.user_account.needs_accepted_terms_of_use?
+        raise Errors::TermsOfUseNotAcceptedError.new message: 'Terms of Use has not been accepted'
+      end
+    end
+
+    def anti_csrf_token
+      @anti_csrf_token ||= SecureRandom.hex
+    end
+
+    def refresh_token
+      @refresh_token ||= create_new_refresh_token(parent_refresh_token_hash:)
+    end
+
+    def double_parent_refresh_token_hash
+      @double_parent_refresh_token_hash ||= get_hash(parent_refresh_token_hash)
+    end
+
+    def refresh_token_hash
+      @refresh_token_hash ||= get_hash(refresh_token.to_json)
+    end
+
+    def parent_refresh_token_hash
+      @parent_refresh_token_hash ||= get_hash(create_new_refresh_token.to_json)
+    end
+
+    def create_new_access_token
+      AccessToken.new(
+        session_handle: handle,
+        client_id: client_config.client_id,
+        user_uuid:,
+        audience: AccessTokenAudienceGenerator.new(client_config:).perform,
+        refresh_token_hash:,
+        parent_refresh_token_hash:,
+        anti_csrf_token:,
+        last_regeneration_time: refresh_creation,
+        user_attributes: JSON.parse(user_attributes)
+      )
+    end
+
+    def create_new_refresh_token(parent_refresh_token_hash: nil)
+      RefreshToken.new(
+        session_handle: handle,
+        user_uuid:,
+        parent_refresh_token_hash:,
+        anti_csrf_token:
+      )
+    end
+
+    def create_new_session
+      OAuthSession.create!(user_account: user_verification.user_account,
+                           user_verification:,
+                           client_id: client_config.client_id,
+                           credential_email:,
+                           handle:,
+                           hashed_refresh_token: double_parent_refresh_token_hash,
+                           refresh_expiration: refresh_expiration_time,
+                           refresh_creation:,
+                           user_attributes:,
+                           hashed_device_secret:)
+    end
+
+    def refresh_expiration_time
+      @refresh_expiration_time ||= refresh_creation + client_config.refresh_token_duration
+    end
+
+    def get_hash(object)
+      Digest::SHA256.hexdigest(object)
+    end
+
+    def user_uuid
+      @user_uuid ||= user_verification.backing_credential_identifier
+    end
+
+    def handle
+      @handle ||= SecureRandom.uuid
+    end
+  end
+end

--- a/app/services/sign_in/token_exchanger.rb
+++ b/app/services/sign_in/token_exchanger.rb
@@ -2,13 +2,7 @@
 
 module SignIn
   class TokenExchanger
-    include ActiveModel::Validations
-
     attr_reader :subject_token, :subject_token_type, :actor_token, :actor_token_type, :client_id
-
-    validates :subject_token, :subject_token_type, :actor_token, :actor_token_type, :client_id, presence: true
-    validate :validate_subject_token, :validate_subject_token_type, :validate_actor_token_type, :validate_actor_token,
-             :validate_client_id, :validate_device_sso_enabled
 
     def initialize(subject_token:, subject_token_type:, actor_token:, actor_token_type:, client_id:)
       @subject_token = subject_token
@@ -19,169 +13,87 @@ module SignIn
     end
 
     def perform
-      validate!
-
-      new_container = create_session_container
-      Rails.logger.info('[SignIn::TokenExchanger] success',
-                        { new_session: { handle: new_container.session.handle, context: to_h } })
-
-      new_container
-    rescue => e
-      Rails.logger.error('[SignIn::TokenExchanger] error', message: e.message, context: to_h)
-      raise Errors::TokenExchangerError.new(message: e.message)
+      validations!
+      create_new_session
     end
 
     private
 
-    def create_session_container
-      SessionContainer.new(session:, access_token:, refresh_token:, anti_csrf_token:, client_config:)
+    def validations!
+      validate_subject_token!
+      validate_subject_token_type!
+      validate_actor_token!
+      validate_actor_token_type!
+      validate_client_id!
+      validate_shared_sessions_client!
+      validate_device_sso!
     end
 
-    def session
-      @session ||= OAuthSession.create!(user_account: current_session.user_account,
-                                        user_verification: current_session.user_verification,
-                                        credential_email: current_session.credential_email,
-                                        hashed_device_secret: current_session.hashed_device_secret,
-                                        user_attributes: current_user_attributes.to_json,
-                                        refresh_creation: current_refresh_creation,
-                                        client_id: client_config.client_id,
-                                        handle: session_handle,
-                                        hashed_refresh_token: hash_token(parent_refresh_token_hash),
-                                        refresh_expiration:)
+    def validate_subject_token!
+      unless subject_token && current_access_token
+        raise Errors::InvalidTokenError.new message: 'subject token is invalid'
+      end
     end
 
-    def access_token
-      @access_token ||= AccessToken.new(session_handle:,
-                                        refresh_token_hash:,
-                                        parent_refresh_token_hash:,
-                                        anti_csrf_token:,
-                                        audience:,
-                                        client_id: client_config.client_id,
-                                        last_regeneration_time: current_refresh_creation,
-                                        user_attributes: current_user_attributes,
-                                        user_uuid: current_user_uuid)
+    def validate_subject_token_type!
+      unless subject_token_type == Constants::Urn::ACCESS_TOKEN
+        raise Errors::InvalidTokenTypeError.new message: 'subject token type is invalid'
+      end
     end
 
-    def refresh_token
-      @refresh_token ||= create_refresh_token(parent_refresh_token_hash)
+    def validate_actor_token_type!
+      unless actor_token_type == Constants::Urn::DEVICE_SECRET
+        raise Errors::InvalidTokenTypeError.new message: 'actor token type is invalid'
+      end
     end
 
-    def anti_csrf_token
-      @anti_csrf_token ||= SecureRandom.hex
+    def validate_actor_token!
+      unless hashed_actor_token == current_session.hashed_device_secret &&
+             hashed_actor_token == current_access_token.device_secret_hash
+        raise Errors::InvalidTokenError.new message: 'actor token is invalid'
+      end
     end
 
-    def create_refresh_token(parent_refresh_token_hash = nil)
-      RefreshToken.new(session_handle:, parent_refresh_token_hash:, anti_csrf_token:, user_uuid: current_user_uuid)
+    def hashed_actor_token
+      @hashed_actor_token ||= Digest::SHA256.hexdigest(actor_token)
     end
 
-    def client_config
-      @client_config ||= ClientConfig.find_by(client_id:)
+    def validate_client_id!
+      unless new_session_client_config
+        raise Errors::InvalidClientConfigError.new message: 'client configuration not found'
+      end
     end
 
-    def session_handle
-      @session_handle ||= SecureRandom.uuid
+    def validate_shared_sessions_client!
+      unless new_session_client_config.shared_sessions
+        raise Errors::InvalidClientConfigError.new message: 'tokens requested for client without shared sessions'
+      end
     end
 
-    def refresh_token_hash
-      @refresh_token_hash ||= hash_token(refresh_token.to_json)
+    def validate_device_sso!
+      unless current_client_config.device_sso_enabled?
+        raise Errors::InvalidSSORequestError.new message: 'token exchange requested from invalid client'
+      end
     end
 
-    def parent_refresh_token_hash
-      @parent_refresh_token_hash ||= hash_token(create_refresh_token.to_json)
+    def create_new_session
+      SessionSpawner.new(current_session:, new_session_client_config:).perform
     end
 
-    def refresh_expiration
-      @refresh_expiration ||= current_refresh_creation + client_config.refresh_token_duration
-    end
-
-    def audience
-      @access_token_audience ||= AccessTokenAudienceGenerator.new(client_config:).perform
+    def new_session_client_config
+      @new_session_client_config ||= ClientConfig.find_by(client_id:)
     end
 
     def current_access_token
       @current_access_token ||= AccessTokenJwtDecoder.new(access_token_jwt: subject_token).perform
-    rescue
-      nil
     end
 
     def current_session
-      @current_session ||= OAuthSession.find_by(handle: current_access_token&.session_handle)
-    end
-
-    def current_refresh_creation
-      @current_refresh_creation ||= current_session&.refresh_creation
-    end
-
-    def current_user_uuid
-      @current_user_uuid ||= current_session.user_verification.backing_credential_identifier
-    end
-
-    def current_user_attributes
-      @current_user_attributes ||= JSON.parse(current_session.user_attributes)
+      @current_session ||= OAuthSession.find_by(handle: current_access_token.session_handle)
     end
 
     def current_client_config
-      @current_client_config ||= ClientConfig.find_by(client_id: current_access_token&.client_id)
-    end
-
-    def device_sso
-      @device_sso ||= current_client_config&.device_sso_enabled?
-    end
-
-    def hash_token(token)
-      Digest::SHA256.hexdigest(token)
-    end
-
-    def to_h
-      {
-        subject_token:,
-        subject_token_type:,
-        actor_token:,
-        actor_token_type:,
-        client_id:
-      }
-    end
-
-    def validate_subject_token
-      return if subject_token.blank?
-
-      errors.add(:subject_token, 'is not valid') if current_access_token.blank?
-    end
-
-    def validate_subject_token_type
-      return if subject_token_type.blank?
-
-      unless subject_token_type == Constants::AccessToken::OAUTH_TOKEN_TYPE
-        errors.add(:subject_token_type, 'is not valid')
-      end
-    end
-
-    def validate_actor_token_type
-      return if actor_token_type.blank?
-
-      errors.add(:actor_token_type, 'is not valid') unless actor_token_type == Constants::Auth::DEVICE_SECRET_TOKEN_TYPE
-    end
-
-    def validate_actor_token
-      return if actor_token.blank?
-
-      hashed_actor_token = hash_token(actor_token)
-
-      mismatched = []
-      mismatched << 'current_session' if hashed_actor_token != current_session&.hashed_device_secret
-      mismatched << 'subject_token' if hashed_actor_token != current_access_token&.device_secret_hash
-
-      errors.add(:actor_token, "does not match #{mismatched.join(' nor ')}") if mismatched.any?
-    end
-
-    def validate_client_id
-      return if client_id.blank?
-
-      errors.add(:client_id, 'is not valid') unless client_config&.client_id == Settings.sign_in.vaweb_client_id
-    end
-
-    def validate_device_sso_enabled
-      errors.add(:device_sso, 'is not enabled') unless device_sso
+      @current_client_config ||= ClientConfig.find_by(client_id: current_access_token.client_id)
     end
   end
 end

--- a/app/services/sign_in/token_exchanger.rb
+++ b/app/services/sign_in/token_exchanger.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+module SignIn
+  class TokenExchanger
+    include ActiveModel::Validations
+
+    attr_reader :subject_token, :subject_token_type, :actor_token, :actor_token_type, :client_id
+
+    validates :subject_token, :subject_token_type, :actor_token, :actor_token_type, :client_id, presence: true
+    validate :validate_subject_token, :validate_subject_token_type, :validate_actor_token_type, :validate_actor_token,
+             :validate_client_id, :validate_device_sso_enabled
+
+    def initialize(subject_token:, subject_token_type:, actor_token:, actor_token_type:, client_id:)
+      @subject_token = subject_token
+      @subject_token_type = subject_token_type
+      @actor_token = actor_token
+      @actor_token_type = actor_token_type
+      @client_id = client_id
+    end
+
+    def perform
+      validate!
+
+      new_container = create_session_container
+      Rails.logger.info('[SignIn::TokenExchanger] success',
+                        { new_session: { handle: new_container.session.handle, context: to_h } })
+
+      new_container
+    rescue => e
+      Rails.logger.error('[SignIn::TokenExchanger] error', message: e.message, context: to_h)
+      raise Errors::TokenExchangerError.new(message: e.message)
+    end
+
+    private
+
+    def create_session_container
+      SessionContainer.new(session:, access_token:, refresh_token:, anti_csrf_token:, client_config:)
+    end
+
+    def session
+      @session ||= OAuthSession.create!(user_account: current_session.user_account,
+                                        user_verification: current_session.user_verification,
+                                        credential_email: current_session.credential_email,
+                                        hashed_device_secret: current_session.hashed_device_secret,
+                                        user_attributes: current_user_attributes.to_json,
+                                        refresh_creation: current_refresh_creation,
+                                        client_id: client_config.client_id,
+                                        handle: session_handle,
+                                        hashed_refresh_token: hash_token(parent_refresh_token_hash),
+                                        refresh_expiration:)
+    end
+
+    def access_token
+      @access_token ||= AccessToken.new(session_handle:,
+                                        refresh_token_hash:,
+                                        parent_refresh_token_hash:,
+                                        anti_csrf_token:,
+                                        audience:,
+                                        client_id: client_config.client_id,
+                                        last_regeneration_time: current_refresh_creation,
+                                        user_attributes: current_user_attributes,
+                                        user_uuid: current_user_uuid)
+    end
+
+    def refresh_token
+      @refresh_token ||= create_refresh_token(parent_refresh_token_hash)
+    end
+
+    def anti_csrf_token
+      @anti_csrf_token ||= SecureRandom.hex
+    end
+
+    def create_refresh_token(parent_refresh_token_hash = nil)
+      RefreshToken.new(session_handle:, parent_refresh_token_hash:, anti_csrf_token:, user_uuid: current_user_uuid)
+    end
+
+    def client_config
+      @client_config ||= ClientConfig.find_by(client_id:)
+    end
+
+    def session_handle
+      @session_handle ||= SecureRandom.uuid
+    end
+
+    def refresh_token_hash
+      @refresh_token_hash ||= hash_token(refresh_token.to_json)
+    end
+
+    def parent_refresh_token_hash
+      @parent_refresh_token_hash ||= hash_token(create_refresh_token.to_json)
+    end
+
+    def refresh_expiration
+      @refresh_expiration ||= current_refresh_creation + client_config.refresh_token_duration
+    end
+
+    def audience
+      @access_token_audience ||= AccessTokenAudienceGenerator.new(client_config:).perform
+    end
+
+    def current_access_token
+      @current_access_token ||= AccessTokenJwtDecoder.new(access_token_jwt: subject_token).perform
+    rescue
+      nil
+    end
+
+    def current_session
+      @current_session ||= OAuthSession.find_by(handle: current_access_token&.session_handle)
+    end
+
+    def current_refresh_creation
+      @current_refresh_creation ||= current_session&.refresh_creation
+    end
+
+    def current_user_uuid
+      @current_user_uuid ||= current_session.user_verification.backing_credential_identifier
+    end
+
+    def current_user_attributes
+      @current_user_attributes ||= JSON.parse(current_session.user_attributes)
+    end
+
+    def current_client_config
+      @current_client_config ||= ClientConfig.find_by(client_id: current_access_token&.client_id)
+    end
+
+    def device_sso
+      @device_sso ||= current_client_config&.device_sso_enabled?
+    end
+
+    def hash_token(token)
+      Digest::SHA256.hexdigest(token)
+    end
+
+    def to_h
+      {
+        subject_token:,
+        subject_token_type:,
+        actor_token:,
+        actor_token_type:,
+        client_id:
+      }
+    end
+
+    def validate_subject_token
+      return if subject_token.blank?
+
+      errors.add(:subject_token, 'is not valid') if current_access_token.blank?
+    end
+
+    def validate_subject_token_type
+      return if subject_token_type.blank?
+
+      unless subject_token_type == Constants::AccessToken::OAUTH_TOKEN_TYPE
+        errors.add(:subject_token_type, 'is not valid')
+      end
+    end
+
+    def validate_actor_token_type
+      return if actor_token_type.blank?
+
+      errors.add(:actor_token_type, 'is not valid') unless actor_token_type == Constants::Auth::DEVICE_SECRET_TOKEN_TYPE
+    end
+
+    def validate_actor_token
+      return if actor_token.blank?
+
+      hashed_actor_token = hash_token(actor_token)
+
+      mismatched = []
+      mismatched << 'current_session' if hashed_actor_token != current_session&.hashed_device_secret
+      mismatched << 'subject_token' if hashed_actor_token != current_access_token&.device_secret_hash
+
+      errors.add(:actor_token, "does not match #{mismatched.join(' nor ')}") if mismatched.any?
+    end
+
+    def validate_client_id
+      return if client_id.blank?
+
+      errors.add(:client_id, 'is not valid') unless client_config&.client_id == Settings.sign_in.vaweb_client_id
+    end
+
+    def validate_device_sso_enabled
+      errors.add(:device_sso, 'is not enabled') unless device_sso
+    end
+  end
+end

--- a/app/services/sign_in/token_params_validator.rb
+++ b/app/services/sign_in/token_params_validator.rb
@@ -4,13 +4,15 @@ module SignIn
   class TokenParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :grant_type, :code, :code_verifier, :client_assertion, :client_assertion_type, :assertion
+    attr_reader :grant_type, :code, :code_verifier, :client_assertion, :client_assertion_type, :assertion,
+                :subject_token, :actor_token, :actor_token_type, :client_id
 
     # rubocop:disable Rails/I18nLocaleTexts
     validates :grant_type, inclusion: {
       in: [
         Constants::Auth::AUTH_CODE_GRANT,
-        Constants::Auth::JWT_BEARER_GRANT
+        Constants::Auth::JWT_BEARER_GRANT,
+        Constants::Auth::TOKEN_EXCHANGE_GRANT
       ],
       message: 'is not valid'
     }
@@ -31,6 +33,10 @@ module SignIn
       validates :assertion, presence: true
     end
 
+    with_options if: :token_exchange_grant? do
+      validates :subject_token, :actor_token, :actor_token_type, :client_id, presence: true
+    end
+
     def initialize(params:)
       @grant_type = params[:grant_type]
       @code = params[:code]
@@ -38,6 +44,10 @@ module SignIn
       @client_assertion = params[:client_assertion]
       @client_assertion_type = params[:client_assertion_type]
       @assertion = params[:assertion]
+      @subject_token = params[:subject_token]
+      @actor_token = params[:actor_token]
+      @actor_token_type = params[:actor_token_type]
+      @client_id = params[:client_id]
     end
 
     def perform
@@ -56,6 +66,10 @@ module SignIn
 
     def jwt_bearer_grant?
       grant_type == Constants::Auth::JWT_BEARER_GRANT
+    end
+
+    def token_exchange_grant?
+      grant_type == Constants::Auth::TOKEN_EXCHANGE_GRANT
     end
 
     def client_assertion_type_present?

--- a/app/services/sign_in/token_params_validator.rb
+++ b/app/services/sign_in/token_params_validator.rb
@@ -5,7 +5,7 @@ module SignIn
     include ActiveModel::Validations
 
     attr_reader :grant_type, :code, :code_verifier, :client_assertion, :client_assertion_type, :assertion,
-                :subject_token, :actor_token, :actor_token_type, :client_id
+                :subject_token, :subject_token_type, :actor_token, :actor_token_type, :client_id
 
     # rubocop:disable Rails/I18nLocaleTexts
     validates :grant_type, inclusion: {
@@ -19,7 +19,7 @@ module SignIn
 
     with_options if: :authorization_code_grant? do
       validates :client_assertion_type, inclusion: {
-        in: [Constants::Auth::CLIENT_ASSERTION_TYPE],
+        in: [Constants::Urn::JWT_BEARER_CLIENT_AUTHENTICATION],
         message: 'is not valid'
       }, if: :client_assertion_type_present?
 
@@ -34,7 +34,7 @@ module SignIn
     end
 
     with_options if: :token_exchange_grant? do
-      validates :subject_token, :actor_token, :actor_token_type, :client_id, presence: true
+      validates :subject_token, :subject_token_type, :actor_token, :actor_token_type, :client_id, presence: true
     end
 
     def initialize(params:)
@@ -45,6 +45,7 @@ module SignIn
       @client_assertion_type = params[:client_assertion_type]
       @assertion = params[:assertion]
       @subject_token = params[:subject_token]
+      @subject_token_type = params[:subject_token_type]
       @actor_token = params[:actor_token]
       @actor_token_type = params[:actor_token_type]
       @client_id = params[:client_id]
@@ -77,7 +78,7 @@ module SignIn
     end
 
     def log_error_and_raise(message)
-      Rails.logger.error('[SignIn::TokenParamsValidator] error', { errors: message })
+      Rails.logger.error('[SignIn][TokenParamsValidator] error', { errors: message })
       raise Errors::MalformedParamsError.new(message:)
     end
   end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -24,6 +24,7 @@ vamobile.update!(authentication: SignIn::Constants::Auth::API,
                  pkce: true,
                  access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_LONG_MINUTES,
                  access_token_audience: 'vamobile',
+                 shared_sessions: true,
                  enforced_terms: SignIn::Constants::Auth::VA_TERMS,
                  terms_of_use_url: 'http://localhost:3001/terms-of-use',
                  refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_LONG_DAYS)

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/application_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/application_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AccreditedRepresentativePortal::ApplicationController, type: :req
 
       context 'with an invalid audience' do
         let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: invalid_access_token).perform }
-        let(:expected_log_message) { '[SignIn::AudienceValidator] Invalid audience' }
+        let(:expected_log_message) { '[SignIn][AudienceValidator] Invalid audience' }
         let(:expected_log_payload) do
           { invalid_audience: invalid_access_token.audience, valid_audience: valid_access_token.audience }
         end

--- a/spec/controllers/sign_in/audience_validator_spec.rb
+++ b/spec/controllers/sign_in/audience_validator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SignIn::AudienceValidator do
 
     context 'with an invalid audience' do
       let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: invalid_access_token).perform }
-      let(:expected_log_message) { '[SignIn::AudienceValidator] Invalid audience' }
+      let(:expected_log_message) { '[SignIn][AudienceValidator] Invalid audience' }
       let(:expected_log_payload) do
         { invalid_audience: invalid_access_token.audience, valid_audience: valid_access_token.audience }
       end

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -1432,7 +1432,12 @@ RSpec.describe V0::SignInController, type: :controller do
                   .merge(grant_type)
                   .merge(client_assertion)
                   .merge(client_assertion_type)
-                  .merge(assertion))
+                  .merge(assertion)
+                  .merge(subject_token)
+                  .merge(subject_token_type)
+                  .merge(actor_token)
+                  .merge(actor_token_type)
+                  .merge(client_id_param))
     end
 
     let(:user_verification) { create(:user_verification) }
@@ -1443,7 +1448,17 @@ RSpec.describe V0::SignInController, type: :controller do
     let(:code_verifier) { { code_verifier: code_verifier_value } }
     let(:grant_type) { { grant_type: grant_type_value } }
     let(:assertion) { { assertion: assertion_value } }
+    let(:subject_token) { { subject_token: subject_token_value } }
+    let(:subject_token_type) { { subject_token_type: subject_token_type_value } }
+    let(:actor_token) { { actor_token: actor_token_value } }
+    let(:actor_token_type) { { actor_token_type: actor_token_type_value } }
+    let(:client_id_param) { { client_id: client_id_value } }
     let(:assertion_value) { nil }
+    let(:subject_token_value) { 'some-subject-token' }
+    let(:subject_token_type_value) { 'some-subject-token-type' }
+    let(:actor_token_value) { 'some-actor-token' }
+    let(:actor_token_type_value) { 'some-actor-token-type' }
+    let(:client_id_value) { 'some-client-id' }
     let(:code_value) { 'some-code' }
     let(:code_verifier_value) { 'some-code-verifier' }
     let(:grant_type_value) { SignIn::Constants::Auth::AUTH_CODE_GRANT }
@@ -1794,7 +1809,7 @@ RSpec.describe V0::SignInController, type: :controller do
             end
 
             context 'and client_assertion_type matches expected value' do
-              let(:client_assertion_type_value) { SignIn::Constants::Auth::CLIENT_ASSERTION_TYPE }
+              let(:client_assertion_type_value) { SignIn::Constants::Urn::JWT_BEARER_CLIENT_AUTHENTICATION }
 
               context 'and client_assertion is not a valid jwt' do
                 let(:client_assertion_value) { 'some-client-assertion' }
@@ -1958,6 +1973,261 @@ RSpec.describe V0::SignInController, type: :controller do
 
                   it 'updates StatsD with a token request success' do
                     expect { subject }.to trigger_statsd_increment(statsd_token_success)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when grant_type is token-exchange' do
+      let(:grant_type_value) { SignIn::Constants::Auth::TOKEN_EXCHANGE_GRANT }
+
+      context 'and subject token param is not given' do
+        let(:subject_token) { {} }
+        let(:expected_error) { "Subject token can't be blank" }
+
+        it_behaves_like 'error response'
+      end
+
+      context 'and subject token type param is not given' do
+        let(:subject_token_type) { {} }
+        let(:expected_error) { "Subject token type can't be blank" }
+
+        it_behaves_like 'error response'
+      end
+
+      context 'and actor_token param is not given' do
+        let(:actor_token) { {} }
+        let(:expected_error) { "Actor token can't be blank" }
+
+        it_behaves_like 'error response'
+      end
+
+      context 'and client_id param is not given' do
+        let(:client_id_param) { {} }
+        let(:expected_error) { "Client can't be blank" }
+
+        it_behaves_like 'error response'
+      end
+
+      context 'and subject token is not a valid access token' do
+        let(:subject_token_value) { 'some-subject-token' }
+        let(:expected_error) { 'Access token JWT is malformed' }
+
+        it_behaves_like 'error response'
+      end
+
+      context 'and subject token is a valid access token' do
+        let(:subject_token_value) { SignIn::AccessTokenJwtEncoder.new(access_token: current_access_token).perform }
+        let(:current_access_token) do
+          create(:access_token, session_handle: current_session.handle,
+                                device_secret_hash: hashed_device_secret,
+                                client_id:)
+        end
+        let!(:current_session) { create(:oauth_session, hashed_device_secret:, user_account:, user_verification:) }
+        let(:hashed_device_secret) { Digest::SHA256.hexdigest(device_secret) }
+        let(:user_account) { user_verification.user_account }
+        let(:device_secret) { 'some-device-secret' }
+
+        context 'and subject token type is arbitrary' do
+          let(:subject_token_type_value) { 'some-subject-token' }
+          let(:expected_error) { 'subject token type is invalid' }
+
+          it_behaves_like 'error response'
+        end
+
+        context 'and subject token type is access token URN' do
+          let(:subject_token_type_value) { SignIn::Constants::Urn::ACCESS_TOKEN }
+
+          context 'and actor token is arbitrary' do
+            let(:actor_token_value) { 'some-actor-token' }
+            let(:expected_error) { 'actor token is invalid' }
+
+            it_behaves_like 'error response'
+          end
+
+          context 'and actor token is a valid device_secret' do
+            let(:actor_token_value) { device_secret }
+
+            context 'and actor token type is invalid' do
+              let(:actor_token_type_value) { 'some-actor-token-type' }
+              let(:expected_error) { 'actor token type is invalid' }
+
+              it_behaves_like 'error response'
+            end
+
+            context 'and actor token type is device_secret URN' do
+              let(:actor_token_type_value) { SignIn::Constants::Urn::DEVICE_SECRET }
+              let(:new_client_config) do
+                create(:client_config,
+                       enforced_terms: new_client_enforced_terms,
+                       shared_sessions: new_client_shared_sessions,
+                       authentication: new_client_authentication,
+                       anti_csrf: new_client_anti_csrf)
+              end
+              let(:new_client_enforced_terms) { nil }
+              let(:new_client_anti_csrf) { true }
+              let(:new_client_authentication) { SignIn::Constants::Auth::COOKIE }
+
+              context 'and client id is not associated with a valid client config' do
+                let(:client_id_value) { 'some-arbitrary-client-id' }
+                let(:expected_error) { 'client configuration not found' }
+
+                it_behaves_like 'error response'
+              end
+
+              context 'and client id is associated with a valid client config' do
+                let(:client_id_value) { new_client_config.client_id }
+
+                context 'and client id is not associated with a shared sessions client' do
+                  let(:new_client_shared_sessions) { false }
+                  let(:expected_error) { 'tokens requested for client without shared sessions' }
+
+                  it_behaves_like 'error response'
+                end
+
+                context 'and client id is associated with a shared sessions client' do
+                  let(:new_client_shared_sessions) { true }
+
+                  context 'and current session is not associated with a device sso enabled client' do
+                    let(:shared_sessions) { false }
+                    let(:expected_error) { 'token exchange requested from invalid client' }
+
+                    it_behaves_like 'error response'
+                  end
+
+                  context 'and current session is associated with a device sso enabled client' do
+                    let(:shared_sessions) { true }
+                    let(:expected_generator_log) { '[SignInService] [SignIn::TokenResponseGenerator] token exchanged' }
+                    let(:expected_log) { '[SignInService] [V0::SignInController] token' }
+
+                    context 'and the retrieved UserVerification is locked' do
+                      let(:user_verification) { create(:user_verification, locked: true) }
+                      let(:expected_error) { 'Credential is locked' }
+
+                      it_behaves_like 'error response'
+                    end
+
+                    context 'and new client config is configured with enforced terms' do
+                      let(:new_client_enforced_terms) { SignIn::Constants::Auth::VA_TERMS }
+
+                      context 'and authenticating user has accepted current terms of use' do
+                        let!(:terms_of_use_agreement) { create(:terms_of_use_agreement, user_account:) }
+
+                        it 'returns ok status' do
+                          expect(subject).to have_http_status(:ok)
+                        end
+                      end
+
+                      context 'and authenticating user has not accepted current terms of use' do
+                        let(:expected_error) { 'Terms of Use has not been accepted' }
+
+                        it_behaves_like 'error response'
+                      end
+                    end
+
+                    it 'creates an OAuthSession' do
+                      expect { subject }.to change(SignIn::OAuthSession, :count).by(1)
+                    end
+
+                    it 'returns ok status' do
+                      expect(subject).to have_http_status(:ok)
+                    end
+
+                    context 'and requested tokens are for a session that is configured as api auth' do
+                      let!(:user) { create(:user, :api_auth, uuid: user_uuid) }
+                      let(:new_client_authentication) { SignIn::Constants::Auth::API }
+
+                      context 'and authentication is for a session set up for device sso' do
+                        let(:shared_sessions) { true }
+                        let(:device_sso) { true }
+
+                        it 'returns expected body without device_secret' do
+                          expect(JSON.parse(subject.body)['data']).not_to have_key('device_secret')
+                        end
+                      end
+
+                      it 'returns expected body with access token' do
+                        expect(JSON.parse(subject.body)['data']).to have_key('access_token')
+                      end
+
+                      it 'returns expected body with refresh token' do
+                        expect(JSON.parse(subject.body)['data']).to have_key('refresh_token')
+                      end
+
+                      it 'logs the successful token request' do
+                        access_token = JWT.decode(JSON.parse(subject.body)['data']['access_token'], nil, false).first
+                        logger_context = {
+                          uuid: access_token['jti'],
+                          user_uuid: access_token['sub'],
+                          session_handle: access_token['session_handle'],
+                          client_id: access_token['client_id'],
+                          audience: access_token['aud'],
+                          version: access_token['version'],
+                          last_regeneration_time: access_token['last_regeneration_time'],
+                          created_time: access_token['iat'],
+                          expiration_time: access_token['exp']
+                        }
+                        expect(Rails.logger).to have_received(:info).with(expected_log, {})
+                        expect(Rails.logger).to have_received(:info).with(expected_generator_log, logger_context)
+                      end
+
+                      it 'updates StatsD with a token request success' do
+                        expect { subject }.to trigger_statsd_increment(statsd_token_success)
+                      end
+                    end
+
+                    context 'and authentication is for a session that is configured as cookie auth' do
+                      let(:new_client_authentication) { SignIn::Constants::Auth::COOKIE }
+                      let(:access_token_cookie_name) { SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME }
+                      let(:refresh_token_cookie_name) { SignIn::Constants::Auth::REFRESH_TOKEN_COOKIE_NAME }
+
+                      it 'returns empty hash for body' do
+                        expect(JSON.parse(subject.body)).to eq({})
+                      end
+
+                      it 'sets access token cookie' do
+                        expect(subject.cookies).to have_key(access_token_cookie_name)
+                      end
+
+                      it 'sets refresh token cookie' do
+                        expect(subject.cookies).to have_key(refresh_token_cookie_name)
+                      end
+
+                      context 'and session is configured as anti csrf enabled' do
+                        let(:new_client_anti_csrf) { true }
+                        let(:anti_csrf_token_cookie_name) { SignIn::Constants::Auth::ANTI_CSRF_COOKIE_NAME }
+
+                        it 'returns expected body with refresh token' do
+                          expect(subject.cookies).to have_key(anti_csrf_token_cookie_name)
+                        end
+                      end
+
+                      it 'logs the successful token request' do
+                        access_token_cookie = subject.cookies[access_token_cookie_name]
+                        access_token = JWT.decode(access_token_cookie, nil, false).first
+                        logger_context = {
+                          uuid: access_token['jti'],
+                          user_uuid: access_token['sub'],
+                          session_handle: access_token['session_handle'],
+                          client_id: access_token['client_id'],
+                          audience: access_token['aud'],
+                          version: access_token['version'],
+                          last_regeneration_time: access_token['last_regeneration_time'],
+                          created_time: access_token['iat'],
+                          expiration_time: access_token['exp']
+                        }
+                        expect(Rails.logger).to have_received(:info).with(expected_log, {})
+                        expect(Rails.logger).to have_received(:info).with(expected_generator_log, logger_context)
+                      end
+
+                      it 'updates StatsD with a token request success' do
+                        expect { subject }.to trigger_statsd_increment(statsd_token_success)
+                      end
+                    end
                   end
                 end
               end

--- a/spec/services/sign_in/client_assertion_validator_spec.rb
+++ b/spec/services/sign_in/client_assertion_validator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SignIn::ClientAssertionValidator do
     end
 
     context 'when client assertion type equals expected value' do
-      let(:client_assertion_type) { SignIn::Constants::Auth::CLIENT_ASSERTION_TYPE }
+      let(:client_assertion_type) { SignIn::Constants::Urn::JWT_BEARER_CLIENT_AUTHENTICATION }
 
       context 'and jwt was not encoded with expected signature' do
         let(:private_key) { OpenSSL::PKey::RSA.new(2048) }

--- a/spec/services/sign_in/code_validator_spec.rb
+++ b/spec/services/sign_in/code_validator_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe SignIn::CodeValidator do
         end
 
         context 'when client assertion type equals expected value' do
-          let(:client_assertion_type) { SignIn::Constants::Auth::CLIENT_ASSERTION_TYPE }
+          let(:client_assertion_type) { SignIn::Constants::Urn::JWT_BEARER_CLIENT_AUTHENTICATION }
 
           context 'and jwt was not encoded with expected signature' do
             let(:private_key) { OpenSSL::PKey::RSA.new(2048) }

--- a/spec/services/sign_in/session_spawner_spec.rb
+++ b/spec/services/sign_in/session_spawner_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::SessionSpawner do
+  let(:session_spawner) do
+    SignIn::SessionSpawner.new(current_session:, new_session_client_config:)
+  end
+
+  describe '#perform' do
+    subject { session_spawner.perform }
+
+    let(:current_session) { create(:oauth_session, handle: current_session_handle, user_verification:) }
+    let(:current_session_handle) { 'edd4c2fc-d776-4596-8dce-71a9848e15e0' }
+    let(:user_uuid) { current_session.user_verification.backing_credential_identifier }
+    let(:user_verification) { create(:user_verification, locked:) }
+    let(:user_account) { user_verification.user_account }
+    let(:locked) { false }
+    let(:new_session_client_config) do
+      create(:client_config, client_id:, refresh_token_duration:, access_token_attributes:, enforced_terms:)
+    end
+    let(:client_id) { 'some-client-id' }
+    let(:refresh_token_duration) { SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES }
+    let(:access_token_attributes) { %w[first_name last_name email] }
+    let(:enforced_terms) { nil }
+    let(:device_sso) { false }
+
+    context 'expected credential_lock validation' do
+      let(:locked) { false }
+      let(:expected_error) { SignIn::Errors::CredentialLockedError }
+      let(:expected_error_message) { 'Credential is locked' }
+
+      context 'when the UserVerification is not locked' do
+        it 'does not return an error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the UserVerification is locked' do
+        let(:locked) { true }
+
+        it 'returns a credential locked error' do
+          expect { subject }.to raise_error(expected_error, expected_error_message)
+        end
+      end
+    end
+
+    context 'when client config is set to enforce terms' do
+      let(:enforced_terms) { SignIn::Constants::Auth::VA_TERMS }
+
+      context 'and user has accepted current terms of use' do
+        let!(:terms_of_use_agreement) { create(:terms_of_use_agreement, user_account:) }
+
+        it 'does not return an error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'and user has not accepted current terms of use' do
+        let(:expected_error) { SignIn::Errors::TermsOfUseNotAcceptedError }
+        let(:expected_error_message) { 'Terms of Use has not been accepted' }
+
+        it 'returns a terms of use not accepted error' do
+          expect { subject }.to raise_error(expected_error, expected_error_message)
+        end
+      end
+    end
+
+    context 'expected anti_csrf_token' do
+      let(:expected_anti_csrf_token) { 'some-anti-csrf-token' }
+
+      before do
+        allow(SecureRandom).to receive(:hex).and_return(expected_anti_csrf_token)
+      end
+
+      it 'returns a Session Container with expected anti_csrf_token' do
+        expect(subject.anti_csrf_token).to be(expected_anti_csrf_token)
+      end
+    end
+
+    context 'expected session' do
+      let(:expected_handle) { SecureRandom.uuid }
+      let(:expected_created_time) { current_session.refresh_creation }
+      let(:expected_token_uuid) { SecureRandom.uuid }
+      let(:expected_parent_token_uuid) { SecureRandom.uuid }
+      let(:expected_user_uuid) { user_uuid }
+      let(:expected_expiration_time) { expected_created_time + refresh_token_duration }
+      let(:expected_user_attributes) { JSON.parse(current_session.user_attributes) }
+      let(:expected_double_hashed_parent_refresh_token) do
+        Digest::SHA256.hexdigest(parent_refresh_token_hash)
+      end
+      let(:stubbed_random_number) { 'some-stubbed-random-number' }
+      let(:parent_refresh_token_hash) { Digest::SHA256.hexdigest(parent_refresh_token.to_json) }
+      let(:refresh_token) do
+        create(:refresh_token,
+               uuid: expected_token_uuid,
+               user_uuid: expected_user_uuid,
+               parent_refresh_token_hash:,
+               session_handle: expected_handle,
+               nonce: stubbed_random_number,
+               anti_csrf_token: stubbed_random_number)
+      end
+      let(:parent_refresh_token) do
+        create(:refresh_token,
+               uuid: expected_parent_token_uuid,
+               user_uuid: expected_user_uuid,
+               parent_refresh_token_hash: nil,
+               session_handle: expected_handle,
+               nonce: stubbed_random_number,
+               anti_csrf_token: stubbed_random_number)
+      end
+      let(:expected_hashed_device_secret) { current_session.hashed_device_secret }
+      let(:expected_credential_email) { current_session.credential_email }
+
+      before do
+        allow(SecureRandom).to receive(:hex).and_return(stubbed_random_number)
+        allow(SecureRandom).to receive(:uuid).and_return(expected_handle)
+      end
+
+      it 'returns a Session Container with expected OAuth Session and fields' do
+        session = subject.session
+
+        expect(session.user_account).to eq(user_account)
+        expect(session.user_verification).to eq(user_verification)
+        expect(session.client_id).to eq(client_id)
+        expect(session.credential_email).to eq(expected_credential_email)
+        expect(session.handle).to eq(expected_handle)
+        expect(session.hashed_refresh_token).to eq(expected_double_hashed_parent_refresh_token)
+        expect(session.refresh_creation).to eq(expected_created_time)
+        expect(session.user_attributes_hash.values).to eq(expected_user_attributes.values)
+        expect(session.hashed_device_secret).to eq(expected_hashed_device_secret)
+      end
+
+      context 'and client is configured for a short token expiration' do
+        let(:refresh_token_duration) { SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES }
+
+        it 'creates a session with the expected expiration time' do
+          expect(subject.session.refresh_expiration).to eq(expected_expiration_time)
+        end
+      end
+
+      context 'and client is configured for a long token expiration' do
+        let(:refresh_token_duration) { SignIn::Constants::RefreshToken::VALIDITY_LENGTH_LONG_DAYS }
+
+        it 'creates a session with the expected expiration time' do
+          expect(subject.session.refresh_expiration).to eq(expected_expiration_time)
+        end
+      end
+    end
+
+    context 'expected refresh_token' do
+      let(:expected_handle) { SecureRandom.uuid }
+      let(:expected_user_uuid) { user_uuid }
+      let(:expected_token_uuid) { SecureRandom.uuid }
+      let(:expected_parent_token_uuid) { SecureRandom.uuid }
+      let(:expected_anti_csrf_token) { stubbed_random_number }
+      let(:stubbed_random_number) { 'some-stubbed-random-number' }
+      let(:expected_parent_refresh_token_hash) { Digest::SHA256.hexdigest(parent_refresh_token.to_json) }
+      let(:refresh_token) do
+        create(:refresh_token,
+               uuid: expected_token_uuid,
+               user_uuid: expected_user_uuid,
+               parent_refresh_token_hash:,
+               session_handle: expected_handle,
+               nonce: stubbed_random_number,
+               anti_csrf_token: stubbed_random_number)
+      end
+      let(:parent_refresh_token) do
+        create(:refresh_token,
+               uuid: expected_parent_token_uuid,
+               user_uuid: expected_user_uuid,
+               parent_refresh_token_hash: nil,
+               session_handle: expected_handle,
+               nonce: stubbed_random_number,
+               anti_csrf_token: stubbed_random_number)
+      end
+
+      before do
+        allow(SecureRandom).to receive(:hex).and_return(stubbed_random_number)
+        allow(SecureRandom).to receive(:uuid).and_return(expected_handle)
+      end
+
+      it 'returns a Session Container with expected Refresh Token and fields' do
+        refresh_token = subject.refresh_token
+        expect(refresh_token.session_handle).to eq(expected_handle)
+        expect(refresh_token.anti_csrf_token).to eq(expected_anti_csrf_token)
+        expect(refresh_token.user_uuid).to eq(expected_user_uuid)
+        expect(refresh_token.parent_refresh_token_hash).to eq(expected_parent_refresh_token_hash)
+      end
+    end
+
+    context 'expected access_token' do
+      let(:expected_handle) { SecureRandom.uuid }
+      let(:expected_user_uuid) { user_uuid }
+      let(:expected_token_uuid) { SecureRandom.uuid }
+      let(:expected_parent_token_uuid) { SecureRandom.uuid }
+      let(:expected_anti_csrf_token) { stubbed_random_number }
+      let(:stubbed_random_number) { 'some-stubbed-random-number' }
+      let(:expected_refresh_token_hash) { Digest::SHA256.hexdigest(refresh_token.to_json) }
+      let(:refresh_token) do
+        create(:refresh_token,
+               uuid: expected_token_uuid,
+               user_uuid: expected_user_uuid,
+               parent_refresh_token_hash: expected_parent_refresh_token_hash,
+               session_handle: expected_handle,
+               nonce: stubbed_random_number,
+               anti_csrf_token: expected_anti_csrf_token)
+      end
+      let(:parent_refresh_token) do
+        create(:refresh_token,
+               uuid: expected_parent_token_uuid,
+               user_uuid: expected_user_uuid,
+               parent_refresh_token_hash: nil,
+               session_handle: expected_handle,
+               nonce: stubbed_random_number,
+               anti_csrf_token: expected_anti_csrf_token)
+      end
+      let(:expected_parent_refresh_token_hash) { Digest::SHA256.hexdigest(parent_refresh_token.to_json) }
+      let(:expected_last_regeneration_time) { current_session.refresh_creation }
+
+      before do
+        allow(SecureRandom).to receive(:hex).and_return(stubbed_random_number)
+        allow(SecureRandom).to receive(:uuid).and_return(expected_handle)
+      end
+
+      it 'returns a Session Container with expected Access Token and fields' do
+        access_token = subject.access_token
+        expect(access_token.session_handle).to eq(expected_handle)
+        expect(access_token.anti_csrf_token).to eq(expected_anti_csrf_token)
+        expect(access_token.user_uuid).to eq(expected_user_uuid)
+        expect(access_token.refresh_token_hash).to eq(expected_refresh_token_hash)
+        expect(access_token.parent_refresh_token_hash).to eq(expected_parent_refresh_token_hash)
+        expect(access_token.last_regeneration_time).to eq(expected_last_regeneration_time)
+        expect(access_token.device_secret_hash).to eq(nil)
+        expect(access_token.user_attributes).to eq(JSON.parse(current_session.user_attributes))
+      end
+    end
+  end
+end

--- a/spec/services/sign_in/token_exchanger_spec.rb
+++ b/spec/services/sign_in/token_exchanger_spec.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::TokenExchanger, type: :model do
+  subject(:token_exchanger) do
+    described_class.new(subject_token:, subject_token_type:, actor_token:, actor_token_type:, client_id:)
+  end
+
+  let!(:current_session) { create(:oauth_session, hashed_device_secret: current_session_device_secret) }
+  let(:current_session_device_secret) { hashed_device_secret }
+  let(:current_access_token_device_secret) { hashed_device_secret }
+  let(:web_client_id) { 'some-web-client-id' }
+  let!(:current_client_config) do
+    create(:client_config, authentication: :api,
+                           shared_sessions: true,
+                           access_token_attributes: %i[first_name last_name email])
+  end
+  let(:current_access_token) do
+    create(:access_token, session_handle: current_session.handle,
+                          device_secret_hash: current_access_token_device_secret,
+                          client_id: current_client_config.client_id)
+  end
+  let(:web_client_config) do
+    create(:client_config, client_id: web_client_id, access_token_attributes: %i[first_name last_name email])
+  end
+
+  let(:subject_token) { SignIn::AccessTokenJwtEncoder.new(access_token: current_access_token).perform }
+  let(:subject_token_type) { SignIn::Constants::AccessToken::OAUTH_TOKEN_TYPE }
+  let(:actor_token) { device_secret }
+  let(:actor_token_type) { SignIn::Constants::Auth::DEVICE_SECRET_TOKEN_TYPE }
+  let(:client_id) { web_client_config.client_id }
+  let(:device_secret) { 'some-device-secret' }
+  let(:hashed_device_secret) { Digest::SHA256.hexdigest(device_secret) }
+
+  shared_examples 'a valid token exchanger' do
+    it 'is valid' do
+      expect(token_exchanger.perform).to be_valid
+    end
+  end
+
+  shared_examples 'an invalid token exchanger' do
+    it 'is invalid' do
+      expect { token_exchanger.perform }.to raise_error(
+        SignIn::Errors::TokenExchangerError
+      ).with_message(/#{attribute.to_s.humanize} #{expected_error_message}/)
+    end
+  end
+
+  before do
+    allow(Settings.sign_in).to receive(:vaweb_client_id).and_return(web_client_id)
+  end
+
+  describe 'validations' do
+    context 'when subject_token' do
+      let(:attribute) { :subject_token }
+
+      context 'is blank' do
+        let(:subject_token) { nil }
+        let(:expected_error_message) { "can't be blank" }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is invalid' do
+        let(:subject_token) { 'some-subject-token' }
+        let(:expected_error_message) { 'is not valid' }
+      end
+
+      context 'is valid' do
+        it_behaves_like 'a valid token exchanger'
+      end
+    end
+
+    context 'when subject_token_type' do
+      let(:attribute) { :subject_token_type }
+
+      context 'is blank' do
+        let(:subject_token_type) { nil }
+        let(:expected_error_message) { "can't be blank" }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is invalid' do
+        let(:subject_token_type) { 'invalid-subject-token-type' }
+        let(:expected_error_message) { 'is not valid' }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is valid' do
+        it_behaves_like 'a valid token exchanger'
+      end
+    end
+
+    context 'when actor_token' do
+      let(:attribute) { :actor_token }
+
+      context 'is blank' do
+        let(:actor_token) { nil }
+        let(:expected_error_message) { "can't be blank" }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'does not match oauth_session hashed device secret' do
+        let(:current_session_device_secret) { 'some-other-hash' }
+        let(:expected_error_message) { 'does not match current_session' }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'does not match subject_token hashed device secret' do
+        let(:current_access_token_device_secret) { 'some-other-hash' }
+        let(:expected_error_message) { 'does not match subject_token' }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is valid' do
+        it_behaves_like 'a valid token exchanger'
+      end
+    end
+
+    context 'when actor_token_type' do
+      let(:attribute) { :actor_token_type }
+
+      context 'is blank' do
+        let(:actor_token_type) { nil }
+        let(:expected_error_message) { "can't be blank" }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is invalid' do
+        let(:actor_token_type) { 'invalid-actor-token-type' }
+        let(:expected_error_message) { 'is not valid' }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is valid' do
+        it_behaves_like 'a valid token exchanger'
+      end
+    end
+
+    context 'when client_id' do
+      let(:attribute) { :client_id }
+
+      context 'is blank' do
+        let(:client_id) { nil }
+        let(:expected_error_message) { "can't be blank" }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'when client_id is not the web client id' do
+        let(:client_id) { 'some-other-client-id' }
+        let(:expected_error_message) { 'is not valid' }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is valid' do
+        it_behaves_like 'a valid token exchanger'
+      end
+    end
+
+    context 'when device_sso' do
+      let(:attribute) { :device_sso }
+
+      context 'is not enabled' do
+        let(:current_client_config) { create(:client_config, authentication: :api, shared_sessions: false) }
+        let(:expected_error_message) { 'is not enabled' }
+
+        it_behaves_like 'an invalid token exchanger'
+      end
+
+      context 'is enabled' do
+        it_behaves_like 'a valid token exchanger'
+      end
+    end
+  end
+
+  describe '#perform' do
+    context 'when token exchanger is invalid' do
+      let(:subject_token) { nil }
+
+      it 'raises an error' do
+        expect do
+          token_exchanger.perform
+        end.to raise_error(SignIn::Errors::TokenExchangerError)
+      end
+    end
+
+    context 'when token exchanger is valid' do
+      let(:session_container) { token_exchanger.perform }
+      let(:new_session) { session_container.session }
+      let(:new_access_token) { session_container.access_token }
+      let(:new_refresh_token) { session_container.refresh_token }
+      let(:new_anti_csrf_token) { session_container.anti_csrf_token }
+      let(:new_client_config) { session_container.client_config }
+
+      let(:expected_session_handle) { Faker::Internet.uuid }
+      let(:expected_client_id) { web_client_config.client_id }
+      let(:expected_user_attributes) { current_session.user_attributes }
+      let(:expected_refresh_creation) { current_session.refresh_creation }
+      let(:expected_parent_refresh_token_hash) { new_refresh_token.parent_refresh_token_hash }
+      let(:expected_anti_csrf_token) { new_anti_csrf_token }
+      let(:expected_user_uuid) { new_session.user_verification.backing_credential_identifier }
+
+      before do
+        allow(SecureRandom).to receive(:uuid).and_return(expected_session_handle)
+      end
+
+      context 'a session container is created' do
+        it 'is valid' do
+          expect(session_container).to be_valid
+        end
+
+        context 'and the session' do
+          let(:expected_user_account_id) { current_session.user_account_id }
+          let(:expected_user_verification_id) { current_session.user_verification_id }
+          let(:expected_credential_email) { current_session.credential_email }
+          let(:expected_hashed_device_secret) { current_session.hashed_device_secret }
+          let(:expected_hashed_refresh_token) { Digest::SHA256.hexdigest(new_refresh_token.parent_refresh_token_hash) }
+
+          let(:expected_refresh_expiration) do
+            expected_refresh_creation + new_client_config.refresh_token_duration
+          end
+
+          it 'has the expected attributes' do
+            expect(new_session).to have_attributes(
+              client_id: expected_client_id,
+              user_account_id: expected_user_account_id,
+              user_verification_id: expected_user_verification_id,
+              credential_email: expected_credential_email,
+              user_attributes: expected_user_attributes,
+              hashed_device_secret: expected_hashed_device_secret,
+              refresh_creation: expected_refresh_creation,
+              handle: expected_session_handle,
+              hashed_refresh_token: expected_hashed_refresh_token,
+              refresh_expiration: expected_refresh_expiration
+            )
+          end
+        end
+
+        context 'and the access_token' do
+          let(:expected_audience) { SignIn::AccessTokenAudienceGenerator.new(client_config: new_client_config).perform }
+          let(:expected_device_secret_hash) { nil }
+          let(:expected_refresh_token_has) { Digest::SHA256.hexdigest(new_refresh_token.to_json) }
+
+          it 'has the attributes' do
+            expect(new_access_token).to have_attributes(
+              session_handle: expected_session_handle,
+              refresh_token_hash: expected_refresh_token_has,
+              parent_refresh_token_hash: expected_parent_refresh_token_hash,
+              anti_csrf_token: expected_anti_csrf_token,
+              audience: expected_audience,
+              client_id: expected_client_id,
+              last_regeneration_time: expected_refresh_creation,
+              user_attributes: JSON.parse(expected_user_attributes),
+              user_uuid: expected_user_uuid,
+              device_secret_hash: expected_device_secret_hash
+            )
+          end
+        end
+
+        context 'and the refresh_token' do
+          it 'has the expected attributes' do
+            expect(new_refresh_token).to have_attributes(
+              session_handle: expected_session_handle,
+              parent_refresh_token_hash: expected_parent_refresh_token_hash,
+              anti_csrf_token: expected_anti_csrf_token,
+              user_uuid: expected_user_uuid
+            )
+          end
+        end
+
+        context 'and the anti_csrf_token' do
+          let(:expected_anti_csrf_token) { SecureRandom.hex }
+
+          before do
+            allow(SecureRandom).to receive(:hex).and_return(expected_anti_csrf_token)
+          end
+
+          it 'is expected' do
+            expect(new_anti_csrf_token).to eq(expected_anti_csrf_token)
+          end
+        end
+
+        context 'and the client_config' do
+          let(:expected_client_id) { web_client_config.client_id }
+
+          it 'is expected' do
+            expect(new_client_config.client_id).to eq(expected_client_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/sign_in/token_exchanger_spec.rb
+++ b/spec/services/sign_in/token_exchanger_spec.rb
@@ -7,294 +7,206 @@ RSpec.describe SignIn::TokenExchanger, type: :model do
     described_class.new(subject_token:, subject_token_type:, actor_token:, actor_token_type:, client_id:)
   end
 
-  let!(:current_session) { create(:oauth_session, hashed_device_secret: current_session_device_secret) }
-  let(:current_session_device_secret) { hashed_device_secret }
-  let(:current_access_token_device_secret) { hashed_device_secret }
-  let(:web_client_id) { 'some-web-client-id' }
-  let!(:current_client_config) do
-    create(:client_config, authentication: :api,
-                           shared_sessions: true,
-                           access_token_attributes: %i[first_name last_name email])
-  end
-  let(:current_access_token) do
-    create(:access_token, session_handle: current_session.handle,
-                          device_secret_hash: current_access_token_device_secret,
-                          client_id: current_client_config.client_id)
-  end
-  let(:web_client_config) do
-    create(:client_config, client_id: web_client_id, access_token_attributes: %i[first_name last_name email])
-  end
-
-  let(:subject_token) { SignIn::AccessTokenJwtEncoder.new(access_token: current_access_token).perform }
-  let(:subject_token_type) { SignIn::Constants::AccessToken::OAUTH_TOKEN_TYPE }
-  let(:actor_token) { device_secret }
-  let(:actor_token_type) { SignIn::Constants::Auth::DEVICE_SECRET_TOKEN_TYPE }
-  let(:client_id) { web_client_config.client_id }
-  let(:device_secret) { 'some-device-secret' }
-  let(:hashed_device_secret) { Digest::SHA256.hexdigest(device_secret) }
-
-  shared_examples 'a valid token exchanger' do
-    it 'is valid' do
-      expect(token_exchanger.perform).to be_valid
-    end
-  end
-
-  shared_examples 'an invalid token exchanger' do
-    it 'is invalid' do
-      expect { token_exchanger.perform }.to raise_error(
-        SignIn::Errors::TokenExchangerError
-      ).with_message(/#{attribute.to_s.humanize} #{expected_error_message}/)
-    end
-  end
-
-  before do
-    allow(Settings.sign_in).to receive(:vaweb_client_id).and_return(web_client_id)
-  end
-
-  describe 'validations' do
-    context 'when subject_token' do
-      let(:attribute) { :subject_token }
-
-      context 'is blank' do
-        let(:subject_token) { nil }
-        let(:expected_error_message) { "can't be blank" }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is invalid' do
-        let(:subject_token) { 'some-subject-token' }
-        let(:expected_error_message) { 'is not valid' }
-      end
-
-      context 'is valid' do
-        it_behaves_like 'a valid token exchanger'
-      end
-    end
-
-    context 'when subject_token_type' do
-      let(:attribute) { :subject_token_type }
-
-      context 'is blank' do
-        let(:subject_token_type) { nil }
-        let(:expected_error_message) { "can't be blank" }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is invalid' do
-        let(:subject_token_type) { 'invalid-subject-token-type' }
-        let(:expected_error_message) { 'is not valid' }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is valid' do
-        it_behaves_like 'a valid token exchanger'
-      end
-    end
-
-    context 'when actor_token' do
-      let(:attribute) { :actor_token }
-
-      context 'is blank' do
-        let(:actor_token) { nil }
-        let(:expected_error_message) { "can't be blank" }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'does not match oauth_session hashed device secret' do
-        let(:current_session_device_secret) { 'some-other-hash' }
-        let(:expected_error_message) { 'does not match current_session' }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'does not match subject_token hashed device secret' do
-        let(:current_access_token_device_secret) { 'some-other-hash' }
-        let(:expected_error_message) { 'does not match subject_token' }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is valid' do
-        it_behaves_like 'a valid token exchanger'
-      end
-    end
-
-    context 'when actor_token_type' do
-      let(:attribute) { :actor_token_type }
-
-      context 'is blank' do
-        let(:actor_token_type) { nil }
-        let(:expected_error_message) { "can't be blank" }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is invalid' do
-        let(:actor_token_type) { 'invalid-actor-token-type' }
-        let(:expected_error_message) { 'is not valid' }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is valid' do
-        it_behaves_like 'a valid token exchanger'
-      end
-    end
-
-    context 'when client_id' do
-      let(:attribute) { :client_id }
-
-      context 'is blank' do
-        let(:client_id) { nil }
-        let(:expected_error_message) { "can't be blank" }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'when client_id is not the web client id' do
-        let(:client_id) { 'some-other-client-id' }
-        let(:expected_error_message) { 'is not valid' }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is valid' do
-        it_behaves_like 'a valid token exchanger'
-      end
-    end
-
-    context 'when device_sso' do
-      let(:attribute) { :device_sso }
-
-      context 'is not enabled' do
-        let(:current_client_config) { create(:client_config, authentication: :api, shared_sessions: false) }
-        let(:expected_error_message) { 'is not enabled' }
-
-        it_behaves_like 'an invalid token exchanger'
-      end
-
-      context 'is enabled' do
-        it_behaves_like 'a valid token exchanger'
-      end
-    end
-  end
+  let(:subject_token) { 'some-subject-token' }
+  let(:subject_token_type) { 'some-subject-token-type' }
+  let(:actor_token) { 'some-actor-token' }
+  let(:actor_token_type) { 'some-actor-token-type' }
+  let(:client_id) { 'some-client-id' }
 
   describe '#perform' do
-    context 'when token exchanger is invalid' do
+    context 'when subject_token is blank' do
       let(:subject_token) { nil }
+      let(:expected_error) { SignIn::Errors::InvalidTokenError }
+      let(:expected_error_message) { 'subject token is invalid' }
 
-      it 'raises an error' do
-        expect do
-          token_exchanger.perform
-        end.to raise_error(SignIn::Errors::TokenExchangerError)
+      it 'raises invalid token error' do
+        expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
       end
     end
 
-    context 'when token exchanger is valid' do
-      let(:session_container) { token_exchanger.perform }
-      let(:new_session) { session_container.session }
-      let(:new_access_token) { session_container.access_token }
-      let(:new_refresh_token) { session_container.refresh_token }
-      let(:new_anti_csrf_token) { session_container.anti_csrf_token }
-      let(:new_client_config) { session_container.client_config }
+    context 'when subject_token is an invalid access token' do
+      let(:subject_token) { 'some-invalid-access-token' }
+      let(:expected_error) { SignIn::Errors::AccessTokenMalformedJWTError }
+      let(:expected_error_message) { 'Access token JWT is malformed' }
 
-      let(:expected_session_handle) { Faker::Internet.uuid }
-      let(:expected_client_id) { web_client_config.client_id }
-      let(:expected_user_attributes) { current_session.user_attributes }
-      let(:expected_refresh_creation) { current_session.refresh_creation }
-      let(:expected_parent_refresh_token_hash) { new_refresh_token.parent_refresh_token_hash }
-      let(:expected_anti_csrf_token) { new_anti_csrf_token }
-      let(:expected_user_uuid) { new_session.user_verification.backing_credential_identifier }
+      it 'raises malformed token error' do
+        expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
+      end
+    end
 
-      before do
-        allow(SecureRandom).to receive(:uuid).and_return(expected_session_handle)
+    context 'when subject_token is a valid access token' do
+      let(:subject_token) { SignIn::AccessTokenJwtEncoder.new(access_token: current_access_token).perform }
+      let!(:current_session) { create(:oauth_session, hashed_device_secret: current_session_device_secret) }
+      let(:current_access_token) do
+        create(:access_token, session_handle: current_session.handle,
+                              device_secret_hash: current_access_token_device_secret,
+                              client_id: current_client_config.client_id)
+      end
+      let(:current_session_device_secret) { 'some-current-session-device-secret' }
+      let(:current_access_token_device_secret) { 'some-current-access-token-device-secret' }
+      let(:current_client_config) do
+        create(:client_config, authentication: :api, shared_sessions: current_shared_sessions, enforced_terms: nil)
+      end
+      let(:current_shared_sessions) { true }
+
+      context 'and subject_token_type does not access token URN' do
+        let(:subject_token_type) { 'some-subject-token-type' }
+        let(:expected_error) { SignIn::Errors::InvalidTokenTypeError }
+        let(:expected_error_message) { 'subject token type is invalid' }
+
+        it 'raises invalid token type error' do
+          expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
+        end
       end
 
-      context 'a session container is created' do
-        it 'is valid' do
-          expect(session_container).to be_valid
-        end
+      context 'and subject_token_type equals access token URN' do
+        let(:subject_token_type) { SignIn::Constants::Urn::ACCESS_TOKEN }
+        let(:device_secret) { 'some-device-secret' }
+        let(:actor_token) { device_secret }
 
-        context 'and the session' do
-          let(:expected_user_account_id) { current_session.user_account_id }
-          let(:expected_user_verification_id) { current_session.user_verification_id }
-          let(:expected_credential_email) { current_session.credential_email }
-          let(:expected_hashed_device_secret) { current_session.hashed_device_secret }
-          let(:expected_hashed_refresh_token) { Digest::SHA256.hexdigest(new_refresh_token.parent_refresh_token_hash) }
+        context 'and hashed actor_token does not equal hashed device secret in current session' do
+          let(:current_session_device_secret) { 'some-invalid-current-session-device-secret' }
+          let(:expected_error) { SignIn::Errors::InvalidTokenError }
+          let(:expected_error_message) { 'actor token is invalid' }
 
-          let(:expected_refresh_expiration) do
-            expected_refresh_creation + new_client_config.refresh_token_duration
-          end
-
-          it 'has the expected attributes' do
-            expect(new_session).to have_attributes(
-              client_id: expected_client_id,
-              user_account_id: expected_user_account_id,
-              user_verification_id: expected_user_verification_id,
-              credential_email: expected_credential_email,
-              user_attributes: expected_user_attributes,
-              hashed_device_secret: expected_hashed_device_secret,
-              refresh_creation: expected_refresh_creation,
-              handle: expected_session_handle,
-              hashed_refresh_token: expected_hashed_refresh_token,
-              refresh_expiration: expected_refresh_expiration
-            )
+          it 'raises invalid token error' do
+            expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
           end
         end
 
-        context 'and the access_token' do
-          let(:expected_audience) { SignIn::AccessTokenAudienceGenerator.new(client_config: new_client_config).perform }
-          let(:expected_device_secret_hash) { nil }
-          let(:expected_refresh_token_has) { Digest::SHA256.hexdigest(new_refresh_token.to_json) }
+        context 'and hashed actor_token equals hashed device secret in current session' do
+          let(:current_session_device_secret) { Digest::SHA256.hexdigest(device_secret) }
 
-          it 'has the attributes' do
-            expect(new_access_token).to have_attributes(
-              session_handle: expected_session_handle,
-              refresh_token_hash: expected_refresh_token_has,
-              parent_refresh_token_hash: expected_parent_refresh_token_hash,
-              anti_csrf_token: expected_anti_csrf_token,
-              audience: expected_audience,
-              client_id: expected_client_id,
-              last_regeneration_time: expected_refresh_creation,
-              user_attributes: JSON.parse(expected_user_attributes),
-              user_uuid: expected_user_uuid,
-              device_secret_hash: expected_device_secret_hash
-            )
-          end
-        end
+          context 'and hashed actor_token does not equal hashed device secret in current access token' do
+            let(:current_access_token_device_secret) { 'some-invalid-current-access-token-device-secret' }
+            let(:expected_error) { SignIn::Errors::InvalidTokenError }
+            let(:expected_error_message) { 'actor token is invalid' }
 
-        context 'and the refresh_token' do
-          it 'has the expected attributes' do
-            expect(new_refresh_token).to have_attributes(
-              session_handle: expected_session_handle,
-              parent_refresh_token_hash: expected_parent_refresh_token_hash,
-              anti_csrf_token: expected_anti_csrf_token,
-              user_uuid: expected_user_uuid
-            )
-          end
-        end
-
-        context 'and the anti_csrf_token' do
-          let(:expected_anti_csrf_token) { SecureRandom.hex }
-
-          before do
-            allow(SecureRandom).to receive(:hex).and_return(expected_anti_csrf_token)
+            it 'raises invalid token error' do
+              expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
+            end
           end
 
-          it 'is expected' do
-            expect(new_anti_csrf_token).to eq(expected_anti_csrf_token)
-          end
-        end
+          context 'and hashed actor_token equals hashed device secret in current access token' do
+            let(:current_access_token_device_secret) { Digest::SHA256.hexdigest(device_secret) }
 
-        context 'and the client_config' do
-          let(:expected_client_id) { web_client_config.client_id }
+            context 'and actor_token_type does not equal device secret urn' do
+              let(:actor_token_type) { 'some-actor-token-type' }
+              let(:expected_error) { SignIn::Errors::InvalidTokenTypeError }
+              let(:expected_error_message) { 'actor token type is invalid' }
 
-          it 'is expected' do
-            expect(new_client_config.client_id).to eq(expected_client_id)
+              it 'raises invalid token type error' do
+                expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
+              end
+            end
+
+            context 'and actor_token_type equals device secret urn' do
+              let(:actor_token_type) { SignIn::Constants::Urn::DEVICE_SECRET }
+              let(:new_client_config) do
+                create(:client_config,
+                       access_token_attributes: %i[first_name last_name email],
+                       shared_sessions:,
+                       enforced_terms: nil)
+              end
+
+              context 'and client_id does not map to a valid client config' do
+                let(:client_id) { 'some-arbitrary-client-id' }
+                let(:expected_error) { SignIn::Errors::InvalidClientConfigError }
+                let(:expected_error_message) { 'client configuration not found' }
+
+                it 'raises invalid client config error' do
+                  expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
+                end
+              end
+
+              context 'and client_id maps to a valid client config' do
+                let(:client_id) { new_client_config.client_id }
+
+                context 'and client_id does not equal a valid client config with shared sessions enabled' do
+                  let(:shared_sessions) { false }
+                  let(:expected_error) { SignIn::Errors::InvalidClientConfigError }
+                  let(:expected_error_message) { 'tokens requested for client without shared sessions' }
+
+                  it 'raises invalid client config error' do
+                    expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
+                  end
+                end
+
+                context 'and client_id does equal a valid client config with shared sessions enabled' do
+                  let(:shared_sessions) { true }
+
+                  context 'and current client is not device_sso enabled' do
+                    let(:current_shared_sessions) { false }
+                    let(:expected_error) { SignIn::Errors::InvalidSSORequestError }
+                    let(:expected_error_message) { 'token exchange requested from invalid client' }
+
+                    it 'raises invalid sso request error' do
+                      expect { token_exchanger.perform }.to raise_error(expected_error, expected_error_message)
+                    end
+                  end
+
+                  context 'and current client is device_sso enabled' do
+                    let(:current_shared_sessions) { true }
+                    let(:expected_user_account_id) { current_session.user_account_id }
+                    let(:expected_user_verification_id) { current_session.user_verification_id }
+                    let(:expected_credential_email) { current_session.credential_email }
+                    let(:expected_session_hashed_device_secret) { current_session.hashed_device_secret }
+                    let(:expected_hashed_refresh_token) do
+                      Digest::SHA256.hexdigest(new_refresh_token.parent_refresh_token_hash)
+                    end
+
+                    let(:expected_refresh_expiration) do
+                      expected_refresh_creation + new_client_config.refresh_token_duration
+                    end
+                    let(:expected_session_handle) { Faker::Internet.uuid }
+                    let(:expected_client_id) { new_client_config.client_id }
+                    let(:expected_user_attributes) { current_session.user_attributes }
+                    let(:expected_refresh_creation) { current_session.refresh_creation }
+                    let(:expected_audience) { SignIn::ClientConfig.where(shared_sessions: true).pluck(:client_id) }
+                    let(:expected_device_secret_hash) { nil }
+                    let(:expected_user_uuid) { current_session.user_verification.backing_credential_identifier }
+
+                    before { allow(SecureRandom).to receive(:uuid).and_return(expected_session_handle) }
+
+                    it 'creates a session with the expected attributes' do
+                      new_session = token_exchanger.perform.session
+                      expect(new_session.client_id).to eq(expected_client_id)
+                      expect(new_session.user_account_id).to eq(expected_user_account_id)
+                      expect(new_session.user_verification_id).to eq(expected_user_verification_id)
+                      expect(new_session.credential_email).to eq(expected_credential_email)
+                      expect(new_session.user_attributes).to eq(expected_user_attributes)
+                      expect(new_session.hashed_device_secret).to eq(expected_session_hashed_device_secret)
+                      expect(new_session.refresh_creation).to eq(expected_refresh_creation)
+                      expect(new_session.handle).to eq(expected_session_handle)
+                      expect(new_session.refresh_expiration).to eq(expected_refresh_expiration)
+                    end
+
+                    it 'returns an access token with expected attributes' do
+                      new_access_token = token_exchanger.perform.access_token
+                      expect(new_access_token.session_handle).to eq(expected_session_handle)
+                      expect(new_access_token.audience).to eq(expected_audience)
+                      expect(new_access_token.client_id).to eq(expected_client_id)
+                      expect(new_access_token.last_regeneration_time).to eq(expected_refresh_creation)
+                      expect(new_access_token.user_attributes).to eq(JSON.parse(expected_user_attributes))
+                      expect(new_access_token.user_uuid).to eq(expected_user_uuid)
+                      expect(new_access_token.device_secret_hash).to eq(expected_device_secret_hash)
+                    end
+
+                    it 'returns a refresh token with the expected attributes' do
+                      new_refresh_token = token_exchanger.perform.refresh_token
+                      expect(new_refresh_token.session_handle).to eq(expected_session_handle)
+                      expect(new_refresh_token.user_uuid).to eq(expected_user_uuid)
+                    end
+
+                    it 'returns the expected client_config' do
+                      token_exchanger_client_config = token_exchanger.perform.client_config
+
+                      expect(token_exchanger_client_config).to eq(new_client_config)
+                    end
+                  end
+                end
+              end
+            end
           end
         end
       end

--- a/spec/services/sign_in/token_params_validator_spec.rb
+++ b/spec/services/sign_in/token_params_validator_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
         client_assertion_type:,
         assertion:,
         subject_token:,
+        subject_token_type:,
         actor_token:,
         actor_token_type:,
         client_id:
@@ -44,6 +45,7 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
     let(:client_assertion_type) { nil }
     let(:assertion) { nil }
     let(:subject_token) { nil }
+    let(:subject_token_type) { nil }
     let(:actor_token) { nil }
     let(:actor_token_type) { nil }
     let(:client_id) { nil }
@@ -76,8 +78,8 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
       context 'when client_assertion_type is present' do
         let(:client_assertion_type) { 'some-client-assertion-type' }
 
-        context 'when client_assertion_type is CLIENT_ASSERTION_TYPE' do
-          let(:client_assertion_type) { SignIn::Constants::Auth::CLIENT_ASSERTION_TYPE }
+        context 'when client_assertion_type is JWT_BEARER_CLIENT_AUTHENTICATION' do
+          let(:client_assertion_type) { SignIn::Constants::Urn::JWT_BEARER_CLIENT_AUTHENTICATION }
 
           context 'when client_assertion is present' do
             let(:client_assertion) { 'some-client-assertion' }
@@ -106,7 +108,7 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
           end
         end
 
-        context 'when client_assertion_type is not CLIENT_ASSERTION_TYPE' do
+        context 'when client_assertion_type is not JWT_BEARER_CLIENT_AUTHENTICATION' do
           let(:client_assertion_type) { 'invalid-client-assertion-type' }
           let(:expected_error_message) { 'Client assertion type is not valid' }
 
@@ -138,6 +140,7 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
         {
           grant_type:,
           subject_token:,
+          subject_token_type:,
           actor_token:,
           actor_token_type:,
           client_id:
@@ -145,6 +148,7 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
       end
 
       let(:subject_token) { 'some-subject-token' }
+      let(:subject_token_type) { 'some-subject-token-type' }
       let(:actor_token) { 'some-actor_token' }
       let(:actor_token_type) { 'some-actor-token-type' }
       let(:client_id) { 'some-client-id' }
@@ -152,6 +156,13 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
       context 'when subject_token is missing' do
         let(:subject_token) { nil }
         let(:expected_error_message) { "Subject token can't be blank" }
+
+        it_behaves_like 'invalid params'
+      end
+
+      context 'when subject_token_type is missing' do
+        let(:subject_token_type) { nil }
+        let(:expected_error_message) { "Subject token type can't be blank" }
 
         it_behaves_like 'invalid params'
       end

--- a/spec/services/sign_in/token_params_validator_spec.rb
+++ b/spec/services/sign_in/token_params_validator_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
         code_verifier:,
         client_assertion:,
         client_assertion_type:,
-        assertion:
+        assertion:,
+        subject_token:,
+        actor_token:,
+        actor_token_type:,
+        client_id:
       }.compact
     end
 
@@ -39,6 +43,10 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
     let(:client_assertion) { nil }
     let(:client_assertion_type) { nil }
     let(:assertion) { nil }
+    let(:subject_token) { nil }
+    let(:actor_token) { nil }
+    let(:actor_token_type) { nil }
+    let(:client_id) { nil }
 
     context 'when grant_type is AUTH_CODE_GRANT' do
       let(:grant_type) { SignIn::Constants::Auth::AUTH_CODE_GRANT }
@@ -121,6 +129,56 @@ RSpec.describe SignIn::TokenParamsValidator, type: :model do
 
           it_behaves_like 'invalid params'
         end
+      end
+    end
+
+    context 'when grant_type is TOKEN_EXCHANGE_GRANT' do
+      let(:grant_type) { SignIn::Constants::Auth::TOKEN_EXCHANGE_GRANT }
+      let(:params) do
+        {
+          grant_type:,
+          subject_token:,
+          actor_token:,
+          actor_token_type:,
+          client_id:
+        }.compact
+      end
+
+      let(:subject_token) { 'some-subject-token' }
+      let(:actor_token) { 'some-actor_token' }
+      let(:actor_token_type) { 'some-actor-token-type' }
+      let(:client_id) { 'some-client-id' }
+
+      context 'when subject_token is missing' do
+        let(:subject_token) { nil }
+        let(:expected_error_message) { "Subject token can't be blank" }
+
+        it_behaves_like 'invalid params'
+      end
+
+      context 'when actor_token is missing' do
+        let(:actor_token) { nil }
+        let(:expected_error_message) { "Actor token can't be blank" }
+
+        it_behaves_like 'invalid params'
+      end
+
+      context 'when actor_token_type is missing' do
+        let(:actor_token_type) { nil }
+        let(:expected_error_message) { "Actor token type can't be blank" }
+
+        it_behaves_like 'invalid params'
+      end
+
+      context 'when client_id is missing' do
+        let(:client_id) { nil }
+        let(:expected_error_message) { "Client can't be blank" }
+
+        it_behaves_like 'invalid params'
+      end
+
+      context 'when all required attributes are present' do
+        it_behaves_like 'valid params'
       end
     end
 


### PR DESCRIPTION
## Summary

- Token exchange for device sso clients

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82121
- https://github.com/department-of-veterans-affairs/vets-api/pull/16838

## Testing
- Authenticate with SiS using a client that has api authentication and shared_sessions (`vamobile` will work)
- When you call `/authorize` send `scope=device_sso` param
- Call `/token` normally to get you tokens, you should receive a `device_secret`
- Exchange tokens by calling `/token` with:
  ```json
  {
    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
    "subject_token": "{access_token}",
    "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
    "actor_token": "{device_secret}",
    "actor_token_type": "urn:x-oath:params:oauth:token-type:device-secret",
    "client_id": "vaweb"
  }
  ```
- You should receive new tokens in the `set-cookie` header

## What areas of the site does it impact?
Authentication

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
