### PR TITLE
API-36848-fix-for-herbicide-additional-exposures-being-nil

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -215,8 +215,10 @@ module ClaimsApi
         end
       end
 
-      def herbicide_hazard
+      def herbicide_hazard # rubocop:disable Metrics/MethodLength
         herb = @pdf_data&.dig(:data, :attributes, :toxicExposure, :herbicideHazardService)
+        return if herb.blank?
+
         if herb[:serviceDates].present?
           herbicide_service_dates_begin = @pdf_data[:data][:attributes][:toxicExposure][:herbicideHazardService][:serviceDates][:beginDate]
           if herbicide_service_dates_begin.present?
@@ -241,6 +243,8 @@ module ClaimsApi
 
       def additional_exposures
         add = @pdf_data&.dig(:data, :attributes, :toxicExposure, :additionalHazardExposures)
+        return if add.blank?
+
         if add[:exposureDates].present?
           additional_exposure_dates_begin = @pdf_data[:data][:attributes][:toxicExposure][:additionalHazardExposures][:exposureDates][:beginDate]
           if additional_exposure_dates_begin.present?

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -310,6 +310,14 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(multi_exp_hazard).to eq('RADIATION')
       end
 
+      it 'maps herbicide correctly when nothing is included' do
+        form_attributes['toxicExposure']['herbicideHazardService'] = nil
+        mapper.map_claim
+
+        herb_exp_data = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:herbicideHazardService]
+        expect(herb_exp_data).to eq(nil)
+      end
+
       it 'maps herbicide correctly when dates are not included' do
         form_attributes['toxicExposure']['herbicideHazardService']['serviceDates'] = nil
 
@@ -319,6 +327,14 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         herb_service_dates = toxic_exp_data[:herbicideHazardService][:serviceDates]
 
         expect(herb_service_dates).to eq(nil)
+      end
+
+      it 'maps additional exposures correctly when nothing is included' do
+        form_attributes['toxicExposure']['additionalHazardExposures'] = nil
+        mapper.map_claim
+
+        add_exp_data = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:additionalHazardExposures]
+        expect(add_exp_data).to eq(nil)
       end
 
       it 'maps additional exposures correctly when dates are not included' do


### PR DESCRIPTION
## Summary
* Updates handling in PDF mapper for nil herbicideHazardService and additionalHazardExposure objects
* Adds two RSpec examples one for each object

## Related issue(s)
[API-36848](https://jira.devops.va.gov/browse/API-36848)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* Should be able to send in a request with `nil` `herbicideHazardService` and/or `additionalHazardExposure` and the PDF mapper handles the request with error.  Everything should still be mapped correctly.

Sample request:
```
{
   "data":{
      "type":"form/526",
      "attributes":{
         "claimantCertification":true,
         "claimProcessType":"STANDARD_CLAIM_PROCESS",
         "veteranIdentification":{
            "currentVaEmployee":false,
            "mailingAddress":{
               "addressLine1":"1234 Couch Street",
               "city":"Portland",
               "country":"USA",
               "zipFirstFive":"12345",
               "state":"OR"
            }
         },
         "toxicExposure":{
            "gulfWarHazardService":{
               "servedInGulfWarHazardLocations":null,
               "serviceDates":{
                  "beginDate":"1999-07",
                  "endDate":"2005-01"
               }
            },
            "herbicideHazardService": null,
            "additionalHazardExposures":null,
            "multipleExposures":[
               {
                  "exposureDates":{
                     "beginDate":"2012-12",
                     "endDate":"2013-07"
                  },
                  "exposureLocation":"Location 1",
                  "hazardExposedTo":"Hazard 1"
               },
               {
                  "exposureDates":{
                     "beginDate":"2013-10",
                     "endDate":"2013-11"
                  },
                  "exposureLocation":"Location 2",
                  "hazardExposedTo":"Hazard 2"
               }
            ]
         },
         "disabilities":[
            {
               "disabilityActionType":"NEW",
               "name":"Diabetes",
               "exposureOrEventOrInjury":"Agent Orange",
               "serviceRelevance":"Service in Vietnam War",
               "approximateDate":"1972-07"
            }
         ],
         "serviceInformation":{
            "servicePeriods":[
               {
                  "serviceBranch":"Air Force",
                  "serviceComponent":"Active",
                  "activeDutyBeginDate": "2008-11-14",
                  "activeDutyEndDate": "2023-10-30"
               }
            ]
         }
      }
   }
} 
```

## Screenshots
<img width="791" alt="Screenshot 2024-05-28 at 2 40 51 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/129893414/9d03503e-039f-4709-8395-6bc7140524fb">

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb


## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
