### PR TITLE
updated url to match API updates

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -22,12 +22,9 @@
       :file_path: "/travel_pay/btsss_token/default"
       :response_delay: 0.3
     - :method: :get
-      :path: "/veis/api/btsss/travelclaim/api/v1/claims/by-contact/*"
-      :file_path: "/travel_pay/claims"
+      :path: "/veis/api/btsss/travelclaim/api/v1/claims"
+      :file_path: "/travel_pay/claims/default"
       :response_delay: 0.3
-      :cache_multiple_responses:
-        :uid_location: url
-        :uid_locator: '\/by-contact\/(.+)'
     - :method: :post
       :path: <%= "/#{Settings.ask_va_api.crm_api.veis_api_path}/inquiries/new" %>
       :file_path: "/ask_va/crm_api/post_inquiries/default"


### PR DESCRIPTION
Quick update to betamocks url that matches changed claims endpoint.

Closes department-of-veterans-affairs/va.gov-team#84113