### PR TITLE
Notify when dev/staging deploys don't succeed

### DIFF
--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -1,0 +1,126 @@
+name: Deploy Delay Notifications
+
+on:
+  schedule:
+    - cron: "*/10 * * * *" # Runs every 10 minutes
+
+jobs:
+  check-deployment:
+    runs-on: ubuntu-latest
+
+    outputs:
+      development_summary: ${{ steps.check-dev-status.outputs.dev_summary }}
+      staging_summary: ${{ steps.check-staging-status.outputs.staging_summary }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: master # Ensure we are checking out the master branch
+
+      - name: Get latest commit SHA and time from master branch
+        id: git-info
+        run: |
+          latest_sha=$(git rev-parse master)
+          commit_time=$(git log -1 --format=%cI master)
+          echo "latest_sha=${latest_sha}" >> $GITHUB_ENV
+          echo "commit_time=${commit_time}" >> $GITHUB_ENV
+
+      - name: Get deployed SHA for development
+        id: dev-deploy-sha
+        run: |
+          deployed_sha=$(curl -s https://dev-api.va.gov/v0/status | jq -r .git_revision)
+          echo "dev_deployed_sha=${deployed_sha}" >> $GITHUB_ENV
+
+      - name: Get deployed SHA for staging
+        id: staging-deploy-sha
+        run: |
+          deployed_sha=$(curl -s https://staging-api.va.gov/v0/status | jq -r .git_revision)
+          echo "staging_deployed_sha=${deployed_sha}" >> $GITHUB_ENV
+
+      - name: Check deployment status for development
+        id: check-dev-status
+        run: |
+          latest_sha=${{ env.latest_sha }}
+          commit_time=${{ env.commit_time }}
+          deployed_sha=${{ env.dev_deployed_sha }}
+          info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to development"
+
+          if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
+            echo "${info_message} has been deployed."
+            echo "dev_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '30 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 30 minutes."
+            echo "Current commit on development is ${deployed_sha:0:8}."
+            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}." >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "Awaiting deployment of ${info_message}."
+            echo "dev_summary=Awaiting deployment of ${info_message}." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check deployment status for staging
+        id: check-staging-status
+        run: |
+          latest_sha=${{ env.latest_sha }}
+          commit_time=${{ env.commit_time }}
+          deployed_sha=${{ env.staging_deployed_sha }}
+          info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to staging"
+
+          if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
+            echo "${info_message} has been deployed."
+            echo "staging_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '30 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 30 minutes."
+            echo "Current commit on staging is ${deployed_sha:0:8}."
+            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}." >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "Awaiting deployment of ${info_message}."
+            echo "staging_summary=Awaiting deployment of ${info_message}." >> $GITHUB_OUTPUT
+          fi
+
+  notify-on-failure:
+    runs-on: ubuntu-latest
+    needs: [check-deployment]
+    if: ${{ failure() }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-gov-west-1"
+
+      - uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Checkout VSP actions
+        uses: actions/checkout@v4
+        with:
+          repository: department-of-veterans-affairs/vsp-github-actions
+          ref: refs/heads/main
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          persist-credentials: false
+          path: ./.github/actions/vsp-github-actions
+
+      - uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb
+        with:
+          ssm_parameter: /devops/github_actions_slack_socket_token
+          env_variable_name: SLACK_APP_TOKEN
+
+      - uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb
+        with:
+          ssm_parameter: /devops/github_actions_slack_bot_user_token
+          env_variable_name: SLACK_BOT_TOKEN
+
+      - name: Slack notify
+        uses: ./.github/actions/vsp-github-actions/slack-socket
+        with:
+          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          message: "Vets API Deployment Delay:"
+          blocks: "[{\"type\": \"divider\"}, {\"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":scared_and_sweating_smiley: GitHub Action Runner Workflow failed! :scared_and_sweating_smiley:\n <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} Run #${{ github.run_number }}>\n\n*Development Summary:*\n${{ needs.check-deployment.outputs.development_summary }}\n\n*Staging Summary:*\n${{ needs.check-deployment.outputs.staging_summary }}\"}}, {\"type\": \"divider\"}]"
+          channel_id: "C039HRTHXDH"

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -60,6 +60,7 @@ jobs:
           fi
 
       - name: Check deployment status for staging
+        if: always()
         id: check-staging-status
         run: |
           latest_sha=${{ env.latest_sha }}


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/84577

This pulls the latest status from dev and https://staging-api.va.gov/v0/status and compares the sha to the latest in master. If the time is >30 minutes, it messages the [be-cop notifications channel](https://dsva.slack.com/archives/C039HRTHXDH). It runs every ten minutes.

Originally I had this in Atlas as I thought the logic would be easiest to implement there as there are already models that pull the commits and deploy status but I'd need to figure out how to get a Rails env running in a workflow or create a Sidekiq job. Once I wrote the logic I realized it was very simple to implement in bash.

Example notification [here](https://dsva.slack.com/archives/C039HRTHXDH/p1718122104560309).