### PR TITLE
[84308] Preventing Sign Up Service Terms of Use calls when user does not have a sec id

### DIFF
--- a/app/controllers/v0/terms_of_use_agreements_controller.rb
+++ b/app/controllers/v0/terms_of_use_agreements_controller.rb
@@ -57,29 +57,15 @@ module V0
     private
 
     def acceptor(sync: false)
-      TermsOfUse::Acceptor.new(
-        user_account: @user_account,
-        common_name:,
-        version: params[:version],
-        sync:
-      )
+      TermsOfUse::Acceptor.new(user_account: @user_account, version: params[:version], sync:)
     end
 
     def decliner
-      TermsOfUse::Decliner.new(
-        user_account: @user_account,
-        common_name:,
-        version: params[:version]
-      )
+      TermsOfUse::Decliner.new(user_account: @user_account, version: params[:version])
     end
 
     def provisioner
-      TermsOfUse::Provisioner.new(
-        icn: @user_account.icn,
-        first_name: mpi_profile.given_names.first,
-        last_name: mpi_profile.family_name,
-        mpi_gcids: mpi_profile.full_mvi_ids
-      )
+      TermsOfUse::Provisioner.new(icn: @user_account.icn)
     end
 
     def recache_user
@@ -129,10 +115,6 @@ module V0
     def mpi_profile
       @mpi_profile ||= MPI::Service.new.find_profile_by_identifier(identifier: @user_account.icn,
                                                                    identifier_type: MPI::Constants::ICN)&.profile
-    end
-
-    def common_name
-      "#{mpi_profile.given_names.first} #{mpi_profile.family_name}"
     end
 
     def render_success(action:, body:, status: :ok)

--- a/spec/services/terms_of_use/acceptor_spec.rb
+++ b/spec/services/terms_of_use/acceptor_spec.rb
@@ -4,12 +4,11 @@ require 'rails_helper'
 
 RSpec.describe TermsOfUse::Acceptor, type: :service do
   describe '#perform!' do
-    subject(:acceptor) { described_class.new(user_account:, common_name:, version:) }
+    subject(:acceptor) { described_class.new(user_account:, version:) }
 
     let(:user_account) { create(:user_account, icn:) }
     let(:icn) { '123456789' }
     let(:version) { 'v1' }
-    let(:common_name) { 'some-common-name' }
 
     describe 'validations' do
       context 'when all attributes are present' do
@@ -34,16 +33,6 @@ RSpec.describe TermsOfUse::Acceptor, type: :service do
           it 'is not valid' do
             expect { acceptor }.to raise_error(TermsOfUse::Errors::AcceptorError).with_message(expected_error_message)
             expect(Rails.logger).to have_received(:error).with(expected_log, { user_account_id: nil })
-          end
-        end
-
-        context 'when common_name is missing' do
-          let(:common_name) { nil }
-          let(:expected_error_message) { 'Validation failed: Common name can\'t be blank' }
-
-          it 'is not valid' do
-            expect { acceptor }.to raise_error(TermsOfUse::Errors::AcceptorError).with_message(expected_error_message)
-            expect(Rails.logger).to have_received(:error).with(expected_log, { user_account_id: user_account.id })
           end
         end
 
@@ -72,12 +61,16 @@ RSpec.describe TermsOfUse::Acceptor, type: :service do
     describe '#perform!' do
       let(:expected_attr_key) { SecureRandom.hex(32) }
       let(:sign_up_service_updater_job) { TermsOfUse::SignUpServiceUpdaterJob.set(sync:) }
+      let(:find_profile_response) { create(:find_profile_response, profile: mpi_profile) }
+      let(:mpi_profile) { build(:mpi_profile, icn:, sec_id:) }
+      let(:sec_id) { 'some-sec-id' }
 
       before do
         allow(SecureRandom).to receive(:hex).and_return(expected_attr_key)
         allow(Rails.logger).to receive(:info)
         allow(TermsOfUse::SignUpServiceUpdaterJob).to receive(:set).and_return(sign_up_service_updater_job)
         allow(sign_up_service_updater_job).to receive(:perform_async)
+        allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(find_profile_response)
       end
 
       context 'when sync is false' do
@@ -92,28 +85,72 @@ RSpec.describe TermsOfUse::Acceptor, type: :service do
           expect(acceptor.perform!).to be_accepted
         end
 
-        it 'enqueues the SignUpServiceUpdaterJob with expected parameters' do
-          acceptor.perform!
-          expect(TermsOfUse::SignUpServiceUpdaterJob).to have_received(:set).with(sync: false)
-          expect(sign_up_service_updater_job).to have_received(:perform_async).with(expected_attr_key)
+        context 'and sec_id exists for the user' do
+          let(:sec_id) { 'some-sec-id' }
+
+          it 'enqueues the SignUpServiceUpdaterJob with expected parameters' do
+            acceptor.perform!
+            expect(TermsOfUse::SignUpServiceUpdaterJob).to have_received(:set).with(sync: false)
+            expect(sign_up_service_updater_job).to have_received(:perform_async).with(expected_attr_key)
+          end
+
+          it 'logs the attr_package key' do
+            acceptor.perform!
+            expect(Rails.logger).to have_received(:info).with('[TermsOfUse] [Acceptor] attr_package key',
+                                                              { icn:, attr_package_key: expected_attr_key })
+          end
         end
 
-        it 'logs the attr_package key' do
-          acceptor.perform!
-          expect(Rails.logger).to have_received(:info).with('[TermsOfUse] [Acceptor] attr_package key',
-                                                            { icn:, attr_package_key: expected_attr_key })
+        context 'and sec_id does not exist for the user' do
+          let(:sec_id) { nil }
+          let(:expected_log) { '[TermsOfUse] [Acceptor] Sign Up Service not updated due to user missing sec_id' }
+
+          it 'does not enqueue the SignUpServiceUpdaterJob' do
+            acceptor.perform!
+            expect(TermsOfUse::SignUpServiceUpdaterJob).not_to have_received(:set)
+          end
+
+          it 'logs a sign up service not updated message' do
+            acceptor.perform!
+            expect(Rails.logger).to have_received(:info).with(expected_log, { icn: })
+          end
         end
       end
 
       context 'when sync is true' do
-        subject(:acceptor) { described_class.new(user_account:, common_name:, version:, sync: true) }
+        subject(:acceptor) { described_class.new(user_account:, version:, sync: true) }
 
         let(:sync) { true }
 
-        it 'calls the SignUpServiceUpdaterJob with expected parameters' do
-          acceptor.perform!
-          expect(TermsOfUse::SignUpServiceUpdaterJob).to have_received(:set).with(sync: true)
-          expect(sign_up_service_updater_job).to have_received(:perform_async).with(expected_attr_key)
+        context 'and sec_id exists for the user' do
+          let(:sec_id) { 'some-sec-id' }
+
+          it 'calls the SignUpServiceUpdaterJob with expected parameters' do
+            acceptor.perform!
+            expect(TermsOfUse::SignUpServiceUpdaterJob).to have_received(:set).with(sync: true)
+            expect(sign_up_service_updater_job).to have_received(:perform_async).with(expected_attr_key)
+          end
+
+          it 'logs the attr_package key' do
+            acceptor.perform!
+            expect(Rails.logger).to have_received(:info).with('[TermsOfUse] [Acceptor] attr_package key',
+                                                              { icn:, attr_package_key: expected_attr_key })
+          end
+        end
+
+        context 'and sec_id does not exist for the user' do
+          let(:sec_id) { nil }
+          let(:expected_log) { '[TermsOfUse] [Acceptor] Sign Up Service not updated due to user missing sec_id' }
+
+          it 'does not enqueue the SignUpServiceUpdaterJob' do
+            acceptor.perform!
+            expect(TermsOfUse::SignUpServiceUpdaterJob).not_to have_received(:set)
+          end
+
+          it 'logs a sign up service not updated message' do
+            acceptor.perform!
+            expect(Rails.logger).to have_received(:info).with(expected_log, { icn: })
+          end
         end
 
         it 'creates a new terms of use agreement with the given version' do
@@ -123,12 +160,6 @@ RSpec.describe TermsOfUse::Acceptor, type: :service do
 
         it 'marks the terms of use agreement as accepted' do
           expect(acceptor.perform!).to be_accepted
-        end
-
-        it 'logs the attr_package key' do
-          acceptor.perform!
-          expect(Rails.logger).to have_received(:info).with('[TermsOfUse] [Acceptor] attr_package key',
-                                                            { icn:, attr_package_key: expected_attr_key })
         end
 
         context 'when the SignUpServiceUpdaterJob raises an error' do

--- a/spec/services/terms_of_use/decliner_spec.rb
+++ b/spec/services/terms_of_use/decliner_spec.rb
@@ -4,12 +4,11 @@ require 'rails_helper'
 
 RSpec.describe TermsOfUse::Decliner, type: :service do
   describe '#perform!' do
-    subject(:decliner) { described_class.new(user_account:, common_name:, version:) }
+    subject(:decliner) { described_class.new(user_account:, version:) }
 
     let(:user_account) { create(:user_account, icn:) }
     let(:icn) { '123456789' }
     let(:version) { 'v1' }
-    let(:common_name) { 'some-common-name' }
 
     describe 'validations' do
       context 'when all attributes are present' do
@@ -37,16 +36,6 @@ RSpec.describe TermsOfUse::Decliner, type: :service do
           end
         end
 
-        context 'when common_name is missing' do
-          let(:common_name) { nil }
-          let(:expected_error_message) { 'Validation failed: Common name can\'t be blank' }
-
-          it 'is not valid' do
-            expect { decliner }.to raise_error(TermsOfUse::Errors::DeclinerError).with_message(expected_error_message)
-            expect(Rails.logger).to have_received(:error).with(expected_log, { user_account_id: user_account.id })
-          end
-        end
-
         context 'when version is missing' do
           let(:version) { nil }
           let(:expected_error_message) { 'Validation failed: Version can\'t be blank' }
@@ -71,11 +60,15 @@ RSpec.describe TermsOfUse::Decliner, type: :service do
 
     describe '#perform!' do
       let(:expected_attr_key) { SecureRandom.hex(32) }
+      let(:find_profile_response) { create(:find_profile_response, profile: mpi_profile) }
+      let(:mpi_profile) { build(:mpi_profile, icn:, sec_id:) }
+      let(:sec_id) { 'some-sec-id' }
 
       before do
         allow(TermsOfUse::SignUpServiceUpdaterJob).to receive(:perform_async)
         allow(SecureRandom).to receive(:hex).and_return(expected_attr_key)
         allow(Rails.logger).to receive(:info)
+        allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(find_profile_response)
       end
 
       it 'creates a new terms of use agreement with the given version' do
@@ -87,15 +80,34 @@ RSpec.describe TermsOfUse::Decliner, type: :service do
         expect(decliner.perform!).to be_declined
       end
 
-      it 'enqueues the SignUpServiceUpdaterJob with expected parameters' do
-        decliner.perform!
-        expect(TermsOfUse::SignUpServiceUpdaterJob).to have_received(:perform_async).with(expected_attr_key)
+      context 'and sec_id exists for the user' do
+        let(:sec_id) { 'some-sec-id' }
+
+        it 'enqueues the SignUpServiceUpdaterJob with expected parameters' do
+          decliner.perform!
+          expect(TermsOfUse::SignUpServiceUpdaterJob).to have_received(:perform_async).with(expected_attr_key)
+        end
+
+        it 'logs the attr_package key' do
+          decliner.perform!
+          expect(Rails.logger).to have_received(:info).with('[TermsOfUse] [Decliner] attr_package key',
+                                                            { icn:, attr_package_key: expected_attr_key })
+        end
       end
 
-      it 'logs the attr_package key' do
-        decliner.perform!
-        expect(Rails.logger).to have_received(:info).with('[TermsOfUse] [Decliner] attr_package key',
-                                                          { icn:, attr_package_key: expected_attr_key })
+      context 'and sec_id does not exist for the user' do
+        let(:sec_id) { nil }
+        let(:expected_log) { '[TermsOfUse] [Decliner] Sign Up Service not updated due to user missing sec_id' }
+
+        it 'does not enqueue the SignUpServiceUpdaterJob' do
+          decliner.perform!
+          expect(TermsOfUse::SignUpServiceUpdaterJob).not_to have_received(:perform_async)
+        end
+
+        it 'logs a sign up service not updated message' do
+          decliner.perform!
+          expect(Rails.logger).to have_received(:info).with(expected_log, { icn: })
+        end
       end
     end
   end

--- a/spec/services/terms_of_use/provisioner_spec.rb
+++ b/spec/services/terms_of_use/provisioner_spec.rb
@@ -3,19 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe TermsOfUse::Provisioner do
-  subject(:provisioner) { described_class.new(icn:, first_name:, last_name:, mpi_gcids:) }
+  subject(:provisioner) { described_class.new(icn:) }
 
   let(:icn) { '123456789' }
   let(:first_name) { 'John' }
   let(:last_name) { 'Doe' }
-  let(:mpi_gcids) do
-    ['1012667145V762142^NI^200M^USVHA^P',
-     '1005490754^NI^200DOD^USDOD^A',
-     '600043201^PI^200CORP^USVBA^A',
-     '123456^PI^200ESR^USVHA^A',
-     '123456^PI^648^USVHA^A',
-     '123456^PI^200BRLS^USVBA^A']
-  end
 
   describe 'validations' do
     context 'when all attributes are present' do
@@ -32,40 +24,21 @@ RSpec.describe TermsOfUse::Provisioner do
           .with_message('Validation failed: Icn can\'t be blank')
       end
     end
-
-    context 'when first_name is missing' do
-      let(:first_name) { nil }
-
-      it 'is not valid' do
-        expect { provisioner }.to raise_error(TermsOfUse::Errors::ProvisionerError)
-          .with_message('Validation failed: First name can\'t be blank')
-      end
-    end
-
-    context 'when last_name is missing' do
-      let(:last_name) { nil }
-
-      it 'is not valid' do
-        expect { provisioner }.to raise_error(TermsOfUse::Errors::ProvisionerError)
-          .with_message('Validation failed: Last name can\'t be blank')
-      end
-    end
-
-    context 'when mpi_gcids is missing' do
-      let(:mpi_gcids) { nil }
-
-      it 'is not valid' do
-        expect { provisioner }.to raise_error(TermsOfUse::Errors::ProvisionerError)
-          .with_message('Validation failed: MPI gcids can\'t be blank')
-      end
-    end
   end
 
   describe '#perform' do
     let(:service) { instance_double(MAP::SignUp::Service) }
+    let(:find_profile_response) { create(:find_profile_response, profile: mpi_profile) }
+    let(:mpi_profile) do
+      build(:mpi_profile,
+            icn:,
+            given_names: [first_name],
+            family_name: last_name)
+    end
 
     before do
       allow(MAP::SignUp::Service).to receive(:new).and_return(service)
+      allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(find_profile_response)
     end
 
     context 'when agreement is signed' do


### PR DESCRIPTION
## Summary

- This PR prevents Terms of Use Accept/Decline calls from being propagated to the Sign Up Service when a user does not have a sec id. It will instead log that the Sign up Service is not being called and accept the terms for VA.gov, still allowing the user to log in

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84308

## Testing done

- Authenticated with a normal verified user and confirmed SignUpServiceUpdaterJob was attempted
- Authenticated with a verified user with no sec_id and confirmed SignUpServiceUpdaterJob was not attempted, and log that states the job will not be called was logged

## What areas of the site does it impact?
Terms of Use
Authentication

## Acceptance criteria

- [ ]  Authenticate with a verified user that does not have a sec id (which has not previously accepted terms of use)
- [ ]  Accept terms and confirm the following log:  '[TermsOfUse] [Acceptor] Sign Up Service not updated due to user missing sec_id'
- [ ] Confirm no calls to the SignUpServiceUpdaterJob were attempted
- [ ] Authenticate with a verified user that does have a sec id
- [ ] Confirm a calla to the SignUpServiceUpdaterJob was attempted

