### PR TITLE
Add submission date stamp to 20-10207

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -95,7 +95,20 @@ module SimpleFormsApi
     end
 
     def submission_date_stamps
-      []
+      [
+        {
+          coords: [460, 710],
+          text: 'Application Submitted:',
+          page: 2,
+          font_size: 12
+        },
+        {
+          coords: [460, 690],
+          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          page: 2,
+          font_size: 12
+        }
+      ]
     end
 
     def track_user_identity(confirmation_number)


### PR DESCRIPTION
## Summary
This PR adds the submission date stamp for Simple Form 20-10207.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/79684

## Screenshots
<img width="1099" alt="Screenshot 2024-05-24 at 10 56 29 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/135a4716-57d7-48d0-bf2d-040a3d3480b6">
