### PR TITLE
83466 New timeout SMS for BTSSS api timeout

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -139,12 +139,14 @@ vanotify:
       template_id:
         claim_submission_success_text: cie_fake_success_template_id
         claim_submission_duplicate_text: cie_fake_duplicate_template_id
+        claim_submission_timeout_text: cie_fake_timeout_template_id
         claim_submission_error_text: cie_fake_error_template_id
     oracle_health:
       sms_sender_id: oh_fake_sms_sender_id
       template_id:
         claim_submission_success_text: oh_fake_success_template_id
         claim_submission_duplicate_text: oh_fake_duplicate_template_id
+        claim_submission_timeout_text: oh_fake_timeout_template_id
         claim_submission_error_text: oh_fake_error_template_id
 
 veteran_readiness_and_employment:

--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -65,7 +65,7 @@ module TravelClaim
       end
     rescue Faraday::TimeoutError
       Rails.logger.error(message: 'BTSSS Timeout Error', uuid: check_in.uuid)
-      Faraday::Response.new(response_body: 'BTSSS timeout error', status: 408)
+      Faraday::Response.new(response_body: { message: 'BTSSS timeout error' }, status: 408)
     rescue => e
       log_message_to_sentry(e.original_body, :error,
                             { uuid: check_in.uuid },
@@ -87,7 +87,7 @@ module TravelClaim
       end
     rescue Faraday::TimeoutError
       Rails.logger.error(message: 'BTSSS Timeout Error', uuid: check_in.uuid)
-      Faraday::Response.new(response_body: 'BTSSS timeout error', status: 408)
+      Faraday::Response.new(response_body: { message: 'BTSSS timeout error' }, status: 408)
     rescue => e
       log_message_to_sentry(e.original_body, :error,
                             { uuid: check_in.uuid },

--- a/modules/check_in/app/services/travel_claim/response.rb
+++ b/modules/check_in/app/services/travel_claim/response.rb
@@ -10,7 +10,7 @@ module TravelClaim
     CODE_APPT_NOT_FOUND = 'CLM_003_APPOINTMENT_NOT_FOUND'
     CODE_INVALID_AUTH = 'CLM_020_INVALID_AUTH'
     CODE_SUBMISSION_ERROR = 'CLM_010_CLAIM_SUBMISSION_ERROR'
-
+    CODE_BTSSS_TIMEOUT = 'CLM_011_CLAIM_TIMEOUT_ERROR'
     def self.build(opts = {})
       new(opts)
     end
@@ -26,11 +26,10 @@ module TravelClaim
       rescue
         body
       end
-
       case status
       when 200
         { data: response_body.merge(code: CODE_SUCCESS), status: }
-      when 400, 401, 404
+      when 400, 401, 404, 408
         { data: error_data(message: response_body[:message]), status: }
       else
         { data: unknown_error_data, status: }
@@ -53,6 +52,8 @@ module TravelClaim
                      CODE_APPT_NOT_FOUND
                    when /unauthorized/i
                      CODE_INVALID_AUTH
+                   when /timeout/i
+                     CODE_BTSSS_TIMEOUT
                    else
                      CODE_SUBMISSION_ERROR
                    end

--- a/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
@@ -16,22 +16,26 @@ module CheckIn
     CIE_SUCCESS_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_success_text
     CIE_DUPLICATE_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_duplicate_text
     CIE_ERROR_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_error_text
+    CIE_TIMEOUT_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_timeout_text
 
     CIE_SMS_SENDER_ID = Settings.vanotify.services.check_in.sms_sender_id
 
     CIE_STATSD_BTSSS_SUCCESS = 'worker.checkin.travel_claim.btsss.success'
     CIE_STATSD_BTSSS_ERROR = 'worker.checkin.travel_claim.btsss.error'
+    CIE_STATSD_BTSSS_TIMEOUT = 'worker.checkin.travel_claim.btsss.timeout'
     CIE_STATSD_BTSSS_DUPLICATE = 'worker.checkin.travel_claim.btsss.duplicate'
 
     # settings for travel claims for oracle health settings
     OH_SUCCESS_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_success_text
     OH_DUPLICATE_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_duplicate_text
     OH_ERROR_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_error_text
+    OH_TIMEOUT_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_timeout_text
 
     OH_SMS_SENDER_ID = Settings.vanotify.services.oracle_health.sms_sender_id
 
     OH_STATSD_BTSSS_SUCCESS = 'worker.oracle_health.travel_claim.btsss.success'
     OH_STATSD_BTSSS_ERROR = 'worker.oracle_health.travel_claim.btsss.error'
+    OH_STATSD_BTSSS_TIMEOUT = 'worker.oracle_health.travel_claim.btsss.timeout'
     OH_STATSD_BTSSS_DUPLICATE = 'worker.oracle_health.travel_claim.btsss.duplicate'
 
     def perform(uuid, appointment_date)
@@ -89,6 +93,8 @@ module CheckIn
                                        [OH_STATSD_BTSSS_SUCCESS, OH_SUCCESS_TEMPLATE_ID]
                                      when TravelClaim::Response::CODE_CLAIM_EXISTS
                                        [OH_STATSD_BTSSS_DUPLICATE, OH_DUPLICATE_TEMPLATE_ID]
+                                     when TravelClaim::Response::CODE_BTSSS_TIMEOUT
+                                       [OH_STATSD_BTSSS_TIMEOUT, OH_TIMEOUT_TEMPLATE_ID]
                                      else
                                        [OH_STATSD_BTSSS_ERROR, OH_ERROR_TEMPLATE_ID]
                                      end
@@ -98,6 +104,8 @@ module CheckIn
                                        [CIE_STATSD_BTSSS_SUCCESS, CIE_SUCCESS_TEMPLATE_ID]
                                      when TravelClaim::Response::CODE_CLAIM_EXISTS
                                        [CIE_STATSD_BTSSS_DUPLICATE, CIE_DUPLICATE_TEMPLATE_ID]
+                                     when TravelClaim::Response::CODE_BTSSS_TIMEOUT
+                                       [CIE_STATSD_BTSSS_TIMEOUT, CIE_TIMEOUT_TEMPLATE_ID]
                                      else
                                        [CIE_STATSD_BTSSS_ERROR, CIE_ERROR_TEMPLATE_ID]
                                      end

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -188,7 +188,7 @@ describe TravelClaim::Client do
     end
 
     context 'when call to claims service times out' do
-      let(:resp) { Faraday::Response.new(response_body: 'BTSSS timeout error', status: 408) }
+      let(:resp) { Faraday::Response.new(response_body: { message: 'BTSSS timeout error' }, status: 408) }
       let(:err_msg) { { message: 'BTSSS Timeout Error', uuid: } }
 
       before do
@@ -305,7 +305,7 @@ describe TravelClaim::Client do
     end
 
     context 'when call to claims service times out' do
-      let(:resp) { Faraday::Response.new(response_body: 'BTSSS timeout error', status: 408) }
+      let(:resp) { Faraday::Response.new(response_body: { message: 'BTSSS timeout error' }, status: 408) }
       let(:err_msg) { { message: 'BTSSS Timeout Error', uuid: } }
 
       before do

--- a/modules/check_in/spec/services/travel_claim/response_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/response_spec.rb
@@ -91,6 +91,17 @@ describe TravelClaim::Response do
       end
     end
 
+    context 'when status 408' do
+      it 'returns a formatted response' do
+        error_message = 'BTSSS timeout error'
+        resp = Faraday::Response.new(response_body: { message: 'BTSSS timeout error' }, status: 408)
+        hsh = { data: { error: true, code: 'CLM_011_CLAIM_TIMEOUT_ERROR', message: error_message },
+                status: resp.status }
+
+        expect(subject.build(response: resp).handle).to eq(hsh)
+      end
+    end
+
     context 'when status 500' do
       it 'returns a formatted response' do
         resp = Faraday::Response.new(response_body: 'Something went wrong', status: 500)

--- a/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
+++ b/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
@@ -8,10 +8,12 @@ shared_examples 'travel claims worker #perform' do |facility_type|
       @sms_sender_id = Settings.vanotify.services.oracle_health.sms_sender_id
       @success_template_id = Settings.vanotify.services.oracle_health.template_id.claim_submission_success_text
       @duplicate_template_id = Settings.vanotify.services.oracle_health.template_id.claim_submission_duplicate_text
+      @timeout_template_id = Settings.vanotify.services.oracle_health.template_id.claim_submission_timeout_text
       @error_template_id = Settings.vanotify.services.oracle_health.template_id.claim_submission_error_text
 
       @statsd_success = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_SUCCESS
       @statsd_duplicate = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_DUPLICATE
+      @statsd_timeout = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_TIMEOUT
       @statsd_error = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_ERROR
 
       allow(redis_client).to receive(:facility_type).and_return('oh')
@@ -19,10 +21,12 @@ shared_examples 'travel claims worker #perform' do |facility_type|
       @sms_sender_id = Settings.vanotify.services.check_in.sms_sender_id
       @success_template_id = Settings.vanotify.services.check_in.template_id.claim_submission_success_text
       @duplicate_template_id = Settings.vanotify.services.check_in.template_id.claim_submission_duplicate_text
+      @timeout_template_id = Settings.vanotify.services.check_in.template_id.claim_submission_timeout_text
       @error_template_id = Settings.vanotify.services.check_in.template_id.claim_submission_error_text
 
       @statsd_success = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_SUCCESS
       @statsd_duplicate = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_DUPLICATE
+      @statsd_timeout = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_TIMEOUT
       @statsd_error = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_ERROR
 
       allow(redis_client).to receive(:facility_type).and_return(nil)
@@ -203,7 +207,7 @@ describe CheckIn::TravelClaimSubmissionWorker, type: :worker do
       allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(Faraday::TimeoutError)
     end
 
-    it 'throws timeout exception and sends notification with error message' do
+    it 'throws timeout exception and sends notification with cie error message' do
       worker = described_class.new
       notify_client = double
 
@@ -212,7 +216,7 @@ describe CheckIn::TravelClaimSubmissionWorker, type: :worker do
 
       expect(notify_client).to receive(:send_sms).with(
         phone_number: patient_cell_phone,
-        template_id: 'cie_fake_error_template_id',
+        template_id: 'cie_fake_timeout_template_id',
         sms_sender_id: 'cie_fake_sms_sender_id',
         personalisation: { claim_number: nil, appt_date: notify_appt_date }
       )
@@ -221,7 +225,33 @@ describe CheckIn::TravelClaimSubmissionWorker, type: :worker do
         worker.perform(uuid, appt_date)
       end
 
-      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_ERROR)
+      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_TIMEOUT)
+                                                 .exactly(1).time
+      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS)
+                                                 .exactly(1).time
+    end
+
+    it 'throws timeout exception and sends notification with oh error message' do
+      allow(redis_client).to receive(:facility_type).and_return('oh')
+
+      worker = described_class.new
+      notify_client = double
+
+      expect(VaNotify::Service).to receive(:new).with(Settings.vanotify.services.check_in.api_key)
+                                                .and_return(notify_client)
+
+      expect(notify_client).to receive(:send_sms).with(
+        phone_number: patient_cell_phone,
+        template_id: 'oh_fake_timeout_template_id',
+        sms_sender_id: 'oh_fake_sms_sender_id',
+        personalisation: { claim_number: nil, appt_date: notify_appt_date }
+      )
+
+      Sidekiq::Testing.inline! do
+        worker.perform(uuid, appt_date)
+      end
+
+      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_TIMEOUT)
                                                  .exactly(1).time
       expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS)
                                                  .exactly(1).time


### PR DESCRIPTION
## Summary

- *Integrating with new timeout template id for sending SMS when BTSSS api times out*

## Related issue(s)

- *https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/gh/department-of-veterans-affairs/va.gov-team/83466*

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_
NA

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
NA

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

