### PR TITLE
Rack attack limits similar to v1 for v2 facilities_api

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -21,11 +21,25 @@ class Rack::Attack
     req.remote_ip if req.path == '/facilities_api/v1/va'
   end
 
+  # Rate-limit facilities_va/v2/va lookup -- part of locator.
+  # See https://dsva.slack.com/archives/C0FQSS30V/p1695046907329529
+  # No systemic failure, but potential "DoS" caused a spike in traffic from one IP.
+  throttle('facilities_va/ip', limit: 30, period: 1.minute) do |req|
+    req.remote_ip if req.path == '/facilities_api/v2/va'
+  end
+
   # Rate-limit PPMS lookup, in order to bore abusers.
   # See https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Postmortems/2021-08-16-facility-locator-possible-DOS.md
   # for details.
   throttle('facility_locator/ip', limit: 8, period: 1.minute) do |req|
     req.remote_ip if req.path == '/facilities_api/v1/ccp/provider'
+  end
+
+  # Rate-limit PPMS lookup, in order to bore abusers.
+  # See https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Postmortems/2021-08-16-facility-locator-possible-DOS.md
+  # for details.
+  throttle('facility_locator/ip', limit: 8, period: 1.minute) do |req|
+    req.remote_ip if req.path == '/facilities_api/v2/ccp/provider'
   end
 
   throttle('vic_profile_photos_download/ip', limit: 8, period: 5.minutes) do |req|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,14 +17,14 @@ class Rack::Attack
   # Rate-limit facilities_va lookup -- part of locator.
   # See https://dsva.slack.com/archives/C0FQSS30V/p1695046907329529
   # No systemic failure, but potential "DoS" caused a spike in traffic from one IP.
-  throttle('facilities_va/ip', limit: 30, period: 1.minute) do |req|
+  throttle('facilities_api/v1/va/ip', limit: 30, period: 1.minute) do |req|
     req.remote_ip if req.path == '/facilities_api/v1/va'
   end
 
   # Rate-limit facilities_va/v2/va lookup -- part of locator.
   # See https://dsva.slack.com/archives/C0FQSS30V/p1695046907329529
   # No systemic failure, but potential "DoS" caused a spike in traffic from one IP.
-  throttle('facilities_va/ip', limit: 30, period: 1.minute) do |req|
+  throttle('facilities_api/v2/va/ip', limit: 30, period: 1.minute) do |req|
     req.remote_ip if req.path == '/facilities_api/v2/va'
   end
 
@@ -38,7 +38,7 @@ class Rack::Attack
   # Rate-limit PPMS lookup, in order to bore abusers.
   # See https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Postmortems/2021-08-16-facility-locator-possible-DOS.md
   # for details.
-  throttle('facility_locator/ip', limit: 8, period: 1.minute) do |req|
+  throttle('facilities_api/v2/ccp/ip', limit: 8, period: 1.minute) do |req|
     req.remote_ip if req.path == '/facilities_api/v2/ccp/provider'
   end
 

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Rack::Attack do
         expect(last_response.status).not_to eq(429)
       end
 
-      get endpoint, nil, other_headers
+      post endpoint, nil, other_headers
     end
 
     context 'response status for repeated requests from the same IP' do

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -151,14 +151,14 @@ RSpec.describe Rack::Attack do
     end
   end
 
-  describe 'facilities_api/v2/ip' do
+  describe 'facilities_api/v2/va/ip' do
     let(:endpoint) { '/facilities_api/v2/va' }
     let(:headers) { { 'X-Real-Ip' => '1.2.3.4' } }
     let(:limit) { 30 }
 
     before do
       limit.times do
-        get endpoint, nil, headers
+        post endpoint, nil, headers
         expect(last_response.status).not_to eq(429)
       end
 

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -120,8 +120,39 @@ RSpec.describe Rack::Attack do
     end
   end
 
-  describe 'facilities_va/ip' do
+  describe 'facilities_api/v1/ip' do
     let(:endpoint) { '/facilities_api/v1/va' }
+    let(:headers) { { 'X-Real-Ip' => '1.2.3.4' } }
+    let(:limit) { 30 }
+
+    before do
+      limit.times do
+        get endpoint, nil, headers
+        expect(last_response.status).not_to eq(429)
+      end
+
+      get endpoint, nil, other_headers
+    end
+
+    context 'response status for repeated requests from the same IP' do
+      let(:other_headers) { headers }
+
+      it 'limits requests' do
+        expect(last_response.status).to eq(429)
+      end
+    end
+
+    context 'response status for request from different IP' do
+      let(:other_headers) { { 'X-Real-Ip' => '4.3.2.1' } }
+
+      it 'does not limit request' do
+        expect(last_response.status).not_to eq(429)
+      end
+    end
+  end
+
+  describe 'facilities_api/v2/ip' do
+    let(:endpoint) { '/facilities_api/v2/va' }
     let(:headers) { { 'X-Real-Ip' => '1.2.3.4' } }
     let(:limit) { 30 }
 
@@ -153,6 +184,37 @@ RSpec.describe Rack::Attack do
 
   describe 'facility_locator/ip' do
     let(:endpoint) { '/facilities_api/v1/ccp/provider' }
+    let(:headers) { { 'X-Real-Ip' => '1.2.3.4' } }
+    let(:limit) { 8 }
+
+    before do
+      limit.times do
+        get endpoint, nil, headers
+        expect(last_response.status).not_to eq(429)
+      end
+
+      get endpoint, nil, other_headers
+    end
+
+    context 'response status for repeated requests from the same IP' do
+      let(:other_headers) { headers }
+
+      it 'limits requests' do
+        expect(last_response.status).to eq(429)
+      end
+    end
+
+    context 'response status for request from different IP' do
+      let(:other_headers) { { 'X-Real-Ip' => '4.3.2.1' } }
+
+      it 'limits requests' do
+        expect(last_response.status).not_to eq(429)
+      end
+    end
+  end
+
+  describe 'facilities_api/v2/ccp/ip' do
+    let(:endpoint) { '/facilities_api/v2/ccp' }
     let(:headers) { { 'X-Real-Ip' => '1.2.3.4' } }
     let(:limit) { 8 }
 

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Rack::Attack do
   end
 
   describe 'facilities_api/v2/ccp/ip' do
-    let(:endpoint) { '/facilities_api/v2/ccp' }
+    let(:endpoint) { '/facilities_api/v2/ccp/provider' }
     let(:headers) { { 'X-Real-Ip' => '1.2.3.4' } }
     let(:limit) { 8 }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)* Adds rack attack limit configuration for v2 facilities_api controller routes
- *(What is the solution, why is this the solution?)* Some of the excess requests would hopefully have been rejected from recent 403 crisis that overwhelmed Sentry
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18237

## Testing done

- [x] *New code is covered by unit tests*
- Could reach high levels of requests/IP/second
- Run vets-api locally, curl a post to http://localhost:3000/facilities_api/v2/va 30 times within a minute and then try 1 more request.

## What areas of the site does it impact?
Affects the `/facilities_api/v2/va` and `/facilities_api/v2/ccp` routes

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Test locally on route /facilities_api/v2/va 31 times in 1 minute