### PR TITLE
83910 access token jwt malformed remove error

### DIFF
--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -70,12 +70,16 @@ module SignIn
 
     def handle_authenticate_error(error, access_token_cookie_name: Constants::Auth::ACCESS_TOKEN_COOKIE_NAME)
       context = {
-        access_token_authorization_header: bearer_token,
+        access_token_authorization_header: scrub_bearer_token,
         access_token_cookie: cookie_access_token(access_token_cookie_name:)
       }.compact
 
-      log_message_to_sentry(error.message, :error, context)
+      log_message_to_sentry(error.message, :error, context) if context.present?
       render json: { errors: error }, status: :unauthorized
+    end
+
+    def scrub_bearer_token
+      bearer_token == 'undefined' ? nil : bearer_token
     end
 
     def validate_request_ip


### PR DESCRIPTION
## Summary

- This PR makes it so the Sign in Service authentication does not send an error to Sentry when the user attempts to authenticate and they send an access token with the string 'undefined'

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83910

## Testing done

- [ ] Called a sign in service authenticated route: `curl -H "Authentication-Method: SIS" -H "Authorization: Bearer undefined" localhost:3000/mobile/v0/user`, saw no `Access token JWT is malformed` log or attempted sentry call
- [ ] Called with a different access token: `curl -H "Authentication-Method: SIS" -H "Authorization: Bearer arbitrary" localhost:3000/mobile/v0/user`, saw the log: `Access token JWT is malformed`

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Attempt the routes described in 'Testing Done' section with these access tokens, or others that make sense