### PR TITLE
Sort by appt date initially

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -93,7 +93,7 @@ module TravelPay
       end
 
       symbolized_body = response.body.deep_symbolize_keys
-      parse_claim_date = ->(c) { Date.parse(c[:modifiedOn]) }
+      parse_claim_date = ->(c) { Date.parse(c[:appointmentDateTime]) }
 
       sorted_claims = symbolized_body[:data].sort_by(&parse_claim_date).reverse
 

--- a/modules/travel_pay/spec/services/client_spec.rb
+++ b/modules/travel_pay/spec/services/client_spec.rb
@@ -87,7 +87,7 @@ describe TravelPay::Client do
                 'id' => 'uuid1',
                 'claimNumber' => 'TC0000000000001',
                 'claimStatus' => 'InProgress',
-                'appointmentDateTime' => '2024-04-22T16:45:34.465Z',
+                'appointmentDateTime' => '2024-01-01T16:45:34.465Z',
                 'facilityName' => 'Cheyenne VA Medical Center',
                 'createdOn' => '2024-03-22T21:22:34.465Z',
                 'modifiedOn' => '2024-01-01T16:44:34.465Z'
@@ -96,7 +96,7 @@ describe TravelPay::Client do
                 'id' => 'uuid2',
                 'claimNumber' => 'TC0000000000002',
                 'claimStatus' => 'InProgress',
-                'appointmentDateTime' => '2024-04-22T16:45:34.465Z',
+                'appointmentDateTime' => '2024-03-01T16:45:34.465Z',
                 'facilityName' => 'Cheyenne VA Medical Center',
                 'createdOn' => '2024-02-22T21:22:34.465Z',
                 'modifiedOn' => '2024-03-01T00:00:00.0Z'
@@ -105,7 +105,7 @@ describe TravelPay::Client do
                 'id' => 'uuid3',
                 'claimNumber' => 'TC0000000000002',
                 'claimStatus' => 'Incomplete',
-                'appointmentDateTime' => '2024-04-22T16:45:34.465Z',
+                'appointmentDateTime' => '2024-02-01T16:45:34.465Z',
                 'facilityName' => 'Cheyenne VA Medical Center',
                 'createdOn' => '2024-01-22T21:22:34.465Z',
                 'modifiedOn' => '2024-02-01T00:00:00.0Z'


### PR DESCRIPTION
## Summary
Fixed assumption about how travel pay claims should be sorted

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#85472

## Testing done

- [x] *New code is covered by unit tests*
- Previously: Sorted by `modifiedOn`
- Now: Sorts by 'appointmentDateTime`

## Screenshots
<img width="966" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/462039/263ff3dd-d02c-4f02-9faa-6781e843907d">

## What areas of the site does it impact?
Travel Pay Status Page only

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
