### PR TITLE
Add feature flag for Appoint a Rep PDF generation

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -501,6 +501,10 @@ features:
     actor_type: cookie_id
     description: Enables Appoint a Representative frontend
     enable_in_development: true
+  appoint_a_representative_enable_pdf:
+    actor_type: user
+    description: Enables Appoint a Representative PDF generation endpoint
+    enable_in_development: true
   form526_legacy:
     actor_type: user
     description: If true, points controllers to the legacy EVSS Form 526 instance. If false, the controllers will use the Dockerized instance running in DVP.


### PR DESCRIPTION
## Summary

Create a feature toggle `appoint_a_representative_enable_pdf` to enable PDF generation of forms `2122` and `2122a`.

## Related issue(s)

-  https://github.com/department-of-veterans-affairs/va.gov-team/issues/84442

## Testing done

n/a

## Screenshots
n/a

## What areas of the site does it impact?
Feature toggle page
<img width="923" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/19937139/31db4ebb-efb5-4e6e-8bbd-93d15267e94b">



## Acceptance criteria

- [x]  Create feature toggle `appoint_a_representative_enable_pdf`.