### PR TITLE
[CST] Add feature flag cst_5103_update_enabled for 5103 changes and removal of Ask

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -169,6 +169,10 @@ features:
     actor_type: user
     description: Diverts codepath to LocalBGSRefactored
     enable_in_development: true
+  cst_5103_update_enabled:
+    actor_type: user
+    description: When enabled, claims status tool will use the new 5103 alert designs and hides the ask your claim decision section
+    enable_in_development: true
   cst_claim_phases:
     actor_type: user
     description: When enabled, claims status tool uses the new claim phase designs


### PR DESCRIPTION
## Summary

- Added new feature flag `cst_5103_update_enabled` for 5103 changes and removal of Ask for your claim decision

## Related issue(s)

- *Link to ticket created in va.gov-team repo https://github.com/department-of-veterans-affairs/va.gov-team/issues/82537*
- *Link to frontend code change https://github.com/department-of-veterans-affairs/vets-website/pull/30149* 


## What areas of the site does it impact?
Claim Status Tool
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
