### PR TITLE
Unsubscribe from ActiveModelSerializers render event

### DIFF
--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -66,3 +66,4 @@ end
 ActiveModelSerializers::Adapter::JsonApi::PaginationLinks.prepend CustomPaginationLinks
 ActiveModelSerializers.config.adapter = :json_api
 ActiveModelSerializers.config.key_transform = :underscore
+ActiveSupport::Notifications.unsubscribe(ActiveModelSerializers::Logging::RENDER_EVENT)

--- a/spec/controllers/v0/pension_claims_controller_spec.rb
+++ b/spec/controllers/v0/pension_claims_controller_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe V0::PensionClaimsController, type: :controller do
       expect(Rails.logger).to receive(:info).with('21P-527EZ submission to Sidekiq success',
                                                   hash_including(:confirmation_number, :user_uuid,
                                                                  :in_progress_form_id))
-      expect(Rails.logger).to receive(:info).at_least(:once)
       post(:create, params: { param_name => { form: form.form } })
     end
   end


### PR DESCRIPTION
## Summary
- Unsubscribes from all the `Rendered ActiveModel::Serializer*` logs
- These are pretty useless and just pollute the logs

## Testing done
- `curl localhost:3000/v0/user` and see that the logs are free from `Rendered ActiveModel::Serializer::Null with Hash` 😌 

## What areas of the site does it impact?
Logging
