### PR TITLE
Feature - route 526 claims to multi-contention classifier in VRO

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -173,6 +173,8 @@ module Form526ClaimFastTrackingConcern
     end
   end
 
+  # Submits contention information to the VRO contention classification service
+  # adds classification to the form for each contention provided a classification
   def update_contention_classification_all!
     params = {}
     classifier_response = classify_vagov_contentions(params)

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -171,13 +171,16 @@ module Form526ClaimFastTrackingConcern
     else
       update_single_contention_classification!
     end
+  end
 
   def update_contention_classification_all!
     params = {}
     classifier_response = classify_vagov_contentions(params)
     classifier_response['contentions'].each do |contention|
       contention['contentionText'] = contention['contentionText'].upcase
-      Rails.logger.info('Classified 526Submission', id:, saved_claim_id:, contention.classification, contention.contention_type)
+      Rails.logger.info('Classified 526Submission',
+                        id:, saved_claim_id:, classification: contention['classification'],
+                        contention_type: contention['contention_type'])
       # update_form_with_classification_code(classification['classification_code'])
     end
   end

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -174,11 +174,12 @@ module Form526ClaimFastTrackingConcern
   end
 
   def update_form_with_classification_codes(classified_contentions)
-    classification_codes.each do |classification_code|
-      # form[Form526Submission::FORM_526]['form526']['disabilities'].each do |disability|
-      #   if disability[]
-      #   disability['classificationCode'] = classification_code
-      # end
+    puts "updating form with classification codes #{classified_contentions}"
+    classified_contentions.each_with_index do |classified_contention, index|
+      classification_code = classified_contention['classification_code']
+      if classified_contentions[index]['classification_code'].present?
+        form[Form526Submission::FORM_526]['form526']['disabilities'][index]['classificationCode'] = classification_code
+      end
     end
 
     update!(form_json: form.to_json)
@@ -222,8 +223,8 @@ module Form526ClaimFastTrackingConcern
       Rails.logger.info('Classified 526Submission',
                         id:, saved_claim_id:, classification:,
                         claim_type: contention['contention_type'])
-      # update_form_with_classification_code(classification['classification_code'])
     end
+    update_form_with_classification_codes(classifier_response['contentions'])
   end
 
   # Submits contention information to the VRO contention classification 

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -174,7 +174,6 @@ module Form526ClaimFastTrackingConcern
   end
 
   def update_form_with_classification_codes(classified_contentions)
-    puts "updating form with classification codes #{classified_contentions}"
     classified_contentions.each_with_index do |classified_contention, index|
       classification_code = classified_contention['classification_code']
       if classified_contentions[index]['classification_code'].present?
@@ -219,7 +218,8 @@ module Form526ClaimFastTrackingConcern
           classification_name: contention['classification_name']
         }
       end
-      # note: claim_type is actually type of contention, but formatting preserved in order to match existing datadog dashboard
+      # NOTE: claim_type is actually type of contention, but formatting
+      # preserved in order to match existing datadog dashboard
       Rails.logger.info('Classified 526Submission',
                         id:, saved_claim_id:, classification:,
                         claim_type: contention['contention_type'])
@@ -227,7 +227,7 @@ module Form526ClaimFastTrackingConcern
     update_form_with_classification_codes(classifier_response['contentions'])
   end
 
-  # Submits contention information to the VRO contention classification 
+  # Submits contention information to the VRO contention classification
   # service for single-contention claims.
   #
   # note: this method is only used for single-contention claims and is

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -212,7 +212,7 @@ module Form526ClaimFastTrackingConcern
     classifier_response = classify_vagov_contentions(params)
     classifier_response['contentions'].each do |contention|
       classification = nil
-      if contention.key?(:classification_code) and contention.key?(:classification_name) do
+      if contention.key?(:classification_code) && contention.key?(:classification_name)
         classification = {
           classification_code: contention['classification_code'],
           classification_name: contention['classification_name']

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -194,7 +194,7 @@ module Form526ClaimFastTrackingConcern
   def format_contention_for_vro(disability)
     contention = {
       contention_text: disability['name'],
-      contention_type: disability['disabilityActionType'],
+      contention_type: disability['disabilityActionType']
     }
     contention[:diagnostic_code] = disability['diagnosticCode'] if disability.key?(:diagnosticCode)
     contention

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -196,7 +196,7 @@ module Form526ClaimFastTrackingConcern
       contention_text: disability['name'],
       contention_type: disability['disabilityActionType']
     }
-    contention[:diagnostic_code] = disability['diagnosticCode'] if disability.key?(:diagnosticCode)
+    contention['diagnostic_code'] = disability['diagnosticCode'] if disability['diagnosticCode']
     contention
   end
 

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -166,6 +166,29 @@ module Form526ClaimFastTrackingConcern
   end
 
   def update_classification!
+    if Flipper.enabled?(:disability_526_classifier_multi_contention)
+      update_contention_classification_all!
+    else
+      update_single_contention_classification!
+    end
+
+  def update_contention_classification_all!
+    params = {}
+    classifier_response = classify_vagov_contentions(params)
+    classifier_response['contentions'].each do |contention|
+      contention['contentionText'] = contention['contentionText'].upcase
+      Rails.logger.info('Classified 526Submission', id:, saved_claim_id:, contention.classification, contention.contention_type)
+      # update_form_with_classification_code(classification['classification_code'])
+    end
+  end
+
+  # Submits contention information to the VRO contention classification 
+  # service for single-contention claims.
+  #
+  # note: this method is only used for single-contention claims and is
+  # deprecated in favor of update_contention_classification_all, which handles
+  # both single and multi-contention claims
+  def update_contention_classification_single_contention!
     return unless increase_or_new?
     return unless disabilities.count == 1
 

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -173,10 +173,30 @@ module Form526ClaimFastTrackingConcern
     end
   end
 
+  def update_form_with_classification_codes(classified_contentions)
+    classification_codes.each do |classification_code|
+      # form[Form526Submission::FORM_526]['form526']['disabilities'].each do |disability|
+      #   if disability[]
+      #   disability['classificationCode'] = classification_code
+      # end
+    end
+
+    update!(form_json: form.to_json)
+    invalidate_form_hash
+  end
+
+  def classify_vagov_contentions(params)
+    vro_client = VirtualRegionalOffice::Client.new
+    response = vro_client.classify_vagov_contentions(params)
+    response.body
+  end
+
   # Submits contention information to the VRO contention classification service
   # adds classification to the form for each contention provided a classification
   def update_contention_classification_all!
-    params = {}
+    params = {
+      # "contentions": disabilities.map do |disability|
+    }
     classifier_response = classify_vagov_contentions(params)
     classifier_response['contentions'].each do |contention|
       contention['contentionText'] = contention['contentionText'].upcase

--- a/config/features.yml
+++ b/config/features.yml
@@ -352,6 +352,10 @@ features:
     actor_type: user
     description: enables sending new 526-ez claims to VRO Contention Classification service for more accurate classification entry.
     enable_in_development: true
+  disability_526_classifier_multi_contention:
+    actor_type: user
+    description: enables submitting multi-contention (in addition to single-contention) 526ez claims to VRO Contention Classification service for more accurate classification entry.
+    enable_in_development: true
   contention_classification_claim_linker:
     actor_type: user
     description: enables sending 526 claim id and vbms submitted claim id to Contention Classification service for linking/monitoring.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1545,6 +1545,7 @@ virtual_regional_office:
   api_key: 9d3868d1-ec15-4889-8002-2bff1b50ba62
   evidence_pdf_path: evidence-pdf
   ctn_classification_path: classifier
+  vagov_classification_path: vagov-claim-classifier
   max_cfi_path: employee-experience/max-ratings
   ep_merge_path: employee-experience-ep-merge-app/merge
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1545,7 +1545,7 @@ virtual_regional_office:
   api_key: 9d3868d1-ec15-4889-8002-2bff1b50ba62
   evidence_pdf_path: evidence-pdf
   ctn_classification_path: classifier
-  vagov_classification_path: vagov-claim-classifier
+  vagov_classification_path: va-gov-claim-classifier
   max_cfi_path: employee-experience/max-ratings
   ep_merge_path: employee-experience-ep-merge-app/merge
 

--- a/lib/virtual_regional_office/client.rb
+++ b/lib/virtual_regional_office/client.rb
@@ -15,6 +15,12 @@ module VirtualRegionalOffice
       end
     end
 
+    def classify_vagov_contentions(params)
+      with_monitoring do
+        perform(:post, Settings.virtual_regional_office.vagov_classification_path, params.to_json.to_s, headers_hash)
+      end
+    end
+
     def get_max_rating_for_diagnostic_codes(diagnostic_codes_array)
       with_monitoring do
         params = { diagnostic_codes: diagnostic_codes_array }

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -187,6 +187,14 @@ FactoryBot.define do
     end
   end
 
+  trait :with_mixed_action_disabilities_and_free_text do
+    form_json do
+      json_string = File.read("#{submissions_path}/only_526_mixed_action_disabilities_and_free_text.json")
+      json = JSON.parse json_string
+      # disabilities = json.dig('form526', 'form526', 'disabilities')
+      json.to_json
+  end
+
   trait :with_pact_related_disabilities do
     form_json do
       json_string = File.read("#{submissions_path}/only_526.json")

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -193,6 +193,7 @@ FactoryBot.define do
       json = JSON.parse json_string
       # disabilities = json.dig('form526', 'form526', 'disabilities')
       json.to_json
+    end
   end
 
   trait :with_pact_related_disabilities do

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -294,7 +294,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
 
       before do
         Flipper.enable(:disability_526_classifier_multi_contention)
-        # allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
       end
 
       after do

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -258,6 +258,31 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       end
     end
 
+    context 'with multi-contention classification enabled' do
+      let(:submission) do
+        create(:form526_submission,
+               :with_multiple_mas_diagnostic_code,
+               user_uuid: user.uuid,
+               auth_headers_json: auth_headers.to_json,
+               saved_claim_id: saved_claim.id)
+      end
+
+      before do
+        Flipper.enable(:disability_526_classifier_multi_contention)
+        # allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
+      end
+
+      after do
+        Flipper.disable(:disability_526_classifier_multi_contention)
+      end
+
+      it 'calls va-gov-claim-classifier' do
+        subject.perform_async(submission.id)
+        expect_any_instance_of(Form526Submission).to receive(:classify_vagov_contentions)
+        described_class.drain
+      end
+    end
+
     context 'with a successful submission job' do
       it 'queues a job for submit' do
         expect do

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -291,6 +291,15 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
                saved_claim_id: saved_claim.id)
       end
 
+      before do
+        Flipper.enable(:disability_526_classifier_multi_contention)
+        # allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
+      end
+
+      after do
+        Flipper.disable(:disability_526_classifier_multi_contention)
+      end
+
       it 'does something when multi-contention api endpoint is hit' do
         VCR.use_cassette('virtual_regional_office/multi_contention_classifier') do
           described_class.drain
@@ -300,18 +309,11 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           plantar_fasciitis_code = 8994
           expected_classification_codes = [asthma_code, plantar_fasciitis_code, nil]
           classification_codes = submission.form['form526']['form526']['disabilities'].pluck('classificationCode')
+          # disabilities = submission.form['form526']['form526']['disabilities']
+          # expect(disabilities).to eq(expected_classification_codes)
           expect(classification_codes).to eq(expected_classification_codes)
         end
         expect(submission.disabilities.first['specialIssues']).to be_nil
-      end
-
-      before do
-        Flipper.enable(:disability_526_classifier_multi_contention)
-        # allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
-      end
-
-      after do
-        Flipper.disable(:disability_526_classifier_multi_contention)
       end
 
       it 'calls va-gov-claim-classifier' do

--- a/spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities_and_free_text.json
+++ b/spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities_and_free_text.json
@@ -1,0 +1,147 @@
+{
+  "form526": {
+    "form526": {
+      "veteran": {
+        "emailAddress": "test@email.com",
+        "alternateEmailAddress": "test2@email.com",
+        "mailingAddress": {
+          "country": "USA",
+          "addressLine1": "1234 Classy Street",
+          "addressLine2": "Apartment 567",
+          "type": "DOMESTIC",
+          "city": "Quaint Town",
+          "state": "OR",
+          "zipFirstFive": "85918",
+          "zipLastFour": "1212"
+        },
+        "forwardingAddress": {
+          "effectiveDate": "2018-03-29",
+          "country": "USA",
+          "addressLine1": "1234 de Buen Tono Calle",
+          "addressLine2": "Apartamento 567",
+          "type": "MILITARY",
+          "militaryPostOfficeTypeCode": "APO",
+          "militaryStateCode": "AA",
+          "zipFirstFive": "12345",
+          "zipLastFour": "6789"
+        },
+        "primaryPhone": {
+          "areaCode": "202",
+          "phoneNumber": "4561111"
+        },
+        "homelessness": {
+          "hasPointOfContact": true,
+          "pointOfContact": {
+            "pointOfContactName": "Ted",
+            "primaryPhone": {
+              "areaCode": "123",
+              "phoneNumber": "4567890"
+            }
+          }
+        },
+        "serviceNumber": "string"
+      },
+      "militaryPayments": {
+        "payments": [],
+        "receiveCompensationInLieuOfRetired": false
+      },
+      "serviceInformation": {
+        "servicePeriods": [
+          {
+            "serviceBranch": "National Oceanic & Atmospheric Administration",
+            "activeDutyBeginDate": "2018-03-29",
+            "activeDutyEndDate": "2018-03-29"
+          }
+        ],
+        "reservesNationalGuardService": {
+          "title10Activation": {
+            "title10ActivationDate": "2018-03-29",
+            "anticipatedSeparationDate": "2018-03-29"
+          },
+          "obligationTermOfServiceFromDate": "2018-03-29",
+          "obligationTermOfServiceToDate": "2018-03-29",
+          "unitName": "string",
+          "inactiveDutyTrainingPay": {
+            "waiveVABenefitsToRetainTrainingPay": false
+          }
+        },
+        "alternateNames": [
+          {
+            "firstName": "string",
+            "middleName": "string",
+            "lastName": "string"
+          }
+        ],
+        "confinements": [
+          {
+            "confinementBeginDate": "2018-03-29",
+            "confinementEndDate": "2018-03-29",
+            "verifiedIndicator": false
+          }
+        ]
+      },
+      "disabilities": [
+        {
+          "name": "Asthma, bronchial",
+          "classificationCode": "string",
+          "disabilityActionType": "INCREASE",
+          "ratedDisabilityId": "1",
+          "diagnosticCode": 6602,
+          "secondaryDisabilities": []
+        },
+        {
+          "name": "Diabetes, mellitus",
+          "classificationCode": "string",
+          "disabilityActionType": "NEW",
+          "ratedDisabilityId": null,
+          "diagnosticCode": 5238,
+          "secondaryDisabilities": []
+        },
+        {
+          "name": "additional free text entry",
+          "classificationCode": "string",
+          "disabilityActionType": "NEW",
+          "ratedDisabilityId": null,
+          "diagnosticCode": 9999,
+          "secondaryDisabilities": []
+        }
+      ],
+      "treatments": [
+        {
+          "center": {
+            "name": "string",
+            "type": "DOD_MTF",
+            "country": "USA",
+            "city": "string",
+            "state": "OR"
+          },
+          "startDate": "2018-03-29",
+          "endDate": "2018-03-29"
+        }
+      ],
+      "specialCircumstances": [
+        {
+          "name": "string",
+          "code": "string",
+          "needed": false
+        }
+      ],
+      "standardClaim": false,
+      "claimantCertification": true,
+      "autoCestPDFGenerationDisabled": false,
+      "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+      "directDeposit": {
+        "accountType": "CHECKING",
+        "accountNumber": "9876543211234",
+        "routingNumber": "042102115",
+        "bankName": "Comerica"
+      }
+    }
+  },
+  "form526_uploads": [],
+  "form4142": null,
+  "form0781": null,
+  "form8940": null,
+  "flashes": []
+}
+

--- a/spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities_and_free_text.json
+++ b/spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities_and_free_text.json
@@ -99,7 +99,7 @@
         },
         {
           "name": "additional free text entry",
-          "classificationCode": "string",
+          "classificationCode": null,
           "disabilityActionType": "NEW",
           "ratedDisabilityId": null,
           "diagnosticCode": 9999,

--- a/spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities_and_free_text.json
+++ b/spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities_and_free_text.json
@@ -90,11 +90,11 @@
           "secondaryDisabilities": []
         },
         {
-          "name": "Diabetes, mellitus",
+          "name": "plantar fasciitis",
           "classificationCode": "string",
           "disabilityActionType": "NEW",
           "ratedDisabilityId": null,
-          "diagnosticCode": 5238,
+          "diagnosticCode": null,
           "secondaryDisabilities": []
         },
         {

--- a/spec/support/vcr_cassettes/virtual_regional_office/multi_contention_classification.yml
+++ b/spec/support/vcr_cassettes/virtual_regional_office/multi_contention_classification.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8120/va-gov-claim-classifier
+    body:
+      encoding: UTF-8
+      string: '{"claim_id":98,"form526_submission_id":53,"contentions":[{"contention_text":"Asthma,
+        bronchial","contention_type":"INCREASE","diagnostic_code":6602},{"contention_text":"plantar
+        fasciitis","contention_type":"NEW"},{"contention_text":"additional free text
+        entry","contention_type":"NEW","diagnostic_code":9999}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      X-Api-Key:
+      - 9d3868d1-ec15-4889-8002-2bff1b50ba62
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 May 2024 23:40:25 GMT
+      Server:
+      - uvicorn
+      Content-Length:
+      - '490'
+      Content-Type:
+      - application/json
+      X-Process-Time:
+      - '0.005565166473388672'
+    body:
+      encoding: UTF-8
+      string: '{"contentions":[{"classification_code":9012,"classification_name":"Respiratory","diagnostic_code":6602,"contention_type":"INCREASE"},{"classification_code":8994,"classification_name":"Musculoskeletal
+        - Foot","diagnostic_code":null,"contention_type":"NEW"},{"classification_code":null,"classification_name":null,"diagnostic_code":9999,"contention_type":"NEW"}],"claim_id":98,"form526_submission_id":53,"is_fully_classified":false,"num_processed_contentions":3,"num_classified_contentions":0}'
+  recorded_at: Fri, 24 May 2024 23:40:25 GMT
+- request:
+    method: post
+    uri: https://viccs-api-test.ibm-intelligent-automation.com/pca/api/test/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&scope=openid&client_id=va_gov_test&client_<DMC_TOKEN>=<LIGHTHOUSE_API_KEY>
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Fri, 24 May 2024 23:40:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '75'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-store
+      X-Xss-Protection:
+      - 1; mode=block
+      Pragma:
+      - no-cache
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - no-referrer
+      Apigw-Requestid:
+      - YTLIqhkLvHMEPPw=
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: UTF-8
+      string: '{"error":"unauthorized_client","error_description":"Invalid client
+        <DMC_TOKEN>"}'
+  recorded_at: Fri, 24 May 2024 23:40:26 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
  - YES
- *(Summarize the changes that have been made to the platform)*
  - This PR adds a conditional for a new feature flag `disability_526_classifier_multi_contention` in the sidekiq job kicked off by the 526-ez form (class for job [here](https://github.com/department-of-veterans-affairs/vets-api/blob/feature-471-conditional-api-request/app/sidekiq/evss/disability_compensation_form/submit_form526.rb#L12))
  - When feature flag is flipped on, vets-api makes an API call to `/va-gov-claim-classifier` in VRO ([defined in settings.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/feature-471-conditional-api-request/config/settings.yml#L1548)) instead of single-contention classifier used currently
- *(If bug, how to reproduce)*
  - n/a
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- Contention Classification team. My team owns the maintenance of the service in VRO.
- *(If introducing a flipper, what is the success criteria being targeted?)*
  - 526 Submission jobs make api calls to new endpoint (linked above).
  - 526 Submission jobs do not make api calls to old endpoint
  - 526 Submission jobs are processed successfully regardless of # of contentions that are classified by service in VRO

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*
- Ticket for capturing these code changes [HERE](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/471).
- Ticket for related code changes in VRO [HERE](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/472).
- Follow-up staging testing ticket [HERE](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/480).

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
- Tests for this are located in `submit_form526_all_claim_spec.rb`
  - to exercise this code, execute the following:
  - ```bundle exec rspec spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb```

## Screenshots
_Note: Optional_
 - n/a
   - example successful request and response in yaml cassette file: [multi_contention_classification.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/feature-471-conditional-api-request/spec/support/vcr_cassettes/virtual_regional_office/multi_contention_classification.yml#L8-L9)

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
  - [x] This is already being monitored in Datadog [HERE](https://vagov.ddog-gov.com/dashboard/tfz-ppf-ie4/benefits---cc-claim-coverage-metrics?refresh_mode=sliding&from_ts=1696594442633&to_ts=1696608842633&live=true)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
  - [ ] n/a

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
