### PR TITLE
[API-34408] Add swagger docs for poa requests

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -15784,6 +15784,885 @@
           }
         }
       }
+    },
+    "/veterans/{veteranId}/power-of-attorney-request": {
+      "post": {
+        "summary": "Create a Power of Attorney appointment request",
+        "description": "Creates a Power of Attorney appointment request.",
+        "tags": [
+          "Power of Attorney"
+        ],
+        "operationId": "postPowerOfAttorneyRequest",
+        "security": [
+          {
+            "productionOauth": [
+              "system/claim.read",
+              "system/claim.write"
+            ]
+          },
+          {
+            "sandboxOauth": [
+              "system/claim.read",
+              "system/claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "veteranId",
+            "in": "path",
+            "required": true,
+            "example": "1012667145V762142",
+            "description": "ID of Veteran",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Valid request response",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "attributes": {
+                      "veteran": {
+                        "serviceNumber": "123678453",
+                        "serviceBranch": "ARMY",
+                        "address": {
+                          "addressLine1": "2719 Hyperion Ave",
+                          "addressLine2": "Apt 2",
+                          "city": "Los Angeles",
+                          "country": "USA",
+                          "stateCode": "CA",
+                          "zipCode": "92264",
+                          "zipCodeSuffix": "0200"
+                        },
+                        "phone": {
+                          "areaCode": "555",
+                          "phoneNumber": "5551234"
+                        },
+                        "email": "test@test.com",
+                        "insuranceNumber": "1234567890"
+                      },
+                      "poa": {
+                        "poaCode": "067",
+                        "registrationNumber": "999999999999",
+                        "jobTitle": "MyJob"
+                      },
+                      "recordConsent": true,
+                      "consentAddressChange": true,
+                      "consentLimits": [
+                        "DRUG_ABUSE",
+                        "SICKLE_CELL",
+                        "HIV",
+                        "ALCOHOLISM"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "attributes"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "veteran",
+                            "poa",
+                            "recordConsent",
+                            "consentAddressChange"
+                          ],
+                          "properties": {
+                            "veteran": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "required": [
+                                "address"
+                              ],
+                              "properties": {
+                                "serviceNumber": {
+                                  "description": "The Veteran's Service Number",
+                                  "type": "string",
+                                  "maxLength": 9
+                                },
+                                "serviceBranch": {
+                                  "description": "Service Branch for the veteran.",
+                                  "type": "string",
+                                  "enum": [
+                                    "AIR_FORCE",
+                                    "ARMY",
+                                    "COAST_GUARD",
+                                    "MARINE_CORPS",
+                                    "NAVY",
+                                    "SPACE_FORCE",
+                                    "OTHER"
+                                  ],
+                                  "example": "ARMY"
+                                },
+                                "address": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "addressLine1",
+                                    "city",
+                                    "stateCode",
+                                    "country",
+                                    "zipCode"
+                                  ],
+                                  "properties": {
+                                    "addressLine1": {
+                                      "description": "Street address with number and name.",
+                                      "type": "string",
+                                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 30
+                                    },
+                                    "addressLine2": {
+                                      "type": "string",
+                                      "maxLength": 5
+                                    },
+                                    "city": {
+                                      "description": "City for the address.",
+                                      "type": "string",
+                                      "example": "Portland",
+                                      "maxLength": 18
+                                    },
+                                    "stateCode": {
+                                      "description": "State for the address.",
+                                      "type": "string",
+                                      "pattern": "^[a-z,A-Z]{2}$",
+                                      "example": "OR"
+                                    },
+                                    "country": {
+                                      "description": "Country of the address. USA is the value to use for United States based addresses, US will not work.",
+                                      "type": "string",
+                                      "example": "USA"
+                                    },
+                                    "zipCode": {
+                                      "description": "Zipcode (First 5 digits) of the address.",
+                                      "type": "string",
+                                      "pattern": "^\\d{5}?$",
+                                      "example": "12345"
+                                    },
+                                    "zipCodeSuffix": {
+                                      "description": "Zipcode (Last 4 digits) of the address.",
+                                      "type": "string",
+                                      "pattern": "^\\d{4}?$",
+                                      "example": "6789"
+                                    }
+                                  }
+                                },
+                                "phone": {
+                                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "areaCode",
+                                    "phoneNumber"
+                                  ],
+                                  "properties": {
+                                    "areaCode": {
+                                      "description": "Area code of the phone number.",
+                                      "type": "string",
+                                      "pattern": "^[2-9][0-9]{2}$",
+                                      "example": "555"
+                                    },
+                                    "phoneNumber": {
+                                      "description": "Phone number.",
+                                      "type": "string",
+                                      "pattern": "^[0-9]{1,14}$",
+                                      "example": "555-5555"
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "description": "Email address of the veteran.",
+                                  "type": "string",
+                                  "pattern": ".@.",
+                                  "maxLength": 61,
+                                  "example": "veteran@example.com"
+                                },
+                                "insuranceNumber": {
+                                  "type": "string",
+                                  "maxLength": 10,
+                                  "description": "Veteran's insurance number, if applicable. Include letter prefix."
+                                }
+                              }
+                            },
+                            "claimant": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "claimantId": {
+                                  "type": "string",
+                                  "example": "123456789",
+                                  "description": "Id of the claimant."
+                                },
+                                "address": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "addressLine1": {
+                                      "description": "Street address with number and name. Required if claimant information provided.",
+                                      "type": "string",
+                                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 30
+                                    },
+                                    "addressLine2": {
+                                      "type": "string",
+                                      "maxLength": 5
+                                    },
+                                    "city": {
+                                      "description": "City for the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "example": "Portland",
+                                      "maxLength": 18
+                                    },
+                                    "stateCode": {
+                                      "description": "State for the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "pattern": "^[a-z,A-Z]{2}$",
+                                      "example": "OR"
+                                    },
+                                    "country": {
+                                      "description": "Country of the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "example": "USA"
+                                    },
+                                    "zipCode": {
+                                      "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "pattern": "^\\d{5}?$",
+                                      "example": "12345"
+                                    },
+                                    "zipCodeSuffix": {
+                                      "description": "Zipcode (Last 4 digits) of the address.",
+                                      "type": "string",
+                                      "pattern": "^\\d{4}?$",
+                                      "example": "6789"
+                                    }
+                                  }
+                                },
+                                "phone": {
+                                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "areaCode",
+                                    "phoneNumber"
+                                  ],
+                                  "properties": {
+                                    "areaCode": {
+                                      "description": "Area code of the phone number.",
+                                      "type": "string",
+                                      "pattern": "^[2-9][0-9]{2}$",
+                                      "example": "555"
+                                    },
+                                    "phoneNumber": {
+                                      "description": "Phone number.",
+                                      "type": "string",
+                                      "pattern": "^[0-9]{1,14}$",
+                                      "example": "555-5555"
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "description": "Email address of the claimant.",
+                                  "type": "string",
+                                  "pattern": ".@.",
+                                  "maxLength": 61,
+                                  "example": "claimant@example.com"
+                                },
+                                "relationship": {
+                                  "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
+                                  "type": "string",
+                                  "example": "Spouse"
+                                }
+                              }
+                            },
+                            "poa": {
+                              "description": "Details of the requested Power of Attorney representing the veteran.",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "required": [
+                                "poaCode",
+                                "registrationNumber"
+                              ],
+                              "properties": {
+                                "poaCode": {
+                                  "description": "The POA code of the accredited representative or organization.",
+                                  "type": "string",
+                                  "example": "A1Q"
+                                },
+                                "registrationNumber": {
+                                  "description": "Registration Number of the accredited representative.",
+                                  "type": "string",
+                                  "example": "12345"
+                                },
+                                "jobTitle": {
+                                  "description": "Job title of the accredited representative.",
+                                  "type": "string",
+                                  "example": "Veteran Service Representative"
+                                }
+                              }
+                            },
+                            "recordConsent": {
+                              "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
+                              "type": "boolean"
+                            },
+                            "consentLimits": {
+                              "description": "Consent in Item 19 for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "DRUG_ABUSE",
+                                  "ALCOHOLISM",
+                                  "HIV",
+                                  "SICKLE_CELL"
+                                ]
+                              },
+                              "example": "DRUG ABUSE"
+                            },
+                            "consentAddressChange": {
+                              "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Not authorized",
+                      "status": "401",
+                      "detail": "Not authorized"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Unprocessable entity",
+                      "detail": "The property /poa did not contain the required key poaCode",
+                      "status": "422",
+                      "source": {
+                        "pointer": "data/attributes/poa"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Resource not found",
+                      "status": "404",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 067"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "attributes",
+                      null
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "description": "POA Request (21-22/a) Schema",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "veteran",
+                          "poa",
+                          "recordConsent",
+                          "consentAddressChange"
+                        ],
+                        "properties": {
+                          "veteran": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "address"
+                            ],
+                            "properties": {
+                              "serviceNumber": {
+                                "description": "The Veteran's Service Number",
+                                "type": "string",
+                                "maxLength": 9
+                              },
+                              "serviceBranch": {
+                                "description": "Service Branch for the veteran.",
+                                "type": "string",
+                                "enum": [
+                                  "AIR_FORCE",
+                                  "ARMY",
+                                  "COAST_GUARD",
+                                  "MARINE_CORPS",
+                                  "NAVY",
+                                  "SPACE_FORCE",
+                                  "OTHER"
+                                ],
+                                "example": "ARMY"
+                              },
+                              "address": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "addressLine1",
+                                  "city",
+                                  "stateCode",
+                                  "country",
+                                  "zipCode"
+                                ],
+                                "properties": {
+                                  "addressLine1": {
+                                    "description": "Street address with number and name.",
+                                    "type": "string",
+                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 30
+                                  },
+                                  "addressLine2": {
+                                    "type": "string",
+                                    "maxLength": 5
+                                  },
+                                  "city": {
+                                    "description": "City for the address.",
+                                    "type": "string",
+                                    "example": "Portland",
+                                    "maxLength": 18
+                                  },
+                                  "stateCode": {
+                                    "description": "State for the address.",
+                                    "type": "string",
+                                    "pattern": "^[a-z,A-Z]{2}$",
+                                    "example": "OR"
+                                  },
+                                  "country": {
+                                    "description": "Country of the address. USA is the value to use for United States based addresses, US will not work.",
+                                    "type": "string",
+                                    "example": "USA"
+                                  },
+                                  "zipCode": {
+                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{5}?$",
+                                    "example": "12345"
+                                  },
+                                  "zipCodeSuffix": {
+                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{4}?$",
+                                    "example": "6789"
+                                  }
+                                }
+                              },
+                              "phone": {
+                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "areaCode",
+                                  "phoneNumber"
+                                ],
+                                "properties": {
+                                  "areaCode": {
+                                    "description": "Area code of the phone number.",
+                                    "type": "string",
+                                    "pattern": "^[2-9][0-9]{2}$",
+                                    "example": "555"
+                                  },
+                                  "phoneNumber": {
+                                    "description": "Phone number.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{1,14}$",
+                                    "example": "555-5555"
+                                  }
+                                }
+                              },
+                              "email": {
+                                "description": "Email address of the veteran.",
+                                "type": "string",
+                                "pattern": ".@.",
+                                "maxLength": 61,
+                                "example": "veteran@example.com"
+                              },
+                              "insuranceNumber": {
+                                "type": "string",
+                                "maxLength": 10,
+                                "description": "Veteran's insurance number, if applicable. Include letter prefix."
+                              }
+                            }
+                          },
+                          "claimant": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "claimantId": {
+                                "type": "string",
+                                "example": "123456789",
+                                "description": "Id of the claimant."
+                              },
+                              "address": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                  "addressLine1": {
+                                    "description": "Street address with number and name. Required if claimant information provided.",
+                                    "type": "string",
+                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 30
+                                  },
+                                  "addressLine2": {
+                                    "type": "string",
+                                    "maxLength": 5
+                                  },
+                                  "city": {
+                                    "description": "City for the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "example": "Portland",
+                                    "maxLength": 18
+                                  },
+                                  "stateCode": {
+                                    "description": "State for the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "pattern": "^[a-z,A-Z]{2}$",
+                                    "example": "OR"
+                                  },
+                                  "country": {
+                                    "description": "Country of the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "example": "USA"
+                                  },
+                                  "zipCode": {
+                                    "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "pattern": "^\\d{5}?$",
+                                    "example": "12345"
+                                  },
+                                  "zipCodeSuffix": {
+                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{4}?$",
+                                    "example": "6789"
+                                  }
+                                }
+                              },
+                              "phone": {
+                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "areaCode",
+                                  "phoneNumber"
+                                ],
+                                "properties": {
+                                  "areaCode": {
+                                    "description": "Area code of the phone number.",
+                                    "type": "string",
+                                    "pattern": "^[2-9][0-9]{2}$",
+                                    "example": "555"
+                                  },
+                                  "phoneNumber": {
+                                    "description": "Phone number.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{1,14}$",
+                                    "example": "555-5555"
+                                  }
+                                }
+                              },
+                              "email": {
+                                "description": "Email address of the claimant.",
+                                "type": "string",
+                                "pattern": ".@.",
+                                "maxLength": 61,
+                                "example": "claimant@example.com"
+                              },
+                              "relationship": {
+                                "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
+                                "type": "string",
+                                "example": "Spouse"
+                              }
+                            }
+                          },
+                          "poa": {
+                            "description": "Details of the requested Power of Attorney representing the veteran.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "poaCode",
+                              "registrationNumber"
+                            ],
+                            "properties": {
+                              "poaCode": {
+                                "description": "The POA code of the accredited representative or organization.",
+                                "type": "string",
+                                "example": "A1Q"
+                              },
+                              "registrationNumber": {
+                                "description": "Registration Number of the accredited representative.",
+                                "type": "string",
+                                "example": "12345"
+                              },
+                              "jobTitle": {
+                                "description": "Job title of the accredited representative.",
+                                "type": "string",
+                                "example": "Veteran Service Representative"
+                              }
+                            }
+                          },
+                          "recordConsent": {
+                            "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
+                            "type": "boolean"
+                          },
+                          "consentLimits": {
+                            "description": "Consent for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "DRUG_ABUSE",
+                                "ALCOHOLISM",
+                                "HIV",
+                                "SICKLE_CELL"
+                              ]
+                            },
+                            "example": "DRUG ABUSE"
+                          },
+                          "consentAddressChange": {
+                            "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "attributes": {
+                      "veteran": {
+                        "serviceNumber": "123678453",
+                        "serviceBranch": "ARMY",
+                        "address": {
+                          "addressLine1": "2719 Hyperion Ave",
+                          "addressLine2": "Apt 2",
+                          "city": "Los Angeles",
+                          "country": "USA",
+                          "stateCode": "CA",
+                          "zipCode": "92264",
+                          "zipCodeSuffix": "0200"
+                        },
+                        "phone": {
+                          "areaCode": "555",
+                          "phoneNumber": "5551234"
+                        },
+                        "email": "test@test.com",
+                        "insuranceNumber": "1234567890"
+                      },
+                      "poa": {
+                        "poaCode": "067",
+                        "registrationNumber": "999999999999",
+                        "jobTitle": "MyJob"
+                      },
+                      "recordConsent": true,
+                      "consentAddressChange": true,
+                      "consentLimits": [
+                        "DRUG_ABUSE",
+                        "SICKLE_CELL",
+                        "HIV",
+                        "ALCOHOLISM"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
     }
   },
   "servers": [

--- a/modules/claims_api/config/schemas/v2/poa_request.json
+++ b/modules/claims_api/config/schemas/v2/poa_request.json
@@ -234,7 +234,7 @@
         "jobTitle": {
           "description": "Job title of the accredited representative.",
           "type": "string",
-          "example": "Veteran Service representative"
+          "example": "Veteran Service Representative"
         }
       }
     },
@@ -243,7 +243,7 @@
       "type": "boolean"
     },
     "consentLimits": {
-      "description": "Consent in Item 19 for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
+      "description": "Consent for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
       "type": "array",
       "items": {
         "type": "string",

--- a/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/request_representative/valid_no_claimant.json
+++ b/modules/claims_api/spec/fixtures/v2/veterans/power_of_attorney/request_representative/valid_no_claimant.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "attributes": {
+      "veteran": {
+        "serviceNumber": "123678453",
+        "serviceBranch": "ARMY",
+        "address": {
+          "addressLine1":  "2719 Hyperion Ave",
+          "addressLine2": "Apt 2",
+          "city": "Los Angeles",
+          "country":  "USA",
+          "stateCode": "CA",
+          "zipCode": "92264",
+          "zipCodeSuffix": "0200"
+        },
+        "phone": {
+          "areaCode": "555",
+          "phoneNumber": "5551234"
+        },
+        "email": "test@test.com",
+        "insuranceNumber": "1234567890"
+      },
+      "poa": {
+        "poaCode": "067",
+        "registrationNumber": "999999999999",
+        "jobTitle": "MyJob"
+      },
+      "recordConsent": true,
+      "consentAddressChange": true,
+      "consentLimits": ["DRUG_ABUSE", "SICKLE_CELL", "HIV", "ALCOHOLISM"]
+    }
+  }
+}

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -939,4 +939,155 @@ describe 'PowerOfAttorney',
       end
     end
   end
+
+  path '/veterans/{veteranId}/power-of-attorney-request', production: false do
+    post 'Create a Power of Attorney appointment request' do
+      description 'Creates a Power of Attorney appointment request.'
+      tags 'Power of Attorney'
+      operationId 'postPowerOfAttorneyRequest'
+      security [
+        { productionOauth: ['system/claim.read', 'system/claim.write'] },
+        { sandboxOauth: ['system/claim.read', 'system/claim.write'] },
+        { bearer_token: [] }
+      ]
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: 'veteranId',
+                in: :path,
+                required: true,
+                type: :string,
+                example: '1012667145V762142',
+                description: 'ID of Veteran'
+      parameter SwaggerSharedComponents::V2.body_examples[:power_of_attorney_request]
+
+      let(:Authorization) { 'Bearer token' }
+      let(:veteranId) { '1013062086V794840' } # rubocop:disable RSpec/VariableName
+      let(:scopes) { %w[system/claim.write] }
+      let(:data) do
+        temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                               'power_of_attorney', 'request_representative', 'valid_no_claimant.json').read
+        JSON.parse(temp)
+      end
+
+      describe 'Getting a successful response' do
+        response '201', 'Valid request response' do
+          schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'veterans',
+                                                      'power_of_attorney', 'request_representative', 'submit.json')))
+
+          before do |example|
+            allow_any_instance_of(ClaimsApi::PowerOfAttorneyRequestService::Orchestrator)
+              .to receive(:submit_request)
+              .and_return(true)
+            Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: ['067'],
+                                                     first_name: 'Abraham', last_name: 'Lincoln',
+                                                     user_types: ['veteran_service_officer'])
+            Veteran::Service::Organization.create!(poa: '067', name: 'DISABLED AMERICAN VETERANS')
+
+            mock_ccg(scopes) do
+              submit_request(example.metadata)
+            end
+          end
+
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end
+
+          it 'returns a valid 201 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+          end
+        end
+      end
+
+      describe 'Getting a 401 response' do
+        response '401', 'Unauthorized' do
+          schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
+                                                      'power_of_attorney', 'default.json')))
+
+          let(:Authorization) { nil }
+
+          before do |example|
+            submit_request(example.metadata)
+          end
+
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end
+
+          it 'returns a 401 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+          end
+        end
+      end
+
+      describe 'Getting a 422 response' do
+        response '422', 'Unprocessable Entity' do
+          schema JSON.parse(File.read(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
+                                                      'power_of_attorney', 'default.json')))
+
+          let(:data) do
+            temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                   'power_of_attorney', 'request_representative', 'invalid_schema.json').read
+            JSON.parse(temp)
+          end
+
+          before do |example|
+            mock_ccg(scopes) do
+              submit_request(example.metadata)
+            end
+          end
+
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end
+
+          it 'returns a 422 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+          end
+        end
+      end
+
+      describe 'Getting a 404 response' do
+        response '404', 'Resource not found' do
+          schema JSON.parse(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'v2', 'errors',
+                                            'power_of_attorney', 'default.json').read)
+
+          let(:data) do
+            temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                   'power_of_attorney', 'request_representative', 'valid_no_claimant.json').read
+            JSON.parse(temp)
+          end
+
+          before do |example|
+            mock_ccg(scopes) do
+              submit_request(example.metadata)
+            end
+          end
+
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end
+
+          it 'returns a 404 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+          end
+        end
+      end
+    end
+  end
 end

--- a/modules/claims_api/spec/support/swagger_shared_components/v2.rb
+++ b/modules/claims_api/spec/support/swagger_shared_components/v2.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SwaggerSharedComponents
-  class V2
+  class V2 # rubocop:disable Metrics/ClassLength
     def self.body_examples # rubocop:disable Metrics/MethodLength
       veteran_identifier_json_schema = JSON.parse(
         File.read(
@@ -177,6 +177,35 @@ module SwaggerSharedComponents
         )
       )
 
+      power_of_attorney_request_json_schema = JSON.parse(
+        File.read(
+          Rails.root.join(
+            'modules',
+            'claims_api',
+            'config',
+            'schemas',
+            'v2',
+            'poa_request.json'
+          )
+        )
+      )
+
+      power_of_attorney_request_body_example = JSON.parse(
+        File.read(
+          Rails.root.join(
+            'modules',
+            'claims_api',
+            'spec',
+            'fixtures',
+            'v2',
+            'veterans',
+            'power_of_attorney',
+            'request_representative',
+            'valid_no_claimant.json'
+          )
+        )
+      )
+
       {
         veteran_identifier: {
           in: :body,
@@ -303,6 +332,25 @@ module SwaggerSharedComponents
               }
             },
             example: power_of_attorney_2122_body_example
+          }
+        },
+        power_of_attorney_request: {
+          in: :body,
+          name: 'data',
+          required: true,
+          schema: {
+            type: :object,
+            required: ['data'],
+            properties: {
+              data: {
+                type: :object,
+                required: ['attributes', power_of_attorney_request_json_schema['required']],
+                properties: {
+                  attributes: power_of_attorney_request_json_schema
+                }
+              }
+            },
+            example: power_of_attorney_request_body_example
           }
         }
       }

--- a/spec/support/schemas/claims_api/v2/veterans/power_of_attorney/request_representative/submit.json
+++ b/spec/support/schemas/claims_api/v2/veterans/power_of_attorney/request_representative/submit.json
@@ -1,0 +1,276 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["data"],
+  "properties": {
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attributes"],
+      "properties": {
+        "attributes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "veteran",
+            "poa",
+            "recordConsent",
+            "consentAddressChange"
+          ],
+          "properties": {
+            "veteran": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "address"
+              ],
+              "properties": {
+                "serviceNumber": {
+                  "description": "The Veteran's Service Number",
+                  "type": "string",
+                  "maxLength": 9
+                },
+                "serviceBranch": {
+                  "description": "Service Branch for the veteran.",
+                  "type": "string",
+                  "enum": [
+                    "AIR_FORCE",
+                    "ARMY",
+                    "COAST_GUARD",
+                    "MARINE_CORPS",
+                    "NAVY",
+                    "SPACE_FORCE",
+                    "OTHER"
+                  ],
+                  "example": "ARMY"
+                },
+                "address": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "addressLine1",
+                    "city",
+                    "stateCode",
+                    "country",
+                    "zipCode"
+                  ],
+                  "properties" : {
+                    "addressLine1": {
+                      "description": "Street address with number and name.",
+                      "type": "string",
+                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                      "maxLength": 30
+                    },
+                    "addressLine2": {
+                      "type": "string",
+                      "maxLength": 5
+                    },
+                    "city": {
+                      "description": "City for the address.",
+                      "type": "string",
+                      "example": "Portland",
+                      "maxLength": 18
+                    },
+                    "stateCode": {
+                      "description": "State for the address.",
+                      "type": "string",
+                      "pattern": "^[a-z,A-Z]{2}$",
+                      "example": "OR"
+                    },
+                    "country": {
+                      "description": "Country of the address. USA is the value to use for United States based addresses, US will not work.",
+                      "type": "string",
+                      "example": "USA"
+                    },
+                    "zipCode": {
+                      "description": "Zipcode (First 5 digits) of the address.",
+                      "type": "string",
+                      "pattern": "^\\d{5}?$",
+                      "example": "12345"
+                    },
+                    "zipCodeSuffix": {
+                      "description": "Zipcode (Last 4 digits) of the address.",
+                      "type": "string",
+                      "pattern": "^\\d{4}?$",
+                      "example": "6789"
+                    }
+                  }
+                },
+                "phone": {
+                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "areaCode",
+                    "phoneNumber"
+                  ],
+                  "properties": {
+                    "areaCode": {
+                      "description": "Area code of the phone number.",
+                      "type": "string", "pattern": "^[2-9][0-9]{2}$",
+                      "example": "555"
+                    },
+                    "phoneNumber": {
+                      "description": "Phone number.",
+                      "type": "string", "pattern": "^[0-9]{1,14}$",
+                      "example": "555-5555"
+                    }
+                  }
+                },
+                "email": {
+                  "description": "Email address of the veteran.",
+                  "type": "string",
+                  "pattern": ".@.",
+                  "maxLength": 61,
+                  "example": "veteran@example.com"
+                },
+                "insuranceNumber": {
+                  "type": "string",
+                  "maxLength": 10,
+                  "description": "Veteran's insurance number, if applicable. Include letter prefix."
+                }
+              }
+            },
+            "claimant": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "claimantId": {
+                  "type": "string",
+                  "example": "123456789",
+                  "description": "Id of the claimant."
+                },
+                "address": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties" : {
+                    "addressLine1": {
+                      "description": "Street address with number and name. Required if claimant information provided.",
+                      "type": "string",
+                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                      "maxLength": 30
+                    },
+                    "addressLine2": {
+                      "type": "string",
+                      "maxLength": 5
+                    },
+                    "city": {
+                      "description": "City for the address. Required if claimant information provided.",
+                      "type": "string",
+                      "example": "Portland",
+                      "maxLength": 18
+                    },
+                    "stateCode": {
+                      "description": "State for the address. Required if claimant information provided.",
+                      "type": "string",
+                      "pattern": "^[a-z,A-Z]{2}$",
+                      "example": "OR"
+                    },
+                    "country": {
+                      "description": "Country of the address. Required if claimant information provided.",
+                      "type": "string",
+                      "example": "USA"
+                    },
+                    "zipCode": {
+                      "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
+                      "type": "string",
+                      "pattern": "^\\d{5}?$",
+                      "example": "12345"
+                    },
+                    "zipCodeSuffix": {
+                      "description": "Zipcode (Last 4 digits) of the address.",
+                      "type": "string",
+                      "pattern": "^\\d{4}?$",
+                      "example": "6789"
+                    }
+                  }
+                },
+                "phone": {
+                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "areaCode",
+                    "phoneNumber"
+                  ],
+                  "properties": {
+                    "areaCode": {
+                      "description": "Area code of the phone number.",
+                      "type": "string", "pattern": "^[2-9][0-9]{2}$",
+                      "example": "555"
+                    },
+                    "phoneNumber": {
+                      "description": "Phone number.",
+                      "type": "string", "pattern": "^[0-9]{1,14}$",
+                      "example": "555-5555"
+                    }
+                  }
+                },
+                "email": {
+                  "description": "Email address of the claimant.",
+                  "type": "string",
+                  "pattern": ".@.",
+                  "maxLength": 61,
+                  "example": "claimant@example.com"
+                },
+                "relationship": {
+                  "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
+                  "type": "string",
+                  "example": "Spouse"
+                }
+              }
+            },
+            "poa": {
+              "description": "Details of the requested Power of Attorney representing the veteran.",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "poaCode",
+                "registrationNumber"
+              ],
+              "properties": {
+                "poaCode": {
+                  "description": "The POA code of the accredited representative or organization.",
+                  "type": "string",
+                  "example": "A1Q"
+                },
+                "registrationNumber": {
+                  "description": "Registration Number of the accredited representative.",
+                  "type": "string",
+                  "example": "12345"
+                },
+                "jobTitle": {
+                  "description": "Job title of the accredited representative.",
+                  "type": "string",
+                  "example": "Veteran Service Representative"
+                }
+              }
+            },
+            "recordConsent": {
+              "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
+              "type": "boolean"
+            },
+            "consentLimits": {
+              "description": "Consent in Item 19 for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "DRUG_ABUSE",
+                  "ALCOHOLISM",
+                  "HIV",
+                  "SICKLE_CELL"
+                ]
+              },
+              "example": "DRUG ABUSE"
+            },
+            "consentAddressChange": {
+              "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- This pr adds rwag specs and swagger docs for the POA Request endpoint in lower environments

## Related issue(s)

- [API-34408](https://jira.devops.va.gov/browse/API-34408)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/fed1441d-28c4-4eb4-89fb-18bbf5cd9fca)

![image](https://github.com/department-of-veterans-affairs/vets-api/assets/144135615/b6de826f-a897-4089-ae82-082b7cf6fd84)


## What areas of the site does it impact?
Adds docs to lower environments

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature