### PR TITLE
81058 backend full transform pt3 expenses

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
@@ -66,14 +66,14 @@ module DebtsApi
 
         def transform_expenses
           expenses = default_expenses
-          
+
           expenses['rentOrMortgage'] = dollars_cents(get_rent_mortgage_expenses)
           expenses['food'] = dollars_cents(get_food_expenses)
           expenses['utilities'] = dollars_cents(get_utilities)
           other = get_other_living_expenses
           expenses['otherLivingExpenses'] = {
-            'name'=> other[:name], 
-            'amount'=>dollars_cents(other[:amount])
+            'name' => other[:name],
+            'amount' => dollars_cents(other[:amount])
           }
           expenses['expensesInstallmentContractsAndOtherDebts'] = dollars_cents(get_installments_and_other_debts)
           expenses['totalMonthlyExpenses'] = dollars_cents(get_monthly_expenses)
@@ -84,12 +84,12 @@ module DebtsApi
 
         def default_expenses
           {
-            "rentOrMortgage" => "0.00",
-            "food" => "0.00",
-            "utilities" => "0.00",
-            "otherLivingExpenses" => {},
-            "expensesInstallmentContractsAndOtherDebts" => "0.00",
-            "totalMonthlyExpenses" => "0.00"
+            'rentOrMortgage' => '0.00',
+            'food' => '0.00',
+            'utilities' => '0.00',
+            'otherLivingExpenses' => {},
+            'expensesInstallmentContractsAndOtherDebts' => '0.00',
+            'totalMonthlyExpenses' => '0.00'
           }
         end
 

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require 'debts_api/v0/fsr_form_transform/expense_calculator'
+require 'debts_api/v0/fsr_form_transform/utils'
 
 module DebtsApi
   module V0
     module FsrFormTransform
       class EnhancedExpenseCalculator
+        include ::FsrFormTransform::Utils
+
         RENT = 'Rent'
         MORTGAGE_PAYMENT = 'Mortgage payment'
         FOOD = 'Food'
@@ -61,7 +64,34 @@ module DebtsApi
           }
         end
 
+        def transform_expenses
+          expenses = default_expenses
+          
+          expenses['rentOrMortgage'] = dollars_cents(get_rent_mortgage_expenses)
+          expenses['food'] = dollars_cents(get_food_expenses)
+          expenses['utilities'] = dollars_cents(get_utilities)
+          other = get_other_living_expenses
+          expenses['otherLivingExpenses'] = {
+            'name'=> other[:name], 
+            'amount'=>dollars_cents(other[:amount])
+          }
+          expenses['expensesInstallmentContractsAndOtherDebts'] = dollars_cents(get_installments_and_other_debts)
+          expenses['totalMonthlyExpenses'] = dollars_cents(get_monthly_expenses)
+          expenses
+        end
+
         private
+
+        def default_expenses
+          {
+            "rentOrMortgage" => "0.00",
+            "food" => "0.00",
+            "utilities" => "0.00",
+            "otherLivingExpenses" => {},
+            "expensesInstallmentContractsAndOtherDebts" => "0.00",
+            "totalMonthlyExpenses" => "0.00"
+          }
+        end
 
         def get_rent_mortgage_expenses
           safe_number(@old_rent_mortgage_attr)

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/asset_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/asset_calculator_spec.rb
@@ -43,12 +43,6 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::AssetCalculator, type: :service d
       transform_assets
     end
 
-    # it 'gets x right' do
-    #   expected_x = post_transform_fsr_form_data['assets']['x']
-    #   actual_x = @assets['x']
-    #   expect(actual_x).to eq(expected_x)
-    # end
-
     it 'gets cashInBank right' do
       expected_cash_in_bank = post_transform_fsr_form_data['assets']['cashInBank']
       actual_cash_in_bank = @assets['cashInBank']

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
@@ -101,4 +101,20 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::ExpenseCalculator, type: :service
       end
     end
   end
+
+  describe '#transform_expenses' do 
+    let(:pre_transform_fsr_form_data) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/pre_transform')
+    end
+    let(:post_transform_fsr_form_data) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform')
+    end
+
+    it 'transforms expenses' do 
+      expected_expenses = post_transform_fsr_form_data['expenses']
+      transformer = described_class.build(pre_transform_fsr_form_data)
+      actual_expenses = transformer.transform_expenses
+      expect(actual_expenses).to eq(expected_expenses)
+    end
+  end
 end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/expense_calculator_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::ExpenseCalculator, type: :service
     end
   end
 
-  describe '#transform_expenses' do 
+  describe '#transform_expenses' do
     let(:pre_transform_fsr_form_data) do
       get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/pre_transform')
     end
@@ -110,7 +110,7 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::ExpenseCalculator, type: :service
       get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform')
     end
 
-    it 'transforms expenses' do 
+    it 'transforms expenses' do
       expected_expenses = post_transform_fsr_form_data['expenses']
       transformer = described_class.build(pre_transform_fsr_form_data)
       actual_expenses = transformer.transform_expenses


### PR DESCRIPTION
## Summary
This PR is part 3 of an effort to move the FSR transform logic from vets-website to vets-api.

## Related issue(s)
[81058](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/83577)

## Testing done
Specs added

## What areas of the site does it impact?
Eventually it will impact the Financial status Report, currently it effects nothing.

## Acceptance criteria
`FsrFormTransform::ExpenseCalculator.build(...).transform_expenses` should generate the `expenses` portion of `modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform.json`
