### PR TITLE
Add specialIssues to generate pdf min validations schema

### DIFF
--- a/modules/claims_api/config/schemas/v2/generate_pdf_526.json
+++ b/modules/claims_api/config/schemas/v2/generate_pdf_526.json
@@ -582,6 +582,17 @@
             "default": false,
             "nullable": true
           },
+          "specialIssues": {
+            "type": ["array", "null"],
+            "nullable": true,
+            "uniqueItems": true,
+            "items": {
+              "maxItems": 2,
+              "additionalProperties": false,
+              "type": "string",
+              "enum": ["POW", "EMP"]
+            }
+          },
           "secondaryDisabilities": {
             "description": "If secondaryDisability is included, the following attributes are required: 'secondaryDisability.name', 'secondaryDisability.disabilityActionType' and 'secondaryDisability.serviceRelevance'",
             "type": "array",

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -3939,12 +3939,23 @@ RSpec.describe 'Disability Claims', type: :request do
     let(:generate_pdf_scopes) { %w[system/526-pdf.override] }
     let(:invalid_scopes) { %w[claim.write claim.read] }
     let(:generate_pdf_path) { "/services/claims/v2/veterans/#{veteran_id}/526/generatePDF/minimum-validations" }
+    let(:special_issues) { ["POW"] }
 
     context 'submission to generatePDF' do
       it 'returns a 200 response when successful' do
         mock_ccg_for_fine_grained_scope(generate_pdf_scopes) do |auth_header|
           post generate_pdf_path, params: data, headers: auth_header
           expect(response.header['Content-Disposition']).to include('filename')
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      it 'returns a 200 response when specialIssues is present for a disability' do
+        json = JSON.parse data
+        json['data']['attributes']['disabilities'][0]['specialIssues'] = special_issues
+        data = json.to_json
+        mock_ccg_for_fine_grained_scope(generate_pdf_scopes) do |auth_header|
+          post generate_pdf_path, params: data, headers: auth_header
           expect(response).to have_http_status(:ok)
         end
       end

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -3939,7 +3939,7 @@ RSpec.describe 'Disability Claims', type: :request do
     let(:generate_pdf_scopes) { %w[system/526-pdf.override] }
     let(:invalid_scopes) { %w[claim.write claim.read] }
     let(:generate_pdf_path) { "/services/claims/v2/veterans/#{veteran_id}/526/generatePDF/minimum-validations" }
-    let(:special_issues) { ["POW"] }
+    let(:special_issues) { ['POW'] }
 
     context 'submission to generatePDF' do
       it 'returns a 200 response when successful' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds specialIssues to 526 generate pdf minimum validations schema, so that 526 submissions with specialIssues can be submitted and the resulting pdf doesn't include special issues.

## Related issue(s)
[API-36437](https://jira.devops.va.gov/browse/API-36437)

## Testing done

- [x] *New code is covered by unit tests*
- Tested locally using Postman, submitting to a 526 form containing special issues to {{uri}}/services/claims/v2/veterans/{{veteran_id}}/526/generatePDF/minimum-validations and confirming the resulting pdf doesn't contain special issues.
- rspec

## What areas of the site does it impact?
526 pdf generation with minimum validations.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

