### PR TITLE
fix: Give up notifiying deploy delay after 45 mins

### DIFF
--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -49,6 +49,9 @@ jobs:
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
             echo "dev_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
+            echo "dev_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
           elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on development is ${deployed_sha:0:8}."
@@ -71,6 +74,9 @@ jobs:
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
             echo "staging_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
+            echo "staging_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
           elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on staging is ${deployed_sha:0:8}."


### PR DESCRIPTION
Once an env is out of sync, notifications roll in every 10 mins. 3-4 notifications should be enough. Ideally we just notify when it's triggered and recovered but this is a quick fix so we can stop receiving spam about the dev env.