### PR TITLE
Full transform on backend, Part 5 [Personal Identification] (81058)

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_identification_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_identification_calculator.rb
@@ -6,7 +6,7 @@ module DebtsApi
       class PersonalIdentificationCalculator
         def initialize(form)
           @form = form['personal_identification']
-          @selected_debts_and_copays = @form['selected_debts_and_copays']
+          @selected_debts_and_copays = form['selected_debts_and_copays']
         end
 
         def transform_personal_id
@@ -20,17 +20,13 @@ module DebtsApi
         private
 
         def get_resolution_options
-          @selected_debts_and_copays
-            .map { |debt_copay| resolution_options_map[debt_copay['resolution_option']] }
-            .join(', ')
+          @selected_debts_and_copays.map do |debt_copay|
+            resolution_options_map[debt_copay['resolution_option']]
+          end.join(', ')
         end
 
         def resolution_options_map
-          {
-            waiver: 'Waiver',
-            monthly: 'Extended monthly payments',
-            compromise: 'Compromise'
-          }
+          { 'waiver' => 'Waiver', 'monthly' => 'Extended monthly payments', 'compromise' => 'Compromise' }
         end
       end
     end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_identification_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_identification_calculator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module DebtsApi
+  module V0
+    module FsrFormTransform
+      class PersonalIdentificationCalculator
+        def initialize(form)
+          @form = form['personal_identification']
+          @selected_debts_and_copays = @form['selected_debts_and_copays']
+        end
+
+        def transform_personal_id
+          output = {}
+          output['ssn'] = @form['ssn']
+          output['fileNumber'] = @form['file_number']
+          output['fsrReason'] = get_resolution_options
+          output
+        end
+
+        private
+
+        def get_resolution_options
+          @selected_debts_and_copays
+            .map { |debt_copay| resolution_options_map[debt_copay['resolution_option']] }
+            .join(', ')
+        end
+
+        def resolution_options_map
+          {
+            waiver: 'Waiver',
+            monthly: 'Extended monthly payments',
+            compromise: 'Compromise'
+          }
+        end
+      end
+    end
+  end
+end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_identification_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_identification_calculator_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'debts_api/v0/fsr_form_transform/personal_identification_calculator'
+
+RSpec.describe DebtsApi::V0::FsrFormTransform::PersonalIdentificationCalculator, type: :service do
+  describe '#initialize' do
+    let(:pre_transform_fsr_form_data) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/pre_transform')
+    end
+    let(:post_transform_fsr_form_data) do
+      get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform')
+    end
+
+    def transform_personal_id
+      transformer = described_class.new(pre_transform_fsr_form_data)
+      @data = transformer.transform_personal_id
+    end
+
+    describe '#transform_personal_id' do
+      before do
+        transform_personal_id
+      end
+
+      it 'gets ssn correct' do
+        expected_ssn = post_transform_fsr_form_data['personalIdentification']['ssn']
+        transformed_ssn = @data['ssn']
+        expect(expected_ssn).to eq(transformed_ssn)
+      end
+
+      it 'gets file number correct' do
+        expected_file_number = post_transform_fsr_form_data['personalIdentification']['fileNumber']
+        transformed_file_number = @data['fileNumber']
+        expect(expected_file_number).to eq(transformed_file_number)
+      end
+
+      it 'gets FSR reasons correct' do
+        expected_fsr_reason = post_transform_fsr_form_data['personalIdentification']['fsrReason']
+        transformed_fsr_reason = @data['fsrReason']
+        expect(expected_fsr_reason).to eq(transformed_fsr_reason)
+      end
+
+      context 'when there are no selected debts and copays' do
+        let(:pre_transform_fsr_form_data) do
+          raw_data = get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/pre_transform')
+          raw_data['selected_debts_and_copays'] = []
+          raw_data
+        end
+
+        it 'returns an empty string for FSR reason' do
+          expected_fsr_reason = ''
+          transformed_fsr_reason = @data['fsrReason']
+          expect(expected_fsr_reason).to eq(transformed_fsr_reason)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This is part of the larger effort to move the transformation logic for the FSR form from the front end to the back end. This pull request is for part five of this effort addressing many of the miscellaneous transformations, specifically the `personal_identification.` This is only one of the miscellaneous properties to transform and is not enough to close the ticket on its own.

I am on the VA debt team, which owns maintenance of this code. This work is not behind a feature toggle.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81058

## Testing done

_This has not been added at the time of this pull request._

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

N/A

## What areas of the site does it impact?

The VA Debt application

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x] I added a screenshot of the developed feature

## Requested Feedback

* That the unit tests cover enough needed scenarios and check the proper data.
* Any potential optimizations in the transform.
