### PR TITLE
Remove va_online_scheduling_request_flow_update feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1175,10 +1175,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for querying Drupal Source of Truth for Acheron flag
-  va_online_scheduling_request_flow_update:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for content update to VA and Community Care request flow
   va_online_scheduling_poc_type_of_care:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Removing the deprecated va_online_scheduling_request_flow_update feature toggle
- Appointments team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/64029

## Testing done

- Ensured existing test suite passes.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
