### PR TITLE
Add Unit Tests for Covid Vaccine AMS Serializers

### DIFF
--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
@@ -13,7 +13,7 @@ module CovidVaccine
 
       %i[vaccine_interest zip_code].each do |attr|
         define_method attr do
-          object.raw_form_data[attr]
+          object.raw_form_data[attr.to_s]
         end
       end
     end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe CovidVaccine::V0::ExpandedRegistrationSerializer do
-
   let(:submission) { build_stubbed(:covid_vax_expanded_registration) }
 
   let(:rendered_hash) do
@@ -12,11 +11,10 @@ describe CovidVaccine::V0::ExpandedRegistrationSerializer do
   let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id].blank?).to be_truthy
+    expect(rendered_hash[:data][:id]).to be_blank
   end
 
   it 'includes :created_at' do
     expect(rendered_attributes[:created_at]).to eq submission.created_at
   end
-
 end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CovidVaccine::V0::ExpandedRegistrationSerializer do
+
+  let(:submission) { build_stubbed(:covid_vax_expanded_registration) }
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(submission, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_attributes[:id]).to eq nil
+  end
+
+  it 'includes :created_at' do
+    expect(rendered_attributes[:created_at]).to eq submission.created_at
+  end
+
+end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
@@ -12,7 +12,7 @@ describe CovidVaccine::V0::ExpandedRegistrationSerializer do
   let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 
   it 'includes :id' do
-    expect(rendered_attributes[:id]).to eq nil
+    expect(rendered_hash[:data][:id].blank?).to be_truthy
   end
 
   it 'includes :created_at' do

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe CovidVaccine::V0::RegistrationSubmissionSerializer do
-
   let(:registration) { build_stubbed(:covid_vax_registration) }
 
   let(:rendered_hash) do
@@ -50,5 +49,4 @@ describe CovidVaccine::V0::RegistrationSubmissionSerializer do
   it 'includes :birth_date' do
     expect(rendered_attributes[:birth_date]).to eq registration.raw_form_data['birth_date']
   end
-
 end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
@@ -4,19 +4,51 @@ require 'rails_helper'
 
 describe CovidVaccine::V0::RegistrationSubmissionSerializer do
 
-  let(:submission) { build_stubbed(:covid_vax_expanded_registration) }
+  let(:registration) { build_stubbed(:covid_vax_registration) }
 
   let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(submission, { serializer: described_class }).as_json
+    ActiveModelSerializers::SerializableResource.new(registration, { serializer: described_class }).as_json
   end
   let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 
   it 'includes :id' do
-    expect(rendered_attributes[:id]).to eq nil
+    expect(rendered_hash[:data][:id]).to eq registration.sid
   end
 
   it 'includes :created_at' do
-    expect(rendered_attributes[:created_at]).to eq submission.created_at
+    expect(rendered_attributes[:created_at]).to eq registration.created_at
+  end
+
+  it 'includes :vaccine_interest' do
+    expect(rendered_attributes[:vaccine_interest]).to eq registration.raw_form_data['vaccine_interest']
+  end
+
+  it 'includes :zip_code' do
+    expect(rendered_attributes[:zip_code]).to eq registration.raw_form_data['zip_code']
+  end
+
+  it 'includes :zip_code_details' do
+    expect(rendered_attributes[:zip_code_details]).to eq registration.raw_form_data['zip_code_details']
+  end
+
+  it 'includes :phone' do
+    expect(rendered_attributes[:phone]).to eq registration.raw_form_data['phone']
+  end
+
+  it 'includes :email' do
+    expect(rendered_attributes[:email]).to eq registration.raw_form_data['email']
+  end
+
+  it 'includes :first_name' do
+    expect(rendered_attributes[:first_name]).to eq registration.raw_form_data['first_name']
+  end
+
+  it 'includes :last_name' do
+    expect(rendered_attributes[:last_name]).to eq registration.raw_form_data['last_name']
+  end
+
+  it 'includes :birth_date' do
+    expect(rendered_attributes[:birth_date]).to eq registration.raw_form_data['birth_date']
   end
 
 end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CovidVaccine::V0::RegistrationSubmissionSerializer do
+
+  let(:submission) { build_stubbed(:covid_vax_expanded_registration) }
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(submission, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_attributes[:id]).to eq nil
+  end
+
+  it 'includes :created_at' do
+    expect(rendered_attributes[:created_at]).to eq submission.created_at
+  end
+
+end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_summary_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_summary_serializer_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe CovidVaccine::V0::RegistrationSummarySerializer do
-
   let(:registration) { build_stubbed(:covid_vax_registration) }
 
   let(:rendered_hash) do
@@ -12,7 +11,7 @@ describe CovidVaccine::V0::RegistrationSummarySerializer do
   let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id].blank?).to be_truthy
+    expect(rendered_hash[:data][:id]).to be_blank
   end
 
   it 'includes :created_at' do
@@ -26,5 +25,4 @@ describe CovidVaccine::V0::RegistrationSummarySerializer do
   it 'includes :zip_code' do
     expect(rendered_attributes[:zip_code]).to eq registration.raw_form_data['zip_code']
   end
-
 end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_summary_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_summary_serializer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CovidVaccine::V0::RegistrationSummarySerializer do
+
+  let(:registration) { build_stubbed(:covid_vax_registration) }
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(registration, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_hash[:data][:id].blank?).to be_truthy
+  end
+
+  it 'includes :created_at' do
+    expect(rendered_attributes[:created_at]).to eq registration.created_at
+  end
+
+  it 'includes :vaccine_interest' do
+    expect(rendered_attributes[:vaccine_interest]).to eq registration.raw_form_data['vaccine_interest']
+  end
+
+  it 'includes :zip_code' do
+    expect(rendered_attributes[:zip_code]).to eq registration.raw_form_data['zip_code']
+  end
+
+end


### PR DESCRIPTION
## Summary

- Add more test examples for missing attributes/specs

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83640

## Testing done

- [x] Add more test examples for missing attributes

## Screenshots

![Screenshot 2024-05-29 at 9 05 53 AM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/017655aa-5b25-45cc-b343-646c326b7dab)

*Note the serializer with 0% coverage is already using jsonapi-serializer

## Acceptance criteria

- [x] unit test coverage is 100% 

## Reviewer Feedback

I updated the following serializer because the `object.raw_form_data` keys are strings not symbols

`modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb`