### PR TITLE
85478 [10-10 EZ] Add New StatsD logs for async vs sync submission failures

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -26,8 +26,8 @@ class HealthCareApplication < ApplicationRecord
   validates(:form, presence: true, on: :create)
   validate(:form_matches_schema, on: :create)
 
-  after_save :send_failure_mail, if: %i[submission_failed? email?]
-  after_save :log_submission_failure, if: :submission_failed?
+  after_save :send_failure_mail, if: %i[async_submission_failed? email?]
+  after_save :log_async_submission_failure, if: :async_submission_failed?
 
   # @param [Account] user
   # @return [Hash]
@@ -56,7 +56,7 @@ class HealthCareApplication < ApplicationRecord
     form.present? && parsed_form['lastServiceBranch'].blank?
   end
 
-  def submission_failed?
+  def async_submission_failed?
     saved_change_to_attribute?(:state) && failed?
   end
 
@@ -81,7 +81,7 @@ class HealthCareApplication < ApplicationRecord
 
     result
   rescue
-    log_submission_failure
+    log_sync_submission_failure
 
     raise
   end
@@ -248,27 +248,36 @@ class HealthCareApplication < ApplicationRecord
     self
   end
 
-  def log_submission_failure
+  def log_sync_submission_failure
+    StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.sync_submission_failed")
+    StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.sync_submission_failed_short_form") if short_form?
+    log_submission_failure_details
+  end
+
+  def log_async_submission_failure
     StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.failed_wont_retry")
     StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.failed_wont_retry_short_form") if short_form?
+    log_submission_failure_details
+  end
 
-    if form.present?
-      PersonalInformationLog.create!(
-        data: parsed_form,
-        error_class: 'HealthCareApplication FailedWontRetry'
-      )
+  def log_submission_failure_details
+    return if form.blank?
 
-      log_message_to_sentry(
-        'HCA total failure',
-        :error,
-        {
-          first_initial: parsed_form['veteranFullName']['first'][0],
-          middle_initial: parsed_form['veteranFullName']['middle'].try(:[], 0),
-          last_initial: parsed_form['veteranFullName']['last'][0]
-        },
-        hca: :total_failure
-      )
-    end
+    PersonalInformationLog.create!(
+      data: parsed_form,
+      error_class: 'HealthCareApplication FailedWontRetry'
+    )
+
+    log_message_to_sentry(
+      'HCA total failure',
+      :error,
+      {
+        first_initial: parsed_form['veteranFullName']['first'][0],
+        middle_initial: parsed_form['veteranFullName']['middle'].try(:[], 0),
+        last_initial: parsed_form['veteranFullName']['last'][0]
+      },
+      hca: :total_failure
+    )
   end
 
   def send_failure_mail

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe HealthCareApplication, type: :model do
               expect do
                 health_care_application.process!
               end.to raise_error(VCR::Errors::UnhandledHTTPRequestError)
-            end.to trigger_statsd_increment('api.1010ez.failed_wont_retry')
+            end.to trigger_statsd_increment('api.1010ez.sync_submission_failed')
           end
 
           it 'increments short form statsd key if its a short form' do
@@ -459,7 +459,7 @@ RSpec.describe HealthCareApplication, type: :model do
               expect do
                 health_care_application.process!
               end.to raise_error(VCR::Errors::UnhandledHTTPRequestError)
-            end.to trigger_statsd_increment('api.1010ez.failed_wont_retry_short_form')
+            end.to trigger_statsd_increment('api.1010ez.sync_submission_failed_short_form')
           end
         end
       end
@@ -532,7 +532,7 @@ RSpec.describe HealthCareApplication, type: :model do
       end
     end
 
-    describe '#log_submission_failure' do
+    describe '#log_async_submission_failure' do
       it 'triggers statsd' do
         expect { subject }.to trigger_statsd_increment('api.1010ez.failed_wont_retry')
       end

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -4,6 +4,12 @@ require 'rails_helper'
 
 RSpec.describe HealthCareApplication, type: :model do
   let(:health_care_application) { create(:health_care_application) }
+  let(:health_care_application_short_form) do
+    short_form = JSON.parse(health_care_application.form)
+    short_form.delete('lastServiceBranch')
+    short_form['vaCompensationType'] = 'highDisability'
+    short_form
+  end
   let(:inelig_character_of_discharge) { HCA::EnrollmentEligibility::Constants::INELIG_CHARACTER_OF_DISCHARGE }
   let(:login_required) { HCA::EnrollmentEligibility::Constants::LOGIN_REQUIRED }
 
@@ -449,10 +455,7 @@ RSpec.describe HealthCareApplication, type: :model do
           end
 
           it 'increments short form statsd key if its a short form' do
-            new_form = JSON.parse(health_care_application.form)
-            new_form.delete('lastServiceBranch')
-            new_form['vaCompensationType'] = 'highDisability'
-            health_care_application.form = new_form.to_json
+            health_care_application.form = health_care_application_short_form.to_json
             health_care_application.instance_variable_set(:@parsed_form, nil)
 
             expect do
@@ -540,10 +543,7 @@ RSpec.describe HealthCareApplication, type: :model do
 
       context 'short form' do
         before do
-          new_form = JSON.parse(health_care_application.form)
-          new_form.delete('lastServiceBranch')
-          new_form['vaCompensationType'] = 'highDisability'
-          health_care_application.form = new_form.to_json
+          health_care_application.form = health_care_application_short_form.to_json
           health_care_application.instance_variable_set(:@parsed_form, nil)
         end
 

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -459,7 +459,8 @@ RSpec.describe HealthCareApplication, type: :model do
               expect do
                 health_care_application.process!
               end.to raise_error(VCR::Errors::UnhandledHTTPRequestError)
-            end.to trigger_statsd_increment('api.1010ez.sync_submission_failed_short_form')
+            end.to trigger_statsd_increment('api.1010ez.sync_submission_failed')
+              .and trigger_statsd_increment('api.1010ez.sync_submission_failed_short_form')
           end
         end
       end
@@ -547,7 +548,8 @@ RSpec.describe HealthCareApplication, type: :model do
         end
 
         it 'triggers statsd' do
-          expect { subject }.to trigger_statsd_increment('api.1010ez.failed_wont_retry_short_form')
+          expect { subject }.to trigger_statsd_increment('api.1010ez.failed_wont_retry')
+            .and trigger_statsd_increment('api.1010ez.failed_wont_retry_short_form')
         end
       end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Updated logic around what `statsD` logs we create when a 10-10 EZ Form submission fails. Previously, we always created a `failed_wont_retry` log for both async and synchronous submission failures. This was confusing since for a synchronous submission failure, it was _never_ going to retry. These changes now log a `failed_wont_retry` when the sidekiq job has run out of retries, and it will log  `sync_submission_failed` for a synchronous form submission that has failed. 
- I also added test coverage around logging _both_ a `failed_wont_retry` and a `failed_wont_retry_short_form` when short forms fail. We want both metrics to be able to more easily aggregate total submissions and total short form submissions. We had the functionality previously, but it was not being tested. 
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85478

## Testing done

- [x] *New code is covered by unit tests*
- We would only ever see a `failed_wont_retry` log. Now we will see either a `failed_wont_retry` or a `sync_submission_failed` depending on the type of form submission. 
- Cause an async and sync submission errors and validate that the correct error message is created. 

## What areas of the site does it impact?
10-10 EZR
## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

