### PR TITLE
83675: Add Sidekiq job to report to DataDog on missing statuses

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1656,6 +1656,10 @@ ivc_forms:
     bucket: "bucket"
     enabled: true
     region: "region"
+  sidekiq:
+    missing_form_status_job:
+      enabled: true
+
 
 coverband:
   github_organization: ~

--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -170,5 +170,8 @@ PERIODIC_JOBS = lambda { |mgr|
 
   # Clean SchemaContact::Validation records every night at midnight
   mgr.register('0 0 * * *', 'SchemaContract::DeleteValidationRecordsJob')
+
+  # Daily 2am job that sends missing Pega statuses to DataDog
+  mgr.register('0 2 * * *', 'IvcChampva::MissingFormStatusJob')
 }
 # rubocop:enable Metrics/BlockLength

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -23,7 +23,7 @@ module IvcChampva
         StatsD.increment('ivc_champva.form_missing_status', tags: ["id: #{form.id}"])
       end
     rescue => e
-      Rails.logger.error "IVC Forms FormStatusJob Error: #{e.message}"
+      Rails.logger.error "IVC Forms MissingFormStatusJob Error: #{e.message}"
       Rails.logger.error e.backtrace.join("\n")
     end
   end

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+# This job grabs all IVC Forms that are missing a status update from the third-party Pega
+# Returns a sends stats to DataDog with the form ids
+module IvcChampva
+  class MissingFormStatusJob
+    include Sidekiq::Job
+
+    def perform
+      return unless Settings.ivc_forms.sidekiq.missing_form_status_job.enabled
+
+      forms = IvcChampvaForm.where(pega_status: nil)
+
+      return unless forms.any?
+
+      # Send the count of forms to DataDog
+      StatsD.gauge('ivc_champva.forms_missing_status.count', forms.count)
+
+      # Send each form UUID to DataDog
+      forms.each do |form|
+        StatsD.increment('ivc_champva.form_missing_status', tags: ["id: #{form.id}"])
+      end
+    rescue => e
+      Rails.logger.error "IVC Forms FormStatusJob Error: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+    end
+  end
+end

--- a/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
+  let!(:forms) { create_list(:ivc_champva_form, 3, pega_status: nil) }
+
+  before do
+    allow(Settings.ivc_forms.sidekiq.missing_form_status_job).to receive(:enabled).and_return(true)
+    allow(StatsD).to receive(:gauge)
+    allow(StatsD).to receive(:increment)
+  end
+
+  it 'sends the count of forms to DataDog' do
+    IvcChampva::MissingFormStatusJob.new.perform
+
+    expect(StatsD).to have_received(:gauge).with('ivc_champva.forms_missing_status.count', forms.count)
+  end
+
+  it 'sends each form UUID to DataDog' do
+    IvcChampva::MissingFormStatusJob.new.perform
+
+    forms.each do |form|
+      expect(StatsD).to have_received(:increment).with('ivc_champva.form_missing_status', tags: ["id:#{form.id}"])
+    end
+  end
+
+  it 'logs an error if an exception occurs' do
+    allow(IvcChampvaForm).to receive(:where).and_raise(StandardError.new('Something went wrong'))
+
+    expect(Rails.logger).to receive(:error).twice
+
+    IvcChampva::MissingFormStatusJob.new.perform
+  end
+end

--- a/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
     IvcChampva::MissingFormStatusJob.new.perform
 
     forms.each do |form|
-      expect(StatsD).to have_received(:increment).with('ivc_champva.form_missing_status', tags: ["id:#{form.id}"])
+      expect(StatsD).to have_received(:increment).with('ivc_champva.form_missing_status', tags: ["id: #{form.id}"])
     end
   end
 


### PR DESCRIPTION
Add a Sidekiq job that pushes data to DataDog that we can review when missing statuses from PEGA

## Summary

- Add new Sidekick job `MissingFormStatusJob`
- Update file to add CRON job to run daily art 2am
- Add tests
- Add settings

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83675

## Testing done

- Rspec 

## Acceptance criteria

Given a file successfully sent to s3

When there is not a successfully callback for the file
- Then then the file's ID is sent to DataDog
- and the file ID in the report can be tied to relevant contact information for the applicant
- and the report is created to a location where it can be reviewed (DataDog)
