### PR TITLE
[84694] STS validation error handling updates

### DIFF
--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -15,7 +15,7 @@ module SignIn
       validate_scopes
       validate_user_attributes
       validate_subject
-      validate_issued_at
+      validate_issued_at_time
       validate_expiration
       create_new_access_token
     end
@@ -58,7 +58,7 @@ module SignIn
       end
     end
 
-    def validate_issued_at
+    def validate_issued_at_time
       if issued_at_time.blank? || issued_at_time > Time.now.to_i
         raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion issuance timestamp is not valid'
       end

--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -10,7 +10,7 @@ module SignIn
 
     def perform
       validate_service_account_config
-      validate_iss
+      validate_issuer
       validate_audience
       validate_scopes
       validate_user_attributes
@@ -28,14 +28,14 @@ module SignIn
       end
     end
 
-    def validate_iss
-      if decoded_assertion.iss != audience
+    def validate_issuer
+      if issuer != audience
         raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion issuer is not valid'
       end
     end
 
     def validate_audience
-      unless Array(decoded_assertion.aud).include?(token_route)
+      unless Array(assertion_audience).include?(token_route)
         raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion audience is not valid'
       end
     end
@@ -115,6 +115,14 @@ module SignIn
 
     def user_identifier
       @user_identifier ||= decoded_assertion.sub
+    end
+
+    def issuer
+      @issuer ||= decoded_assertion.iss
+    end
+
+    def assertion_audience
+      @assertion_audience ||= decoded_assertion.aud
     end
 
     def audience

--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -35,7 +35,7 @@ module SignIn
     end
 
     def validate_audience
-      unless Array(assertion_audience).include?(token_route)
+      unless assertion_audience.include?(token_route)
         raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion audience is not valid'
       end
     end
@@ -59,13 +59,13 @@ module SignIn
     end
 
     def validate_issued_at
-      if iat.blank? || iat > Time.now.to_i
+      if issued_at_time.blank? || issued_at_time > Time.now.to_i
         raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion issuance timestamp is not valid'
       end
     end
 
     def validate_expiration
-      if exp.blank?
+      if expiration.blank?
         raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion expiration timestamp is not valid'
       end
     end
@@ -122,19 +122,19 @@ module SignIn
     end
 
     def assertion_audience
-      @assertion_audience ||= decoded_assertion.aud
+      @assertion_audience ||= Array(decoded_assertion.aud)
     end
 
     def audience
       @audience ||= service_account_config.access_token_audience
     end
 
-    def iat
-      @iat ||= decoded_assertion.iat
+    def issued_at_time
+      @issued_at_time ||= decoded_assertion.iat
     end
 
-    def exp
-      @exp ||= decoded_assertion.exp
+    def expiration
+      @expiration ||= decoded_assertion.exp
     end
 
     def service_account_config

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -1547,6 +1547,7 @@ RSpec.describe V0::SignInController, type: :controller do
             aud:,
             sub:,
             jti:,
+            iat:,
             exp:,
             service_account_id:,
             scopes:
@@ -1556,6 +1557,7 @@ RSpec.describe V0::SignInController, type: :controller do
         let(:aud) { "https://#{Settings.hostname}#{SignIn::Constants::Auth::TOKEN_ROUTE_PATH}" }
         let(:sub) { user_identifier }
         let(:jti) { 'some-jti' }
+        let(:iat) { 1.month.ago.to_i }
         let(:exp) { 1.month.since.to_i }
         let(:user_identifier) { 'some-user-identifier' }
         let(:service_account_id) { service_account_config.service_account_id }

--- a/spec/services/sign_in/assertion_validator_spec.rb
+++ b/spec/services/sign_in/assertion_validator_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SignIn::AssertionValidator do
         aud:,
         sub:,
         jti:,
+        iat:,
         exp:,
         service_account_id:,
         scopes:
@@ -23,6 +24,7 @@ RSpec.describe SignIn::AssertionValidator do
     let(:aud) { 'some-aud' }
     let(:sub) { 'some-sub' }
     let(:jti) { 'some-jti' }
+    let(:iat) { 1.month.ago.to_i }
     let(:exp) { 1.month.since.to_i }
     let(:scopes) { service_account_config.scopes }
     let(:service_account_id) { service_account_config.service_account_id }
@@ -66,6 +68,7 @@ RSpec.describe SignIn::AssertionValidator do
 
     context 'when jwt is valid' do
       let(:assertion) { JWT.encode(assertion_payload, private_key, assertion_encode_algorithm) }
+      let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
 
       context 'and service account config in assertion does not match an existing service account config' do
         let(:service_account_id) { 'some-service-account-id' }
@@ -82,7 +85,6 @@ RSpec.describe SignIn::AssertionValidator do
 
         context 'and iss does not equal service account config audience' do
           let(:iss) { 'some-iss' }
-          let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
           let(:expected_error_message) { 'Assertion issuer is not valid' }
 
           it 'raises service account assertion attributes error' do
@@ -93,9 +95,18 @@ RSpec.describe SignIn::AssertionValidator do
         context 'and iss equals service account config audience' do
           let(:iss) { service_account_audience }
 
+          context 'and audience is not present' do
+            before { assertion_payload.delete(:aud) }
+
+            let(:expected_error_message) { 'Assertion audience is not valid' }
+
+            it 'raises service account assertion attributes error' do
+              expect { subject }.to raise_error(expected_error, expected_error_message)
+            end
+          end
+
           context 'and audience does not match token route' do
             let(:aud) { 'some-aud' }
-            let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
             let(:expected_error_message) { 'Assertion audience is not valid' }
 
             it 'raises service account assertion attributes error' do
@@ -106,9 +117,30 @@ RSpec.describe SignIn::AssertionValidator do
           context 'and audience matches token route' do
             let(:aud) { token_route }
 
+            context 'and scopes are not present' do
+              before { assertion_payload.delete(:scopes) }
+
+              let(:expected_error_message) { 'Assertion scopes are not valid' }
+
+              context 'and service account config scopes are not present' do
+                let(:service_account_config) do
+                  create(:service_account_config, certificates: [assertion_certificate], scopes: [])
+                end
+
+                it 'does not raise an error' do
+                  expect { subject }.not_to raise_error
+                end
+              end
+
+              context 'and service account config scopes are present' do
+                it 'raises service account assertion attributes error' do
+                  expect { subject }.to raise_error(expected_error, expected_error_message)
+                end
+              end
+            end
+
             context 'and scopes are not a subset of service account config scopes' do
               let(:scopes) { ['some-scopes'] }
-              let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
               let(:expected_error_message) { 'Assertion scopes are not valid' }
 
               it 'raises service account assertion attributes error' do
@@ -119,20 +151,63 @@ RSpec.describe SignIn::AssertionValidator do
             context 'and scopes are a subset of service account config scopes' do
               let(:scopes) { [service_account_config.scopes.first] }
 
-              it 'returns service account access token with expected service account id' do
-                expect(subject.service_account_id).to eq(service_account_id)
+              context 'and subject is not present' do
+                before { assertion_payload.delete(:sub) }
+
+                let(:expected_error_message) { 'Assertion subject is not valid' }
+
+                it 'raises service account assertion attributes error' do
+                  expect { subject }.to raise_error(expected_error, expected_error_message)
+                end
               end
 
-              it 'returns service account access token with expected audience' do
-                expect(subject.audience).to eq(service_account_audience)
-              end
+              context 'and subject is present' do
+                context 'and iat is missing' do
+                  before { assertion_payload.delete(:iat) }
 
-              it 'returns service account access token with expected scopes' do
-                expect(subject.scopes).to eq(scopes)
-              end
+                  let(:expected_error_message) { 'Assertion issuance timestamp is not valid' }
 
-              it 'returns service account access token with expected user identifier' do
-                expect(subject.user_identifier).to eq(sub)
+                  it 'raises service account assertion attributes error' do
+                    expect { subject }.to raise_error(expected_error, expected_error_message)
+                  end
+                end
+
+                context 'and iat is in the future' do
+                  let(:iat) { 1.month.from_now.to_i }
+                  let(:expected_error_message) { 'Assertion issuance timestamp is not valid' }
+
+                  it 'raises service account assertion attributes error' do
+                    expect { subject }.to raise_error(expected_error, expected_error_message)
+                  end
+                end
+
+                context 'and exp is missing' do
+                  before { assertion_payload.delete(:exp) }
+
+                  let(:expected_error_message) { 'Assertion expiration timestamp is not valid' }
+
+                  it 'raises service account assertion attributes error' do
+                    expect { subject }.to raise_error(expected_error, expected_error_message)
+                  end
+                end
+
+                context 'and iat & exp are present and valid' do
+                  it 'returns service account access token with expected service account id' do
+                    expect(subject.service_account_id).to eq(service_account_id)
+                  end
+
+                  it 'returns service account access token with expected audience' do
+                    expect(subject.audience).to eq(service_account_audience)
+                  end
+
+                  it 'returns service account access token with expected scopes' do
+                    expect(subject.scopes).to eq(scopes)
+                  end
+
+                  it 'returns service account access token with expected user identifier' do
+                    expect(subject.user_identifier).to eq(sub)
+                  end
+                end
               end
             end
           end
@@ -149,6 +224,7 @@ RSpec.describe SignIn::AssertionValidator do
             aud: token_route,
             sub:,
             jti:,
+            iat:,
             exp: 1.month.from_now.to_i,
             service_account_id: service_account_config.service_account_id,
             scopes: [service_account_config.scopes.first],

--- a/spec/services/sign_in/assertion_validator_spec.rb
+++ b/spec/services/sign_in/assertion_validator_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe SignIn::AssertionValidator do
           let(:iss) { service_account_audience }
 
           context 'and audience is not present' do
-            before { assertion_payload.delete(:aud) }
-
             let(:expected_error_message) { 'Assertion audience is not valid' }
+
+            before { assertion_payload.delete(:aud) }
 
             it 'raises service account assertion attributes error' do
               expect { subject }.to raise_error(expected_error, expected_error_message)
@@ -120,8 +120,6 @@ RSpec.describe SignIn::AssertionValidator do
             context 'and scopes are not present' do
               before { assertion_payload.delete(:scopes) }
 
-              let(:expected_error_message) { 'Assertion scopes are not valid' }
-
               context 'and service account config scopes are not present' do
                 let(:service_account_config) do
                   create(:service_account_config, certificates: [assertion_certificate], scopes: [])
@@ -133,6 +131,8 @@ RSpec.describe SignIn::AssertionValidator do
               end
 
               context 'and service account config scopes are present' do
+                let(:expected_error_message) { 'Assertion scopes are not valid' }
+
                 it 'raises service account assertion attributes error' do
                   expect { subject }.to raise_error(expected_error, expected_error_message)
                 end
@@ -152,9 +152,9 @@ RSpec.describe SignIn::AssertionValidator do
               let(:scopes) { [service_account_config.scopes.first] }
 
               context 'and subject is not present' do
-                before { assertion_payload.delete(:sub) }
-
                 let(:expected_error_message) { 'Assertion subject is not valid' }
+
+                before { assertion_payload.delete(:sub) }
 
                 it 'raises service account assertion attributes error' do
                   expect { subject }.to raise_error(expected_error, expected_error_message)
@@ -163,9 +163,9 @@ RSpec.describe SignIn::AssertionValidator do
 
               context 'and subject is present' do
                 context 'and iat is missing' do
-                  before { assertion_payload.delete(:iat) }
-
                   let(:expected_error_message) { 'Assertion issuance timestamp is not valid' }
+
+                  before { assertion_payload.delete(:iat) }
 
                   it 'raises service account assertion attributes error' do
                     expect { subject }.to raise_error(expected_error, expected_error_message)
@@ -182,9 +182,9 @@ RSpec.describe SignIn::AssertionValidator do
                 end
 
                 context 'and exp is missing' do
-                  before { assertion_payload.delete(:exp) }
-
                   let(:expected_error_message) { 'Assertion expiration timestamp is not valid' }
+
+                  before { assertion_payload.delete(:exp) }
 
                   it 'raises service account assertion attributes error' do
                     expect { subject }.to raise_error(expected_error, expected_error_message)


### PR DESCRIPTION
# Summary

- Updates STS assertion validation to cover missing attributes and improve other validations.

## Updated Validations
### `aud`
- Updated to take a string or array argument, passing an array will result in the first item in the array evaluated as `aud`.
- Updated to return `400` with `Assertion audience is not valid` if attribute is missing.

### `scopes`
- Updated to return `400` with `Assertion scopes are not valid` if attribute is missing.
- Will only error if `scopes` param is empty AND the related `ServiceAccountConfig` has populated `scopes` - empty scopes can be passed if the request is tied to a SAC with no saved scopes.

### `sub`
- Updated to return `400` with `Assertion subject is not valid` if attribute is missing.

### `iat`
- Updated to return `400` with `Assertion issuance timestamp is not valid` if attribute is missing or `iat` is set to a date in the future.

### `exp`
- Updated to return `400` with `Assertion expiration timestamp is not valid` if attribute is missing.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84694

## Testing done

- [x] *New code is covered by unit tests*
- To test, start with a valid STS assertion:
```ruby
string_key = File.read('spec/fixtures/sign_in/identity_dashboard_service_account.pem')
private_key = OpenSSL::PKey::RSA.new(string_key)

current_time = Time.now.to_i
token = {
'iss' => 'http://localhost:4000',
'sub' => 'vets.gov.user+0@gmail.com',
'aud' => 'http://127.0.0.1:3000/v0/sign_in/token',
'iat' => current_time,
'exp' => current_time + 300,
'scopes' => ['http://localhost:3000/v0/account_controls/credential_index'],
'service_account_id' => '01b8ebaac5215f84640ade756b645f28',
'jti' => '2ed8a21d207adf50eb935e32d25a41ff',
'user_attributes' => { 'icn' => '1012667122V019349' }
}

JWT.encode(token, private_key, 'RS256')
```
- Test the validation by re-creating the token payload without the attribute to be tested.

### `aud`
- Remove `aud` attribute - `[SignInService] [V0::SignInController] token error -- { :errors => "Assertion audience is not valid" }`
- Wrap `aud` attribute in an array - `['http://127.0.0.1:3000/v0/sign_in/token']` - passes validation

### `scopes`
- Remove `scopes` attribute - `[SignInService] [V0::SignInController] token error -- { :errors => "Assertion scopes are not valid" }`
- Update `ServiceAccountConfig` to remove saved scopes:
```ruby
account = SignIn::ServiceAccountConfig.find('01b8ebaac5215f84640ade756b645f28')
account.scopes = []
account.save
```
- Attempt same assertion without `scopes` attribute - passes validation. Reset `ServiceAccountConfig` to original scopes to prevent further validation failures.

### `sub`
- Remove `sub` attribute - `[SignInService] [V0::SignInController] token error -- { :errors => "Assertion subject is not valid" }`

### `iat`
- Remove `iat` attribute - `[SignInService] [V0::SignInController] token error -- { :errors => "Assertion issuance timestamp is not valid" }`
- Set `iat` attribute to the future, validation should fail.
```ruby
current_time = 1.month.from_now.to_i
```

### `exp`
- Remove `iat` attribute - `[SignInService] [V0::SignInController] token error -- { :errors => "Assertion expiration timestamp is not valid" }`

## What areas of the site does it impact?
STS token requests.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  [Documentation has been updated](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Products/Sign-In%20Service/Engineering%20Docs/auth_flows/service_account.md)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added logs of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
