### PR TITLE
[SIMPLE_FORMS] fix: 21-4138 - update submission stamps to properly populate pdf

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
@@ -20,7 +20,20 @@ module SimpleFormsApi
     end
 
     def submission_date_stamps
-      []
+      [
+        {
+          coords: [460, 710],
+          text: 'Application Submitted:',
+          page: 0,
+          font_size: 12
+        },
+        {
+          coords: [460, 690],
+          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          page: 0,
+          font_size: 12
+        }
+      ]
     end
 
     def metadata


### PR DESCRIPTION
## Summary

- The work adding submission stamp data to form 21-4138, allowed it to be properly stamped upon filling

## Related issue(s)

- [21-4138 Add date / time stamp to upper right hand corner of form](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1387)

## Testing done

- [x] *New code is covered by unit tests*

## Requested Feedback

Any
