### PR TITLE
80465: Add logic for sending email after status update

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1325,6 +1325,10 @@ vanotify:
       api_key: fake_secret
       template_id:
         form526_document_upload_failure_notification_template_id: form526_document_upload_failure_notification_template_id
+    ivc_champva:
+      api_key: fake_secret
+      template_id:
+        pega_status_update_email_template_id: pega_status_update_email_template_id
   mock: false
   links:
     connected_applications: https://www.va.gov/profile/connected-applications

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -40,12 +40,34 @@ module IvcChampva
               pega_status: status
             )
           end
+
+          ivc_forms_by_email = ivc_forms.select { |record| record.email.present? }.group_by(&:email)
+          send_emails(ivc_forms_by_email) if ivc_forms_by_email.present?
+
           { status: 200 }
         else
           {
             status: 202,
             error: "No form(s) found with the form_uuid: #{form_uuid} and/or the file_names: #{file_names}."
           }
+        end
+      end
+
+      def send_emails(ivc_forms_by_email)
+        form_data = ivc_forms_by_email.map do |email, forms|
+          {
+            email:,
+            first_name: forms.first.first_name,
+            last_name: forms.first.last_name,
+            form_number: forms.first.form_number,
+            file_names: forms.map(&:file_name),
+            pega_status: forms.first.pega_status,
+            updated_at: forms.first.updated_at.strftime('%B %d, %Y')
+          }
+        end
+
+        form_data.each do |data|
+          IvcChampva::Email.new(data).send_email
         end
       end
 

--- a/modules/ivc_champva/app/services/ivc_champva/email.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/email.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module IvcChampva
+  class Email
+    attr_reader :data
+
+    def initialize(data)
+      @data = data
+    end
+
+    def send_email
+      Datadog::Tracing.trace('Send PEGA Status Update Email') do
+        return unless valid_environment?
+
+        VANotify::EmailJob.perform_async(
+          data[:email],
+          Settings.vanotify.services.va_gov.template_id.ivc_champva_form_callback_email,
+          {
+            'form_number' => data[:form_number],
+            'first_name' => data[:first_name],
+            'last_name' => data[:last_name],
+            'file_names' => data[:file_names],
+            'pega_status' => data[:pega_status],
+            'updated_at' => data[:updated_at]
+          }
+        )
+      rescue => e
+        raise e.message.to_s
+      end
+    end
+
+    private
+
+    def valid_environment?
+      %w[production staging].include?(Rails.env)
+    end
+  end
+end

--- a/modules/ivc_champva/spec/requests/v1/pega_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/pega_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Pega callback', type: :request do
         ivc_forms = [IvcChampvaForm.all]
         status_array = ivc_forms.map { |form| form.pluck(:pega_status) }
 
-        # only 2/3 should be updatedinva
+        # only 2/3 should be updated
         expect(status_array.flatten).not_to eq(%w[Processed Processed])
         expect(response).to have_http_status(:ok)
       end

--- a/modules/ivc_champva/spec/services/email_spec.rb
+++ b/modules/ivc_champva/spec/services/email_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IvcChampva::Email, type: :service do
+  subject { described_class.new(data) }
+
+  let(:data) do
+    {
+      email: 'test@example.com',
+      form_number: '10-10D',
+      first_name: 'John',
+      last_name: 'Doe',
+      file_names: ['file1.pdf', 'file2.pdf'],
+      pega_status: 'Processed',
+      updated_at: Time.zone.now.to_s
+    }
+  end
+
+  describe '#send_email' do
+    context 'in valid environments' do
+      before do
+        allow(Rails).to receive(:env).and_return('staging')
+      end
+
+      it 'traces the sending email process' do
+        expect(Datadog::Tracing).to receive(:trace).with('Send PEGA Status Update Email').and_yield
+        subject.send_email
+      end
+
+      it 'enqueues VANotify::EmailJob with correct parameters' do
+        expect(VANotify::EmailJob).to receive(:perform_async).with(
+          data[:email],
+          Settings.vanotify.services.va_gov.template_id.ivc_champva_form_callback_email,
+          {
+            'form_number' => data[:form_number],
+            'first_name' => data[:first_name],
+            'last_name' => data[:last_name],
+            'file_names' => data[:file_names],
+            'pega_status' => data[:pega_status],
+            'updated_at' => data[:updated_at]
+          }
+        )
+        subject.send_email
+      end
+    end
+
+    context 'in invalid environments' do
+      before do
+        allow(Rails).to receive(:env).and_return('development')
+      end
+
+      it 'does not enqueue VANotify::EmailJob' do
+        expect(VANotify::EmailJob).not_to receive(:perform_async)
+        subject.send_email
+      end
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(Rails).to receive(:env).and_return('staging')
+        allow(VANotify::EmailJob).to receive(:perform_async).and_raise(StandardError.new('Test error'))
+      end
+
+      it 'handles the error and returns a 500 status' do
+        allow(Datadog::Tracing).to receive(:trace).and_yield
+
+        expect { subject.send_email }.to raise_error(StandardError, 'Test error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
As a VFMP applicant, I need to receive confirmation that VA is processing my application so that I know when the status of my application has been updated.


## Summary

- Add logic to `pega_controller` to format data and prepare it for VANotify email
- Add Email service to handle data and actually hit Sidkiq job to send email
- Add spec
- Add settings

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80465

## Testing done

- Rspec
- Can't test emails locally


## Acceptance criteria

Given that I am a Veteran or family member submitting a VFMP form on VA.gov
When my information has been successfully imported into PEGA
Then I should receive an email that tells me my application is being processed
When my information has NOT been successfully imported into PEGA

Then I should receive an email that tells me that I need to resubmit my information
Scope for this story is just a VA-notify proof of concept and doesn't include a fully formed email, just a basic template.

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
