### PR TITLE
84169: Add case_id to IvcChampVAForms table

### DIFF
--- a/db/migrate/20240605161809_add_case_id_to_ivc_champva_forms.rb
+++ b/db/migrate/20240605161809_add_case_id_to_ivc_champva_forms.rb
@@ -1,7 +1,5 @@
 class AddCaseIdToIvcChampvaForms < ActiveRecord::Migration[7.1]
   def change
-    safety_assured do
-      add_column :ivc_champva_forms, :pega_case_id, :string, null: true
-    end
+    add_column :ivc_champva_forms, :pega_case_id, :string, null: true
   end
 end

--- a/db/migrate/20240605161809_add_case_id_to_ivc_champva_forms.rb
+++ b/db/migrate/20240605161809_add_case_id_to_ivc_champva_forms.rb
@@ -1,0 +1,7 @@
+class AddCaseIdToIvcChampvaForms < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      add_column :ivc_champva_forms, :pega_case_id, :string, null: true
+    end
+  end
+end

--- a/db/migrate/20240605161809_add_case_id_to_ivc_champva_forms.rb
+++ b/db/migrate/20240605161809_add_case_id_to_ivc_champva_forms.rb
@@ -1,5 +1,5 @@
 class AddCaseIdToIvcChampvaForms < ActiveRecord::Migration[7.1]
   def change
-    add_column :ivc_champva_forms, :pega_case_id, :string, null: true
+    add_column :ivc_champva_forms, :case_id, :string, null: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -865,7 +865,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_161809) do
     t.string "pega_status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "pega_case_id"
+    t.string "case_id"
     t.index ["form_uuid"], name: "index_ivc_champva_forms_on_form_uuid"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_20_191416) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_161809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -865,6 +865,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_191416) do
     t.string "pega_status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "pega_case_id"
     t.index ["form_uuid"], name: "index_ivc_champva_forms_on_form_uuid"
   end
 


### PR DESCRIPTION
First of a couple of PRs, this one just adds the column to the DB table.

## Summary

- Generate migration to add `case_id` to IvcChampVaForms table

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84169

## Screenshots
<img width="155" alt="Screenshot 2024-06-05 at 1 09 34 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/1422922/9fdb1fc1-5bd3-4781-b05c-54eae96c218f">
