### PR TITLE
Bugfix ee logging failed request

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -124,7 +124,8 @@ module Form526ClaimFastTrackingConcern
     begin
       is_claim_fully_classified = update_classification!
     rescue => e
-      Rails.logger.error "Contention Classification failed #{e.message}.", backtrace: e.backtrace
+      Rails.logger.error "Contention Classification failed #{e.message}."
+      Rails.logger.error e.backtrace.join('\n')
     end
 
     prepare_for_ep_merge! if disabilities.count == 1 && increase_only? && is_claim_fully_classified

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -388,6 +388,7 @@ module Form526ClaimFastTrackingConcern
     end
   rescue => e
     Rails.logger.error('EP Merge failed open claim review check', backtrace: e.backtrace)
+    Rails.logger.error(e.backtrace.join('\n'))
     true
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1558,7 +1558,7 @@ virtual_regional_office:
   api_key: 9d3868d1-ec15-4889-8002-2bff1b50ba62
   evidence_pdf_path: evidence-pdf
   ctn_classification_path: classifier
-  vagov_classification_path: va-gov-claim-classifier
+  vagov_classification_path: contention-classification/va-gov-claim-classifier
   max_cfi_path: employee-experience/max-ratings
   ep_merge_path: employee-experience-ep-merge-app/merge
 

--- a/spec/support/vcr_cassettes/virtual_regional_office/multi_contention_classification.yml
+++ b/spec/support/vcr_cassettes/virtual_regional_office/multi_contention_classification.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8120/va-gov-claim-classifier
+    uri: http://localhost:8120/contention-classification/va-gov-claim-classifier
     body:
       encoding: UTF-8
       string: '{"claim_id":366,"form526_submission_id":366,"contentions":[{"contention_text":"Asthma,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- Depends on https://github.com/department-of-veterans-affairs/vets-api/pull/17063
- includes backtrace in logs if ep merge fails
- I experienced similar issue where backtrace info wasn't visible and I think this pattern affects the EE error handling as well (see linked PR)
