### PR TITLE
[DBX-83277] patch 526 backup path 4142 sig date

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1338,6 +1338,7 @@ spec/lib/common/client/concerns/mhv_locked_session_client_spec.rb @department-of
 spec/lib/common/client/middleware @department-of-veterans-affairs/backend-review-group
 spec/lib/debt_management_center @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/lib/decision_review @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/decision_review_v1 @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/disability_compensation @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/efolder/service_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/lib/evss/auth_headers_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/lib/decision_review_v1/utilities/form_4142_processor.rb
+++ b/lib/decision_review_v1/utilities/form_4142_processor.rb
@@ -15,8 +15,8 @@ module DecisionReviewV1
       attr_reader :request_body
 
       def initialize(form_data:, submission_id: nil)
-        @form = set_signature_date(form_data)
         @submission = Form526Submission.find_by(id: submission_id)
+        @form = set_signature_date(form_data)
         @pdf_path = generate_stamp_pdf
         @uuid = SecureRandom.uuid
         @request_body = {

--- a/lib/decision_review_v1/utilities/form_4142_processor.rb
+++ b/lib/decision_review_v1/utilities/form_4142_processor.rb
@@ -8,9 +8,9 @@ require 'simple_forms_api_submission/metadata_validator'
 module DecisionReviewV1
   module Processor
     class Form4142Processor
-      SIGNATURE_DATE_KEY = 'signatureDate'.freeze
-      SIGNATURE_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'.freeze
-      TIMEZONE = 'Central Time (US & Canada)'.freeze
+      SIGNATURE_DATE_KEY = 'signatureDate'
+      SIGNATURE_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
+      TIMEZONE = 'Central Time (US & Canada)'
       # @return [Pathname] the generated PDF path
       attr_reader :pdf_path
 

--- a/lib/decision_review_v1/utilities/form_4142_processor.rb
+++ b/lib/decision_review_v1/utilities/form_4142_processor.rb
@@ -78,7 +78,7 @@ module DecisionReviewV1
 
       def submission_date
         if @submission.nil?
-          Time.now.in_time_zone('Central Time (US & Canada)')
+          Time.now.in_time_zone(TIMEZONE)
         else
           @submission.created_at.in_time_zone(TIMEZONE)
         end

--- a/lib/decision_review_v1/utilities/form_4142_processor.rb
+++ b/lib/decision_review_v1/utilities/form_4142_processor.rb
@@ -8,6 +8,9 @@ require 'simple_forms_api_submission/metadata_validator'
 module DecisionReviewV1
   module Processor
     class Form4142Processor
+      SIGNATURE_DATE_KEY = 'signatureDate'.freeze
+      SIGNATURE_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'.freeze
+      TIMEZONE = 'Central Time (US & Canada)'.freeze
       # @return [Pathname] the generated PDF path
       attr_reader :pdf_path
 
@@ -77,16 +80,16 @@ module DecisionReviewV1
         if @submission.nil?
           Time.now.in_time_zone('Central Time (US & Canada)')
         else
-          @submission.created_at.in_time_zone('Central Time (US & Canada)')
+          @submission.created_at.in_time_zone(TIMEZONE)
         end
       end
 
       def received_date
-        submission_date.strftime('%Y-%m-%d %H:%M:%S')
+        submission_date.strftime(SIGNATURE_TIMESTAMP_FORMAT)
       end
 
       def set_signature_date(incoming_data)
-        incoming_data.merge({ 'signatureDate' => received_date })
+        incoming_data.merge({ SIGNATURE_DATE_KEY => received_date })
       end
     end
   end

--- a/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
+++ b/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
@@ -51,6 +51,6 @@ describe DecisionReviewV1::Processor::Form4142Processor do
         sig_dat = processor.instance_variable_get('@form')[key]
         expect(sig_dat).to eq(created_at.strftime(time_format))
       end
-      end
     end
   end
+end

--- a/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
+++ b/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
@@ -38,4 +38,22 @@ describe DecisionReviewV1::Processor::Form4142Processor do
       expect(processor.instance_variable_get(:@request_body)).to be_a(Hash)
     end
   end
+
+
+  context 'setting a correct signed-at date' do
+    context 'when a submission was created more than a day before processing' do
+      describe '#submission_date' do
+        let!(:created_at) { 6.months.ago.in_time_zone(described_class::TIMEZONE) }
+
+        it 'returns the date of submission creation' do
+          Timecop.freeze(created_at) { submission }
+
+          key = described_class::SIGNATURE_DATE_KEY
+          time_format = described_class::SIGNATURE_TIMESTAMP_FORMAT
+          sig_dat = processor.instance_variable_get('@form')[key]
+          expect(sig_dat).to eq(created_at.strftime(time_format))
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
+++ b/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
@@ -39,7 +39,6 @@ describe DecisionReviewV1::Processor::Form4142Processor do
     end
   end
 
-
   context 'setting a correct signed-at date' do
     context 'when a submission was created more than a day before processing' do
       describe '#submission_date' do

--- a/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
+++ b/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
@@ -41,18 +41,16 @@ describe DecisionReviewV1::Processor::Form4142Processor do
 
   context 'setting a correct signed-at date' do
     context 'when a submission was created more than a day before processing' do
-      describe '#submission_date' do
-        let!(:created_at) { 6.months.ago.in_time_zone(described_class::TIMEZONE) }
+      let!(:created_at) { 6.months.ago.in_time_zone(described_class::TIMEZONE) }
 
-        it 'returns the date of submission creation' do
-          Timecop.freeze(created_at) { submission }
+      it 'sets the signed at date to the date of submission creation' do
+        Timecop.freeze(created_at) { submission }
 
-          key = described_class::SIGNATURE_DATE_KEY
-          time_format = described_class::SIGNATURE_TIMESTAMP_FORMAT
-          sig_dat = processor.instance_variable_get('@form')[key]
-          expect(sig_dat).to eq(created_at.strftime(time_format))
-        end
+        key = described_class::SIGNATURE_DATE_KEY
+        time_format = described_class::SIGNATURE_TIMESTAMP_FORMAT
+        sig_dat = processor.instance_variable_get('@form')[key]
+        expect(sig_dat).to eq(created_at.strftime(time_format))
+      end
       end
     end
   end
-end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- fix a bug in the 526 backup submission path that was incorrectly setting the 'signed at' date for an ancillary 4142 submission

## Related issue(s)

- [Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/84377)

## Testing done

- [ ] *New code is covered by unit tests*
- at date set time, `@submission` was nil, incorrectly triggering a failsafe that set 'signed at' dates to the date the processing was ran *INSTEAD* of the date the form submission was created

## What areas of the site does it impact?
Form 526 backup submissions with 4142 ancillary documents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- ~~[ ]  Documentation has been updated (link to documentation)~~ N/A
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- ~~[ ]  I added a screenshot of the developed feature~~ N/A