### PR TITLE
Deprecate CH33 controller

### DIFF
--- a/app/controllers/v0/profile/ch33_bank_accounts_controller.rb
+++ b/app/controllers/v0/profile/ch33_bank_accounts_controller.rb
@@ -6,6 +6,7 @@ module V0
   module Profile
     class Ch33BankAccountsController < ApplicationController
       service_tag 'direct-deposit'
+      before_action :controller_enabled?
       before_action { authorize :ch33_dd, :access? }
 
       def index
@@ -31,6 +32,12 @@ module V0
       end
 
       private
+
+      def controller_enabled?
+        if Flipper.enabled?(:profile_show_direct_deposit_single_form_edu_downtime, @current_user)
+          raise Common::Exceptions::Forbidden, detail: 'This endpoint is deprecated and will be removed soon.'
+        end
+      end
 
       def render_find_ch33_dd_eft
         get_ch33_dd_eft_info = service.get_ch33_dd_eft_info

--- a/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
+++ b/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
@@ -8,6 +8,29 @@ RSpec.describe V0::Profile::Ch33BankAccountsController, type: :controller do
   before do
     sign_in_as(user)
     allow_any_instance_of(User).to receive(:common_name).and_return('abraham.lincoln@vets.gov')
+    allow(Flipper).to receive(:enabled?).with(
+      :profile_show_direct_deposit_single_form_edu_downtime,
+      instance_of(User)
+    ).and_return(true)
+  end
+
+  context 'single form feature flag enabled' do
+    before do
+      allow(Flipper).to receive(:enabled?).with(
+        :profile_show_direct_deposit_single_form_edu_downtime,
+        instance_of(User)
+      ).and_return(true)
+    end
+
+    it 'returns forbidden with message' do
+      get(:index)
+
+      expect(response.status).to eq(403)
+
+      json = JSON.parse(response.body)
+      error = json['errors'].first
+      expect(error['detail']).to eq('This endpoint is deprecated and will be removed soon.')
+    end
   end
 
   context 'unauthorized user' do

--- a/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
+++ b/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe V0::Profile::Ch33BankAccountsController, type: :controller do
     allow(Flipper).to receive(:enabled?).with(
       :profile_show_direct_deposit_single_form_edu_downtime,
       instance_of(User)
-    ).and_return(true)
+    ).and_return(false)
   end
 
   context 'single form feature flag enabled' do

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -2548,9 +2548,16 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
       end
 
       context 'ch33 bank accounts methods' do
-        let(:mhv_user) { FactoryBot.build(:ch33_dd_user) }
+        before do
+          allow_any_instance_of(User).to receive(:common_name).and_return('abraham.lincoln@vets.gov')
 
-        before { allow_any_instance_of(User).to receive(:common_name).and_return('abraham.lincoln@vets.gov') }
+          allow(Flipper).to receive(:enabled?).with(
+            :profile_show_direct_deposit_single_form_edu_downtime,
+            instance_of(User)
+          ).and_return(false)
+        end
+
+        let(:mhv_user) { FactoryBot.build(:ch33_dd_user) }
 
         it 'supports the update ch33 bank account api 400 response' do
           res = {


### PR DESCRIPTION
## Summary
EDU direct deposit will be supported by Lighthouse moving forward, so the CH33 controller is being deprecated.

This PR adds a feature flag to disable the controller.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83731

## Testing done
Added specs for testing the feature flag.