### PR TITLE
Add DD_COMMIT_SHA to deployments

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -83,7 +83,8 @@ type: application
 # 0.12.18 - Disable common configmaps
 # 0.12.19 - Condensed value secrets
 # 0.12.20 - Reverted 12.18 and 12.19 modifications
-version: 0.12.20
+# 0.12.21 - Add DD_GIT_COMMIT_SHA
+version: 0.12.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -106,6 +106,8 @@ spec:
                   fieldPath: metadata.name
             - name: GIT_REVISION
               value: {{ $root.Values.image.tag}}
+            - name: DD_GIT_COMMIT_SHA
+              value: {{ $root.Values.image.tag}}
 {{ toYaml $root.Values.web.envSecrets | indent 12 }}
           {{- range $keys, $key := $root.Values.common.secrets }}
           {{- range $secrets, $secret := $key }}

--- a/chart/templates/worker-deployment.yaml
+++ b/chart/templates/worker-deployment.yaml
@@ -85,6 +85,8 @@ spec:
                   fieldPath: metadata.name
             - name: GIT_REVISION
               value: {{ .Values.image.tag}}
+            - name: DD_COMMIT_SHA
+              value: {{ .Values.image.tag}}
 {{ toYaml .Values.worker.envSecrets | indent 12 }}
           {{- range $keys, $key := .Values.common.secrets }}
           {{- range $secrets, $secret := $key }}


### PR DESCRIPTION
## Summary

- Add `DD_COMMIT_SHA` to `server-deployment` and `worker-deployment` to enable [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration)

## Related
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2859
