### PR TITLE
[CST] [Backend] Expanded status logging for claims

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -33,7 +33,7 @@ module V0
                             claim_type_code: claim_info['claimTypeCode'],
                             num_contentions: claim_info['contentions'].count,
                             ep_code: claim_info['endProductCode'],
-                            current_phaseback: claim_info['claimPhaseDates']['currentPhaseBack'],
+                            current_phase_back: claim_info['claimPhaseDates']['currentPhaseBack'],
                             latest_phase_type: claim_info['claimPhaseDates']['latestPhaseType'],
                             decision_letter_sent: claim_info['decisionLetterSent'],
                             development_letter_sent: claim_info['developmentLetterSent'],

--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -33,6 +33,10 @@ module V0
                             claim_type_code: claim_info['claimTypeCode'],
                             num_contentions: claim_info['contentions'].count,
                             ep_code: claim_info['endProductCode'],
+                            current_phaseback: claim_info['claimPhaseDates']['currentPhaseBack'],
+                            latest_phase_type: claim_info['claimPhaseDates']['latestPhaseType'],
+                            decision_letter_sent: claim_info['decisionLetterSent'],
+                            development_letter_sent: claim_info['developmentLetterSent'],
                             claim_id: params[:id] })
       log_evidence_requests(params[:id], claim_info)
 

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -143,6 +143,10 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
                   claim_type_code: '020NEW',
                   num_contentions: 1,
                   ep_code: '020',
+                  current_phaseback: false,
+                  latest_phase_type: 'GATHERING_OF_EVIDENCE',
+                  decision_letter_sent: false,
+                  development_letter_sent: true,
                   claim_id: '600383363' })
       end
 

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
                   claim_type_code: '020NEW',
                   num_contentions: 1,
                   ep_code: '020',
-                  current_phaseback: false,
+                  current_phase_back: false,
                   latest_phase_type: 'GATHERING_OF_EVIDENCE',
                   decision_letter_sent: false,
                   development_letter_sent: true,


### PR DESCRIPTION
## Summary

- Added the following to claim type logging in `benefits_claims_controller.rb`:
  - `attributes.claimPhaseDates.currentPhaseBack`
  - `attributes.claimPhaseDates.latestPhaseType`
  - `attributes.decisionLetterSent`
  - `attributes.developmentLetterSent`
- Updated `benefits_claims_controller_spec.rb`

## Related issue(s)

- [[CST] Expand status logging for claims](https://github.com/department-of-veterans-affairs/va.gov-team/issues/84632)

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x] We are logging the attribute that tells us if the claim is currently phased back or not
- [x] We are logging the attribute related to the current claim status
- [x] We are logging the attribute related to whether a decision letter has been sent
- [x] We are logging the attribute related to whether a development letter has been sent