### PR TITLE
add build json

### DIFF
--- a/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe 'Forms uploader', type: :request do
 
     context 'when status codes are mixed' do
       it 'returns a status of 206 and a partial failure message' do
-        expect(controller.send(:build_json, [200, 400], 'Error')).to eq({ error_message: 
+        expect(controller.send(:build_json, [200, 400], 'Error')).to eq({ error_message:
         'Partial upload failure', status: 206 })
       end
     end

--- a/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
@@ -160,4 +160,27 @@ RSpec.describe 'Forms uploader', type: :request do
       end
     end
   end
+
+  describe '#build_json' do
+    let(:controller) { IvcChampva::V1::UploadsController.new }
+
+    context 'when all status codes are 200' do
+      it 'returns a status of 200' do
+        expect(controller.send(:build_json, [200, 200], 'Error')).to eq({ status: 200 })
+      end
+    end
+
+    context 'when all status codes are 400' do
+      it 'returns a status of 400 and an error message' do
+        expect(controller.send(:build_json, [400, 400], 'Error')).to eq({ error_message: 'Error', status: 400 })
+      end
+    end
+
+    context 'when status codes are mixed' do
+      it 'returns a status of 206 and a partial failure message' do
+        expect(controller.send(:build_json, [200, 400], 'Error')).to eq({ error_message: 
+        'Partial upload failure', status: 206 })
+      end
+    end
+  end
 end


### PR DESCRIPTION

## Summary

Just adding one more unit test to the uploads controller. The method for build json unit test was added.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-api/pull/16964

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
