### PR TITLE
Update VA Form 10203 models to use BenefitsEducation::Service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,6 +103,7 @@ app/controllers/v0/letters_controller.rb @department-of-veterans-affairs/benefit
 app/controllers/v0/letters_generator_controller.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/letters_generator_controller_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/lighthouse/letters_generator/ @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/support/vcr_cassettes/form_10203/gi_bill_status_200_response.yml @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/maintenance_windows_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/map_services_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -301,6 +301,7 @@ app/models/prescription.rb @department-of-veterans-affairs/vfs-mhv-medications @
 app/models/rate_limited_search.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/saml_request_tracker.rb @department-of-veterans-affairs/octo-identity
 app/models/saved_claim.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/saved_claim/education_benefits/va_10203.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/disability_compensation.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/session.rb @department-of-veterans-affairs/octo-identity
 app/models/saved_claim/burial.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pensions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/form_profiles/va_10203.rb
+++ b/app/models/form_profiles/va_10203.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'evss/gi_bill_status/service'
+require 'lighthouse/benefits_education/service'
 
 module VA10203
   FORM_ID = '22-10203'
@@ -52,7 +52,7 @@ class FormProfiles::VA10203 < FormProfile
   private
 
   def get_gi_bill_status
-    service = EVSS::GiBillStatus::Service.new(user)
+    service = BenefitsEducation::Service.new(user.icn)
     service.get_gi_bill_status
   rescue => e
     Rails.logger.error "Failed to retrieve GiBillStatus data: #{e.message}"

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1497,7 +1497,7 @@ RSpec.describe FormProfile, type: :model do
           expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
           v22_10203_expected['remainingEntitlement'] = {
             'months' => 0,
-            'days' => 12
+            'days' => 10
           }
           v22_10203_expected['schoolName'] = 'OLD DOMINION UNIVERSITY'
           v22_10203_expected['schoolCity'] = 'NORFOLK'
@@ -1508,14 +1508,17 @@ RSpec.describe FormProfile, type: :model do
         it 'prefills 10203 with VA Profile and entitlement information' do
           VCR.use_cassette('evss/pciu_address/address_domestic') do
             VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
-              VCR.use_cassette('evss/gi_bill_status/gi_bill_status') do
+              VCR.use_cassette('form_10203/gi_bill_status_200_response') do
                 VCR.use_cassette('gi_client/gets_the_institution_details') do
                   VCR.use_cassette('va_profile/military_personnel/post_read_service_histories_200',
                                    allow_playback_repeats: true) do
+                    expect(BenefitsEducation::Service).to receive(:new).with(user.icn).and_call_original
+
                     prefilled_data = Oj.load(
                       described_class.for(form_id: '22-10203', user:).prefill.to_json
                     )['form_data']
-                    expect(prefilled_data).to eq(form_profile.send(:clean!, v22_10203_expected))
+                    actual = form_profile.send(:clean!, v22_10203_expected)
+                    expect(prefilled_data).to eq(actual)
                   end
                 end
               end

--- a/spec/support/vcr_cassettes/form_10203/gi_bill_status_200_response.yml
+++ b/spec/support/vcr_cassettes/form_10203/gi_bill_status_200_response.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://sandbox-api.va.gov/oauth2/benefits-education/system/v1/token
+      body:
+        encoding: US-ASCII
+        string: grant_type=client_credentials&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiIwb2FzM2diNDlvWFhGWkVmazJwNyIsInN1YiI6IjBvYXMzZ2I0OW9YWEZaRWZrMnA3IiwiYXVkIjoiaHR0cHM6Ly9kZXB0dmEtZXZhbC5va3RhLmNvbS9vYXV0aDIvYXVzbG4ybW80akNBWVJybFIycDcvdjEvdG9rZW4iLCJpYXQiOjE3MDkxMjM5NTQsImV4cCI6MTcwOTEyNDI1NH0.e1hLrznderXXoU9Wo5IXZHbzXGXWAp3B7Hd0PeYtBsQWtjIU7LeQ5zoCvZ2ipFN8BCKvNK3mNNQw9t_N5-lZto-KIBtd1po7BtC0_UAoXRRW9t29QNnnsWGOlurlV-eMCqqTz8tAYwODBxKpc3i9VyI51kcnjgcybxoizV6pwUPTGf9mLDIkC3zWJ6pqckdWIPqTHJfhDncivM8PXtBtVfyj3Q3S8u7KCAy8iYedAbJdlQAXZobpcURWpRFy3Qj5hhy0muvWIr8mjbs_2X0H6KzmUVF1eNba-mPzcQLRKLDSx3_isFq9uLUgakN7Ri1y61mTNHfDoHdPof7JDOxB9w&scope=education.read
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/x-www-form-urlencoded
+        User-Agent:
+          - Vets.gov Agent
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Wed, 28 Feb 2024 12:39:14 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Connection:
+          - keep-alive
+        Vary:
+          - Origin
+        Cache-Control:
+          - no-cache, no-store
+        Pragma:
+          - no-cache
+        Etag:
+          - W/"3e5-UuDkStSLf0iq4J7d3I+e1M/3eCk"
+        Transfer-Encoding:
+          - chunked
+      body:
+        encoding: ASCII-8BIT
+        string: '{"access_token":"eyJraWQiOiJkRFlXN0dQSG82M3FZYk5yNGJkZGZWcUNFQk95TnhjT1k5YWIwRGtOY0I0IiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULjRzUmRJTzhjazZZdDZBQjdVTVBpUDFZNXk5N2RtQ1U5OTlPZVhoTGxMZlEiLCJpc3MiOiJodHRwczovL2RlcHR2YS1ldmFsLm9rdGEuY29tL29hdXRoMi9hdXNsbjJtbzRqQ0FZUnJsUjJwNyIsImF1ZCI6Imh0dHBzOi8vc2FuZGJveC1hcGkudmEuZ292L3NlcnZpY2VzL2JlbmVmaXRzLWVkdWNhdGlvbiIsImlhdCI6MTcwOTEyMzk1NCwiZXhwIjoxNzA5MTI0MjU0LCJjaWQiOiIwb2FzM2diNDlvWFhGWkVmazJwNyIsInNjcCI6WyJlZHVjYXRpb24ucmVhZCJdLCJzdWIiOiIwb2FzM2diNDlvWFhGWkVmazJwNyIsImxhYmVsIjoiVkEuZ292IElJUiBQcm9kdWN0IFRlYW0gLSBLeWxlIn0.EczPcpnB-mB9A9x6UpbH6RL15XEzgDhEbGzgA3-aisi11BmnnSJ_LHLJxfXpbGBx4w4m-WLF4Tu0uFLdistgngcg13XIX8G6du-s6Dm9qVVvh-U2xggVXSrLjejAOe1ev5HzORRVlTl1CAnQNkxKufaGc-CFPXK4-fYDsUjdofuAhjcamvLzguKAaRBB9uY8QBZrK_uRzzOTMdL-dnjDOBz191KZHCDxAv_5KwVd0h4EpKWF3YbBtSwZWXe1LOm2R0Nik2fkLFuo0NPiCGk7E5Fshi20UHoFo98yi2novSBzLZ7dAtoc2dOyAeoNS7RmULzUa0MOcfkUrSLp8tUoMQ","token_type":"Bearer","scope":"education.read","expires_in":300,"state":null}'
+    recorded_at: Wed, 28 Feb 2024 12:39:14 GMT
+  - request:
+      method: get
+      uri: https://sandbox-api.va.gov/services/benefits-education/v1/education/chapter33?icn=123498767V234859
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Authorization: Bearer <TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: ""
+      headers:
+        Date:
+          - Wed, 28 Feb 2024 12:39:16 GMT
+        Content-Type:
+          - application/json
+        Connection:
+          - keep-alive
+        X-Ratelimit-Remaining-Minute:
+          - "59"
+        X-Ratelimit-Limit-Minute:
+          - "60"
+        Ratelimit-Remaining:
+          - "59"
+        Ratelimit-Limit:
+          - "60"
+        Ratelimit-Reset:
+          - "45"
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+          - max-age=31536000; includeSubDomains; preload
+        Access-Control-Allow-Origin:
+          - "*"
+        Cache-Control:
+          - ""
+          - no-cache, no-store
+        X-Frame-Options:
+          - SAMEORIGIN
+        Pragma:
+          - no-cache
+        Transfer-Encoding:
+          - chunked
+      body:
+        encoding: ASCII-8BIT
+        string:
+          '{"messages":[{"key":"chapter33Education.response.info","text":"Chapter33Education
+          Response info for veteran from chapter33 endpoint.","severity":"INFO"}],"chapter33EducationInfo":{"firstName":"Tamara","lastName":"Ellis","nameSuffix":"","dateTimeOfBirth":"1967-06-19T06:00:00Z","vaFileNumber":"796130115","activeDuty":false,"veteranIsEligible":true,"regionalProcessingOffice":"Northern
+          Office Boston, MA","eligibilityDateTime":"2005-08-01T04:00:00Z","delimitingDateTime":"2016-08-01T04:00:00Z","percentageBenefit":100,"originalEntitlement":{"months":0,"days":21},"usedEntitlement":{"months":0,"days":11},"remainingEntitlement":{"months":0,"days":10},"enrollments":[{"beginDateTime":"2015-08-01T04:00:00Z","endDateTime":"2015-12-01T05:00:00Z","facilityCode":11902614,"facilityName":"University
+          of Virginia","participantId":11179999,"trainingType":null,"termId":"","hourType":"Semester","fullTimeHours":12,"fullTimeCreditHourUnderGrad":null,"vacationDayCount":0,"onCampusHours":12.0,"onlineHours":0.0,"yellowRibbonAmount":2999.0,"status":"Approved","amendments":[]},{"beginDateTime":"2015-01-01T04:00:00Z","endDateTime":"2015-08-01T05:00:00Z","facilityCode":11902614,"facilityName":"University
+          of Virginia","participantId":11179999,"trainingType":null,"termId":"","hourType":"Semester","fullTimeHours":12,"fullTimeCreditHourUnderGrad":null,"vacationDayCount":0,"onCampusHours":12.0,"onlineHours":3.0,"yellowRibbonAmount":2999.0,"status":"Approved","amendments":[{"residenceHours":0.0,"distanceHours":3.0,"yellowRibbonAmount":0.0,"amendmentType":"CourseDrop","amendmentStatus":"Approved","amendmentEffectiveDate":"2015-01-02T05:00:00Z"}]},{"beginDateTime":"2014-08-01T04:00:00Z","endDateTime":"2013-05-01T04:00:00Z","facilityCode":25047343,"facilityName":"University
+          of Virginia","participantId":11180666,"trainingType":null,"termId":"","hourType":"Semester","fullTimeHours":12,"fullTimeCreditHourUnderGrad":null,"vacationDayCount":null,"onCampusHours":1.0,"onlineHours":0.0,"yellowRibbonAmount":0.0,"status":"Approved","amendments":[]}]}}'
+    recorded_at: Wed, 28 Feb 2024 12:39:16 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Previous work migrated the GI Bill Status check from a request to EVSS to a request to Lighthouse.  VA form 10203 (Edith Nourse Roberts STEM Scholarship) makes a check to see a veteran's GI Bill Status.  Code in that form was not updated to use the new service and, as a result, continued to send requests to EVSS.  This is undesirable because EVSS is slated for decommissioning in 2024.

This PR updates VA-10203 models to use the previously created `BenefitsEducation::Service`. [Previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15642)

## Summary

This work is not behind a feature toggle.  The new service, `BenefitsEducation::Service` has been active and in-use in production for ~2 months.  We can safely swap out the call to the old service and use the new one.

## Related issue(s)

- [GitHub Issue](https://github.com/department-of-veterans-affairs/va-iir/issues/738)

## Testing done

- [x] New code is covered by unit tests
- Prior to the change, The Rogers Stem Scholarship page were using the [Old Service](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/evss/gi_bill_status/service.rb) which queried EVSS for GI Bill Status.  Now we call the [new one](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/lighthouse/benefits_education/service.rb).  Using test user `vets.gov.user+229@gmail.com`, I placed my debugger on [line 56](https://github.com/department-of-veterans-affairs/vets-api/blob/c5ebf1047b6cba7a29a897c75eee7981809b7c3f/app/models/form_profiles/va_10203.rb#L56) of `app/models/form_profiles/va_10203.rb` and was able to see that the request was now firing off to the new service, as opposed to the old one.  I am having difficulty finding how to debug the other model (`app/models/saved_claim/education_benefits/va_10203.rb`) but it should work just the same.

## What areas of the site does it impact?

https://www.va.gov/education/other-va-education-benefits/stem-scholarship/

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
