### PR TITLE
Remove va_online_scheduling_GA4_migration feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1142,10 +1142,6 @@ features:
     actor_type: user
     description: Allows toggling of MAP STS OAuth token for VAOS
     enable_in_development: true
-  va_online_scheduling_GA4_migration:
-    actor_type: user
-    description: Toggle for the GA4 events migration work.
-    enable_in_development: true
   va_online_scheduling_vaos_service_cc_appointments:
     actor_type: user
     description: Toggle for new vaos service cc appointments.


### PR DESCRIPTION
## Summary

- Removing va_online_scheduling_GA4_migration feature toggle which is now obsolete.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82973

## Testing done

- Ensure existing test suite passes

## Acceptance criteria

- [ ] Remove any references of the feature toggle va_online_scheduling_GA4_migration
- [ ] Changes have been updated in vets-api
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
