### PR TITLE
[DBX-84106] de-intensify 526 backup logging for menial failures

### DIFF
--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -84,8 +84,9 @@ module Sidekiq
         job_status.update(status: Form526JobStatus::STATUS[:success])
         submission.deliver_to_backup!
       rescue => e
-        ::Rails.logger.error(
-          message: "FORM526 BACKUP SUBMISSION FAILURE. Investigate immediately: #{e.message}.",
+        ::Rails.logger.warn(
+          message: "Form 526 backup submission failure. retrying...",
+          error_message: e.message,
           backtrace: e.backtrace,
           submission_id: form526_submission_id
         )

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -85,7 +85,7 @@ module Sidekiq
         submission.deliver_to_backup!
       rescue => e
         ::Rails.logger.warn(
-          message: "Form 526 backup submission failure. retrying...",
+          message: 'Form 526 backup submission failure. retrying...',
           error_message: e.message,
           backtrace: e.backtrace,
           submission_id: form526_submission_id


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- We are simply making an existing error message less alarmist for future generations. This 'failure' is actually just the start of a retry. There are more salient messages and processes in place for capturing real backup failures.

## Related issue(s)

- [ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/84106)

## Testing done

- The class has been instantiated and the method run locally to ensure syntax and logger output

## What areas of the site does it impact?
- Form526 Backup path submission

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- ~~[ ]  Documentation has been updated (link to documentation)~~ N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- ~~[ ]  I added a screenshot of the developed feature~~ N/A