### PR TITLE
84597: Increase retry count for DR evidence upload sidekiq job

### DIFF
--- a/app/sidekiq/decision_review/submit_upload.rb
+++ b/app/sidekiq/decision_review/submit_upload.rb
@@ -10,7 +10,7 @@ module DecisionReview
 
     STATSD_KEY_PREFIX = 'worker.decision_review.submit_upload'
 
-    sidekiq_options retry: 5
+    sidekiq_options retry: 13
 
     sidekiq_retries_exhausted do |_msg, _ex|
       StatsD.increment("#{STATSD_KEY_PREFIX}.permanent_error")


### PR DESCRIPTION
## Summary
This increases the retry count for the SubmitUpload job from 5 to 13, to allow for more time for issues/outages to resolve before a job's retries are exhausted.

- *This work is behind a feature toggle (flipper): YES/NO*
 No

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84597

## Testing done

- [ ] *New code is covered by unit tests*
 Not applicable

## What areas of the site does it impact?
Decision Review sidekiq jobs can retry up to 13 times (roughly 17 hours) which can potentially increase the number of jobs in the sidekiq queue

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
