### PR TITLE
API 37228 fix claim headers for birthdate value

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -32,6 +32,10 @@ module ClaimsApi
 
       def validate_veteran_identifiers(require_birls: false) # rubocop:disable Metrics/MethodLength
         ids = target_veteran&.mpi&.participant_ids || []
+        if header_request?
+          validate_header_values_format
+        end
+
         if ids.size > 1
           claims_v1_logging('multiple_ids', message: "multiple_ids: #{ids.size},
                                             header_request: #{header_request?}")
@@ -188,6 +192,25 @@ module ClaimsApi
             "Unable to locate Veteran's EDIPI in Master Person Index (MPI). " \
             'Please submit an issue at ask.va.gov or call 1-800-MyVA411 (800-698-2411) for assistance.')
         end
+      end
+
+      def validate_header_values_format
+        headers_to_validate = %w[HTTP_X_VA_SSN
+                              HTTP_X_VA_BIRTH_DATE]
+
+        unless birth_date_valid?(header('X-VA-Birth-Date'))
+          raise ::Common::Exceptions::UnprocessableEntity.new(detail: 'Birth date is in an invalid format')
+        end
+
+        unless ssn_valid_format?(header('X-VA-SSN'))
+          raise ::Common::Exceptions::UnprocessableEntity.new(detail: 'Birth date is in an invalid format')
+        end
+      end
+
+      def birth_date_valid_format?(birth_date)
+        return false if birth_date.blank?
+        byebug
+        return true
       end
 
       def claims_v1_logging(tag = 'traceability', level: :info, message: nil, icn: target_veteran&.mpi&.icn)

--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -20,6 +20,7 @@ module ClaimsApi
       skip_after_action :set_csrf_header
       before_action :authenticate, except: %i[schema] # rubocop:disable Rails/LexicallyScopedActionFilter
       before_action :validate_json_format, if: -> { request.post? }
+      before_action :validate_header_values_format, if: -> { header_request? }
       before_action :validate_veteran_identifiers
 
       # fetch_audience: defines the audience used for oauth
@@ -32,9 +33,6 @@ module ClaimsApi
 
       def validate_veteran_identifiers(require_birls: false) # rubocop:disable Metrics/MethodLength
         ids = target_veteran&.mpi&.participant_ids || []
-        if header_request?
-          validate_header_values_format
-        end
 
         if ids.size > 1
           claims_v1_logging('multiple_ids', message: "multiple_ids: #{ids.size},
@@ -195,22 +193,15 @@ module ClaimsApi
       end
 
       def validate_header_values_format
-        headers_to_validate = %w[HTTP_X_VA_SSN
-                              HTTP_X_VA_BIRTH_DATE]
-
-        unless birth_date_valid?(header('X-VA-Birth-Date'))
-          raise ::Common::Exceptions::UnprocessableEntity.new(detail: 'Birth date is in an invalid format')
-        end
-
-        unless ssn_valid_format?(header('X-VA-SSN'))
-          raise ::Common::Exceptions::UnprocessableEntity.new(detail: 'Birth date is in an invalid format')
+        if header('X-VA-Birth-Date').blank?
+          raise ::Common::Exceptions::UnprocessableEntity.new(
+            detail: 'The following values are invalid: birth date'
+          )
         end
       end
 
       def birth_date_valid_format?(birth_date)
-        return false if birth_date.blank?
-        byebug
-        return true
+        false if birth_date.blank?
       end
 
       def claims_v1_logging(tag = 'traceability', level: :info, message: nil, icn: target_veteran&.mpi&.icn)


### PR DESCRIPTION
## Summary
* Creates a check for empty string in headers for birthdate value
* Adds test

## Related issue(s)
[API-37228](https://jira.devops.va.gov/browse/API-37228)

## Testing done
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
    modified:   modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
    modified:   modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
