### PR TITLE
[#1267] Remove upgraded webchat feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1425,9 +1425,6 @@ features:
   virtual_agent_enable_pva2_chatbot:
     actor_type: user
     description: If enabled, switches VA chatbot from PVA1 to PVA2
-  virtual_agent_upgrade_webchat_14_15_8:
-    actor_type: user
-    description: If enabled, switches VA webchat from using version 4.15.2 to 4.15.8
   virtual_agent_component_testing:
     actor_type: user
     description: If enabled, allows for testing of the chatbot components


### PR DESCRIPTION
## Summary
Removing the feature toggle for upgrading the webchat. The feature toggle is currently flipped on for all users.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/1267
- https://github.com/department-of-veterans-affairs/vets-website/pull/30151

## Testing done

- vets-website unit testing completed
- Ran vets-website locally and verified behavior

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
