### PR TITLE
Remove/refactor call to endpoint that used to require a param

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -82,13 +82,7 @@ module TravelPay
       btsss_url = Settings.travel_pay.base_url
       api_key = Settings.travel_pay.subscription_key
 
-      ### TODO: Remove this token parsing code.
-      ### This is a very temporary workaround.
-      ### A fix is being worked on by the API team, deployed soon
-      payload = JWT.decode(btsss_token, nil, false)[0]
-      contact_id = payload['ContactID']
-
-      response = connection(server_url: btsss_url).get("api/v1/claims/by-contact/#{contact_id}") do |req|
+      response = connection(server_url: btsss_url).get("api/v1/claims") do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['Ocp-Apim-Subscription-Key'] = api_key

--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -82,7 +82,7 @@ module TravelPay
       btsss_url = Settings.travel_pay.base_url
       api_key = Settings.travel_pay.subscription_key
 
-      response = connection(server_url: btsss_url).get("api/v1/claims") do |req|
+      response = connection(server_url: btsss_url).get('api/v1/claims') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['Ocp-Apim-Subscription-Key'] = api_key

--- a/modules/travel_pay/spec/services/client_spec.rb
+++ b/modules/travel_pay/spec/services/client_spec.rb
@@ -77,7 +77,7 @@ describe TravelPay::Client do
       payload = { ContactID: 'test' }
       fake_btsss_token = JWT.encode(payload, nil, 'none')
 
-      @stubs.get("/api/v1/claims") do
+      @stubs.get('/api/v1/claims') do
         [
           200,
           {},

--- a/modules/travel_pay/spec/services/client_spec.rb
+++ b/modules/travel_pay/spec/services/client_spec.rb
@@ -77,7 +77,7 @@ describe TravelPay::Client do
       payload = { ContactID: 'test' }
       fake_btsss_token = JWT.encode(payload, nil, 'none')
 
-      @stubs.get("/api/v1/claims/by-contact/#{payload[:ContactID]}") do
+      @stubs.get("/api/v1/claims") do
         [
           200,
           {},


### PR DESCRIPTION
API was refactored to no longer require a contact ID, which is good, because this increases security.

Ticket: department-of-veterans-affairs/va.gov-team#83977