### PR TITLE
Increase SignUpServiceUpdaterJob attr_package expire time

### DIFF
--- a/app/services/terms_of_use/acceptor.rb
+++ b/app/services/terms_of_use/acceptor.rb
@@ -53,7 +53,7 @@ module TermsOfUse
     end
 
     def attr_package_key
-      @attr_package_key ||= Sidekiq::AttrPackage.create(icn:, signature_name:, version:, expires_in: 2.days)
+      @attr_package_key ||= Sidekiq::AttrPackage.create(icn:, signature_name:, version:, expires_in: 72.hours)
     end
 
     def signature_name

--- a/app/services/terms_of_use/decliner.rb
+++ b/app/services/terms_of_use/decliner.rb
@@ -61,7 +61,7 @@ module TermsOfUse
     end
 
     def attr_package_key
-      @attr_package_key ||= Sidekiq::AttrPackage.create(icn:, signature_name:, version:, expires_in: 2.days)
+      @attr_package_key ||= Sidekiq::AttrPackage.create(icn:, signature_name:, version:, expires_in: 72.hours)
     end
   end
 end

--- a/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
+++ b/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
@@ -7,14 +7,14 @@ module TermsOfUse
   class SignUpServiceUpdaterJob
     include Sidekiq::Job
 
-    sidekiq_options retry_for: 47.hours
+    sidekiq_options retry_for: 48.hours
 
     sidekiq_retries_exhausted do |job, exception|
       attr_package_key = job['args'].first
       attrs = Sidekiq::AttrPackage.find(attr_package_key)
 
       Rails.logger.warn('[TermsOfUse][SignUpServiceUpdaterJob] retries exhausted',
-                        { icn: attrs[:icn], exception_message: exception.message, attr_package_key: })
+                        { icn: attrs&.dig(:icn), exception_message: exception.message, attr_package_key: })
     end
 
     attr_reader :icn, :signature_name, :version


### PR DESCRIPTION
## Summary
- Increase AttrPackage expire time
- The current times of retry for 47 hours an package expires in 48 must be too close because the package cant be found when it hits the retry block
- Increase attr_package expire time to 72 hours. This will give us a good buffer and allow us to look up a package if needed.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84480

## Testing 
- Nothing to really test, I updated unit tests to test retry time and expired time

## What areas of the site does it impact?
Terms of use

