### PR TITLE
[DBEX] add detail to lighthouse validation error response

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -467,17 +467,15 @@ class Form526Submission < ApplicationRecord
     created_at.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.')
   end
 
-  # Synchronous access to lighthouse API validation boolean for 526 submission
-  # Since this method hits an external API, there could be
+  # Synchronous access to Lighthouse API validation boolean for 526 submission
+  # Because this method hits an external API, there could be
   # exceptions generated for non-200 response codes.
   #
-  # If return is false then the errors are expected
-  # to be in the lighthouse_validation_errors Array
-  # of Hash.
+  # If return is false, then the errors are expected to be
+  # in the lighthouse_validation_errors Array of Hashes.
   #
-  # NOTE: This is a synchronous access to an external
-  #       API so should not be used within a request/response
-  #       workflow.
+  # NOTE: This is a synchronous access to an external API
+  #       so should not be used within a request/response workflow.
   #
   def form_content_valid?
     begin
@@ -486,25 +484,30 @@ class Form526Submission < ApplicationRecord
 
       @lighthouse_validation_response = lighthouse_service.validate526(body)
     rescue => e
-      error_msg = "#{e} -- #{e.backtrace[0]}"
-      fake_lighthouse_response(error: error_msg)
+      errors = e.errors if e.respond_to?(:errors)
+      detail = errors&.dig(0, :detail)
+      status = errors&.dig(0, :status)
+
+      if detail
+        match_data = detail.match(/"description"=>"([^"]+)"/)
+        description = match_data ? match_data[1] : nil
+      end
+
+      error_msg = "#{description || e} -- #{e.backtrace[0]}"
+      mock_lighthouse_response(status:, error: error_msg)
       return false
     end
 
-    if lighthouse_validation_response&.status == 200
-      return true
-    elsif lighthouse_validation_response&.status == 422
-      return false
-    end
+    return true if lighthouse_validation_response&.status == 200
 
-    fake_lighthouse_response(status: lighthouse_validation_response&.status)
+    mock_lighthouse_response(status: lighthouse_validation_response&.status)
     false
   end
 
   # Returns an Array of Hashes when response.status is 422
-  # otherwise its an empty Array.
+  # otherwise it's an empty Array.
   #
-  # The Array#empty? is true when there are not errors
+  # The Array#empty? is true when there are no errors
   # A Hash entry looks like this ...
   # {
   #   "title": "Unprocessable entity",
@@ -523,29 +526,27 @@ class Form526Submission < ApplicationRecord
     end
   end
 
-  ###############################################
   private
 
   attr_accessor :lighthouse_validation_response
 
-  # Setup the lighthouse service for this
-  # user account.  The lighthouse calls the
-  # user_account.icn the "ID of Veteran"
+  # Setup the Lighthouse service for this user account.
+  # Lighthouse calls the user_account.icn the "ID of Veteran"
   #
   def lighthouse_service
     BenefitsClaims::Service.new(user_account.icn)
   end
 
-  def fake_lighthouse_response(status: 609, error: 'Unknown')
-    fake_response        = Struct.new(:status, :body).new
-    fake_response.status = status || 609
-    fake_response.body   = { 'errors' => [
+  def mock_lighthouse_response(status:, error: 'Unknown')
+    mock_response = Struct.new(:status, :body).new(609, nil)
+    mock_response.status = status if status
+    mock_response.body = { 'errors' => [
       {
         'title' => "Response Status Code '#{status}' - #{error}"
       }
     ] }
 
-    @lighthouse_validation_response = fake_response
+    @lighthouse_validation_response = mock_response
   end
 
   def queue_central_mail_backup_submission_for_non_retryable_error!(e: nil)


### PR DESCRIPTION
## Summary

In the current implementation, an error object lacks sufficient detail. Additional available detail in the response from Lighthouse requires logging. This PR adds the detail description to the error that is returned.

In addition, current `lighthouse_validation_errors` for a `Form526Submission` record with a 422 error response from Lighthouse appear as:
```
[{
  "title"=>"Response Status Code '609' - Common::Exceptions::UnprocessableEntity -- /app/lib/lighthouse/service_exception.rb:37:in `send_error'"
}]
```
In the event a call to the Lighthouse service `validate526` returns a 422 error, this update corrects the `form_content_valid?` logic that is responsible for gathering error data that formulates a `lighthouse_validation_response`, to include the correct status code and error description. 

- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- **Responsible team:** Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82149

## Testing done

- [ ] *New code is covered by unit tests* 
  -  no existing unit tests cover the modified methods as they are not currently intended to be utilized by the application, but instead serve in the gathering of data for a [script](https://github.com/department-of-veterans-affairs/vets-api/blob/a7f83b50718628b5696fb210630a06b5e6418e21/rakelib/form526.rake#L731C3-L731C55) that checks select submissions for errors
- To verify the update is functioning as expected, in Argo CD, vets-api-staging application, execute the following:
```
sub = Form526Submission.find 1229
sub.form_content_valid?
puts sub.lighthouse_validation_errors
```
The result should resemble:
```
[{
  "title"=>"Response Status Code '422' - Account number for the direct deposit. -- /app/lib/lighthouse/service_exception.rb:37:in `send_error'"
}]
```

## What areas of the site does it impact?

- Form 526EZ

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
