### PR TITLE
VACMS-18206 Add flipper for Search.gov maintenance outages

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -953,6 +953,10 @@ features:
     actor_type: user
     description: Enables typeahead 2.0 functionality
     enable_in_development: true
+  search_gov_maintenance:
+    actor_type: user
+    description: Use when Search.gov system maintenance impacts sitewide search
+    enable_in_development: true
   show526_wizard:
     actor_type: user
     description: This determines when the wizard should show up on the form 526 intro page


### PR DESCRIPTION
## Summary
Adds flipper for Search.gov maintenance (outside of their typical maintenance window).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18206