### PR TITLE
81128 Reducing the timeout to 2 minutes

### DIFF
--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -58,7 +58,7 @@ module TravelClaim
     #
     def submit_claim(token:, patient_icn:, appointment_date:)
       connection(server_url: claims_url).post("/#{claims_base_path}/api/ClaimIngest/submitclaim") do |req|
-        req.options.timeout = 180
+        req.options.timeout = 120
         req.headers = claims_default_header.merge('Authorization' => "Bearer #{token}")
         req.body = claims_data.merge({ ClaimantID: patient_icn, Appointment:
           { AppointmentDateTime: appointment_date } }).to_json
@@ -77,7 +77,7 @@ module TravelClaim
       patient_identifier_type = opts.fetch(:patient_identifier_type, 'icn')
 
       connection(server_url: claims_url).post("/#{claims_base_path}/api/ClaimIngest/submitclaim") do |req|
-        req.options.timeout = 180
+        req.options.timeout = 120
         req.headers = claims_default_header.merge('Authorization' => "Bearer #{token}")
         req.body = claims_data.merge({
                                        ClaimantID: opts[:patient_identifier],


### PR DESCRIPTION
## Summary

- *Reducing the BTSSS api call timeout to 2 minutes for Check-in-experience application*

## Related issue(s)

- *https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/gh/department-of-veterans-affairs/va.gov-team/81128*

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
NA

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

