### PR TITLE
update base_path for GIBS service config

### DIFF
--- a/lib/lighthouse/benefits_education/configuration.rb
+++ b/lib/lighthouse/benefits_education/configuration.rb
@@ -10,8 +10,6 @@ module BenefitsEducation
   #
   class Configuration < Common::Client::Configuration::REST
     SYSTEM_NAME = 'VA.gov'
-    TOKEN_PATH = 'oauth2/benefits-education/system/v1/token'
-    API_PATH = 'services/benefits-education/v1/education/chapter33'
 
     # Scopes can be found here:
     # https://developer.va.gov/explore/api/education-benefits/client-credentials#:~:text=Retrieving%20an%20access%20token
@@ -25,17 +23,17 @@ module BenefitsEducation
     end
 
     ##
-    # @return [String] Base path for benefits_education URLs.
+    # @return [String] API endpoint for benefits_education
     #
     def base_path
-      benefits_education_settings.host.to_s
+      "#{benefits_education_settings.host.to_s}/services/benefits-education/v1/education/chapter33"
     end
 
     ##
-    # @return [String] API endpoint for benefits_education
+    # @return [String] Endpoint to request authentication token
     #
-    def base_api_path
-      "#{base_path}/#{API_PATH}"
+    def token_path
+      "#{benefits_education_settings.host.to_s}/oauth2/benefits-education/system/v1/token"
     end
 
     ##
@@ -58,7 +56,7 @@ module BenefitsEducation
     # @return [Faraday::Connection] a Faraday connection instance.
     #
     def connection
-      @conn ||= Faraday.new(base_api_path, headers: base_request_headers, request: request_options) do |faraday|
+      @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
         faraday.use :breakers
         faraday.use Faraday::Response::RaiseError
 
@@ -105,7 +103,7 @@ module BenefitsEducation
       aud_claim_url ||= benefits_education_settings.access_token.aud_claim_url
 
       @token_service ||= Auth::ClientCredentials::Service.new(
-        "#{base_path}/#{TOKEN_PATH}",
+        token_path,
         API_SCOPES,
         lighthouse_client_id,
         aud_claim_url,

--- a/lib/lighthouse/benefits_education/configuration.rb
+++ b/lib/lighthouse/benefits_education/configuration.rb
@@ -10,6 +10,8 @@ module BenefitsEducation
   #
   class Configuration < Common::Client::Configuration::REST
     SYSTEM_NAME = 'VA.gov'
+    TOKEN_PATH = 'oauth2/benefits-education/system/v1/token'
+    API_PATH = 'services/benefits-education/v1/education/chapter33'
 
     # Scopes can be found here:
     # https://developer.va.gov/explore/api/education-benefits/client-credentials#:~:text=Retrieving%20an%20access%20token
@@ -26,14 +28,7 @@ module BenefitsEducation
     # @return [String] API endpoint for benefits_education
     #
     def base_path
-      "#{benefits_education_settings.host}/services/benefits-education/v1/education/chapter33"
-    end
-
-    ##
-    # @return [String] Endpoint to request authentication token
-    #
-    def token_path
-      "#{benefits_education_settings.host}/oauth2/benefits-education/system/v1/token"
+      "#{benefits_education_settings.host}/#{API_PATH}"
     end
 
     ##
@@ -97,13 +92,14 @@ module BenefitsEducation
     def token_service
       lighthouse_client_id = benefits_education_settings.access_token.client_id
       lighthouse_rsa_key_path = benefits_education_settings.access_token.rsa_key
+      token_url = "#{benefits_education_settings.host}/#{TOKEN_PATH}"
 
       # aud_claim_url found here:
       # https://developer.va.gov/explore/api/education-benefits/client-credentials#:~:text=Description-,aud,-True
       aud_claim_url ||= benefits_education_settings.access_token.aud_claim_url
 
       @token_service ||= Auth::ClientCredentials::Service.new(
-        token_path,
+        token_url,
         API_SCOPES,
         lighthouse_client_id,
         aud_claim_url,

--- a/lib/lighthouse/benefits_education/configuration.rb
+++ b/lib/lighthouse/benefits_education/configuration.rb
@@ -10,6 +10,7 @@ module BenefitsEducation
   #
   class Configuration < Common::Client::Configuration::REST
     SYSTEM_NAME = 'VA.gov'
+    BENEFITS_EDUCATION_HOST = benefits_education_settings.host.to_s
 
     # Scopes can be found here:
     # https://developer.va.gov/explore/api/education-benefits/client-credentials#:~:text=Retrieving%20an%20access%20token
@@ -26,14 +27,14 @@ module BenefitsEducation
     # @return [String] API endpoint for benefits_education
     #
     def base_path
-      "#{benefits_education_settings.host.to_s}/services/benefits-education/v1/education/chapter33"
+      "#{BENEFITS_EDUCATION_HOST}/services/benefits-education/v1/education/chapter33"
     end
 
     ##
     # @return [String] Endpoint to request authentication token
     #
     def token_path
-      "#{benefits_education_settings.host.to_s}/oauth2/benefits-education/system/v1/token"
+      "#{BENEFITS_EDUCATION_HOST}/oauth2/benefits-education/system/v1/token"
     end
 
     ##

--- a/lib/lighthouse/benefits_education/configuration.rb
+++ b/lib/lighthouse/benefits_education/configuration.rb
@@ -10,7 +10,6 @@ module BenefitsEducation
   #
   class Configuration < Common::Client::Configuration::REST
     SYSTEM_NAME = 'VA.gov'
-    BENEFITS_EDUCATION_HOST = benefits_education_settings.host.to_s
 
     # Scopes can be found here:
     # https://developer.va.gov/explore/api/education-benefits/client-credentials#:~:text=Retrieving%20an%20access%20token
@@ -27,14 +26,14 @@ module BenefitsEducation
     # @return [String] API endpoint for benefits_education
     #
     def base_path
-      "#{BENEFITS_EDUCATION_HOST}/services/benefits-education/v1/education/chapter33"
+      "#{benefits_education_settings.host}/services/benefits-education/v1/education/chapter33"
     end
 
     ##
     # @return [String] Endpoint to request authentication token
     #
     def token_path
-      "#{BENEFITS_EDUCATION_HOST}/oauth2/benefits-education/system/v1/token"
+      "#{benefits_education_settings.host}/oauth2/benefits-education/system/v1/token"
     end
 
     ##

--- a/lib/lighthouse/benefits_education/service.rb
+++ b/lib/lighthouse/benefits_education/service.rb
@@ -50,7 +50,7 @@ module BenefitsEducation
       raw_response = begin
         config.get(@icn)
       rescue => e
-        handle_error(e, config.service_name, config.base_api_path)
+        handle_error(e, config.service_name, config.base_path)
       end
       BenefitsEducation::Response.new(raw_response.status, raw_response)
     end


### PR DESCRIPTION
## Summary
I am a member of the VA-IIR team, and we are the owners of this component.

See [slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1718033925620709)

The `base_path` attribute of the `EducationBenefits::Configuration` object was too generic and it matched the `base_path` of the Forms API.  When the `EducationBenefits` service had a downtime event (this service is flaky, it happens somewhat frequently), the Breakers service blocked access to the Forms API, shutting out thousands of users.

This PR modifies the `base_path` attribute to be the fully qualified URI for the Lighthouse endpoint.  That way, the matcher logic in the Breakers service will not confuse it with any other services.

## Related issue(s)

[GitHub Issue](https://github.com/department-of-veterans-affairs/va-iir/issues/770)

## Testing done

Code is covered by unit tests.  I tested in local development:
- log in as a test user
- navigate to `/education/gi-bill/post-9-11/ch-33-benefit/status`
    - in chrome dev tools, see that the network request is behaving as it should
    - in running docker container, place a debugger, inspect the response that comes back from Lighthouse
- Existing functionality is maintained.

## What areas of the site does it impact?

Post-9/11 GI Bill Statement of Benefits at `/education/gi-bill/post-9-11/ch-33-benefit/status/`

## Acceptance criteria

Current tests are passing with no issues.  Existing functionality is maintained.  `base_path` attribute is now a unique, full URI (as opposed to the base url value it held before).  We should see no conflict with the Breakers functionality in the future. 

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
