### PR TITLE
Add Unit Tests for MebApi AMS Serializers - Part 1

### DIFF
--- a/modules/meb_api/spec/serializers/automation_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/automation_serializer_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dgi/automation/claimant_response'
+
+describe AutomationSerializer do
+
+  let(:claimant) do
+    {
+      'claimant_id': 600_010_259,
+      'suffix': '',
+      'date_of_birth': '1990-08-01',
+      'first_name': 'Hector',
+      'last_name': 'Allen',
+      'middle_name': 'James',
+      'notification_method': 'NONE',
+      'contact_info': {
+        'address_line1': '1291 Boston Post Rd',
+        'address_line2': '',
+        'city': 'Madison',
+        'zipcode': '06443',
+        'email_address': 'testing@test.com',
+        'address_type': 'DOMESTIC',
+        'mobile_phone_number': '1231231234',
+        'home_phone_number': '1231231234',
+        'country_code': 'US',
+        'state_code': 'CT'
+      },
+      'preferred_contact': nil
+    }
+  end
+
+  let(:service_data) do
+    [
+      {
+        'branch_of_service': 'Air Force',
+        'begin_date': '2010-06-01',
+        'end_date': '2020-06-01',
+        'character_of_service': 'Honorable',
+        'reason_for_separation': 'Expiration Term Of Service',
+        'exclusion_periods': [],
+        'training_periods': []
+      }
+    ]
+  end
+
+  let(:automation_claimant_response) do
+    response = double('response', body: { 'claimant' => claimant, 'service_data' => service_data })
+    MebApi::DGI::Automation::ClaimantResponse.new(201, response)
+  end
+
+  let(:expected_response) do
+    {
+      'data': {
+        'id': '',
+        'type': 'meb_api_dgi_automation_claimant_responses',
+        'attributes': {
+          'claimant': {
+            'claimant_id': 600_010_259,
+            'suffix': '',
+            'date_of_birth': '1990-08-01',
+            'first_name': 'Hector',
+            'last_name': 'Allen',
+            'middle_name': 'James',
+            'notification_method': 'NONE',
+            'contact_info': {
+              'address_line1': '1291 Boston Post Rd',
+              'address_line2': '',
+              'city': 'Madison',
+              'zipcode': '06443',
+              'email_address': 'testing@test.com',
+              'address_type': 'DOMESTIC',
+              'mobile_phone_number': '1231231234',
+              'home_phone_number': '1231231234',
+              'country_code': 'US',
+              'state_code': 'CT'
+            },
+            'preferred_contact': nil
+          },
+          'service_data': [
+            {
+              'branch_of_service': 'Air Force',
+              'begin_date': '2010-06-01',
+              'end_date': '2020-06-01',
+              'character_of_service': 'Honorable',
+              'reason_for_separation': 'Expiration Term Of Service',
+              'exclusion_periods': [],
+              'training_periods': []
+            }
+          ]
+        }
+      }
+    }
+  end
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(automation_claimant_response, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_hash[:data][:id]).to be_blank
+  end
+
+  it 'includes :claimant' do
+    expect(rendered_attributes[:claimant]).to eq expected_response[:data][:attributes][:claimant]
+  end
+
+  it 'includes :service_data' do
+    expect(rendered_attributes[:service_data]).to eq expected_response[:data][:attributes][:service_data]
+  end
+end

--- a/modules/meb_api/spec/serializers/automation_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/automation_serializer_spec.rb
@@ -7,7 +7,7 @@ describe AutomationSerializer do
 
   let(:claimant) do
     {
-      'claimant_id': 600_010_259,
+      'claimant_id': 600010259,
       'suffix': '',
       'date_of_birth': '1990-08-01',
       'first_name': 'Hector',
@@ -30,20 +30,6 @@ describe AutomationSerializer do
     }
   end
 
-  let(:service_data) do
-    [
-      {
-        'branch_of_service': 'Air Force',
-        'begin_date': '2010-06-01',
-        'end_date': '2020-06-01',
-        'character_of_service': 'Honorable',
-        'reason_for_separation': 'Expiration Term Of Service',
-        'exclusion_periods': [],
-        'training_periods': []
-      }
-    ]
-  end
-
   let(:automation_claimant_response) do
     response = double('response', body: { 'claimant' => claimant, 'service_data' => service_data })
     MebApi::DGI::Automation::ClaimantResponse.new(201, response)
@@ -56,7 +42,7 @@ describe AutomationSerializer do
         'type': 'meb_api_dgi_automation_claimant_responses',
         'attributes': {
           'claimant': {
-            'claimant_id': 600_010_259,
+            'claimant_id': '600010259',
             'suffix': '',
             'date_of_birth': '1990-08-01',
             'first_name': 'Hector',

--- a/modules/meb_api/spec/serializers/automation_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/automation_serializer_spec.rb
@@ -30,6 +30,20 @@ describe AutomationSerializer do
     }
   end
 
+  let(:service_data) do
+    [
+      {
+        'branch_of_service': 'Air Force',
+        'begin_date': '2010-06-01',
+        'end_date': '2020-06-01',
+        'character_of_service': 'Honorable',
+        'reason_for_separation': 'Expiration Term Of Service',
+        'exclusion_periods': [],
+        'training_periods': []
+      }
+    ]
+  end
+
   let(:automation_claimant_response) do
     response = double('response', body: { 'claimant' => claimant, 'service_data' => service_data })
     MebApi::DGI::Automation::ClaimantResponse.new(201, response)
@@ -42,7 +56,7 @@ describe AutomationSerializer do
         'type': 'meb_api_dgi_automation_claimant_responses',
         'attributes': {
           'claimant': {
-            'claimant_id': '600010259',
+            'claimant_id': 600010259,
             'suffix': '',
             'date_of_birth': '1990-08-01',
             'first_name': 'Hector',

--- a/modules/meb_api/spec/serializers/automation_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/automation_serializer_spec.rb
@@ -4,42 +4,41 @@ require 'rails_helper'
 require 'dgi/automation/claimant_response'
 
 describe AutomationSerializer do
-
   let(:claimant) do
     {
-      'claimant_id': 600010259,
-      'suffix': '',
-      'date_of_birth': '1990-08-01',
-      'first_name': 'Hector',
-      'last_name': 'Allen',
-      'middle_name': 'James',
-      'notification_method': 'NONE',
-      'contact_info': {
-        'address_line1': '1291 Boston Post Rd',
-        'address_line2': '',
-        'city': 'Madison',
-        'zipcode': '06443',
-        'email_address': 'testing@test.com',
-        'address_type': 'DOMESTIC',
-        'mobile_phone_number': '1231231234',
-        'home_phone_number': '1231231234',
-        'country_code': 'US',
-        'state_code': 'CT'
+      claimant_id: 600_010_259,
+      suffix: '',
+      date_of_birth: '1990-08-01',
+      first_name: 'Hector',
+      last_name: 'Allen',
+      middle_name: 'James',
+      notification_method: 'NONE',
+      contact_info: {
+        address_line1: '1291 Boston Post Rd',
+        address_line2: '',
+        city: 'Madison',
+        zipcode: '06443',
+        email_address: 'testing@test.com',
+        address_type: 'DOMESTIC',
+        mobile_phone_number: '1231231234',
+        home_phone_number: '1231231234',
+        country_code: 'US',
+        state_code: 'CT'
       },
-      'preferred_contact': nil
+      preferred_contact: nil
     }
   end
 
   let(:service_data) do
     [
       {
-        'branch_of_service': 'Air Force',
-        'begin_date': '2010-06-01',
-        'end_date': '2020-06-01',
-        'character_of_service': 'Honorable',
-        'reason_for_separation': 'Expiration Term Of Service',
-        'exclusion_periods': [],
-        'training_periods': []
+        branch_of_service: 'Air Force',
+        begin_date: '2010-06-01',
+        end_date: '2020-06-01',
+        character_of_service: 'Honorable',
+        reason_for_separation: 'Expiration Term Of Service',
+        exclusion_periods: [],
+        training_periods: []
       }
     ]
   end
@@ -51,41 +50,41 @@ describe AutomationSerializer do
 
   let(:expected_response) do
     {
-      'data': {
-        'id': '',
-        'type': 'meb_api_dgi_automation_claimant_responses',
-        'attributes': {
-          'claimant': {
-            'claimant_id': 600010259,
-            'suffix': '',
-            'date_of_birth': '1990-08-01',
-            'first_name': 'Hector',
-            'last_name': 'Allen',
-            'middle_name': 'James',
-            'notification_method': 'NONE',
-            'contact_info': {
-              'address_line1': '1291 Boston Post Rd',
-              'address_line2': '',
-              'city': 'Madison',
-              'zipcode': '06443',
-              'email_address': 'testing@test.com',
-              'address_type': 'DOMESTIC',
-              'mobile_phone_number': '1231231234',
-              'home_phone_number': '1231231234',
-              'country_code': 'US',
-              'state_code': 'CT'
+      data: {
+        id: '',
+        type: 'meb_api_dgi_automation_claimant_responses',
+        attributes: {
+          claimant: {
+            claimant_id: 600_010_259,
+            suffix: '',
+            date_of_birth: '1990-08-01',
+            first_name: 'Hector',
+            last_name: 'Allen',
+            middle_name: 'James',
+            notification_method: 'NONE',
+            contact_info: {
+              address_line1: '1291 Boston Post Rd',
+              address_line2: '',
+              city: 'Madison',
+              zipcode: '06443',
+              email_address: 'testing@test.com',
+              address_type: 'DOMESTIC',
+              mobile_phone_number: '1231231234',
+              home_phone_number: '1231231234',
+              country_code: 'US',
+              state_code: 'CT'
             },
-            'preferred_contact': nil
+            preferred_contact: nil
           },
-          'service_data': [
+          service_data: [
             {
-              'branch_of_service': 'Air Force',
-              'begin_date': '2010-06-01',
-              'end_date': '2020-06-01',
-              'character_of_service': 'Honorable',
-              'reason_for_separation': 'Expiration Term Of Service',
-              'exclusion_periods': [],
-              'training_periods': []
+              branch_of_service: 'Air Force',
+              begin_date: '2010-06-01',
+              end_date: '2020-06-01',
+              character_of_service: 'Honorable',
+              reason_for_separation: 'Expiration Term Of Service',
+              exclusion_periods: [],
+              training_periods: []
             }
           ]
         }
@@ -94,7 +93,8 @@ describe AutomationSerializer do
   end
 
   let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(automation_claimant_response, { serializer: described_class }).as_json
+    ActiveModelSerializers::SerializableResource.new(automation_claimant_response,
+                                                     { serializer: described_class }).as_json
   end
   let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 

--- a/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
@@ -10,7 +10,7 @@ describe ClaimStatusSerializer do
   let(:claim_status) { 'ELIGIBLE' }
   let(:received_date) { '2022-06-13' }
 
-  let(:claimant_response) do
+  let(:claim_status_response) do
     response = double('response', body: {
         'claimant_id' => claimant,
         'claim_service_id' => claim_service_id,
@@ -36,7 +36,7 @@ describe ClaimStatusSerializer do
   end
 
   let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(claimant_response, { serializer: described_class }).as_json
+    ActiveModelSerializers::SerializableResource.new(claim_status_response, { serializer: described_class }).as_json
   end
   let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 

--- a/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
@@ -4,32 +4,31 @@ require 'rails_helper'
 require 'dgi/status/status_response'
 
 describe ClaimStatusSerializer do
-
-  let(:claimant) { 600000001 }
-  let(:claim_service_id) { 99000000113358369 }
+  let(:claimant) { 600_000_001 }
+  let(:claim_service_id) { 99_000_000_113_358_369 }
   let(:claim_status) { 'ELIGIBLE' }
   let(:received_date) { '2022-06-13' }
 
   let(:claim_status_response) do
     response = double('response', body: {
-        'claimant_id' => claimant,
-        'claim_service_id' => claim_service_id,
-        'claim_status' => claim_status,
-        'received_date' => received_date
-    })
+                        'claimant_id' => claimant,
+                        'claim_service_id' => claim_service_id,
+                        'claim_status' => claim_status,
+                        'received_date' => received_date
+                      })
     MebApi::DGI::Status::StatusResponse.new(201, response)
   end
 
   let(:expected_response) do
     {
-      'data': {
-        'id': '',
-        'type': 'meb_api_dgi_status_status_responses',
-        'attributes': {
-          'claimant_id': 600000001,
-          'claim_service_id': 99000000113358369,
-          'claim_status': 'ELIGIBLE',
-          'received_date': '2022-06-13'
+      data: {
+        id: '',
+        type: 'meb_api_dgi_status_status_responses',
+        attributes: {
+          claimant_id: 600_000_001,
+          claim_service_id: 99_000_000_113_358_369,
+          claim_status: 'ELIGIBLE',
+          received_date: '2022-06-13'
         }
       }
     }
@@ -59,5 +58,4 @@ describe ClaimStatusSerializer do
   it 'includes :received_date' do
     expect(rendered_attributes[:received_date]).to eq expected_response[:data][:attributes][:received_date]
   end
-
 end

--- a/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dgi/status/status_response'
+
+describe ClaimStatusSerializer do
+
+  let(:claimant) { 600000001 }
+  let(:claim_service_id) { 99000000113358369 }
+  let(:claim_status) { 'ELIGIBLE' }
+  let(:received_date) { '2022-06-13' }
+
+  let(:claimant_response) do
+    response = double('response', body: {
+        'claimant_id' => claimant,
+        'claim_service_id' => claim_service_id,
+        'claim_status' => claim_status,
+        'received_date' => received_date
+    })
+    MebApi::DGI::Status::StatusResponse.new(201, response)
+  end
+
+  let(:expected_response) do
+    {
+      'data': {
+        'id': '',
+        'type': 'meb_api_dgi_status_status_responses',
+        'attributes': {
+          'claimant_id': 600000001,
+          'claim_service_id': 99000000113358369,
+          'claim_status': 'ELIGIBLE',
+          'received_date': '2022-06-13'
+        }
+      }
+    }
+  end
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(claimant_response, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_hash[:data][:id]).to be_blank
+  end
+
+  it 'includes :claimant_id' do
+    expect(rendered_attributes[:claimant_id]).to eq expected_response[:data][:attributes][:claimant_id]
+  end
+
+  it 'includes :claim_service_id' do
+    expect(rendered_attributes[:claim_service_id]).to eq expected_response[:data][:attributes][:claim_service_id]
+  end
+
+  it 'includes :claim_status' do
+    expect(rendered_attributes[:claim_status]).to eq expected_response[:data][:attributes][:claim_status]
+  end
+
+  it 'includes :received_date' do
+    expect(rendered_attributes[:received_date]).to eq expected_response[:data][:attributes][:received_date]
+  end
+
+end

--- a/modules/meb_api/spec/serializers/claimant_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/claimant_serializer_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 require 'dgi/claimant/claimant_response'
 
 describe ClaimantSerializer do
-
-  let(:claimant) { 600010259 }
+  let(:claimant) { 600_010_259 }
 
   let(:claimant_response) do
     response = double('response', body: { 'claimant_id' => claimant })
@@ -14,11 +13,11 @@ describe ClaimantSerializer do
 
   let(:expected_response) do
     {
-      'data': {
-        'id': '',
-        'type': 'meb_api_dgi_claimant_claimant_responses',
-        'attributes': {
-          'claimant_id': '600010259',
+      data: {
+        id: '',
+        type: 'meb_api_dgi_claimant_claimant_responses',
+        attributes: {
+          claimant_id: '600010259'
         }
       }
     }
@@ -36,5 +35,4 @@ describe ClaimantSerializer do
   it 'includes :claimant_id' do
     expect(rendered_attributes[:claimant_id]).to eq expected_response[:data][:attributes][:claimant_id]
   end
-
 end

--- a/modules/meb_api/spec/serializers/claimant_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/claimant_serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dgi/claimant/claimant_response'
+
+describe ClaimantSerializer do
+
+  let(:claimant) { 600010259 }
+
+  let(:claimant_response) do
+    response = double('response', body: { 'claimant_id' => claimant })
+    MebApi::DGI::Claimant::ClaimantResponse.new(201, response)
+  end
+
+  let(:expected_response) do
+    {
+      'data': {
+        'id': '',
+        'type': 'meb_api_dgi_claimant_claimant_responses',
+        'attributes': {
+          'claimant_id': '600010259',
+        }
+      }
+    }
+  end
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(claimant_response, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_hash[:data][:id]).to be_blank
+  end
+
+  it 'includes :claimant_id' do
+    expect(rendered_attributes[:claimant_id]).to eq expected_response[:data][:attributes][:claimant_id]
+  end
+
+end

--- a/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dgi/contact_info/response'
+
+describe ContactInfoSerializer do
+  let(:contact_info_response) do
+    response = double('response', body: {
+                        'emails' => [{ 'address': 'test@test.com', 'dupe': 'false' }],
+                        'phones' => [{ 'number': '8013090123', 'dupe': 'false' }]
+                      })
+    MebApi::DGI::ContactInfo::Response.new(201, response)
+  end
+
+  let(:expected_response) do
+    {
+      data: {
+        id: '',
+        type: 'meb_api_dgi_contact_info_responses',
+        attributes: {
+          phone: [{ number: '8013090123', dupe: 'false' }],
+          email: [{ address: 'test@test.com', dupe: 'false' }]
+        }
+      }
+    }
+  end
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(contact_info_response, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_hash[:data][:id]).to be_blank
+  end
+
+  it 'includes :phone' do
+    expect(rendered_attributes[:phone]).to eq expected_response[:data][:attributes][:phone]
+  end
+
+  it 'includes :email' do
+    expect(rendered_attributes[:email]).to eq expected_response[:data][:attributes][:email]
+  end
+end

--- a/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
@@ -6,8 +6,8 @@ require 'dgi/contact_info/response'
 describe ContactInfoSerializer do
   let(:contact_info_response) do
     response = double('response', body: {
-                        'emails' => [{ 'address': 'test@test.com', 'dupe': 'false' }],
-                        'phones' => [{ 'number': '8013090123', 'dupe': 'false' }]
+                        'emails' => [{ address: 'test@test.com', dupe: 'false' }],
+                        'phones' => [{ number: '8013090123', dupe: 'false' }]
                       })
     MebApi::DGI::ContactInfo::Response.new(201, response)
   end

--- a/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
@@ -6,10 +6,10 @@ require 'dgi/eligibility/eligibility_response'
 describe EligibilitySerializer do
   let(:eligibility_response) do
     response = double('response', body: [
-      {"veteran_is_eligible"=>true, "chapter"=>"Chapter33"},
-      {"veteran_is_eligible"=>false, "chapter"=>"Chapter30"},
-      {"veteran_is_eligible"=>false, "chapter"=>"Chapter1606"}
-    ])
+                        { 'veteran_is_eligible': true, 'chapter': 'Chapter33' },
+                        { 'veteran_is_eligible': false, 'chapter': 'Chapter30' },
+                        { 'veteran_is_eligible': false, 'chapter': 'Chapter1606' }
+                      ])
     MebApi::DGI::Eligibility::EligibilityResponse.new(201, response)
   end
 
@@ -20,9 +20,9 @@ describe EligibilitySerializer do
         type: 'meb_api_dgi_eligibility_eligibility_responses',
         attributes: {
           eligibility: [
-            {"veteran_is_eligible": true, "chapter": "Chapter33"},
-            {"veteran_is_eligible": false, "chapter": "Chapter30"},
-            {"veteran_is_eligible": false, "chapter": "Chapter1606"}
+            { veteran_is_eligible: true, chapter: 'Chapter33' },
+            { veteran_is_eligible: false, chapter: 'Chapter30' },
+            { veteran_is_eligible: false, chapter: 'Chapter1606' }
           ]
         }
       }

--- a/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
@@ -6,9 +6,9 @@ require 'dgi/eligibility/eligibility_response'
 describe EligibilitySerializer do
   let(:eligibility_response) do
     response = double('response', body: [
-                        { 'veteran_is_eligible': true, 'chapter': 'Chapter33' },
-                        { 'veteran_is_eligible': false, 'chapter': 'Chapter30' },
-                        { 'veteran_is_eligible': false, 'chapter': 'Chapter1606' }
+                        { veteran_is_eligible: true, chapter: 'Chapter33' },
+                        { veteran_is_eligible: false, chapter: 'Chapter30' },
+                        { veteran_is_eligible: false, chapter: 'Chapter1606' }
                       ])
     MebApi::DGI::Eligibility::EligibilityResponse.new(201, response)
   end

--- a/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dgi/eligibility/eligibility_response'
+
+describe EligibilitySerializer do
+  let(:eligibility_response) do
+    response = double('response', body: [
+      {"veteran_is_eligible"=>true, "chapter"=>"Chapter33"},
+      {"veteran_is_eligible"=>false, "chapter"=>"Chapter30"},
+      {"veteran_is_eligible"=>false, "chapter"=>"Chapter1606"}
+    ])
+    MebApi::DGI::Eligibility::EligibilityResponse.new(201, response)
+  end
+
+  let(:expected_response) do
+    {
+      data: {
+        id: '',
+        type: 'meb_api_dgi_eligibility_eligibility_responses',
+        attributes: {
+          eligibility: [
+            {"veteran_is_eligible": true, "chapter": "Chapter33"},
+            {"veteran_is_eligible": false, "chapter": "Chapter30"},
+            {"veteran_is_eligible": false, "chapter": "Chapter1606"}
+          ]
+        }
+      }
+    }
+  end
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(eligibility_response, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_hash[:data][:id]).to be_blank
+  end
+
+  it 'includes :eligibility' do
+    expect(rendered_attributes[:eligibility]).to eq expected_response[:data][:attributes][:eligibility]
+  end
+end

--- a/modules/meb_api/spec/serializers/enrollement_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/enrollement_serializer_spec.rb
@@ -4,21 +4,24 @@ require 'rails_helper'
 require 'dgi/enrollment/enrollment_response'
 
 describe EnrollmentSerializer do
+  let(:enrollment_verifications) do
+    [{ 'verification_month' => 'January 2021',
+       'certified_begin_date' => '2021-01-01',
+       'certified_end_date' => '2021-01-31',
+       'certified_through_date' => nil,
+       'certification_method' => nil,
+       'enrollments' => [{
+         'facility_name' => 'UNIVERSITY OF HAWAII AT HILO',
+         'begin_date' => '2020-01-01',
+         'end_date' => '2021-01-01',
+         'total_credit_hours' => 17.0
+       }],
+       'verification_response' => 'NR',
+       'created_date' => nil }]
+  end
+
   let(:eligibility_response) do
-    response = double('response', status: 201, body:
-                        { 'enrollment_verifications' => [{ 'verification_month' => 'January 2021',
-                                                           'certified_begin_date' => '2021-01-01',
-                                                           'certified_end_date' => '2021-01-31',
-                                                           'certified_through_date' => nil,
-                                                           'certification_method' => nil,
-                                                           'enrollments' => [{
-                                                             'facility_name' => 'UNIVERSITY OF HAWAII AT HILO',
-                                                             'begin_date' => '2020-01-01',
-                                                             'end_date' => '2021-01-01',
-                                                             'total_credit_hours' => 17.0
-                                                           }],
-                                                           'verification_response' => 'NR',
-                                                           'created_date' => nil }] })
+    response = double('response', status: 201, body: { 'enrollment_verifications' => enrollment_verifications })
     MebApi::DGI::Enrollment::Response.new(response)
   end
 

--- a/modules/meb_api/spec/serializers/enrollement_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/enrollement_serializer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dgi/enrollment/enrollment_response'
+
+describe EnrollmentSerializer do
+  let(:eligibility_response) do
+    response = double('response', status: 201, body:
+                        { 'enrollment_verifications' => [{ 'verification_month' => 'January 2021',
+                                                           'certified_begin_date' => '2021-01-01',
+                                                           'certified_end_date' => '2021-01-31',
+                                                           'certified_through_date' => nil,
+                                                           'certification_method' => nil,
+                                                           'enrollments' => [{
+                                                             'facility_name' => 'UNIVERSITY OF HAWAII AT HILO',
+                                                             'begin_date' => '2020-01-01',
+                                                             'end_date' => '2021-01-01',
+                                                             'total_credit_hours' => 17.0
+                                                           }],
+                                                           'verification_response' => 'NR',
+                                                           'created_date' => nil }] })
+    MebApi::DGI::Enrollment::Response.new(response)
+  end
+
+  let(:expected_response) do
+    {
+      data: {
+        id: '',
+        type: 'meb_api_dgi_enrollment_responses',
+        attributes: {
+          enrollment_verifications: [{
+            verification_month: 'January 2021', certified_begin_date: '2021-01-01',
+            certified_end_date: '2021-01-31', certified_through_date: nil, certification_method: nil,
+            enrollments: [
+              {
+                facility_name: 'UNIVERSITY OF HAWAII AT HILO',
+                begin_date: '2020-01-01',
+                end_date: '2021-01-01',
+                total_credit_hours: 17.0
+              }
+            ],
+            verification_response: 'NR', created_date: nil
+          }],
+          last_certified_through_date: nil,
+          payment_on_hold: nil
+        }
+      }
+    }.deep_stringify_keys
+  end
+
+  let(:rendered_hash) do
+    ActiveModelSerializers::SerializableResource.new(eligibility_response, { serializer: described_class }).as_json
+  end
+  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+
+  it 'includes :id' do
+    expect(rendered_hash[:data][:id]).to be_blank
+  end
+
+  it 'includes :enrollment_verifications' do
+    expect_enrollment_verifications = expected_response['data']['attributes']['enrollment_verifications']
+    expect(rendered_attributes[:enrollment_verifications]).to eq expect_enrollment_verifications
+  end
+
+  it 'includes :last_certified_through_date' do
+    expected_last_certified_through_date = expected_response['data']['attributes']['last_certified_through_date']
+    expect(rendered_attributes[:last_certified_through_date]).to eq expected_last_certified_through_date
+  end
+
+  it 'includes :payment_on_hold' do
+    expect(rendered_attributes[:payment_on_hold]).to eq expected_response['data']['attributes']['payment_on_hold']
+  end
+end


### PR DESCRIPTION
## Summary

- Add more test examples for missing attributes/specs
- Only for:
    - AutomationSerializer, ClaimantSerializer, ClaimStatusSerializer,  EligibilitySerializer, EnrollmentSerializer
- The rest of the serializers will be in a separate PR

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83642

## Testing done

- [x] Add new tests

## Screenshots
![Screenshot 2024-05-31 at 2 56 58 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/ccf97095-0dc7-4cdd-904b-4697068f3f85)

## Acceptance criteria

- [x] unit test coverage is 100%
