### PR TITLE
Enable single-contention new claims for EP400 Merge

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -120,6 +120,12 @@ module Form526ClaimFastTrackingConcern
     disabilities.pluck('diagnosticCode')
   end
 
+  def eligible_for_ep_merge?
+    return false unless disabilities.count == 1
+
+    Flipper.enabled?(:disability_526_ep_merge_new_claims, User.find(user_uuid)) ? increase_or_new? : increase_only?
+  end
+
   def prepare_for_evss!
     begin
       is_claim_fully_classified = update_classification!
@@ -127,7 +133,7 @@ module Form526ClaimFastTrackingConcern
       Rails.logger.error "Contention Classification failed #{e.message}.", backtrace: e.backtrace
     end
 
-    prepare_for_ep_merge! if disabilities.count == 1 && increase_only? && is_claim_fully_classified
+    prepare_for_ep_merge! if eligible_for_ep_merge? && is_claim_fully_classified
 
     return if pending_eps? || disabilities_not_service_connected?
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -379,6 +379,9 @@ features:
   disability_526_ep_merge_api:
     actor_type: user
     description: enables sending 526 claims with a pending EP to VRO EP Merge API for automated merging.
+  disability_526_ep_merge_new_claims:
+    actor_type: user
+    description: enables EP Merge for single-contention 526 claims for a new condition
   disability_526_toxic_exposure:
     actor_type: user
     description: enables new pages, processing, and submission of toxic exposure claims

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1238,4 +1238,32 @@ RSpec.describe Form526Submission do
       end
     end
   end
+
+  describe '#eligible_for_ep_merge?' do
+    subject { Form526Submission.create(form_json: File.read(path)).eligible_for_ep_merge? }
+
+    context 'when there are multiple contentions' do
+      let(:path) { 'spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities.json' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when there is a single new contention' do
+      let(:path) { 'spec/support/disability_compensation_form/submissions/only_526_new_disability.json' }
+
+      context 'when new claims are eligible' do
+        before { Flipper.enable(:disability_526_ep_merge_new_claims) }
+        after { Flipper.disable(:disability_526_ep_merge_new_claims) }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when new claims are not eligible' do
+        before { Flipper.disable(:disability_526_ep_merge_new_claims) }
+        after { Flipper.enable(:disability_526_ep_merge_new_claims) }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
 end

--- a/spec/support/disability_compensation_form/submissions/only_526_new_disability.json
+++ b/spec/support/disability_compensation_form/submissions/only_526_new_disability.json
@@ -1,0 +1,127 @@
+{
+  "form526": {
+    "form526": {
+      "veteran": {
+        "emailAddress": "test@email.com",
+        "alternateEmailAddress": "test2@email.com",
+        "mailingAddress": {
+          "country": "USA",
+          "addressLine1": "1234 Classy Street",
+          "addressLine2": "Apartment 567",
+          "type": "DOMESTIC",
+          "city": "Quaint Town",
+          "state": "OR",
+          "zipFirstFive": "85918",
+          "zipLastFour": "1212"
+        },
+        "forwardingAddress": {
+          "effectiveDate": "2018-03-29",
+          "country": "USA",
+          "addressLine1": "1234 de Buen Tono Calle",
+          "addressLine2": "Apartamento 567",
+          "type": "MILITARY",
+          "militaryPostOfficeTypeCode": "APO",
+          "militaryStateCode": "AA",
+          "zipFirstFive": "12345",
+          "zipLastFour": "6789"
+        },
+        "primaryPhone": {
+          "areaCode": "202",
+          "phoneNumber": "4561111"
+        },
+        "homelessness": {
+          "hasPointOfContact": true,
+          "pointOfContact": {
+            "pointOfContactName": "Ted",
+            "primaryPhone": {
+              "areaCode": "123",
+              "phoneNumber": "4567890"
+            }
+          }
+        },
+        "serviceNumber": "string"
+      },
+      "militaryPayments": {
+        "payments": [],
+        "receiveCompensationInLieuOfRetired": false
+      },
+      "serviceInformation": {
+        "servicePeriods": [
+          {
+            "serviceBranch": "National Oceanic & Atmospheric Administration",
+            "activeDutyBeginDate": "2018-03-29",
+            "activeDutyEndDate": "2018-03-29"
+          }
+        ],
+        "reservesNationalGuardService": {
+          "title10Activation": {
+            "title10ActivationDate": "2018-03-29",
+            "anticipatedSeparationDate": "2018-03-29"
+          },
+          "obligationTermOfServiceFromDate": "2018-03-29",
+          "obligationTermOfServiceToDate": "2018-03-29",
+          "unitName": "string",
+          "inactiveDutyTrainingPay": {
+            "waiveVABenefitsToRetainTrainingPay": false
+          }
+        },
+        "alternateNames": [
+          {
+            "firstName": "string",
+            "middleName": "string",
+            "lastName": "string"
+          }
+        ],
+        "confinements": [
+          {
+            "confinementBeginDate": "2018-03-29",
+            "confinementEndDate": "2018-03-29",
+            "verifiedIndicator": false
+          }
+        ]
+      },
+      "disabilities": [
+        {
+          "name": "Diabetes mellitus",
+          "classificationCode": "string",
+          "disabilityActionType": "NEW"
+        }
+      ],
+      "treatments": [
+        {
+          "center": {
+            "name": "string",
+            "type": "DOD_MTF",
+            "country": "USA",
+            "city": "string",
+            "state": "OR"
+          },
+          "startDate": "2018-03-29",
+          "endDate": "2018-03-29"
+        }
+      ],
+      "specialCircumstances": [
+        {
+          "name": "string",
+          "code": "string",
+          "needed": false
+        }
+      ],
+      "standardClaim": false,
+      "claimantCertification": true,
+      "autoCestPDFGenerationDisabled": false,
+      "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+      "directDeposit": {
+        "accountType": "CHECKING",
+        "accountNumber": "9876543211234",
+        "routingNumber": "042102115",
+        "bankName": "Comerica"
+      }
+    }
+  },
+  "form526_uploads": [],
+  "form4142": null,
+  "form0781": null,
+  "form8940": null,
+  "flashes": []
+}


### PR DESCRIPTION
## Summary

- This work is behind the feature toggle `disability_526_ep_merge_new_claims`.
  - Feature toggle will be removed 30 days after initial launch (ETA late June) -- assuming no unrecoverable errors are seen in the EP Merge API monitor.
- This PR enables 526 submissions with a single NEW contention to be eligible for EP400 Merge.
- I'm on the Employee Experience team, and we work with the Disability Benefits team on this codebase.

## Related issue(s)
- department-of-veterans-affairs/abd-vro#3035

## Testing done
- [x] *New code is covered by unit tests*
- Old behavior: only 526 claims with a single contention for increase are eligible
- New RSpec added to cover eligibility test for feature toggle on and off
- Testing plan for rollout: Verify eligibility in Staging + VBMS UAT

## What areas of the site does it impact?
* No user-facing changes

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
