### PR TITLE
Income and Assets (21P-0969) endpoint boilerplate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,7 @@ app/controllers/concerns/vet360 @department-of-veterans-affairs/vfs-authenticate
 app/controllers/facilities_controller.rb @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/flipper_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/gids_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/v0/income_and_assets_claims_controller.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 app/controllers/inherited_proofing_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/preneeds_controller.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/rx_controller.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -308,6 +309,7 @@ app/models/saved_claim/disability_compensation.rb @department-of-veterans-affair
 app/models/session.rb @department-of-veterans-affairs/octo-identity
 app/models/saved_claim/burial.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pensions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/disability_compensation.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/backend-review-group
+app/models/saved_claim/income_and_assets.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/pension.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/education_career_counseling_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -491,6 +493,7 @@ app/swagger/swagger/requests/hca_attachments.rb @department-of-veterans-affairs/
 app/swagger/swagger/requests/health_care_applications.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/form1010_ezrs.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/in_progress_forms.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/swagger/swagger/requests/income_and_assets_claims.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/maintenance_windows.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/medical_copays.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
@@ -1145,6 +1148,7 @@ spec/factories/health_care_application.rb @department-of-veterans-affairs/vfs-au
 spec/factories/iam_introspection_responses.rb @department-of-veterans-affairs/octo-identity
 spec/factories/iam_user_identities.rb @department-of-veterans-affairs/octo-identity
 spec/factories/iam_users.rb @department-of-veterans-affairs/octo-identity
+spec/factories/income_and_assets_claim.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 spec/factories/inherited_proofing @department-of-veterans-affairs/octo-identity
 spec/factories/in_progress_forms @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/ivc_champva_forms.rb @department-of-veterans-affairs/champva-engineering @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1521,6 +1525,7 @@ spec/models/redis_caching_spec.rb @department-of-veterans-affairs/va-api-enginee
 spec/models/schema_contract @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/saml_request_tracker_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/saved_claim @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/models/saved_claim/income_and_assets_spec.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 spec/models/session_spec.rb @department-of-veterans-affairs/octo-identity @department-of-veterans-affairs/octo-identity
 spec/models/sign_in @department-of-veterans-affairs/octo-identity
 spec/models/single_logout_request_spec.rb @department-of-veterans-affairs/octo-identity
@@ -1590,6 +1595,7 @@ spec/requests/health_care_applications_request_spec.rb @department-of-veterans-a
 spec/requests/form1010_ezrs_request_spec.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/health_records_request_spec.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/http_method_not_allowed_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/requests/income_and_assets_claims_controller_spec.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 spec/requests/id_card_attributes_request_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/requests/in_progress_forms_request_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/intent_to_files_request_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ gem 'swagger-blocks'
 # POSIX systems should have this already, so we're not going to bring it in on other platforms
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'utf8-cleaner'
-gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'correct-capitalization'
+gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'
 gem 'warden-github'
 gem 'will_paginate'

--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ gem 'swagger-blocks'
 # POSIX systems should have this already, so we're not going to bring it in on other platforms
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'utf8-cleaner'
-gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
+gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'correct-capitalization'
 gem 'virtus'
 gem 'warden-github'
 gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 70557e02ecd63b9cc10dca138fdfcb17e176e09a
-  branch: master
+  revision: 8fff0f52de3cd2b1a9bbc4eafc76ee7c176cb852
+  branch: correct-capitalization
   specs:
     vets_json_schema (22.3.1)
       multi_json (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,10 +73,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 7176cb057f11f66f16889005a1873a084bad188c
+  revision: 70557e02ecd63b9cc10dca138fdfcb17e176e09a
   branch: master
   specs:
-    vets_json_schema (22.1.1)
+    vets_json_schema (22.3.1)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 
@@ -140,7 +140,8 @@ GEM
       gserver
       sidekiq (>= 7.2.0, < 8)
       sidekiq-pro (>= 7.2.0, < 8)
-    sidekiq-pro (7.2.0)
+    sidekiq-pro (7.2.1)
+      base64
       sidekiq (>= 7.2.0, < 8)
 
 GEM
@@ -442,6 +443,7 @@ GEM
     fastimage (2.3.1)
     ffi (1.16.3)
     ffi (1.16.3-java)
+    ffi (1.16.3-x86-mingw32)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -521,6 +523,9 @@ GEM
       bigdecimal
       ffi (~> 1)
       ffi-compiler (~> 1)
+      rake (>= 13)
+    google-protobuf (4.27.0-x86-mingw32)
+      bigdecimal
       rake (>= 13)
     google-protobuf (4.27.0-x86_64-linux)
       bigdecimal
@@ -683,6 +688,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.5-java)
       racc (~> 1.4)
+    nokogiri (1.16.5-x86-mingw32)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     nori (2.7.0)
@@ -736,6 +743,7 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.5.6)
+    pg (1.5.6-x86-mingw32)
     pg_query (5.1.0)
       google-protobuf (>= 3.22.3)
     pg_search (2.3.6)
@@ -1304,4 +1312,4 @@ RUBY VERSION
    ruby 3.2.4p170
 
 BUNDLED WITH
-   2.4.9
+   2.5.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 8fff0f52de3cd2b1a9bbc4eafc76ee7c176cb852
-  branch: correct-capitalization
+  revision: 23bf453428474f73d1b519fe588b0b707ec9ebd7
+  branch: master
   specs:
     vets_json_schema (22.3.1)
       multi_json (~> 1.0)

--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -163,6 +163,7 @@ module V0
       Swagger::Requests::MviUsers,
       Swagger::Requests::OnsiteNotifications,
       Swagger::Requests::PensionClaims,
+      Swagger::Requests::IncomeAndAssetsClaims,
       Swagger::Requests::Post911GIBillStatuses,
       Swagger::Requests::PPIU,
       Swagger::Requests::PreneedsClaims,

--- a/app/controllers/v0/income_and_assets_claims_controller.rb
+++ b/app/controllers/v0/income_and_assets_claims_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'pension_21p527ez/tag_sentry'
+require 'pension_21p527ez/monitor'
+
+module V0
+  class IncomeAndAssetsClaimsController < ClaimsBaseController
+    service_tag 'income-and-assets-application'
+
+    def short_name
+      'income_and_assets_claim'
+    end
+
+    def claim_class
+      SavedClaim::IncomeAndAssets
+    end
+  end
+end

--- a/app/models/saved_claim/income_and_assets.rb
+++ b/app/models/saved_claim/income_and_assets.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'pension_burial/processing_office'
+
+class SavedClaim::IncomeAndAssets < SavedClaim
+  FORM = '21P-0969'
+
+  def regional_office
+    ['REGIONAL_OFFICE TBD']
+  end
+
+  def attachment_keys
+    [:files].freeze
+  end
+end

--- a/app/swagger/swagger/requests/income_and_assets_claims.rb
+++ b/app/swagger/swagger/requests/income_and_assets_claims.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Requests
+    class IncomeAndAssetsClaims
+      include Swagger::Blocks
+
+      swagger_path '/v0/form0969' do
+        operation :post do
+          extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::SavedForm
+
+          key :description, 'Submit a income and assets statement'
+          key :operationId, 'addIncomeAndAssetsClaim'
+          key :tags, %w[benefits_forms]
+
+          parameter :optional_authorization
+
+          parameter do
+            key :name, :form
+            key :in, :body
+            key :description, 'Income and assets statement form data'
+            key :required, true
+
+            schema do
+              key :type, :string
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,9 @@ Rails.application.routes.draw do
       resources :burial_claims, only: %i[create show]
     end
 
+    post 'form0969', to: 'income_and_assets_claims#create'
+    get 'form0969', to: 'income_and_assets_claims#show'
+
     resources :benefits_claims, only: %i[index show] do
       post :submit5103, on: :member
       post 'benefits_documents', to: 'benefits_documents#create'

--- a/spec/factories/income_and_assets_claim.rb
+++ b/spec/factories/income_and_assets_claim.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :income_and_assets_claim, class: 'SavedClaim::IncomeAndAssets' do
+    form_id { '21P-0969' }
+    form do
+      {
+        veteranFullName: {
+          first: 'John',
+          middle: 'Edmund',
+          last: 'Doe'
+        },
+        veteranSocialSecurityNumber: '333224444',
+        statementOfTruthCertified: true,
+        statementOfTruthSignature: 'John Edmund Doe'
+      }.to_json
+    end
+  end
+end

--- a/spec/models/saved_claim/income_and_assets_spec.rb
+++ b/spec/models/saved_claim/income_and_assets_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'lib/saved_claims_spec_helper'
+
+RSpec.describe SavedClaim::IncomeAndAssets, uploader_helpers: true do
+  subject { described_class.new }
+
+  let(:instance) { FactoryBot.build(:income_and_assets_claim) }
+
+  it_behaves_like 'saved_claim_with_confirmation_number'
+end

--- a/spec/requests/income_and_assets_claims_controller_spec.rb
+++ b/spec/requests/income_and_assets_claims_controller_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+reg_office = 'REGIONAL_OFFICE TBD'
+
+RSpec.describe 'Income and Assets Claim Integration', type: %i[request serializer] do
+  before do
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  let(:full_claim) do
+    build(:income_and_assets_claim).parsed_form
+  end
+
+  describe 'POST create' do
+    subject do
+      post('/v0/form0969',
+           params: params.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json', 'HTTP_X_KEY_INFLECTION' => 'camel' })
+    end
+
+    context 'with invalid params' do
+      before do
+        allow(Settings.sentry).to receive(:dsn).and_return('asdf')
+      end
+
+      let(:params) do
+        {
+          incomeAndAssetsClaim: {
+            form: full_claim.merge('veteranSocialSecurityNumber' => 'just a string').to_json
+          }
+        }
+      end
+
+      it 'shows the validation errors' do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(
+          JSON.parse(response.body)['errors'][0]['detail'].include?(
+            "The property '#/veteranSocialSecurityNumber' value \"just a string\" did not match the regex"
+          )
+        ).to eq(true)
+      end
+    end
+
+    context 'with valid params' do
+      let(:params) do
+        {
+          incomeAndAssetsClaim: {
+            form: full_claim.to_json
+          }
+        }
+      end
+
+      it 'renders success' do
+        subject
+        expect(JSON.parse(response.body)['data']['attributes'].keys.sort)
+          .to eq(%w[confirmationNumber form guid regionalOffice submittedAt])
+      end
+
+      it 'returns the expected regional office' do
+        subject
+        expect(JSON.parse(response.body)['data']['attributes']['regionalOffice'].join(', '))
+          .to eq(reg_office)
+      end
+    end
+  end
+end

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'API doc validations', type: :request do
     it 'has valid json' do
       get '/v0/apidocs.json'
       json = response.body
+      print JSON.parse(json)
       JSON.parse(json).to_yaml
     end
   end
@@ -418,6 +419,30 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           }
         )
       end
+    end
+
+    it 'supports adding an income and assets statement' do
+      expect(subject).to validate(
+        :post,
+        '/v0/form0969',
+        200,
+        '_data' => {
+          'income_and_assets_claim' => {
+            'form' => build(:income_and_assets_claim).form
+          }
+        }
+      )
+
+      expect(subject).to validate(
+        :post,
+        '/v0/form0969',
+        422,
+        '_data' => {
+          'income_and_assets_claim' => {
+            'invalid-form' => { invalid: true }.to_json
+          }
+        }
+      )
     end
 
     context 'MDOT tests' do

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'API doc validations', type: :request do
     it 'has valid json' do
       get '/v0/apidocs.json'
       json = response.body
-      print JSON.parse(json)
       JSON.parse(json).to_yaml
     end
   end


### PR DESCRIPTION
## Summary

Adds boilerplate code for the income and assets (`/v0/form0969`) endpoint. Submissions are successfully posted to the v0/form0969 endpoint, but aren't yet forwarded to VBA. PDF mapping, VBA submission, and logging/metrics are planned in later issues in the epic.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82554

## Testing done

- [x] Added unit tests for new route
- [x] Ran Swagger UI locally to confirm presence of endpoint (following guidelines in `app/swagger/readme.md`)
- [x] [Updated vets-website](https://github.com/department-of-veterans-affairs/vets-website/pull/30053) to allow submission to the endpoint locally, and confirmed successful submission.

## Screenshots
<img width="1506" alt="Screenshot 2024-05-29 at 1 47 39 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/21046714/7d85bc0b-49a8-4b95-aa2e-102914bb26fc">
<img width="1293" alt="Screenshot 2024-05-29 at 1 49 32 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/21046714/e1eed449-4612-4b76-bce6-bc9c5e97c680">

## What areas of the site does it impact?
Income and Assets

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

