### PR TITLE
Adds necessary correlation ID to the request(s)

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -35,6 +35,7 @@ module TravelPay
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
         req.headers['BTSSS-API-Client-Number'] = client_number.to_s
+        req.headers['X-Correlation-ID'] = SecureRandom.uuid
         req.body = { authJwt: sts_token }
       end
 
@@ -53,6 +54,7 @@ module TravelPay
       connection(server_url: btsss_url).get('api/v1/Sample/ping') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
+        req.headers['X-Correlation-ID'] = SecureRandom.uuid
       end
     end
 
@@ -69,6 +71,7 @@ module TravelPay
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
+        req.headers['X-Correlation-ID'] = SecureRandom.uuid
       end
     end
 
@@ -92,6 +95,7 @@ module TravelPay
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['Ocp-Apim-Subscription-Key'] = api_key
+        req.headers['X-Correlation-ID'] = SecureRandom.uuid
       end
 
       symbolized_body = response.body.deep_symbolize_keys


### PR DESCRIPTION
The BTSSS API was changed to support client-to-server traceability and auditing. It requires a "correlation ID" to all requests made to the API, per request.

Ticket: department-of-veterans-affairs/va.gov-team#83976