### PR TITLE
Add new feature flag for the Appointments application

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1230,6 +1230,10 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for redesigning the appointment details page.
+  va_online_scheduling_recent_locations_filter:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle for displaying the most recent facilities on the Choose your VA location page.
   va_view_dependents_access:
     actor_type: user
     description: Allows us to gate the View/ Modify dependents content in a progressive rollout


### PR DESCRIPTION



## Summary

Create a feature toggle `va_online_scheduling_recent_locations_filter` for displaying the most recent facilities on the Appointments application.

## Related issue(s)

- *Link to ticket created in [va.gov-team repo](https://github.com/department-of-veterans-affairs/va.gov-team/issues/80770) 


## Testing done

n/a

## Screenshots
n/a

## What areas of the site does it impact?
feature toggle page

## Acceptance criteria

- [ ]  Create a feature toggle `va_online_scheduling_recent_locations_filter` on the features.yml page

expected
- [ ]  `va_online_scheduling_recent_locations_filter` added to the features.yml page


