### PR TITLE
Add missing require statement to form upload controller

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'simple_forms_api_submission/metadata_validator'
+
 module SimpleFormsApi
   module V1
     class ScannedFormUploadsController < ApplicationController


### PR DESCRIPTION
## Summary
This PR adds a missing line so that the metadata validator can work in the scanned form uploads controller.
