### PR TITLE
Adds claim notes to schema, pdf mapper, and pdf mapper spec.

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -2424,6 +2424,11 @@
                               "description": "Claimant certifies and authorizes release of information.",
                               "default": false
                             },
+                            "claimNotes": {
+                              "type": "string",
+                              "description": "An optional notes section.",
+                              "maxLength": 4000
+                            },
                             "claimId": {
                               "type": "string",
                               "example": "600517517"
@@ -3724,6 +3729,11 @@
                             "type": "boolean",
                             "description": "Claimant certifies and authorizes release of information.",
                             "default": false
+                          },
+                          "claimNotes": {
+                            "type": "string",
+                            "description": "An optional notes section.",
+                            "maxLength": 4000
                           }
                         }
                       }
@@ -4243,7 +4253,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "bc1d7188-ab00-44f1-b750-deca551305ff",
+                    "id": "8ed58c63-2737-4fbf-a1bb-8b5d79286e0f",
                     "type": "forms/526",
                     "attributes": {
                       "claimId": "600442191",
@@ -4425,7 +4435,7 @@
                         },
                         "federalActivation": {
                           "activationDate": "2023-10-01",
-                          "anticipatedSeparationDate": "2024-05-26"
+                          "anticipatedSeparationDate": "2024-06-01"
                         },
                         "confinements": [
                           {
@@ -5603,6 +5613,11 @@
                               "description": "Claimant certifies and authorizes release of information.",
                               "default": false
                             },
+                            "claimNotes": {
+                              "type": "string",
+                              "description": "An optional notes section.",
+                              "maxLength": 4000
+                            },
                             "claimId": {
                               "type": "string",
                               "example": "600517517"
@@ -6903,6 +6918,11 @@
                             "type": "boolean",
                             "description": "Claimant certifies and authorizes release of information.",
                             "default": false
+                          },
+                          "claimNotes": {
+                            "type": "string",
+                            "description": "An optional notes section.",
+                            "maxLength": 4000
                           }
                         }
                       }
@@ -8745,6 +8765,11 @@
                             "type": "boolean",
                             "description": "Claimant certifies and authorizes release of information.",
                             "default": false
+                          },
+                          "claimNotes": {
+                            "type": "string",
+                            "description": "An optional notes section.",
+                            "maxLength": 4000
                           }
                         }
                       }
@@ -9014,7 +9039,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "5930ed85-bbe6-41cb-85f7-1f05232d7d62",
+                    "id": "3e0b168e-e2a1-4ae6-ae82-bcf127adb44b",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -10653,6 +10678,20 @@
                                   "default": false,
                                   "nullable": true
                                 },
+                                "specialIssues": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "uniqueItems": true,
+                                  "items": {
+                                    "maxItems": 2,
+                                    "additionalProperties": false,
+                                    "type": "string",
+                                    "enum": [
+                                      "POW",
+                                      "EMP"
+                                    ]
+                                  }
+                                },
                                 "secondaryDisabilities": {
                                   "description": "If secondaryDisability is included, the following attributes are required: 'secondaryDisability.name', 'secondaryDisability.disabilityActionType' and 'secondaryDisability.serviceRelevance'",
                                   "type": "array",
@@ -11830,8 +11869,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-05-24",
-                      "expirationDate": "2025-05-24",
+                      "creationDate": "2024-05-30",
+                      "expirationDate": "2025-05-30",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -12710,7 +12749,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "aa8c9ccb-358a-4d09-8daf-680f3ca74ad7",
+                    "id": "ffd59642-3899-46ad-801f-66cdc1668bb5",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -13406,7 +13445,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "d6c2cdcd-35b0-4b70-8257-bd4474e1808b",
+                    "id": "7d3c0b35-73c1-4563-9860-43a2485ea0bb",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -15366,11 +15405,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "025ca847-79de-4bc8-815e-4ceda70d7ef1",
+                    "id": "012dfe7d-662e-47ea-a0b0-f36927838872",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "status": "submitted",
-                      "dateRequestAccepted": "2024-05-24",
+                      "dateRequestAccepted": "2024-05-30",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -1044,6 +1044,11 @@
       "type": "boolean",
       "description": "Claimant certifies and authorizes release of information.",
       "default": false
+    },
+    "claimNotes": {
+      "type": "string",
+      "description": "An optional notes section.",
+      "maxLength": 4000
     }
   }
 }

--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -56,8 +56,15 @@ module ClaimsApi
         @pdf_data[:data][:attributes].delete(:claimantCertification)
         claim_date_and_signature
         claim_process_type
+        claim_notes
 
         @pdf_data
+      end
+
+      def claim_notes
+        if @auto_claim&.dig('claimNotes').present?
+          @pdf_data[:data][:attributes][:claimNotes] = @auto_claim&.dig('claimNotes')
+        end
       end
 
       def claim_process_type

--- a/modules/claims_api/spec/fixtures/v2/veterans/disability_compensation/form_526_json_api.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/disability_compensation/form_526_json_api.json
@@ -3,6 +3,7 @@
     "type": "form/526",
     "attributes": {
       "claimProcessType": "STANDARD_CLAIM_PROCESS",
+      "claimNotes": "Some things that are important to know, and are not included in any other place.",
       "veteranIdentification": {
         "serviceNumber": "123456789",
         "veteranNumber": {

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -48,8 +48,10 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         mapper.map_claim
 
         claim_process_type = pdf_data[:data][:attributes][:claimProcessType]
+        claim_notes = pdf_data[:data][:attributes][:claimNotes]
 
         expect(claim_process_type).to eq('STANDARD_CLAIM_PROCESS')
+        expect(claim_notes).to eq('Some things that are important to know, and are not included in any other place.')
       end
 
       describe 'when the claimProcessType is BDD_PROGRAM' do


### PR DESCRIPTION
## Summary

- Adds claim notes to schema, 
- pdf mapper, and 
- pdf mapper spec.

## Related issue(s)

- [API-36481](https://jira.devops.va.gov/browse/API-36481)

## Testing done

- [X] *New code is covered by unit tests*
- Postman: 526 sync & async
- local swagger ui


## Screenshots
![Screenshot 2024-05-30 at 2 42 19 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/25069483/869ca61a-25b4-4fa7-b605-a4b639bde9c6)
![Screenshot 2024-05-30 at 1 56 07 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/25069483/bae23d54-41b3-4a9a-b7f7-1934f6ba989f)

## What areas of the site does it impact?
	modified:   modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
	modified:   modules/claims_api/config/schemas/v2/526.json
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/fixtures/v2/veterans/disability_compensation/form_526_json_api.json
	modified:   modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb



## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature