### PR TITLE
Removed extra FACILITY_ERROR_MSG

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -16,7 +16,6 @@ module VAOS
       AVS_ERROR_MESSAGE = 'Error retrieving AVS link'
       AVS_APPT_TEST_ID = '192308'
       MANILA_PHILIPPINES_FACILITY_ID = '358'
-      FACILITY_ERROR_MSG = 'Error fetching facility details'
 
       AVS_FLIPPER = :va_online_scheduling_after_visit_summary
       ORACLE_HEALTH_CANCELLATIONS = :va_online_scheduling_enable_OH_cancellations


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Saw this message in the rails console: `/app/modules/vaos/app/services/vaos/v2/appointments_service.rb:19: warning: already initialized constant VAOS::V2::AppointmentsService::FACILITY_ERROR_MSG /app/modules/vaos/app/services/vaos/v2/appointments_service.rb:15: warning: previous definition of FACILITY_ERROR_MSG was here`.

2 weeks ago, the FACILITY_ERROR_MSG was added when already defined on line 15.