### PR TITLE
dbex/71773: EVSS Migration - 526 Submit - hook up SubmitForm526 job to Lighthouse synchronous submit endpoint

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -109,6 +109,7 @@ module EVSS
             # send submission data to either EVSS or Lighthouse (LH)
             response = if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration, user) ||
                           submit_to_claims_api # right operand evaluation not needed once fully migrated to LH
+                         debugger
                          # submit 526 through LH API
                          # 1. get user's ICN
                          icn = user_account.icn
@@ -121,14 +122,10 @@ module EVSS
                          options = generate_options_hash(submit_to_claims_api, user)
                          raw_response = service.submit526(body, options)
                          # 4. convert LH raw response to a FormSubmitResponse for further processing (claim_id, status)
-                         # JSON.parse when it matters to get the claim id
-                         # something like response_json = JSON.parse(raw_response.body)
+                         # parse claimId from LH response
+                         submitted_claim_id = JSON.parse(raw_response.body).dig('data', 'attributes', 'claimId').to_i
                          raw_response_struct = OpenStruct.new({
-                                                                # TODO: for now, set claim id to unix time stamp.
-                                                                # When the lighthouse synchronous
-                                                                # submit response is ready,
-                                                                # switch to VBMS claim id.
-                                                                body: { claim_id: Time.now.to_i },
+                                                                body: { claim_id: submitted_claim_id },
                                                                 status: raw_response.status
                                                               })
                          EVSS::DisabilityCompensationForm::FormSubmitResponse

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -109,7 +109,6 @@ module EVSS
             # send submission data to either EVSS or Lighthouse (LH)
             response = if Flipper.enabled?(:disability_compensation_lighthouse_submit_migration, user) ||
                           submit_to_claims_api # right operand evaluation not needed once fully migrated to LH
-                         debugger
                          # submit 526 through LH API
                          # 1. get user's ICN
                          icn = user_account.icn

--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -197,16 +197,19 @@ module EVSS
       def transform_treatments(treatments_source)
         treatments_source.map do |treatment|
           center = treatment['center']
-          Requests::Treatment.new(
+          request_treatment = Requests::Treatment.new(
             treated_disability_names: treatment['treatedDisabilityNames'],
             center: Requests::Center.new(
               name: center['name'],
               state: center['state'],
               city: center['city']
-            ),
-            # LH spec says YYYY-DD or YYYY date format
-            begin_date: convert_approximate_date(treatment['startDate'], short: true)
+            )
           )
+          if treatment['startDate'].present?
+            # LH spec says YYYY-DD or YYYY date format
+            request_treatment.begin_date = convert_approximate_date(treatment['startDate'], short: true)
+          end
+          request_treatment
         end
       end
 

--- a/lib/lighthouse/benefits_claims/configuration.rb
+++ b/lib/lighthouse/benefits_claims/configuration.rb
@@ -13,7 +13,7 @@ module BenefitsClaims
   class Configuration < Common::Client::Configuration::REST
     self.read_timeout = Settings.lighthouse.benefits_claims.timeout || 20
 
-    API_SCOPES = %w[system/claim.read system/claim.write system/526-pdf.override].freeze
+    API_SCOPES = %w[system/claim.read system/claim.write system/526-pdf.override system/526.override].freeze
     CLAIMS_PATH = 'services/claims/v2/veterans'
     TOKEN_PATH = 'oauth2/claims/system/v1/token'
 

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -99,9 +99,7 @@ RSpec.describe BenefitsClaims::Service do
                                'data' => {
                                  'type' => 'form/526',
                                  'attributes' => {
-                                   'serviceInformation' => {
-                                     'confinements' => []
-                                   },
+                                   'serviceInformation' => {},
                                    'toxicExposure' => {
                                      'herbicideHazardService' => {
                                        'serviceDates' => {
@@ -116,34 +114,37 @@ RSpec.describe BenefitsClaims::Service do
         end
 
         it 'when given a full request body, posts to the Lighthouse API' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
             response = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
             response_json = JSON.parse(response)
             expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+            expect(response_json['data']['attributes']['claimId']).to eq('12345678')
           end
         end
 
         it 'when given a only the form data in the request body, posts to the Lighthouse API' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
             response = @service.submit526({}, '', '', { body_only: true })
             response_json = JSON.parse(response)
             expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+            expect(response_json['data']['attributes']['claimId']).to eq('12345678')
           end
         end
 
         it 'returns only the response body' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
             body = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
             response_json = JSON.parse(body)
             expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+            expect(response_json['data']['attributes']['claimId']).to eq('12345678')
           end
         end
 
         it 'returns the whole response' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response') do
+          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
             raw_response = @service.submit526({}, '', '', { body_only: false })
-            # TODO: re-visit claim_id value when VBMS id is returned synchronously from Lighthouse
-            claim_id = Time.now.to_i
+
+            claim_id = JSON.parse(raw_response.body).dig('data', 'attributes', 'claimId').to_i
             raw_response_struct = OpenStruct.new({
                                                    body: { claim_id: },
                                                    status: raw_response.status

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
     let(:lh_upload) { 'lighthouse/benefits_intake/200_lighthouse_intake_upload_location' }
     let(:evss_get_pdf) { 'form526_backup/200_evss_get_pdf' }
     let(:lh_intake_upload) { 'lighthouse/benefits_intake/200_lighthouse_intake_upload' }
-    let(:lh_submission) { 'lighthouse/benefits_claims/submit526/200_response' }
+    let(:lh_submission) { 'lighthouse/benefits_claims/submit526/200_synchronous_response' }
     let(:cassettes) do
       [open_claims_cassette, caseflow_cassette, rated_disabilities_cassette,
        submit_form_cassette, lh_upload, evss_get_pdf,
@@ -469,8 +469,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           expect { described_class.drain }.not_to change(backup_klass.jobs, :size)
           expect(Form526JobStatus.last.status).to eq Form526JobStatus::STATUS[:success]
           submission.reload
-          # TODO: re-visit when using lighthouse synchronous response endpoint
-          expect(submission.submitted_claim_id).to eq(Form526JobStatus.last.submission.submitted_claim_id)
+
+          expect(Form526JobStatus.last.submission.submitted_claim_id).to eq(12_345_678)
         end
       end
 

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/submit526/200_synchronous_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/submit526/200_synchronous_response.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-api.va.gov/services/claims/v2/veterans/123498767V234859/526/synchronous
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Bearer blahblahblah
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Feb 2023 21:02:39 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '59'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      Ratelimit-Remaining:
+      - '59'
+      Ratelimit-Limit:
+      - '60'
+      Ratelimit-Reset:
+      - '25'
+      Etag:
+      - W/"6571c42e57529000188d704a3cd1f46a"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Git-Sha:
+      - b20885293917fd081d24899644d2718d2ab4ccf9
+      X-Github-Repository:
+      - https://github.com/department-of-veterans-affairs/vets-api
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - d687047e-5004-43c1-babb-c2f52f2fda40
+      X-Runtime:
+      - '3.569014'
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Kong-Upstream-Latency:
+      - '3573'
+      X-Kong-Proxy-Latency:
+      - '24'
+      Via:
+      - kong/3.0.2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id": "46285849-9d82-4001-8572-2323d521eb8c", "attributes": {"claimId": "12345678"}}}'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- hooks up SubmitForm526 job to Lighthouse synchronous submit endpoint

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#71773

## Testing done

- [x] yes
- as the name and endpoint path suggests, pointing the form526 job to new lighthouse synchronous endpoint
- fixes the "treatmentDate" issue found in department-of-veterans-affairs/va.gov-team#84199

## Screenshots
n/a

## What areas of the site does it impact?
n/a

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
