### PR TITLE
[85616] User Email Identifier Rake Task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,6 +183,7 @@ group :test do
   gem 'rspec-sidekiq'
   gem 'rubocop-junit-formatter'
   gem 'rufus-scheduler'
+  gem 'rubyXL'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'super_diff'

--- a/rakelib/user_email_identifier.rake
+++ b/rakelib/user_email_identifier.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'roo'
+
+desc 'Build a CSV of user email identifiers'
+
+namespace :user_email_identifier do
+  task :build_csv, %i[uuid_list] => :environment do |_, args|
+    xlsx = Roo::Excelx.new(args[:uuid_list])
+    xlsx.sheet(0)
+    row_count = xlsx.last_row - 1
+    puts "[UserEmailIdentifier] Building CSV from #{args[:uuid_list]}, processing #{row_count} rows..."
+
+    CSV.open('./tmp/user_email_identifiers.csv', 'w') do |csv|
+      csv << %w[data_type form_type va_gov_submission_created_at va_gov_user_uuid va_gov_credential_email]
+      xlsx.each_row_streaming(offset: 1, pad_cells: true) do |row|
+        next if row[3].nil? || row[3].cell_value.nil?
+
+        original_columns = row[0..3].map { |cell| cell && cell.cell_value.to_s.strip }
+        csp_uuid = original_columns[3]
+        type = csp_uuid.scan(/-/).empty? ? 'idme' : 'logingov'
+        verification = UserVerification.find_by_type!(type, csp_uuid)
+        user_credential_email = verification.user_credential_email.credential_email
+
+        csv << (original_columns + [user_credential_email])
+      rescue ActiveRecord::RecordNotFound
+        puts "[UserEmailIdentifier] Record not found for #{type}: #{csp_uuid}"
+        row << original_columns
+      end
+    end
+    puts '[UserEmailIdentifier] CSV creation successful, file location: tmp/user_email_identifiers.csv'
+  end
+end

--- a/rakelib/user_email_identifier.rake
+++ b/rakelib/user_email_identifier.rake
@@ -24,8 +24,7 @@ namespace :user_email_identifier do
 
         csv << (original_columns + [user_credential_email])
       rescue ActiveRecord::RecordNotFound
-        puts "[UserEmailIdentifier] Record not found for #{type}: #{csp_uuid}"
-        row << original_columns
+        csv << original_columns
       end
     end
     puts '[UserEmailIdentifier] CSV creation successful, file location: tmp/user_email_identifiers.csv'

--- a/spec/rakelib/user_email_identifier_spec.rb
+++ b/spec/rakelib/user_email_identifier_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+require 'roo'
+require 'rubyXL'
+require 'tempfile'
+
+describe 'user_email_identifier rake task' do # rubocop:disable RSpec/DescribeClass
+  describe 'build_csv' do
+    let(:task) { Rake::Task['user_email_identifier:build_csv'] }
+    let(:idme_email) { create(:user_credential_email) }
+    let(:idme_user_verification) { create(:idme_user_verification, user_credential_email: idme_email) }
+    let(:logingov_email) { create(:user_credential_email) }
+    let(:logingov_user_verification) { create(:logingov_user_verification, user_credential_email: logingov_email) }
+    let(:mhv_email) { create(:user_credential_email) }
+    let(:mhv_user_verification) { create(:mhv_user_verification, user_credential_email: mhv_email) }
+    let(:dslogon_email) { create(:user_credential_email) }
+    let(:dslogon_user_verification) { create(:dslogon_user_verification, user_credential_email: dslogon_email) }
+    let(:uuid_list) do
+      Tempfile.new(['uuid_list', '.xlsx']).tap do |file|
+        workbook = RubyXL::Workbook.new
+        worksheet = workbook[0]
+        worksheet.add_cell(0, 0, 'data_type')
+        worksheet.add_cell(0, 1, 'form_type')
+        worksheet.add_cell(0, 2, 'va_gov_submission_created_at')
+        worksheet.add_cell(0, 3, 'va_gov_user_uuid')
+        worksheet.add_cell(1, 0, 'some_data_type')
+        worksheet.add_cell(1, 1, 'some_form_type')
+        worksheet.add_cell(1, 2, '2019-01-01')
+        worksheet.add_cell(1, 3, idme_user_verification.backing_credential_identifier)
+        worksheet.add_cell(2, 0, 'some_data_type')
+        worksheet.add_cell(2, 1, 'some_form_type')
+        worksheet.add_cell(2, 2, '2020-01-01')
+        worksheet.add_cell(2, 3, logingov_user_verification.backing_credential_identifier)
+        worksheet.add_cell(3, 0, 'some_data_type')
+        worksheet.add_cell(3, 1, 'some_form_type')
+        worksheet.add_cell(3, 2, '2021-01-01')
+        worksheet.add_cell(3, 3, mhv_user_verification.backing_credential_identifier)
+        worksheet.add_cell(4, 0, 'some_data_type')
+        worksheet.add_cell(4, 1, 'some_form_type')
+        worksheet.add_cell(4, 2, '2022-01-01')
+        worksheet.add_cell(4, 3, dslogon_user_verification.backing_credential_identifier)
+        worksheet.add_cell(5, 0, 'some_data_type')
+        worksheet.add_cell(5, 1, 'some_form_type')
+        worksheet.add_cell(5, 2, '2023-01-01')
+        worksheet.add_cell(5, 3, 'some-unknown-uuid')
+        workbook.write(file.path)
+      end
+    end
+    let(:output_path) { './tmp/user_email_identifiers.csv' }
+
+    before do
+      Rake.application.rake_require '../rakelib/user_email_identifier'
+      Rake::Task.define_task(:environment)
+    end
+
+    after do
+      uuid_list.unlink
+    end
+
+    it 'adds the queried credential emails to the produced CSV' do
+      task.invoke(uuid_list.path)
+
+      csv_content = CSV.read(output_path)
+      expect(csv_content.size).to eq(6)
+      expect(csv_content[1]).to eq(['some_data_type', 'some_form_type', '2019-01-01',
+                                    idme_user_verification.backing_credential_identifier,
+                                    idme_email.credential_email])
+      expect(csv_content[2]).to eq(['some_data_type', 'some_form_type', '2020-01-01',
+                                    logingov_user_verification.backing_credential_identifier,
+                                    logingov_email.credential_email])
+      expect(csv_content[3]).to eq(['some_data_type', 'some_form_type', '2021-01-01',
+                                    mhv_user_verification.backing_credential_identifier,
+                                    mhv_email.credential_email])
+      expect(csv_content[4]).to eq(['some_data_type', 'some_form_type', '2022-01-01',
+                                    dslogon_user_verification.backing_credential_identifier,
+                                    dslogon_email.credential_email])
+    end
+
+    it 'does not add the queried credential email to the produced CSV when a user verification is not found' do
+      task.invoke(uuid_list.path)
+
+      csv_content = CSV.read(output_path)
+      expect(csv_content[5]).to eq(%w[some_data_type some_form_type 2023-01-01 some-unknown-uuid])
+    end
+
+    it 'logs an alert to the console when a user verification is not found' do
+      expect { task.invoke(uuid_list.path) }.to output(
+        "[UserEmailIdentifier] Building CSV from #{uuid_list.path}, processing 5 rows...\n" \
+        "[UserEmailIdentifier] Error: UserVerification not found for uuid: some-unknown-uuid\n" \
+        "[UserEmailIdentifier] CSV creation successful, file location: tmp/user_email_identifiers.csv\n"
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a Rake task to take an Excel `.xlsx` file with vets-api CSP user uuids and use them to look up the correlated email address used with that CSP.
- Creates `user_email_identifiers.csv` in vets-api `tmp` directory, file converts original file columns with credential email column appended.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85616


## Testing done
- Download the [test file](https://github.com/user-attachments/files/15792136/noICN_test.xlsx) into your vets-api `tmp` directory.
- Perform the following local authentications to populate the necessary `UserVerification` data:
  - vets.gov.user+0@gmail.com - Login.gov
  - vets.gov.user+0@gmail.com - ID.me
  - vets.gov.user+82@gmail.com - ID.me
  - vets.gov.user+83@gmail.com - ID.me
- Run the rake task from `vets-api` root.
```bash
# bash
bundle exec rake user_email_identifier:build_csv[tmp/noICN_test.xlsx]
# zsh, escape arguments brackets
bundle exec rake user_email_identifier:build_csv\[tmp/noICN_test.xlsx\]

[UserEmailIdentifier] Building CSV from tmp/noICN_test.xlsx, processing 4 rows...
[UserEmailIdentifier] CSV creation successful, file location: tmp/user_email_identifiers.csv
```
* Verify the email addresses have been appended in the output file `tmp/user_email_identifiers.csv`.
```
data_type,form_type,va_gov_submission_created_at,va_gov_user_uuid,va_gov_credential_email
P2A,21P-527,2022-01-17T22:30:03-05:00,a589c0a411bb4e32a90ac706dfb4c072,vets.gov.user+82@gmail.com
P2A,21P-527,2022-02-03T15:51:56-05:00,eb172e31-36a0-4266-aa7b-b44c939e6850,vets.gov.user+0@gmail.com
P2A,21P-527,2022-02-22T13:59:42-05:00,88f572d491af46efa393cba6c351e252,vets.gov.user+0@gmail.com
P2A,21P-527,2022-01-12T17:32:36-05:00,17467052601b4d4e80e2d0369a092aef,vets.gov.user+83@gmail.com
```
- To test `RecordNotFound` handling add dummy CSP uuids to the Excel file or alter the existing uuids. The row that failed to find a UserVerification will be included in the CSV with its original values.
```csv
data_type,form_type,va_gov_submission_created_at,va_gov_user_uuid,va_gov_credential_email
P2A,21P-527,2022-02-03T15:51:56-05:00,eb172e31-36a0-4266-aa7b-b44c939e6850,vets.gov.user+0@gmail.com
P2A,21P-527,2022-01-28T17:32:36-05:00,1231223123ea3802af
P2A,21P-527,2022-01-12T17:32:36-05:00,17467052601b4d4e80e2d0369a092aef,vets.gov.user+83@gmail.com
```

## Acceptance criteria

- [x]  No error nor warning in the console.
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature

