### PR TITLE
Api 36824 establish claim in vbms correctly

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
@@ -65,11 +65,11 @@ module ClaimsApi
       def transform_disability_values!(disability)
         disability.delete(:diagnosticCode) if disability&.dig(:diagnosticCode).nil?
         disability.delete(:serviceRelevance) if disability&.dig(:serviceRelevance).blank?
-        disability.delete(:classificationCode) if disability&.dig(:classificationCode).blank?
+        disability.delete(:classificationCode) if disability&.dig(:classificationCode).nil? # blank is ok
 
         if disability&.dig(:secondaryDisabilities).present?
           disability[:secondaryDisabilities] = disability[:secondaryDisabilities]&.map do |secondary|
-            secondary.delete(:classificationCode) if secondary&.dig(:classificationCode).blank?
+            secondary.delete(:classificationCode) if secondary&.dig(:classificationCode).nil? # blank is ok
 
             secondary.except(:exposureOrEventOrInjury, :approximateDate)
           end

--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
@@ -65,8 +65,12 @@ module ClaimsApi
       def transform_disability_values!(disability)
         disability.delete(:diagnosticCode) if disability&.dig(:diagnosticCode).nil?
         disability.delete(:serviceRelevance) if disability&.dig(:serviceRelevance).blank?
+        disability.delete(:classificationCode) if disability&.dig(:classificationCode).blank?
+
         if disability&.dig(:secondaryDisabilities).present?
           disability[:secondaryDisabilities] = disability[:secondaryDisabilities]&.map do |secondary|
+            secondary.delete(:classificationCode) if secondary&.dig(:classificationCode).blank?
+
             secondary.except(:exposureOrEventOrInjury, :approximateDate)
           end
         end

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_evss_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_evss_mapper_spec.rb
@@ -225,31 +225,6 @@ describe ClaimsApi::V2::DisabilityCompensationEvssMapper do
           expect(disability[:classificationCode]).to eq(nil)
         end
       end
-
-      context 'When classificationcode is an empty string' do
-        let(:disability) do
-          {
-            disabilityActionType: 'INCREASE',
-            name: 'hypertension',
-            approximateDate: nil,
-            classificationCode: '',
-            serviceRelevance: '',
-            isRelatedToToxicExposure: false,
-            exposureOrEventOrInjury: '',
-            ratedDisabilityId: '',
-            diagnosticCode: 0,
-            secondaryDisabilities: nil
-          }
-        end
-
-        it 'mapping logic removes attribute' do
-          form_data['data']['attributes']['disabilities'][1] = disability
-          auto_claim = create(:auto_established_claim, form_data: form_data['data']['attributes'])
-          evss_data = ClaimsApi::V2::DisabilityCompensationEvssMapper.new(auto_claim, file_number).map_claim[:form526]
-          disability = evss_data[:disabilities][1]
-          expect(disability[:classificationCode]).to eq(nil)
-        end
-      end
     end
 
     context '526 section 6, service information: service periods' do

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_evss_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_evss_mapper_spec.rb
@@ -200,6 +200,56 @@ describe ClaimsApi::V2::DisabilityCompensationEvssMapper do
           expect(disability[:serviceRelevance]).to eq(nil)
         end
       end
+
+      context 'When classificationcode is null' do
+        let(:disability) do
+          {
+            disabilityActionType: 'INCREASE',
+            name: 'hypertension',
+            approximateDate: nil,
+            classificationCode: nil,
+            serviceRelevance: '',
+            isRelatedToToxicExposure: false,
+            exposureOrEventOrInjury: '',
+            ratedDisabilityId: '',
+            diagnosticCode: 0,
+            secondaryDisabilities: nil
+          }
+        end
+
+        it 'mapping logic correctly removes attribute' do
+          form_data['data']['attributes']['disabilities'][1] = disability
+          auto_claim = create(:auto_established_claim, form_data: form_data['data']['attributes'])
+          evss_data = ClaimsApi::V2::DisabilityCompensationEvssMapper.new(auto_claim, file_number).map_claim[:form526]
+          disability = evss_data[:disabilities][1]
+          expect(disability[:classificationCode]).to eq(nil)
+        end
+      end
+
+      context 'When classificationcode is an empty string' do
+        let(:disability) do
+          {
+            disabilityActionType: 'INCREASE',
+            name: 'hypertension',
+            approximateDate: nil,
+            classificationCode: '',
+            serviceRelevance: '',
+            isRelatedToToxicExposure: false,
+            exposureOrEventOrInjury: '',
+            ratedDisabilityId: '',
+            diagnosticCode: 0,
+            secondaryDisabilities: nil
+          }
+        end
+
+        it 'mapping logic removes attribute' do
+          form_data['data']['attributes']['disabilities'][1] = disability
+          auto_claim = create(:auto_established_claim, form_data: form_data['data']['attributes'])
+          evss_data = ClaimsApi::V2::DisabilityCompensationEvssMapper.new(auto_claim, file_number).map_claim[:form526]
+          disability = evss_data[:disabilities][1]
+          expect(disability[:classificationCode]).to eq(nil)
+        end
+      end
     end
 
     context '526 section 6, service information: service periods' do


### PR DESCRIPTION
## Summary
* removes `classificationCode` before sending to the Docker container if it is sent in `null`
* Updates tests to check scenario for null value and verifies it gets removed before being sent to the Docker container

## Related issue(s)
[API-36824](https://jira.devops.va.gov/browse/API-36824)

## Testing done
- [x] *New code is covered by unit tests*

#### Testing notes
* Submitting a 526 with classificationCode set to `null` for disabilities and secondaryDisabilities should still show the contentions in VBMS when viewing the claim (it previously would not in this scenario)
```
{
    "data": {
        "type": "form/526",
        "attributes": {
            "claimantCertification": true,
            "claimProcessType": "STANDARD_CLAIM_PROCESS",
            "veteranIdentification": {
                "mailingAddress": {
                    "addressLine1": "PO Box 501205",
                    "addressLine2": null,
                    "addressLine3": null,
                    "city": "Saipan",
                    "country": "USA",
                    "zipFirstFive": "96950",
                    "zipLastFour": "",
                    "state": "MP"
                },
                "serviceNumber": "",
                "emailAddress": {
                    "email": "a@a.co",
                    "agreeToEmailRelatedToClaim": null
                },
                "veteranNumber": {
                    "telephone": null,
                    "internationalTelephone": ""
                },
                "currentVaEmployee": false
            },
            "changeOfAddress": {
                "typeOfAddressChange": "PERMANENT", 
                "addressLine1": "456 Main Street", 
                "addressLine2": "",
                "addressLine3": "",
                "city": "Atlanta", 
                "state": "GA", 
                "country": "USA", 
                "zipFirstFive": "42220", 
                "zipLastFour": "",
                "dates": {
                    "beginDate": "2025-06-04", 
                    "endDate": null
                }
            },
            "homeless":
            {
                "currentlyHomeless": {
                    "homelessSituationOptions": "FLEEING_CURRENT_RESIDENCE",
                    "otherDescription": ""
                },
                "pointOfContact": "John Doe", 
                "pointOfContactNumber": {
                    "telephone": null,
                    "internationalTelephone": ""
                }
            },
            "toxicExposure": 
            {
                "gulfWarHazardService": {
                    "servedInGulfWarHazardLocations": null,
                    "serviceDates": {
                        "beginDate": null,
                        "endDate": null
                    }
                },
                "herbicideHazardService": {
                    "servedInHerbicideHazardLocations": null,
                    "otherLocationsServed": null,
                    "serviceDates": {
                        "beginDate": null,
                        "endDate": null
                    }
                },
                "additionalHazardExposures": {
                    "additionalExposures": null,
                    "specifyOtherExposures": null,
                    "exposureDates": {
                        "beginDate": null,
                        "endDate": null
                    }
                },
                "multipleExposures": 
                [
                    {
                        "exposureDates": {
                            "beginDate": null,
                            "endDate": null
                        },
                        "exposureLocation": null,
                        "hazardExposedTo": null
                    }
                ]
            },
            "disabilities": [
                {
                    "disabilityActionType": "NEW",
                    "name": "hypertension",
                    "approximateDate": null,
                    "classificationCode": "",
                    "serviceRelevance": "Acquired during service.",
                    "isRelatedToToxicExposure": false,
                    "exposureOrEventOrInjury": "",
                    "ratedDisabilityId": "",
                    "diagnosticCode": 0,
                    "secondaryDisabilities": [
                        {
                            "name": "Vertigo",
                            "disabilityActionType": "SECONDARY",
                            "classificationCode": null,
                            "serviceRelevance": "Related to hypertension service injury",
                            "approximateDate": null,
                            "exposureOrEventOrInjury": ""
                        }
                    ]
                },
                {
                    "disabilityActionType": "NEW",
                    "name": "anemia",
                    "classificationCode": null,
                    "serviceRelevance": "Caused by an in-service event, injury, or exposure test",
                    "isRelatedToToxicExposure": true,
                    "exposureOrEventOrInjury": "",
                    "ratedDisabilityId": null,
                    "diagnosticCode": null,
                    "specialIssues": ["POW"],
                    "secondaryDisabilities": []
                }
            ],
            "treatments": [
                {
                    "treatedDisabilityNames": [],
                    "center": {
                        "name": "",
                        "city": "",
                        "state": ""
                    },
                    "beginDate": null
                }
            ],
            "serviceInformation": {
                "servicePeriods": [
                    {
                        "serviceBranch": "Army",
                        "activeDutyBeginDate": "1996-09-30",
                        "activeDutyEndDate": "2016-09-29",
                        "serviceComponent": "Active",
                        "separationLocationCode": ""
                    }
                ],
                "reservesNationalGuardService":
                {
                    "component": null,
                    "obligationTermsOfService": {
                        "beginDate": "1990-11-24", 
                        "endDate": "2005-11-17" 
                    },
                    "unitName": "",
                    "unitAddress": "",
                    "unitPhone": {
                        "areaCode": "",
                        "phoneNumber": ""
                    },
                    "receivingInactiveDutyTrainingPay": null
                },
                "alternateNames": [],
                "servedInActiveCombatSince911": null,
                "federalActivation": {
                },
                "confinements": [
                    {
                        "approximateBeginDate": "2001-06-11", 
                        "approximateEndDate": "2001-09-11" 
                    }
                ]
            },
            "servicePay": 
            {
                "receivingMilitaryRetiredPay": null,
                "futureMilitaryRetiredPay": null,
                "futureMilitaryRetiredPayExplanation": null,
                "militaryRetiredPay": {
                    "branchOfService": null,
                    "monthlyAmount": null
                },
                "retiredStatus": null,
                "favorMilitaryRetiredPay": null,
                
                "receivedSeparationOrSeverancePay": null,
                "separationSeverancePay": {
                    "datePaymentReceived": null,
                    "branchOfService": null,
                    "preTaxAmountReceived": null
                },
                "favorTrainingPay": null
            },
            "directDeposit": 
            {
                "noAccount": false,
                "accountType": "CHECKING", 
                "accountNumber": "123123123123", 
                "routingNumber": "123456789", 
                "financialInstitutionName": "Bank of America"
            }
        }
    }
}
```

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/disability_compensation_evss_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
