### PR TITLE
API-36890-remove-phone-dash

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -652,7 +652,8 @@ module ClaimsApi
 
           area_code = reserves&.dig(:unitPhone, :areaCode)
           phone_number = reserves&.dig(:unitPhone, :phoneNumber)
-          reserves[:unitPhoneNumber] = convert_phone(area_code + phone_number) if area_code && phone_number
+          phone_number&.delete! '-'
+          reserves[:unitPhoneNumber] = (area_code + phone_number) if area_code && phone_number
           reserves.delete(:unitPhone)
 
           reserves[:receivingInactiveDutyTrainingPay] = handle_yes_no(reserves[:receivingInactiveDutyTrainingPay])

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -613,7 +613,7 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(obl_end).to eq({ month: '06', day: '04', year: '2020' })
         expect(unit_name).to eq('National Guard Unit Name')
         expect(unit_address).to eq('1243 pine court')
-        expect(unit_phone).to eq('555-555-5555')
+        expect(unit_phone).to eq('5555555555')
         expect(act_duty_pay).to eq('YES')
         expect(other_name).to eq('YES')
         expect(alt_names).to eq(['john jacob', 'johnny smith'])
@@ -630,6 +630,17 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
 
         actual = pdf_data[:data][:attributes][:serviceInformation][:reservesNationalGuardService][:unitPhoneNumber]
         expect(actual).to eq(nil)
+      end
+
+      it 'maps service info correctly when a phone number has a dash' do
+        form_attributes['serviceInformation']['reservesNationalGuardService']['unitPhone']['areaCode'] = '303'
+        arr = form_attributes['serviceInformation']['reservesNationalGuardService']['unitPhone']['phoneNumber'].chars
+        arr.insert(3, '-')
+        form_attributes['serviceInformation']['reservesNationalGuardService']['unitPhone']['phoneNumber'] = arr.join
+        mapper.map_claim
+
+        actual = pdf_data[:data][:attributes][:serviceInformation][:reservesNationalGuardService][:unitPhoneNumber]
+        expect(actual).to eq('3035555555')
       end
 
       it 'maps servedInReservesOrNationalGuard info correctly with a nil' do


### PR DESCRIPTION
## Summary

- Removes dashes from reserves phone number, and 
- adds a test to the mapper spec

## Related issue(s)

- [API-36890](https://jira.devops.va.gov/browse/API-36890)

## Testing done

- [X] *New code is covered by unit tests*
- Postman (add a dash tot he reserves phone number


## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature