### PR TITLE
Remove feature toggle flag for the vaos app

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1201,10 +1201,6 @@ features:
   va_dependents_v2:
     actor_type: user
     description: Allows us to toggle bewteen V1 and V2 of the 686c-674 forms.
-  va_online_scheduling_physical_location:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle to display the physical location of an appointment.
   va_online_scheduling_enable_OH_reads:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION


## Summary

This PR removes the feature toggle `va_online_scheduling_physical_location` from the features.yml file

## Related issue(s)

- Link to ticket created in va.gov-team [84111](https://github.com/department-of-veterans-affairs/va.gov-team/issues/84111)


## Testing done

n/a

## Screenshots
n/a

## What areas of the site does it impact?
vaos application

## Acceptance criteria

- [ ]  removes the feature toggle `va_online_scheduling_physical_location` from the features.yml file.


