### PR TITLE
API-36848 Handle null for Herbicide serviceDates and Additional Exposure exposureDates in Pdf mapper

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -216,8 +216,8 @@ module ClaimsApi
       end
 
       def herbicide_hazard
-        herb = @pdf_data&.dig(:data, :attributes, :toxicExposure, :herbicideHazardService).present?
-        if herb
+        herb = @pdf_data&.dig(:data, :attributes, :toxicExposure, :herbicideHazardService)
+        if herb[:serviceDates].present?
           herbicide_service_dates_begin = @pdf_data[:data][:attributes][:toxicExposure][:herbicideHazardService][:serviceDates][:beginDate]
           if herbicide_service_dates_begin.present?
             @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:herbicideHazardService][:serviceDates][:start] =
@@ -230,6 +230,9 @@ module ClaimsApi
               make_date_object(herbicide_service_dates_end, herbicide_service_dates_end.length)
           end
           @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:herbicideHazardService][:serviceDates].delete(:endDate)
+        end
+
+        if herb.present?
           served_in_herbicide_hazard_locations = @pdf_data[:data][:attributes][:toxicExposure][:herbicideHazardService][:servedInHerbicideHazardLocations]
           @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:herbicideHazardService][:servedInHerbicideHazardLocations] =
             served_in_herbicide_hazard_locations ? 'YES' : 'NO'
@@ -237,8 +240,8 @@ module ClaimsApi
       end
 
       def additional_exposures
-        add = @pdf_data&.dig(:data, :attributes, :toxicExposure, :additionalHazardExposures).present?
-        if add
+        add = @pdf_data&.dig(:data, :attributes, :toxicExposure, :additionalHazardExposures)
+        if add[:exposureDates].present?
           additional_exposure_dates_begin = @pdf_data[:data][:attributes][:toxicExposure][:additionalHazardExposures][:exposureDates][:beginDate]
           if additional_exposure_dates_begin.present?
             @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:additionalHazardExposures][:exposureDates][:start] =

--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -235,7 +235,7 @@ module ClaimsApi
         if herb.present?
           served_in_herbicide_hazard_locations = @pdf_data[:data][:attributes][:toxicExposure][:herbicideHazardService][:servedInHerbicideHazardLocations]
           @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:herbicideHazardService][:servedInHerbicideHazardLocations] =
-            served_in_herbicide_hazard_locations ? 'YES' : 'NO'
+            served_in_herbicide_hazard_locations ? 'YES' : nil
         end
       end
 

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -309,6 +309,88 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(multi_exp_location).to eq('Guam')
         expect(multi_exp_hazard).to eq('RADIATION')
       end
+
+      it 'maps herbicide correctly when dates are not included' do
+        form_attributes['toxicExposure']['herbicideHazardService']['serviceDates'] = nil
+
+        mapper.map_claim
+
+        toxic_exp_data = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+        herb_service_dates = toxic_exp_data[:herbicideHazardService][:serviceDates]
+
+        expect(herb_service_dates).to eq(nil)
+      end
+
+      it 'maps additional exposures correctly when dates are not included' do
+        form_attributes['toxicExposure']['additionalHazardExposures']['exposureDates'] = nil
+
+        mapper.map_claim
+
+        toxic_exp_data = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+        additional_exposure_dates = toxic_exp_data[:additionalHazardExposures][:exposureDates]
+
+        expect(additional_exposure_dates).to eq(nil)
+      end
+
+      context '526 section 4, herbicideHazardService exposures null data' do
+        it 'maps the attributes correctly' do
+          toxic_exp_data = form_attributes['toxicExposure']
+          toxic_exp_data['herbicideHazardService']['serviceDates']['beginDate'] = nil
+          toxic_exp_data['herbicideHazardService']['serviceDates']['endDate'] = nil
+          toxic_exp_data['herbicideHazardService']['servedInHerbicideHazardLocations'] = nil
+          toxic_exp_data['herbicideHazardService']['otherLocationsServed'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:herbicideHazardService][:servedInHerbicideHazardLocations]).to eq('NO')
+        end
+      end
+
+      context '526 section 4, additionalHazardExposures null data' do
+        it 'maps the attributes correctly' do
+          toxic_exp_data = form_attributes['toxicExposure']
+          toxic_exp_data['additionalHazardExposures']['exposureDates']['beginDate'] = nil
+          toxic_exp_data['additionalHazardExposures']['exposureDates']['endDate'] = nil
+          toxic_exp_data['additionalHazardExposures']['additionalExposures'] = nil
+          toxic_exp_data['additionalHazardExposures']['specifyOtherExposures'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:additionalHazardExposures]).to eq(nil)
+        end
+      end
+
+      context '526 section 4, multiple exposures null data' do
+        it 'maps the attributes correctly' do
+          toxic_exp_data = form_attributes['toxicExposure']
+          toxic_exp_data['multipleExposures'][0]['exposureDates']['beginDate'] = nil
+          toxic_exp_data['multipleExposures'][0]['exposureDates']['endDate'] = nil
+          toxic_exp_data['multipleExposures'][0]['exposureLocation'] = nil
+          toxic_exp_data['multipleExposures'][0]['hazardExposedTo'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:multipleExposures]).to eq(nil)
+        end
+      end
+
+      context '526 section 4, multiple exposures null endDate' do
+        it 'maps the attributes correctly' do
+          toxic_exp_data = form_attributes['toxicExposure']
+          toxic_exp_data['multipleExposures'][0]['exposureDates']['endDate'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:multipleExposures][0][:exposureLocation]).to eq('Guam')
+          expect(exposure_info[:multipleExposures][0][:hazardExposedTo]).to eq('RADIATION')
+          expect(exposure_info[:multipleExposures][0][:exposureDates][:start][:month]).to eq('12')
+          expect(exposure_info[:multipleExposures][0][:exposureDates][:start][:year]).to eq('2012')
+        end
+      end
     end
 
     context '526 section 5, claimInfo: diabilities' do
@@ -408,66 +490,6 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
 
         expect(start_date).to eq(nil)
         expect(no_date).to eq(true)
-      end
-    end
-
-    context '526 section 5, herbicideHazardService exposures null data' do
-      it 'maps the attributes correctly' do
-        toxic_exp_data = form_attributes['toxicExposure']
-        toxic_exp_data['herbicideHazardService']['serviceDates']['beginDate'] = nil
-        toxic_exp_data['herbicideHazardService']['serviceDates']['endDate'] = nil
-        toxic_exp_data['herbicideHazardService']['servedInHerbicideHazardLocations'] = nil
-        toxic_exp_data['herbicideHazardService']['otherLocationsServed'] = nil
-
-        mapper.map_claim
-
-        exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
-        expect(exposure_info[:herbicideHazardService][:servedInHerbicideHazardLocations]).to eq('NO')
-      end
-    end
-
-    context '526 section 5, additionalHazardExposures null data' do
-      it 'maps the attributes correctly' do
-        toxic_exp_data = form_attributes['toxicExposure']
-        toxic_exp_data['additionalHazardExposures']['exposureDates']['beginDate'] = nil
-        toxic_exp_data['additionalHazardExposures']['exposureDates']['endDate'] = nil
-        toxic_exp_data['additionalHazardExposures']['additionalExposures'] = nil
-        toxic_exp_data['additionalHazardExposures']['specifyOtherExposures'] = nil
-
-        mapper.map_claim
-
-        exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
-        expect(exposure_info[:additionalHazardExposures]).to eq(nil)
-      end
-    end
-
-    context '526 section 5, multiple exposures null data' do
-      it 'maps the attributes correctly' do
-        toxic_exp_data = form_attributes['toxicExposure']
-        toxic_exp_data['multipleExposures'][0]['exposureDates']['beginDate'] = nil
-        toxic_exp_data['multipleExposures'][0]['exposureDates']['endDate'] = nil
-        toxic_exp_data['multipleExposures'][0]['exposureLocation'] = nil
-        toxic_exp_data['multipleExposures'][0]['hazardExposedTo'] = nil
-
-        mapper.map_claim
-
-        exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
-        expect(exposure_info[:multipleExposures]).to eq(nil)
-      end
-    end
-
-    context '526 section 5, multiple exposures null endDate' do
-      it 'maps the attributes correctly' do
-        toxic_exp_data = form_attributes['toxicExposure']
-        toxic_exp_data['multipleExposures'][0]['exposureDates']['endDate'] = nil
-
-        mapper.map_claim
-
-        exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
-        expect(exposure_info[:multipleExposures][0][:exposureLocation]).to eq('Guam')
-        expect(exposure_info[:multipleExposures][0][:hazardExposedTo]).to eq('RADIATION')
-        expect(exposure_info[:multipleExposures][0][:exposureDates][:start][:month]).to eq('12')
-        expect(exposure_info[:multipleExposures][0][:exposureDates][:start][:year]).to eq('2012')
       end
     end
 

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -343,7 +343,7 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
           mapper.map_claim
 
           exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
-          expect(exposure_info[:herbicideHazardService][:servedInHerbicideHazardLocations]).to eq('NO')
+          expect(exposure_info[:herbicideHazardService]).to eq(nil)
         end
       end
 
@@ -389,6 +389,30 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
           expect(exposure_info[:multipleExposures][0][:hazardExposedTo]).to eq('RADIATION')
           expect(exposure_info[:multipleExposures][0][:exposureDates][:start][:month]).to eq('12')
           expect(exposure_info[:multipleExposures][0][:exposureDates][:start][:year]).to eq('2012')
+        end
+      end
+
+      context '526 section 4, gulfWarHazardService' do
+        it "does not default to 'NO'" do
+          toxic_exp_data = form_attributes['toxicExposure']['gulfWarHazardService']
+          toxic_exp_data['servedInGulfWarHazardLocations'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:gulfWarHazardService][:servedInGulfWarHazardLocations]).to eq(nil)
+        end
+      end
+
+      context '526 section 4, herbicideHazardService' do
+        it "does not default to 'NO'" do
+          toxic_exp_data = form_attributes['toxicExposure']['herbicideHazardService']
+          toxic_exp_data['servedInHerbicideHazardLocations'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:herbicideHazardService][:servedInHerbicideHazardLocations]).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
## Summary
- Updates mapper to handle nil serviceDates and nil exposureDates (herbicide and additionalExposures)
- Adds tests for scenario
- Adjusts some misplaced tests that were labelled as section 5 (disabilities) but were section 4 (toxic exposure)
- Adjusts mapper so toxicExposures do not default to 'NO' when null is sent in

## Related issue(s)

- [API-36848](https://jira.devops.va.gov/browse/API-36848)
- [API-36866](https://jira.devops.va.gov/browse/API-36866) (not defaulting to 'NO')

## Testing done
- [x] *New code is covered by unit tests
- Can also send in a request like below and then check out the PDF.  You should NOT have any errors related to PDF Mapper handling the null values, PDF should get set in S3 and look correct.
#### Testing Notes
* The boxes for YES and NO in `15b` and `15c` should not be checked if `null` is sent in
* You should get a generated PDF even when the dates are sent in `null`

```
{
   "data":{
      "type":"form/526",
      "attributes":{
         "claimantCertification":true,
         "claimProcessType":"STANDARD_CLAIM_PROCESS",
         "veteranIdentification":{
            "currentVaEmployee":false,
            "mailingAddress":{
               "addressLine1":"1234 Couch Street",
               "city":"Portland",
               "country":"USA",
               "zipFirstFive":"12345",
               "state":"OR"
            }
         },
         "toxicExposure":{
            "gulfWarHazardService":{
               "servedInGulfWarHazardLocations":null,
               "serviceDates":{
                  "beginDate":"1999-07",
                  "endDate":"2005-01"
               }
            },
            "herbicideHazardService":{
               "servedInHerbicideHazardLocations":null,
               "otherLocationsServed":"Guam",
               "serviceDates": null
            },
            "additionalHazardExposures":{
               "additionalExposures":[
                  "ASBESTOS",
                  "SHIPBOARD_HAZARD_AND_DEFENSE",
                  "OTHER"
               ],
               "specifyOtherExposures":"Other exposure details",
               "exposureDates": null
            },
            "multipleExposures":[
               {
                  "exposureDates":{
                     "beginDate":"2012-12",
                     "endDate":"2013-07"
                  },
                  "exposureLocation":"Location 1",
                  "hazardExposedTo":"Hazard 1"
               },
               {
                  "exposureDates":{
                     "beginDate":"2013-10",
                     "endDate":"2013-11"
                  },
                  "exposureLocation":"Location 2",
                  "hazardExposedTo":"Hazard 2"
               }
            ]
         },
         "disabilities":[
            {
               "disabilityActionType":"NEW",
               "name":"Diabetes",
               "exposureOrEventOrInjury":"Agent Orange",
               "serviceRelevance":"Service in Vietnam War",
               "approximateDate":"1972-07"
            }
         ],
         "serviceInformation":{
            "servicePeriods":[
               {
                  "serviceBranch":"Air Force",
                  "serviceComponent":"Active",
                  "activeDutyBeginDate": "2008-11-14",
                  "activeDutyEndDate": "2023-10-30"
               }
            ]
         }
      }
   }
}
```
## Screenshots
<img width="755" alt="Screenshot 2024-05-28 at 9 01 43 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/129893414/40a4bb6b-8af5-4869-a42b-8f796e35847d">


## What areas of the site does it impact?
* modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
* modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
