### PR TITLE
check flag status by user

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -287,12 +287,12 @@ class HealthCareApplication < ApplicationRecord
   end
 
   def current_schema
-    schema = VetsJsonSchema::SCHEMAS[self.class::FORM_ID]
-    return schema unless Flipper.enabled?(:hca_use_facilities_API)
-
     Rails.logger.warn(
-      "HealthCareApplication::hca_use_facilitiesAPI enabled = #{Flipper.enabled?(:hca_use_facilities_API)}"
+      "HealthCareApplication::hca_use_facilitiesAPI enabled = #{Flipper.enabled?(:hca_use_facilities_API, user)}"
     )
+
+    schema = VetsJsonSchema::SCHEMAS[self.class::FORM_ID]
+    return schema unless Flipper.enabled?(:hca_use_facilities_API, user)
 
     schema.deep_dup.tap do |c|
       c['properties']['vaMedicalFacility'] = { type: 'string' }.as_json

--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -287,12 +287,13 @@ class HealthCareApplication < ApplicationRecord
   end
 
   def current_schema
+    feature_enabled_for_user = Flipper.enabled?(:hca_use_facilities_API, user)
     Rails.logger.warn(
-      "HealthCareApplication::hca_use_facilitiesAPI enabled = #{Flipper.enabled?(:hca_use_facilities_API, user)}"
+      "HealthCareApplication::hca_use_facilitiesAPI enabled = #{feature_enabled_for_user}"
     )
 
     schema = VetsJsonSchema::SCHEMAS[self.class::FORM_ID]
-    return schema unless Flipper.enabled?(:hca_use_facilities_API, user)
+    return schema unless feature_enabled_for_user
 
     schema.deep_dup.tap do |c|
       c['properties']['vaMedicalFacility'] = { type: 'string' }.as_json

--- a/spec/requests/health_care_applications_request_spec.rb
+++ b/spec/requests/health_care_applications_request_spec.rb
@@ -485,6 +485,29 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
           expect(JSON.parse(response.body)['data']['attributes']).to eq(body)
         end
       end
+
+      context 'with hca_use_facilities_API disabled' do
+        let(:current_user) { create(:user) }
+
+        before do
+          sign_in_as(current_user)
+          Flipper.disable(:hca_use_facilities_API)
+        end
+
+        let(:params) do
+          test_veteran['vaMedicalFacility'] = '000'
+          {
+            form: test_veteran.to_json
+          }
+        end
+
+        it 'errors on vaMedicalFacility validation' do
+          subject
+
+          expect(JSON.parse(response.body)['errors']).not_to be_blank
+          expect(JSON.parse(response.body)['errors'].first['title']).to include('"000" did not match')
+        end
+      end
     end
   end
 end

--- a/spec/requests/health_care_applications_request_spec.rb
+++ b/spec/requests/health_care_applications_request_spec.rb
@@ -455,8 +455,12 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
       end
 
       context 'with hca_use_facilities_API enabled' do
+        let(:current_user) { create(:user) }
+
         before do
-          Flipper.enable(:hca_use_facilities_API)
+          sign_in_as(current_user)
+          Flipper.disable(:hca_use_facilities_API)
+          Flipper.enable(:hca_use_facilities_API, current_user)
         end
 
         let(:params) do
@@ -476,6 +480,8 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
 
         it 'does not error on vaMedicalFacility validation' do
           subject
+
+          expect(JSON.parse(response.body)['errors']).to be_blank
           expect(JSON.parse(response.body)['data']['attributes']).to eq(body)
         end
       end


### PR DESCRIPTION
## Summary

- Fixes the preceding implementation to take the current User into account for evaluating whether the Flipper feature flag is enabled, so when we enable it for 25% of logged in users we don't wind up failing to validate API-derived facilities against the stale static JSON.
- *This work is behind a feature toggle (flipper): YES*
- *(If bug, how to reproduce)* Enable the feature flag for a % of logged in users, log in, go through the 10-10EZ form, select a Facility not in the static JSON constant, and submit. Produces an error that the (valid) Facility ID is not in the (stale) list.
- *(What is the solution, why is this the solution?)* do the Feature Flag check with the current User, which syncs up the backend validation with the frontend decision of which Facilities UI to show
- *(Which team do you work for, does your team own the maintenance of this component?)* 10-10 Health Enrollment Team, EZ/CG subteam

## Related issue(s)

- https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/79437

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?

* 10-10EZ form's Medical Facility selection page

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
