### PR TITLE
API-37197: Add Setting to Toggle `VAForms::FormReloader` Job On/Off Per Environment

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1341,6 +1341,8 @@ va_forms:
   drupal_username: ~
   drupal_password: ~
   drupal_url: https://fake-url.com
+  form_reloader:
+    enabled: false
   # A notification for when a forms url has changed
   slack:
     enabled: false

--- a/modules/va_forms/app/sidekiq/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_reloader.rb
@@ -54,6 +54,8 @@ module VAForms
     end
 
     def perform
+      return unless enabled?
+
       all_forms_data.each { |form| VAForms::FormBuilder.perform_async(form) }
 
       # append new tags for pg_search
@@ -87,6 +89,12 @@ module VAForms
       options = { ssl: { verify: false } }
       options[:proxy] = { uri: URI.parse('socks://localhost:2001') } unless Rails.env.production?
       options
+    end
+
+    private
+
+    def enabled?
+      Settings.va_forms.form_reloader.enabled
     end
   end
 end


### PR DESCRIPTION
## Summary
This PR adds a new setting, `Settings.va_forms.form_reloader.enabled` that allows us to control whether the `VAForms::FormReloader` job takes any action in a given environment. We will be using this setting to disable the job in the Dev and Sandbox environments.

This PR should not be merged until the corresponding [lower environment settings PR](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2903) and [prod settings PR](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/2904) are also merged.

My team (Lighthouse Team Banana Peels) owns the `va_forms` module.

## Related issue(s)
[API-37197](https://jira.devops.va.gov/browse/API-37197)

## Testing done
Tested running the job with the new setting toggled on and off in `config/settings.yml`. Added and updated specs for the settings on/off scenarios.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `VAForms::FormReloader` job only.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) – N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected – N/A
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
