### PR TITLE
Move modify_desired_date logic into appointments service

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -134,40 +134,7 @@ module VAOS
 
       # Makes a call to the VAOS service to create a new appointment.
       def get_new_appointment
-        if create_params[:kind] == 'clinic' && create_params[:status] == 'booked' # a direct scheduled appointment
-          modify_desired_date(create_params, appointments_service.get_facility_timezone(create_params[:location_id]))
-        end
-
         appointments_service.post_appointment(create_params)
-      end
-
-      # Modifies params so that the facility timezone offset is included in the desired date.
-      # The desired date is sent in this format: 2019-12-31T00:00:00-00:00
-      # This modifies the params in place. If params does not contain a desired date, it is not modified.
-      #
-      # @param [ActionController::Parameters] create_params - the params to be modified
-      # @param [String] timezone - the facility timezone id
-      def modify_desired_date(create_params, timezone)
-        desired_date = create_params[:extension]&.[](:desired_date)
-
-        return create_params if desired_date.nil?
-
-        create_params[:extension][:desired_date] = add_timezone_offset(desired_date, timezone)
-      end
-
-      # Returns a [DateTime] object with the timezone offset added. Given a desired date of 2019-12-31T00:00:00-00:00
-      # and a timezone of America/New_York, the returned date will be 2019-12-31T00:00:00-05:00.
-      #
-      # @param [DateTime] date - the date to be modified,  required
-      # @param [String] tz - the timezone id, if nil, the offset is not added
-      # @return [DateTime] date with timezone offset
-      #
-      def add_timezone_offset(date, tz)
-        raise Common::Exceptions::ParameterMissing, 'date' if date.nil?
-
-        utc_date = date.to_time.utc
-        timezone_offset = utc_date.in_time_zone(tz).formatted_offset
-        utc_date.change(offset: timezone_offset).to_datetime
       end
 
       # Checks if the appointment is associated with cerner. It looks through each identifier and checks if the system

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -67,6 +67,7 @@ module VAOS
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
       def post_appointment(request_object_body)
         filtered_reason_code_text = filter_reason_code_text(request_object_body)
         request_object_body[:reason_code][:text] = filtered_reason_code_text if filtered_reason_code_text.present?
@@ -82,7 +83,7 @@ module VAOS
                      end
 
           if request_object_body[:kind] == 'clinic' &&
-            request_object_body[:status] == 'booked' # a direct scheduled appointment
+             request_object_body[:status] == 'booked' # a direct scheduled appointment
             modify_desired_date(request_object_body, get_facility_timezone(request_object_body[:location_id]))
           end
 
@@ -95,6 +96,7 @@ module VAOS
           raise e
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def update_appointment(appt_id, status)
         with_monitoring do

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -68,11 +68,6 @@ module VAOS
       end
 
       def post_appointment(request_object_body)
-
-        if request_object_body[:kind] == 'clinic' && request_object_body[:status] == 'booked' # a direct scheduled appointment
-          modify_desired_date(request_object_body, get_facility_timezone(request_object_body[:location_id]))
-        end
-
         filtered_reason_code_text = filter_reason_code_text(request_object_body)
         request_object_body[:reason_code][:text] = filtered_reason_code_text if filtered_reason_code_text.present?
 
@@ -85,6 +80,11 @@ module VAOS
                      else
                        perform(:post, appointments_base_path_vaos, params, headers)
                      end
+
+          if request_object_body[:kind] == 'clinic' &&
+            request_object_body[:status] == 'booked' # a direct scheduled appointment
+            modify_desired_date(request_object_body, get_facility_timezone(request_object_body[:location_id]))
+          end
 
           new_appointment = response.body
           convert_appointment_time(new_appointment)

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -68,6 +68,11 @@ module VAOS
       end
 
       def post_appointment(request_object_body)
+
+        if request_object_body[:kind] == 'clinic' && request_object_body[:status] == 'booked' # a direct scheduled appointment
+          modify_desired_date(request_object_body, get_facility_timezone(request_object_body[:location_id]))
+        end
+
         filtered_reason_code_text = filter_reason_code_text(request_object_body)
         request_object_body[:reason_code][:text] = filtered_reason_code_text if filtered_reason_code_text.present?
 
@@ -151,6 +156,35 @@ module VAOS
       memoize :get_facility_timezone_memoized
 
       private
+
+      # Modifies params so that the facility timezone offset is included in the desired date.
+      # The desired date is sent in this format: 2019-12-31T00:00:00-00:00
+      # This modifies the params in place. If params does not contain a desired date, it is not modified.
+      #
+      # @param [ActionController::Parameters] create_params - the params to be modified
+      # @param [String] timezone - the facility timezone id
+      def modify_desired_date(create_params, timezone)
+        desired_date = create_params[:extension]&.[](:desired_date)
+
+        return create_params if desired_date.nil?
+
+        create_params[:extension][:desired_date] = add_timezone_offset(desired_date, timezone)
+      end
+
+      # Returns a [DateTime] object with the timezone offset added. Given a desired date of 2019-12-31T00:00:00-00:00
+      # and a timezone of America/New_York, the returned date will be 2019-12-31T00:00:00-05:00.
+      #
+      # @param [DateTime] date - the date to be modified,  required
+      # @param [String] tz - the timezone id, if nil, the offset is not added
+      # @return [DateTime] date with timezone offset
+      #
+      def add_timezone_offset(date, tz)
+        raise Common::Exceptions::ParameterMissing, 'date' if date.nil?
+
+        utc_date = date.to_time.utc
+        timezone_offset = utc_date.in_time_zone(tz).formatted_offset
+        utc_date.change(offset: timezone_offset).to_datetime
+      end
 
       def fetch_clinic_appointments(start_time, end_time, statuses)
         get_appointments(start_time, end_time, statuses)[:data].select { |appt| appt.kind == 'clinic' }

--- a/modules/vaos/spec/controllers/v2/appointments_controller_spec.rb
+++ b/modules/vaos/spec/controllers/v2/appointments_controller_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe VAOS::V2::AppointmentsController, type: :request do
     end
   end
 
+  describe '#get_clinic_memoized' do
+    context 'when clinic service throws an error' do
+      it 'returns nil' do
+        allow_any_instance_of(VAOS::V2::MobileFacilityService).to receive(:get_clinic_with_cache)
+          .and_raise(Common::Exceptions::BackendServiceException.new('VAOS_502', {}))
+
+        expect(subject.send(:get_clinic_memoized, '123', '3456')).to be_nil
+      end
+    end
+  end
+
   describe '#start_date' do
     context 'with an invalid date' do
       it 'throws an InvalidFieldValue exception' do

--- a/modules/vaos/spec/controllers/v2/appointments_controller_spec.rb
+++ b/modules/vaos/spec/controllers/v2/appointments_controller_spec.rb
@@ -3,56 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe VAOS::V2::AppointmentsController, type: :request do
-  let(:va_booked_request_body) do
-    FactoryBot.build(:appointment_form_v2, :va_booked).attributes
-  end
-
-  describe '#add_timezone_offset' do
-    let(:desired_date) { '2022-09-21T00:00:00+00:00'.to_datetime }
-
-    context 'with a date and timezone' do
-      it 'adds the timezone offset to the date' do
-        date_with_offset = subject.send(:add_timezone_offset, desired_date, 'America/New_York')
-        expect(date_with_offset.to_s).to eq('2022-09-21T00:00:00-04:00')
-      end
-    end
-
-    context 'with a date and nil timezone' do
-      it 'leaves the date as is' do
-        date_with_offset = subject.send(:add_timezone_offset, desired_date, nil)
-        expect(date_with_offset.to_s).to eq(desired_date.to_s)
-      end
-    end
-
-    context 'with a nil date' do
-      it 'throws a ParameterMissing exception' do
-        expect do
-          subject.send(:add_timezone_offset, nil, 'America/New_York')
-        end.to raise_error(Common::Exceptions::ParameterMissing)
-      end
-    end
-  end
-
-  describe '#modify_desired_date' do
-    context 'with a request body and facility timezone' do
-      it 'updates the direct scheduled appt desired date with facilities time zone offset' do
-        subject.send(:modify_desired_date, va_booked_request_body, 'America/Denver')
-        expect(va_booked_request_body[:extension][:desired_date].to_s).to eq('2022-11-30T00:00:00-07:00')
-      end
-    end
-  end
-
-  describe '#get_clinic_memoized' do
-    context 'when clinic service throws an error' do
-      it 'returns nil' do
-        allow_any_instance_of(VAOS::V2::MobileFacilityService).to receive(:get_clinic_with_cache)
-          .and_raise(Common::Exceptions::BackendServiceException.new('VAOS_502', {}))
-
-        expect(subject.send(:get_clinic_memoized, '123', '3456')).to be_nil
-      end
-    end
-  end
-
   describe '#start_date' do
     context 'with an invalid date' do
       it 'throws an InvalidFieldValue exception' do

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1231,6 +1231,7 @@ describe VAOS::V2::AppointmentsService do
     let(:va_booked_request_body) do
       FactoryBot.build(:appointment_form_v2, :va_booked).attributes
     end
+
     context 'with a request body and facility timezone' do
       it 'updates the direct scheduled appt desired date with facilities time zone offset' do
         subject.send(:modify_desired_date, va_booked_request_body, 'America/Denver')

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1197,4 +1197,45 @@ describe VAOS::V2::AppointmentsService do
       end
     end
   end
+
+  describe '#add_timezone_offset' do
+    let(:va_booked_request_body) do
+      FactoryBot.build(:appointment_form_v2, :va_booked).attributes
+    end
+    let(:desired_date) { '2022-09-21T00:00:00+00:00'.to_datetime }
+
+    context 'with a date and timezone' do
+      it 'adds the timezone offset to the date' do
+        date_with_offset = subject.send(:add_timezone_offset, desired_date, 'America/New_York')
+        expect(date_with_offset.to_s).to eq('2022-09-21T00:00:00-04:00')
+      end
+    end
+
+    context 'with a date and nil timezone' do
+      it 'leaves the date as is' do
+        date_with_offset = subject.send(:add_timezone_offset, desired_date, nil)
+        expect(date_with_offset.to_s).to eq(desired_date.to_s)
+      end
+    end
+
+    context 'with a nil date' do
+      it 'throws a ParameterMissing exception' do
+        expect do
+          subject.send(:add_timezone_offset, nil, 'America/New_York')
+        end.to raise_error(Common::Exceptions::ParameterMissing)
+      end
+    end
+  end
+
+  describe '#modify_desired_date' do
+    let(:va_booked_request_body) do
+      FactoryBot.build(:appointment_form_v2, :va_booked).attributes
+    end
+    context 'with a request body and facility timezone' do
+      it 'updates the direct scheduled appt desired date with facilities time zone offset' do
+        subject.send(:modify_desired_date, va_booked_request_body, 'America/Denver')
+        expect(va_booked_request_body[:extension][:desired_date].to_s).to eq('2022-11-30T00:00:00-07:00')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- As part of the vets-api consolidation work, we want to move the date modification logic from the appointments controller to the appointments service.
- This area is owned and maintained by the Appointments team.

## Related issue(s)

- [ZenHub Ticket](https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/zh/327)

## Testing done

- [x] *New code is covered by unit tests*
- The existing unit tests were moved from the controller to the service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
