### PR TITLE
Revert renaming veteran_icn to user_uuid

### DIFF
--- a/db/migrate/20240613175759_revert_itf_queue_exhaustions_icn_rename.rb
+++ b/db/migrate/20240613175759_revert_itf_queue_exhaustions_icn_rename.rb
@@ -1,0 +1,7 @@
+class RevertItfQueueExhaustionsIcnRename < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      rename_column :intent_to_file_queue_exhaustions, :user_uuid, :veteran_icn
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_11_183430) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_13_175759) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -848,12 +848,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_183430) do
   end
 
   create_table "intent_to_file_queue_exhaustions", force: :cascade do |t|
-    t.string "user_uuid", null: false
+    t.string "veteran_icn", null: false
     t.string "form_type"
     t.datetime "form_start_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_uuid"], name: "index_intent_to_file_queue_exhaustions_on_user_uuid"
+    t.index ["veteran_icn"], name: "index_intent_to_file_queue_exhaustions_on_veteran_icn"
   end
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is a partial reversion of a previous migration where we renamed a field on the intent_to_file_queue_exhaustions table. veteran_icn was renamed to user_uuid, but will be reverted back to veteran_icn. This change is necessary because we cannot use a redis store's key (user_uuid) as a reliable source of truth for retrieving user info.
- Pension benefits team to own this work.

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/81536)
- [*Link to previous change of the code*](https://github.com/department-of-veterans-affairs/vets-api/pull/17087)
- [*Link to epic*](https://app.zenhub.com/workspaces/benefits-pension-64e775aaa6b1ca1ed49b2ede/issues/gh/department-of-veterans-affairs/va.gov-team/81536)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
