### PR TITLE
API-36866-fix-response-setting-for-served-in-herbicide

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -195,10 +195,8 @@ module ClaimsApi
       # rubocop:disable Layout/LineLength
       def gulfwar_hazard
         gulf = @pdf_data&.dig(:data, :attributes, :toxicExposure, :gulfWarHazardService)
-        if gulf.present?
-          served_gulf_loc = @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:gulfWarHazardService][:servedInGulfWarHazardLocations]
-          served_gulf_loc == 'NO' || served_gulf_loc.blank? ? 'NO' : 'YES'
-        end
+        return if gulf.blank?
+
         if gulf[:serviceDates].present?
           gulfwar_service_dates_begin = @pdf_data[:data][:attributes][:toxicExposure][:gulfWarHazardService][:serviceDates][:beginDate]
           if gulfwar_service_dates_begin.present?
@@ -215,7 +213,7 @@ module ClaimsApi
         end
       end
 
-      def herbicide_hazard # rubocop:disable Metrics/MethodLength
+      def herbicide_hazard
         herb = @pdf_data&.dig(:data, :attributes, :toxicExposure, :herbicideHazardService)
         return if herb.blank?
 
@@ -232,12 +230,6 @@ module ClaimsApi
               make_date_object(herbicide_service_dates_end, herbicide_service_dates_end.length)
           end
           @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:herbicideHazardService][:serviceDates].delete(:endDate)
-        end
-
-        if herb.present?
-          served_in_herbicide_hazard_locations = @pdf_data[:data][:attributes][:toxicExposure][:herbicideHazardService][:servedInHerbicideHazardLocations]
-          @pdf_data[:data][:attributes][:exposureInformation][:toxicExposure][:herbicideHazardService][:servedInHerbicideHazardLocations] =
-            served_in_herbicide_hazard_locations ? 'YES' : nil
         end
       end
 

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -348,6 +348,35 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(additional_exposure_dates).to eq(nil)
       end
 
+      context "526 section 4, herbicideHazardService.servedInHerbicideHazardLocations exposures can answer 'NO'" do
+        it 'maps the attributes correctly' do
+          toxic_exp_data = form_attributes['toxicExposure']
+          toxic_exp_data['herbicideHazardService']['serviceDates']['beginDate'] = nil
+          toxic_exp_data['herbicideHazardService']['serviceDates']['endDate'] = nil
+          toxic_exp_data['herbicideHazardService']['servedInHerbicideHazardLocations'] = 'NO'
+          toxic_exp_data['herbicideHazardService']['otherLocationsServed'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:herbicideHazardService][:servedInHerbicideHazardLocations]).to eq('NO')
+        end
+      end
+
+      context '526 section 4, gulfWarHazardService exposures null data' do
+        it 'maps the attributes correctly' do
+          toxic_exp_data = form_attributes['toxicExposure']
+          toxic_exp_data['gulfWarHazardService']['serviceDates']['beginDate'] = nil
+          toxic_exp_data['gulfWarHazardService']['serviceDates']['endDate'] = nil
+          toxic_exp_data['gulfWarHazardService']['servedInGulfWarHazardLocations'] = nil
+
+          mapper.map_claim
+
+          exposure_info = pdf_data[:data][:attributes][:exposureInformation][:toxicExposure]
+          expect(exposure_info[:gulfWarHazardService]).to eq(nil)
+        end
+      end
+
       context '526 section 4, herbicideHazardService exposures null data' do
         it 'maps the attributes correctly' do
           toxic_exp_data = form_attributes['toxicExposure']


### PR DESCRIPTION
## Summary
* Updates the logic so `YES`, `NO` and `null` all mark the boxes, or do not mark the boxes in the case of `null`, as expected
* Cleans out some unused code from gulfWarHazard method in PDF mapper
* Adds RSpec tests

## Related issue(s)
[API-36866](https://jira.devops.va.gov/browse/API-36866)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* Sending in the below request should mark both boxes `YES` on the PDF
 ```
         "toxicExposure":{
            "gulfWarHazardService": {
                "servedInGulfWarHazardLocations": "YES",
                "serviceDates": {
                    "beginDate": "1972-05",
                    "endDate": "1980-10"
                }
            },
            "herbicideHazardService": {
                "servedInHerbicideHazardLocations": "YES",
                "otherLocationsServed": null,
                "serviceDates": {}
                },
                "additionalHazardExposures": null
         },
```
* Sending in the below request should mark both boxes 'NO' in the PDF
```
         "toxicExposure":{
            "gulfWarHazardService": {
                "servedInGulfWarHazardLocations": "NO",
                "serviceDates": {
                    "beginDate": "1972-05",
                    "endDate": "1980-10"
                }
            },
            "herbicideHazardService": {
                "servedInHerbicideHazardLocations": "NO",
                "otherLocationsServed": null,
                "serviceDates": {}
                },
                "additionalHazardExposures": null
         },
```
* Sending in the below request should leave both boxes empty in the PDF
```
         "toxicExposure":{
            "gulfWarHazardService": {
                "servedInGulfWarHazardLocations": null,
                "serviceDates": {
                    "beginDate": "1972-05",
                    "endDate": "1980-10"
                }
            },
            "herbicideHazardService": {
                "servedInHerbicideHazardLocations": null,
                "otherLocationsServed": null,
                "serviceDates": {}
                },
                "additionalHazardExposures": null
         },
```

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
