### PR TITLE
Update request spec to use new GIBS service endpoint

### DIFF
--- a/spec/controllers/v0/post911_gi_bill_statuses_controller_spec.rb
+++ b/spec/controllers/v0/post911_gi_bill_statuses_controller_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe V0::Post911GIBillStatusesController, type: :controller do
 
       gi_bill_200 = { cassette_name: 'evss/gi_bill_status/gi_bill_status' }
       context 'when EVSS response is 403', vcr: gi_bill_200 do
-        it 'has a response that matches the schema' do
-          get :show
-          expect(response).to have_http_status(:ok)
-          expect(response).to match_response_schema('post911_gi_bill_status', strict: false)
-        end
-
         it 'does not increment the fail counter' do
           expect { get :show }
             .not_to trigger_statsd_increment(described_class::STATSD_GI_BILL_FAIL_KEY)

--- a/spec/requests/post911_gi_bill_status_request_spec.rb
+++ b/spec/requests/post911_gi_bill_status_request_spec.rb
@@ -5,12 +5,13 @@ require 'rails_helper'
 RSpec.describe 'Post 911 GI Bill Status' do
   include SchemaMatchers
 
-  let(:tz) { ActiveSupport::TimeZone.new(EVSS::GiBillStatus::Service::OPERATING_ZONE) }
+  let(:tz) { ActiveSupport::TimeZone.new(BenefitsEducation::Service::OPERATING_ZONE) }
   let(:noon) { tz.parse('1st Feb 2018 12:00:00') }
   let(:midnight) { tz.parse('15th Mar 2018 00:00:00') }
+  let(:user) { create(:user, icn: '1012667145V762142') }
 
   before do
-    sign_in
+    sign_in_as(user)
     allow(Settings.evss).to receive(:mock_gi_bill_status).and_return(false)
   end
 
@@ -19,44 +20,12 @@ RSpec.describe 'Post 911 GI Bill Status' do
 
     after { Timecop.return }
 
-    context 'with a valid evss response' do
-      it 'GET /v0/post911_gi_bill_status returns proper json' do
-        VCR.use_cassette('evss/gi_bill_status/gi_bill_status') do
-          get v0_post911_gi_bill_status_url, params: nil
+    context 'with a 200 response' do
+      it 'GET /v1/post911_gi_bill_status returns proper json' do
+        VCR.use_cassette('lighthouse/benefits_education/gi_bill_status/200_response') do
+          get v1_post911_gi_bill_status_url, params: nil
           expect(response).to match_response_schema('post911_gi_bill_status')
           assert_response :success
-        end
-      end
-    end
-
-    # TODO(AJD): this use case happens, 500 status but unauthorized message
-    # check with evss that they shouldn't be returning 403 instead
-    context 'with an 500 unauthorized response' do
-      it 'returns a forbidden response' do
-        VCR.use_cassette('evss/gi_bill_status/unauthorized') do
-          get v0_post911_gi_bill_status_url, params: nil
-          expect(response).to have_http_status(:forbidden)
-        end
-      end
-    end
-
-    # TODO: - is this a real scenario?
-    context 'with a 403 response' do
-      it 'returns a forbidden response' do
-        VCR.use_cassette('evss/gi_bill_status/gi_bill_status_403') do
-          get v0_post911_gi_bill_status_url, params: nil
-          expect(response).to have_http_status(:forbidden)
-        end
-      end
-    end
-
-    # a 500 and does not contain one of the errors defined in:
-    # https://csraciapp6.evss.srarad.com/wss-education-services-web/swagger-ui/ext-docs/education-error-keys.html
-    context 'with an undefined 500 evss response' do
-      it 'returns internal server error' do
-        VCR.use_cassette('evss/gi_bill_status/gi_bill_status_500') do
-          get v0_post911_gi_bill_status_url, params: nil
-          expect(response).to have_http_status(:internal_server_error)
         end
       end
     end
@@ -68,18 +37,18 @@ RSpec.describe 'Post 911 GI Bill Status' do
     after { Timecop.return }
 
     it 'returns 503' do
-      get v0_post911_gi_bill_status_url, params: nil
+      get v1_post911_gi_bill_status_url, params: nil
       expect(response).to have_http_status(:service_unavailable)
     end
 
     it 'includes a Retry-After header' do
-      get v0_post911_gi_bill_status_url, params: nil
+      get v1_post911_gi_bill_status_url, params: nil
       expect(response.headers).to include('Retry-After')
     end
 
     it 'ignores OutsideWorkingHours exception' do
       expect(Sentry).not_to receive(:capture_message)
-      get v0_post911_gi_bill_status_url, params: nil
+      get v1_post911_gi_bill_status_url, params: nil
     end
   end
 

--- a/spec/support/schemas/amendment.json
+++ b/spec/support/schemas/amendment.json
@@ -1,26 +1,43 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": [ "type" ],
+  "required": [
+    "type"
+  ],
   "additionalProperties": false,
   "properties": {
     "on_campus_hours": {
-      "type": "number"
+      "type": [
+        "number",
+        "null"
+      ]
     },
     "online_hours": {
-      "type": "number"
+      "type": [
+        "number",
+        "null"
+      ]
     },
     "yellow_ribbon_amount": {
       "type": "number"
     },
     "type": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "status": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "change_effective_date": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }

--- a/spec/support/schemas/enrollment.json
+++ b/spec/support/schemas/enrollment.json
@@ -1,7 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": ["begin_date"],
+  "required": [
+    "begin_date"
+  ],
   "additionalProperties": false,
   "properties": {
     "begin_date": {
@@ -17,37 +19,64 @@
       "type": "string"
     },
     "participant_id": {
-      "type": "string"
+      "type": "integer"
     },
     "training_type": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "term_id": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "hour_type": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "full_time_hours": {
       "type": "integer"
     },
     "full_time_credit_hour_under_grad": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "vacation_day_count": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "on_campus_hours": {
-      "type": ["number", "null"]
+      "type": [
+        "number",
+        "null"
+      ]
     },
     "online_hours": {
-      "type": ["number", "null"]
+      "type": [
+        "number",
+        "null"
+      ]
     },
     "yellow_ribbon_amount": {
-      "type": ["number", "null"]
+      "type": [
+        "number",
+        "null"
+      ]
     },
     "status": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "amendments": {
       "type": "array",

--- a/spec/support/schemas/post911_gi_bill_status.json
+++ b/spec/support/schemas/post911_gi_bill_status.json
@@ -1,49 +1,135 @@
 {
-  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": ["data"],
+  "required": [
+    "data"
+  ],
   "properties": {
     "data": {
-      "type": ["object", "null"],
-      "required": ["id", "type", "attributes"],
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
       "properties": {
-        "id": { "type": "string" },
-        "type": { "type": "string"},
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
         "attributes": {
           "type": "object",
-          "required": [ "first_name", "last_name" ],
+          "required": [
+            "first_name",
+            "last_name"
+          ],
           "properties": {
-            "first_name": { "type": ["string", "null"] },
-            "last_name": { "type": ["string", "null"] },
-            "name_suffix": { "type": ["string", "null"] },
-            "date_of_birth": { "type": ["string", "null"] },
-            "va_file_number": { "type": ["string", "null"] },
-            "regional_processing_office": { "type": ["string", "null"] },
-            "eligibility_date": { "type": ["string", "null"] },
-            "delimiting_date": { "type": ["string", "null"] },
-            "percentage_benefit": { "type": ["integer", "null"] },
+            "first_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "last_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name_suffix": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "date_of_birth": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "va_file_number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "regional_processing_office": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "eligibility_date": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "delimiting_date": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "percentage_benefit": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "original_entitlement": {
               "oneOf": [
-                { "type": "null" },
-                { "$ref": "entitlement.json" }
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "entitlement.json"
+                }
               ]
             },
             "used_entitlement": {
               "oneOf": [
-                { "type": "null" },
-                { "$ref": "entitlement.json" }
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "entitlement.json"
+                }
               ]
             },
             "remaining_entitlement": {
               "oneOf": [
-                  { "type": "null" },
-                  { "$ref": "entitlement.json" }
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "entitlement.json"
+                }
               ]
             },
-            "veteran_is_eligible": { "type": ["boolean", "null"] },
-            "active_duty": { "type": ["boolean", "null"] },
+            "veteran_is_eligible": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "active_duty": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "enrollments": {
-              "type": ["array", "null"],
+              "type": [
+                "array",
+                "null"
+              ],
               "items": {
                 "$ref": "enrollment.json"
               }
@@ -51,20 +137,6 @@
           }
         }
       }
-    },
-    "meta": {
-      "properties": {
-        "status": {
-          "description": "EVSS API may return an error message in a 200 response, vets-api catches all errors other than not found as server error",
-          "enum": [
-            "OK",
-            "NOT_AUTHORIZED",
-            "NOT_FOUND",
-            "SERVER_ERROR"
-          ]
-        }
-      },
-      "type": "object"
     }
   }
 }


### PR DESCRIPTION
## Summary

I'm Adam King, a developer working on the VA-IIR team.  We own this component.  This PR is part of a series of cleanup tickets to remove the old `v0/post_911_gi_bill_status` API endpoint.  We moved to `v1/post_911_gi_bill_status` and are now making a call to Lighthouse in order to retrieve education benefit information (previously EVSS).

Because this removal is a significant chunk of work, I'm breaking it apart into smaller PRs, and also discovering updates that should've been made at the time, like this one: testing that the response returns data in an expected way.  There are some small changes in the data contract - some fields are now nullable, some are also integers where previously they were strings.

There is no production code modified in this PR, only tests.

## Related issue(s)

[GitHub Issue 688](https://github.com/department-of-veterans-affairs/va-iir/issues/688) encompasses the work that's needed.  This is one small component of it.

## Testing done

- run the new tests with VCR cassettes recorded by hitting the Lighthouse service instead of EVSS

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).


