### PR TITLE
[DR-77455] Update pundit policy used in ITF controller

### DIFF
--- a/app/controllers/v0/intent_to_files_controller.rb
+++ b/app/controllers/v0/intent_to_files_controller.rb
@@ -65,7 +65,7 @@ module V0
     private
 
     def authorize_service
-      # Is this necessary if we've fully migrated to Lighthouse? EVSS tests still exist in the request spec, 
+      # Is this necessary if we've fully migrated to Lighthouse? EVSS tests still exist in the request spec,
       # so it might be necessary until those are removed
       if Flipper.enabled?(ApiProviderFactory::FEATURE_TOGGLE_INTENT_TO_FILE, @current_user)
         authorize :lighthouse, :itf_access?

--- a/app/policies/lighthouse_policy.rb
+++ b/app/policies/lighthouse_policy.rb
@@ -12,7 +12,7 @@ LighthousePolicy = Struct.new(:user, :lighthouse) do
   end
 
   def itf_access?
-    # Need to check for first name as Lighthouse will check for it 
+    # Need to check for first name as Lighthouse will check for it
     # and throw an error if it's not present
     user.participant_id.present? && user.ssn.present? && user.first_name && user.last_name
   end

--- a/app/policies/lighthouse_policy.rb
+++ b/app/policies/lighthouse_policy.rb
@@ -11,6 +11,12 @@ LighthousePolicy = Struct.new(:user, :lighthouse) do
       user.icn.present? && user.participant_id.present?
   end
 
+  def itf_access?
+    # Need to check for first name as Lighthouse will check for it 
+    # and throw an error if it's not present
+    user.participant_id.present? && user.ssn.present? && user.first_name && user.last_name
+  end
+
   def access_update?
     user.loa3? &&
       allowed_providers.include?(user.identity.sign_in[:service_name]) &&

--- a/app/policies/lighthouse_policy.rb
+++ b/app/policies/lighthouse_policy.rb
@@ -13,8 +13,8 @@ LighthousePolicy = Struct.new(:user, :lighthouse) do
 
   def itf_access?
     # Need to check for first name as Lighthouse will check for it
-    # and throw an error if it's not present
-    user.participant_id.present? && user.ssn.present? && user.first_name && user.last_name
+    # and throw an error if it's nil
+    user.participant_id.present? && user.ssn.present? && user.last_name.present? && user.first_name
   end
 
   def access_update?

--- a/spec/policies/lighthouse_policy_spec.rb
+++ b/spec/policies/lighthouse_policy_spec.rb
@@ -85,6 +85,16 @@ describe LighthousePolicy do
         end
       end
 
+      context 'user with blank first name (single name user)' do
+        let(:user) { build(:user, :loa3) }
+
+        before { allow(user).to receive(:first_name).and_return('') }
+
+        it 'grants access' do
+          expect(subject).to permit(user, :lighthouse)
+        end
+      end
+
       context 'user without Participant ID' do
         let(:user) { build(:user, :loa3) }
 

--- a/spec/policies/lighthouse_policy_spec.rb
+++ b/spec/policies/lighthouse_policy_spec.rb
@@ -76,6 +76,56 @@ describe LighthousePolicy do
       end
     end
 
+    permissions :itf_access? do
+      context 'user has Participant ID and SSN and First/Last Name ' do
+        let(:user) { build(:user, :loa3) }
+  
+        it 'grants access' do
+          expect(subject).to permit(user, :lighthouse)
+        end
+      end
+  
+      context 'user without Participant ID' do
+        let(:user) { build(:user, :loa3) }
+  
+        before { allow(user).to receive(:participant_id).and_return(nil) }
+  
+        it 'denies access' do
+          expect(subject).not_to permit(user, :lighthouse)
+        end
+      end
+
+      context 'user without SSN' do
+        let(:user) { build(:user, :loa3) }
+  
+        before { allow(user).to receive(:ssn).and_return(nil) }
+  
+        it 'denies access' do
+          expect(subject).not_to permit(user, :lighthouse)
+        end
+      end
+
+      context 'user without first name' do
+        let(:user) { build(:user, :loa3) }
+  
+        before { allow(user).to receive(:first_name).and_return(nil) }
+  
+        it 'denies access' do
+          expect(subject).not_to permit(user, :lighthouse)
+        end
+      end
+
+      context 'user without last name' do
+        let(:user) { build(:user, :loa3) }
+  
+        before { allow(user).to receive(:last_name).and_return(nil) }
+  
+        it 'denies access' do
+          expect(subject).not_to permit(user, :lighthouse)
+        end
+      end
+    end
+
     context 'with a login.gov user' do
       before do
         allow_any_instance_of(UserIdentity).to receive(:sign_in)

--- a/spec/policies/lighthouse_policy_spec.rb
+++ b/spec/policies/lighthouse_policy_spec.rb
@@ -77,19 +77,19 @@ describe LighthousePolicy do
     end
 
     permissions :itf_access? do
-      context 'user has Participant ID and SSN and First/Last Name ' do
+      context 'user has Participant ID and SSN and First/Last Name' do
         let(:user) { build(:user, :loa3) }
-  
+
         it 'grants access' do
           expect(subject).to permit(user, :lighthouse)
         end
       end
-  
+
       context 'user without Participant ID' do
         let(:user) { build(:user, :loa3) }
-  
+
         before { allow(user).to receive(:participant_id).and_return(nil) }
-  
+
         it 'denies access' do
           expect(subject).not_to permit(user, :lighthouse)
         end
@@ -97,9 +97,9 @@ describe LighthousePolicy do
 
       context 'user without SSN' do
         let(:user) { build(:user, :loa3) }
-  
+
         before { allow(user).to receive(:ssn).and_return(nil) }
-  
+
         it 'denies access' do
           expect(subject).not_to permit(user, :lighthouse)
         end
@@ -107,9 +107,9 @@ describe LighthousePolicy do
 
       context 'user without first name' do
         let(:user) { build(:user, :loa3) }
-  
+
         before { allow(user).to receive(:first_name).and_return(nil) }
-  
+
         it 'denies access' do
           expect(subject).not_to permit(user, :lighthouse)
         end
@@ -117,9 +117,9 @@ describe LighthousePolicy do
 
       context 'user without last name' do
         let(:user) { build(:user, :loa3) }
-  
+
         before { allow(user).to receive(:last_name).and_return(nil) }
-  
+
         it 'denies access' do
           expect(subject).not_to permit(user, :lighthouse)
         end

--- a/spec/requests/intent_to_files_request_spec.rb
+++ b/spec/requests/intent_to_files_request_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe 'Intent to file' do
             expect(response).to match_camelized_response_schema('intent_to_files')
           end
         end
+
+        it 'does not throw a 403 when user is missing birls_id and edipi' do
+          # Stub blank birls_id and blank edipi
+          expect(user.identity).to receive(:edipi).and_return(nil)
+          expect(user).to receive(:edipi_mpi).and_return(nil)
+          expect(user).to receive(:birls_id).and_return(nil)
+          VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response') do
+            get '/v0/intent_to_file'
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_response_schema('intent_to_files')
+          end
+        end
       end
 
       context 'error handling tests' do

--- a/spec/requests/intent_to_files_request_spec.rb
+++ b/spec/requests/intent_to_files_request_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe 'Intent to file' do
 
         it 'does not throw a 403 when user is missing birls_id and edipi' do
           # Stub blank birls_id and blank edipi
-          expect(user.identity).to receive(:edipi).and_return(nil)
-          expect(user).to receive(:edipi_mpi).and_return(nil)
-          expect(user).to receive(:birls_id).and_return(nil)
+          allow(user.identity).to receive(:edipi).and_return(nil)
+          allow(user).to receive(:edipi_mpi).and_return(nil)
+          allow(user).to receive(:birls_id).and_return(nil)
           VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response') do
             get '/v0/intent_to_file'
             expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## Summary
We've been seeing a number of 403 errors in our ITF dashboard in Datadog, and they're often due to users lacking an `edipi` or `birls_id` which are required in the current pundit policy used to authorize requests made to the `V0::IntentToFilesController`. I noticed that pundit policy was defined for EVSS, so this PR adds a new policy definition for ITF under the LH policy that checks for participant id, ssn, and name ([Slack thread for reference](https://dsva.slack.com/archives/CE6UEJ6BZ/p1717108841451019?thread_ts=1717100090.559599&cid=CE6UEJ6BZ)) and updates the controller to use that instead of the EVSS policy

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/77455

## Testing done

- [x] *New code is covered by unit tests*


## What areas of the site does it impact?
ITF backend (but [errors in ITF API calls no longer block form submissions](https://dsva.slack.com/archives/C5AGLBNRK/p1715180649505129))

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
