### PR TITLE
Update Breakers to user new GIBS Service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1089,6 +1089,7 @@ spec/controllers/v0/veteran_onboardings_controller_spec.rb @department-of-vetera
 spec/controllers/v0/virtual_agent @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/virtual_agent_token_msft_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/virtual_agent_token_nlu_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/controllers/v1/profile/ @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/sessions_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/factories/686c @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/backend_statuses_controller.rb
+++ b/app/controllers/v0/backend_statuses_controller.rb
@@ -26,8 +26,8 @@ module V0
       be_status = BackendStatus.new(name: @backend_service)
       case @backend_service
       when BackendServices::GI_BILL_STATUS
-        be_status.is_available = EVSS::GiBillStatus::Service.within_scheduled_uptime?
-        be_status.uptime_remaining = EVSS::GiBillStatus::Service.seconds_until_downtime
+        be_status.is_available = BenefitsEducation::Service.within_scheduled_uptime?
+        be_status.uptime_remaining = BenefitsEducation::Service.seconds_until_downtime
       else
         # default service is up!
         be_status.is_available = true

--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -12,13 +12,13 @@ require 'evss/dependents/configuration'
 require 'evss/disability_compensation_form/configuration'
 require 'evss/documents_service'
 require 'evss/letters/service'
-require 'evss/gi_bill_status/service'
 require 'evss/pciu_address/configuration'
 require 'evss/reference_data/configuration'
 require 'facilities/bulk_configuration'
 require 'gi/configuration'
 require 'gibft/configuration'
 require 'hca/configuration'
+require 'lighthouse/benefits_education/configuration'
 require 'mhv_ac/configuration'
 require 'mpi/configuration'
 require 'pagerduty/configuration'
@@ -47,13 +47,13 @@ Rails.application.reloader.to_prepare do
     DecisionReview::Configuration.instance.breakers_service,
     Rx::Configuration.instance.breakers_service,
     BB::Configuration.instance.breakers_service,
+    BenefitsEducation::Configuration.instance.breakers_service,
     EVSS::ClaimsService.breakers_service,
     EVSS::CommonService.breakers_service,
     EVSS::DisabilityCompensationForm::Configuration.instance.breakers_service,
     EVSS::DocumentsService.breakers_service,
     EVSS::Letters::Configuration.instance.breakers_service,
     EVSS::PCIUAddress::Configuration.instance.breakers_service,
-    EVSS::GiBillStatus::Configuration.instance.breakers_service,
     EVSS::Dependents::Configuration.instance.breakers_service,
     EVSS::ReferenceData::Configuration.instance.breakers_service,
     Gibft::Configuration.instance.breakers_service,

--- a/lib/lighthouse/auth/client_credentials/access_token_tracker.rb
+++ b/lib/lighthouse/auth/client_credentials/access_token_tracker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'common/models/redis_store'
+
 module Auth
   module ClientCredentials
     class AccessTokenTracker < Common::RedisStore

--- a/spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb
+++ b/spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe V1::Post911GIBillStatusesController, type: :controller do
 
       VCR.use_cassette('lighthouse/benefits_education/gi_bill_status/200_response') do
         expect(StatsD).to receive(:increment).with(V1::Post911GIBillStatusesController::STATSD_GI_BILL_TOTAL_KEY)
+        expect(StatsD).to receive(:increment).with(
+          "api.external_http_request.#{BenefitsEducation::Configuration.instance.service_name}.success", 1, anything
+        )
         get :show
       end
 

--- a/spec/requests/backend_status_request_spec.rb
+++ b/spec/requests/backend_status_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Backend Status' do
   describe '#show' do
     let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
     let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
-    let(:tz) { ActiveSupport::TimeZone.new(EVSS::GiBillStatus::Service::OPERATING_ZONE) }
+    let(:tz) { ActiveSupport::TimeZone.new(BenefitsEducation::Service::OPERATING_ZONE) }
     let(:offline_saturday) { tz.parse('17th Mar 2018 19:00:01') }
     let(:online_weekday) { tz.parse('24th Jan 2018 06:00:00') }
 


### PR DESCRIPTION
## Summary

I am Adam King, I work on the VA-IIR team and we own the GI Bill Status component on `vets-api`.

We have shifted the network call to query GI Bill Status from [EVSS:GiBillStatus::Service](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/evss/gi_bill_status/service.rb) to [BenefitsEducation::Service](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/lighthouse/benefits_education/service.rb).  We need to update the Breakers service to prevent network calls to the upstream (Lighthouse, LTS) service during scheduled downtime.  

This PR adds an entry for the new service in the Breakers configuration, and removes the (now deprecated) EVSS service.  It also updates the backend services controller, which is queried by FE clients who then can display a "try again later" message to the user.

This work is not behind a feature toggle.

## Related issue(s)

[GitHub Issue 740](https://github.com/department-of-veterans-affairs/va-iir/issues/740)

## Testing done

New code is covered by unit tests.  Previously, FE clients requesting uptime status of the service were querying the status of the old (EVSS, now deprecated).  Now clients will receive information about the new Lighthouse service.

## What areas of the site does it impact?

[GI Bill Statement of Benefits Tool](https://staging.va.gov/education/check-post-9-11-gi-bill-benefits/)
[Edith Nourse Roberts STEM Scholarship](https://staging.va.gov/education/other-va-education-benefits/stem-scholarship/)

Both these pages make queries to determine a veteran's GI Bill status

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
