### PR TITLE
84572 add constants

### DIFF
--- a/modules/check_in/app/sidekiq/check_in/constants.rb
+++ b/modules/check_in/app/sidekiq/check_in/constants.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CheckIn
+  module Constants
+    # settings for travel claims for vista appts
+    STATSD_NOTIFY_ERROR = 'worker.checkin.travel_claim.notify.error'
+    STATSD_NOTIFY_SUCCESS = 'worker.checkin.travel_claim.notify.success'
+
+    CIE_SUCCESS_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_success_text
+    CIE_DUPLICATE_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_duplicate_text
+    CIE_ERROR_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_error_text
+    CIE_TIMEOUT_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_timeout_text
+
+    CIE_SMS_SENDER_ID = Settings.vanotify.services.check_in.sms_sender_id
+
+    CIE_STATSD_BTSSS_SUCCESS = 'worker.checkin.travel_claim.btsss.success'
+    CIE_STATSD_BTSSS_ERROR = 'worker.checkin.travel_claim.btsss.error'
+    CIE_STATSD_BTSSS_TIMEOUT = 'worker.checkin.travel_claim.btsss.timeout'
+    CIE_STATSD_BTSSS_DUPLICATE = 'worker.checkin.travel_claim.btsss.duplicate'
+
+    # settings for travel claims for oracle health appts
+    OH_SUCCESS_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_success_text
+    OH_DUPLICATE_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_duplicate_text
+    OH_ERROR_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_error_text
+    OH_TIMEOUT_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_timeout_text
+
+    OH_SMS_SENDER_ID = Settings.vanotify.services.oracle_health.sms_sender_id
+
+    OH_STATSD_BTSSS_SUCCESS = 'worker.oracle_health.travel_claim.btsss.success'
+    OH_STATSD_BTSSS_ERROR = 'worker.oracle_health.travel_claim.btsss.error'
+    OH_STATSD_BTSSS_TIMEOUT = 'worker.oracle_health.travel_claim.btsss.timeout'
+    OH_STATSD_BTSSS_DUPLICATE = 'worker.oracle_health.travel_claim.btsss.duplicate'
+  end
+end

--- a/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
@@ -9,35 +9,6 @@ module CheckIn
 
     sidekiq_options retry: false
 
-    # settings for travel claims for vista appts
-    STATSD_NOTIFY_ERROR = 'worker.checkin.travel_claim.notify.error'
-    STATSD_NOTIFY_SUCCESS = 'worker.checkin.travel_claim.notify.success'
-
-    CIE_SUCCESS_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_success_text
-    CIE_DUPLICATE_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_duplicate_text
-    CIE_ERROR_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_error_text
-    CIE_TIMEOUT_TEMPLATE_ID = Settings.vanotify.services.check_in.template_id.claim_submission_timeout_text
-
-    CIE_SMS_SENDER_ID = Settings.vanotify.services.check_in.sms_sender_id
-
-    CIE_STATSD_BTSSS_SUCCESS = 'worker.checkin.travel_claim.btsss.success'
-    CIE_STATSD_BTSSS_ERROR = 'worker.checkin.travel_claim.btsss.error'
-    CIE_STATSD_BTSSS_TIMEOUT = 'worker.checkin.travel_claim.btsss.timeout'
-    CIE_STATSD_BTSSS_DUPLICATE = 'worker.checkin.travel_claim.btsss.duplicate'
-
-    # settings for travel claims for oracle health settings
-    OH_SUCCESS_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_success_text
-    OH_DUPLICATE_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_duplicate_text
-    OH_ERROR_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_error_text
-    OH_TIMEOUT_TEMPLATE_ID = Settings.vanotify.services.oracle_health.template_id.claim_submission_timeout_text
-
-    OH_SMS_SENDER_ID = Settings.vanotify.services.oracle_health.sms_sender_id
-
-    OH_STATSD_BTSSS_SUCCESS = 'worker.oracle_health.travel_claim.btsss.success'
-    OH_STATSD_BTSSS_ERROR = 'worker.oracle_health.travel_claim.btsss.error'
-    OH_STATSD_BTSSS_TIMEOUT = 'worker.oracle_health.travel_claim.btsss.timeout'
-    OH_STATSD_BTSSS_DUPLICATE = 'worker.oracle_health.travel_claim.btsss.duplicate'
-
     def perform(uuid, appointment_date)
       redis_client = TravelClaim::RedisClient.build
       mobile_phone = redis_client.patient_cell_phone(uuid:)
@@ -56,7 +27,7 @@ module CheckIn
       claim_number, template_id = submit_claim(uuid:, appointment_date:, station_number:, facility_type:)
 
       send_notification(mobile_phone:, appointment_date:, template_id:, claim_number:, facility_type:)
-      StatsD.increment(STATSD_NOTIFY_SUCCESS)
+      StatsD.increment(Constants::STATSD_NOTIFY_SUCCESS)
     end
 
     def submit_claim(opts = {})
@@ -71,11 +42,11 @@ module CheckIn
     rescue => e
       logger.error({ message: "Error calling BTSSS Service: #{e.message}" }.merge(opts))
       if 'oh'.casecmp?(opts[:facility_type])
-        StatsD.increment(OH_STATSD_BTSSS_ERROR)
-        template_id = OH_ERROR_TEMPLATE_ID
+        StatsD.increment(Constants::OH_STATSD_BTSSS_ERROR)
+        template_id = Constants::OH_ERROR_TEMPLATE_ID
       else
-        StatsD.increment(CIE_STATSD_BTSSS_ERROR)
-        template_id = CIE_ERROR_TEMPLATE_ID
+        StatsD.increment(Constants::CIE_STATSD_BTSSS_ERROR)
+        template_id = Constants::CIE_ERROR_TEMPLATE_ID
       end
       [nil, template_id]
     end
@@ -90,24 +61,24 @@ module CheckIn
                                    when 'oh'
                                      case code
                                      when TravelClaim::Response::CODE_SUCCESS
-                                       [OH_STATSD_BTSSS_SUCCESS, OH_SUCCESS_TEMPLATE_ID]
+                                       [Constants::OH_STATSD_BTSSS_SUCCESS, Constants::OH_SUCCESS_TEMPLATE_ID]
                                      when TravelClaim::Response::CODE_CLAIM_EXISTS
-                                       [OH_STATSD_BTSSS_DUPLICATE, OH_DUPLICATE_TEMPLATE_ID]
+                                       [Constants::OH_STATSD_BTSSS_DUPLICATE, Constants::OH_DUPLICATE_TEMPLATE_ID]
                                      when TravelClaim::Response::CODE_BTSSS_TIMEOUT
-                                       [OH_STATSD_BTSSS_TIMEOUT, OH_TIMEOUT_TEMPLATE_ID]
+                                       [Constants::OH_STATSD_BTSSS_TIMEOUT, Constants::OH_TIMEOUT_TEMPLATE_ID]
                                      else
-                                       [OH_STATSD_BTSSS_ERROR, OH_ERROR_TEMPLATE_ID]
+                                       [Constants::OH_STATSD_BTSSS_ERROR, Constants::OH_ERROR_TEMPLATE_ID]
                                      end
                                    else
                                      case code
                                      when TravelClaim::Response::CODE_SUCCESS
-                                       [CIE_STATSD_BTSSS_SUCCESS, CIE_SUCCESS_TEMPLATE_ID]
+                                       [Constants::CIE_STATSD_BTSSS_SUCCESS, Constants::CIE_SUCCESS_TEMPLATE_ID]
                                      when TravelClaim::Response::CODE_CLAIM_EXISTS
-                                       [CIE_STATSD_BTSSS_DUPLICATE, CIE_DUPLICATE_TEMPLATE_ID]
+                                       [Constants::CIE_STATSD_BTSSS_DUPLICATE, Constants::CIE_DUPLICATE_TEMPLATE_ID]
                                      when TravelClaim::Response::CODE_BTSSS_TIMEOUT
-                                       [CIE_STATSD_BTSSS_TIMEOUT, CIE_TIMEOUT_TEMPLATE_ID]
+                                       [Constants::CIE_STATSD_BTSSS_TIMEOUT, Constants::CIE_TIMEOUT_TEMPLATE_ID]
                                      else
-                                       [CIE_STATSD_BTSSS_ERROR, CIE_ERROR_TEMPLATE_ID]
+                                       [Constants::CIE_STATSD_BTSSS_ERROR, Constants::CIE_ERROR_TEMPLATE_ID]
                                      end
                                    end
 
@@ -130,7 +101,7 @@ module CheckIn
       notify_client.send_sms(
         phone_number: opts[:mobile_phone],
         template_id: opts[:template_id],
-        sms_sender_id: 'oh'.casecmp?(opts[:facility_type]) ? OH_SMS_SENDER_ID : CIE_SMS_SENDER_ID,
+        sms_sender_id: 'oh'.casecmp?(opts[:facility_type]) ? Constants::OH_SMS_SENDER_ID : Constants::CIE_SMS_SENDER_ID,
         personalisation: {
           claim_number: opts[:claim_number],
           appt_date: appt_date_in_mmm_dd_format
@@ -148,7 +119,7 @@ module CheckIn
           claim_number: opts[:claim_number] },
         { error: :check_in_va_notify_job, team: 'check-in' }
       )
-      StatsD.increment(STATSD_NOTIFY_ERROR)
+      StatsD.increment(Constants::STATSD_NOTIFY_ERROR)
     end
   end
 end

--- a/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
+++ b/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
@@ -11,10 +11,10 @@ shared_examples 'travel claims worker #perform' do |facility_type|
       @timeout_template_id = Settings.vanotify.services.oracle_health.template_id.claim_submission_timeout_text
       @error_template_id = Settings.vanotify.services.oracle_health.template_id.claim_submission_error_text
 
-      @statsd_success = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_SUCCESS
-      @statsd_duplicate = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_DUPLICATE
-      @statsd_timeout = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_TIMEOUT
-      @statsd_error = CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_ERROR
+      @statsd_success = CheckIn::Constants::OH_STATSD_BTSSS_SUCCESS
+      @statsd_duplicate = CheckIn::Constants::OH_STATSD_BTSSS_DUPLICATE
+      @statsd_timeout = CheckIn::Constants::OH_STATSD_BTSSS_TIMEOUT
+      @statsd_error = CheckIn::Constants::OH_STATSD_BTSSS_ERROR
 
       allow(redis_client).to receive(:facility_type).and_return('oh')
     else
@@ -24,10 +24,10 @@ shared_examples 'travel claims worker #perform' do |facility_type|
       @timeout_template_id = Settings.vanotify.services.check_in.template_id.claim_submission_timeout_text
       @error_template_id = Settings.vanotify.services.check_in.template_id.claim_submission_error_text
 
-      @statsd_success = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_SUCCESS
-      @statsd_duplicate = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_DUPLICATE
-      @statsd_timeout = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_TIMEOUT
-      @statsd_error = CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_ERROR
+      @statsd_success = CheckIn::Constants::CIE_STATSD_BTSSS_SUCCESS
+      @statsd_duplicate = CheckIn::Constants::CIE_STATSD_BTSSS_DUPLICATE
+      @statsd_timeout = CheckIn::Constants::CIE_STATSD_BTSSS_TIMEOUT
+      @statsd_error = CheckIn::Constants::CIE_STATSD_BTSSS_ERROR
 
       allow(redis_client).to receive(:facility_type).and_return(nil)
     end
@@ -56,7 +56,7 @@ shared_examples 'travel claims worker #perform' do |facility_type|
 
       expect(StatsD).to have_received(:increment).with(@statsd_success).exactly(1).time
       expect(StatsD).to have_received(:increment)
-        .with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS).exactly(1).time
+        .with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS).exactly(1).time
     end
   end
 
@@ -82,7 +82,7 @@ shared_examples 'travel claims worker #perform' do |facility_type|
 
       expect(StatsD).to have_received(:increment).with(@statsd_duplicate).exactly(1).time
       expect(StatsD).to have_received(:increment)
-        .with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS).exactly(1).time
+        .with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS).exactly(1).time
     end
   end
 
@@ -108,7 +108,7 @@ shared_examples 'travel claims worker #perform' do |facility_type|
 
       expect(StatsD).to have_received(:increment).with(@statsd_error).exactly(1).time
       expect(StatsD).to have_received(:increment)
-        .with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS).exactly(1).time
+        .with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS).exactly(1).time
     end
   end
 
@@ -138,7 +138,7 @@ shared_examples 'travel claims worker #perform' do |facility_type|
 
       expect(StatsD).to have_received(:increment).with(@statsd_error).exactly(1).time
       expect(StatsD).to have_received(:increment)
-        .with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS).exactly(1).time
+        .with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS).exactly(1).time
     end
   end
 
@@ -152,9 +152,9 @@ shared_examples 'travel claims worker #perform' do |facility_type|
       )
 
       expect(StatsD).not_to receive(:increment)
-        .with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS)
+        .with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS)
       expect(StatsD).to receive(:increment)
-        .with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_ERROR).exactly(1).time
+        .with(CheckIn::Constants::STATSD_NOTIFY_ERROR).exactly(1).time
 
       Sidekiq::Testing.inline! do
         VCR.use_cassette('check_in/vanotify/send_sms_403_forbidden', match_requests_on: [:host]) do
@@ -225,9 +225,9 @@ describe CheckIn::TravelClaimSubmissionWorker, type: :worker do
         worker.perform(uuid, appt_date)
       end
 
-      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::CIE_STATSD_BTSSS_TIMEOUT)
+      expect(StatsD).to have_received(:increment).with(CheckIn::Constants::CIE_STATSD_BTSSS_TIMEOUT)
                                                  .exactly(1).time
-      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS)
+      expect(StatsD).to have_received(:increment).with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS)
                                                  .exactly(1).time
     end
 
@@ -251,9 +251,9 @@ describe CheckIn::TravelClaimSubmissionWorker, type: :worker do
         worker.perform(uuid, appt_date)
       end
 
-      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::OH_STATSD_BTSSS_TIMEOUT)
+      expect(StatsD).to have_received(:increment).with(CheckIn::Constants::OH_STATSD_BTSSS_TIMEOUT)
                                                  .exactly(1).time
-      expect(StatsD).to have_received(:increment).with(CheckIn::TravelClaimSubmissionWorker::STATSD_NOTIFY_SUCCESS)
+      expect(StatsD).to have_received(:increment).with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS)
                                                  .exactly(1).time
     end
   end


### PR DESCRIPTION
Move the Travel Claim worker constants to a separate file so they can be used by other (forthcoming) workers

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84752

## Testing done
- [X] rspecs
- [ ] local integration testing

## What areas of the site does it impact?
check-in travel claim submissions

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
