### PR TITLE
Mobile: Abide to JSON API Spec

### DIFF
--- a/modules/mobile/app/controllers/mobile/discovery_controller.rb
+++ b/modules/mobile/app/controllers/mobile/discovery_controller.rb
@@ -7,7 +7,18 @@ module Mobile
     def welcome
       routes = Mobile::Engine.app.routes.routes
       endpoints = routes.collect { |r| "mobile#{r.path.spec.to_s[0...-10]}" }
-      render json: { data: { attributes: { message: 'Welcome to the mobile API.', endpoints: } } }
+      render json: {
+        data:
+          {
+            type: 'welcome',
+            id: 'welcome',
+            attributes:
+              {
+                message: 'Welcome to the mobile API.',
+                endpoints:
+              }
+          }
+      }
     end
   end
 end

--- a/modules/mobile/spec/request/discovery_request_spec.rb
+++ b/modules/mobile/spec/request/discovery_request_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../support/helpers/rails_helper'
 
-RSpec.describe 'discovery', skip_json_api_validation: true, type: :request do
+RSpec.describe 'discovery', type: :request do
   describe 'GET /mobile' do
     before { get '/mobile' }
 


### PR DESCRIPTION
## Summary
After reviewing which specs are skipping json_api_spec_validation, this was deemed the only actionable change. We expected to skip validation for endpoints that return files, but we currently have several endpoints out of spec that are not returning files.

We cannot change these endpoints without versioning due to json api dictating that 
```
{
  data: {}
}
```
must be an object. We have endpoints that are
```
{
  data: []
}
```
Changing this would significantly affect front end


## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8530

## Testing done
Existing tests cover these changes

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
