### PR TITLE
Fix bug where Simple Forms API emailer would fail if Flipper is off

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/confirmation_email.rb
@@ -26,7 +26,7 @@ module SimpleFormsApi
     def send
       return unless SUPPORTED_FORMS.include?(form_number)
 
-      data = form_specific_data
+      data = form_specific_data || empty_form_specific_data
 
       return if data[:email].blank? || data[:personalization]['first_name'].blank?
 
@@ -104,6 +104,10 @@ module SimpleFormsApi
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    def empty_form_specific_data
+      { email: '', personalization: {} }
+    end
 
     # personalization hash shared by all simple form confirmation emails
     def default_personalization(first_name)

--- a/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/confirmation_email_spec.rb
@@ -4,6 +4,50 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::ConfirmationEmail do
+  describe '#send' do
+    let(:data) do
+      fixture_path = Rails.root.join(
+        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210.json'
+      )
+      JSON.parse(fixture_path.read)
+    end
+
+    context 'flipper is on' do
+      before do
+        allow(Flipper).to receive(:enabled?).and_return true
+      end
+
+      it 'sends the email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        data['claim_ownership'] = 'self'
+        data['claimant_type'] = 'veteran'
+
+        subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
+                                      confirmation_number: 'confirmation_number')
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async)
+      end
+    end
+
+    context 'flipper is off' do
+      before do
+        allow(Flipper).to receive(:enabled?).and_return false
+      end
+
+      it 'does not send the email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
+                                      confirmation_number: 'confirmation_number')
+
+        subject.send
+
+        expect(VANotify::EmailJob).not_to have_received(:perform_async)
+      end
+    end
+  end
+
   describe '21_10210' do
     let(:data) do
       fixture_path = Rails.root.join(


### PR DESCRIPTION
## Summary
This PR fixes a bug in the Simple Forms API confirmation emailer where an error would be raised if the Flipper was off on a form because an unexpected `nil` was being returned.
