### PR TITLE
[86012] FSR Feature Flag Removal (vets-api)

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -224,10 +224,6 @@ features:
     actor_type: user
     description: Enables users to submit FSR forms for VHA and VBA debts
     enable_in_development: true
-  combined_financial_status_report_enhancements:
-    actor_type: user
-    description: Enables users to interact with the new cFSR enhancements and avoid list loops
-    enable_in_development: true
   communication_preferences:
     actor_type: user
     description: Allow user to access backend communication_preferences API
@@ -483,14 +479,6 @@ features:
   financial_status_report_expenses_update:
     actor_type: user
     description: Update expense lists in the Financial Status Report (FSR - 5655) form
-    enable_in_development: true
-  financial_status_report_streamlined_waiver:
-    actor_type: user
-    description: Enables streamlined waiver flow for qualifying users completing the Financial Status Report (FSR) form
-    enable_in_development: true
-  financial_status_report_streamlined_waiver_assets:
-    actor_type: user
-    description: Enables a simplified asset calculation flow, including Cash in Bank, for users completing the Financial Status Report (FSR) form.
     enable_in_development: true
   financial_status_report_review_page_navigation:
     actor_type: user


### PR DESCRIPTION
## Summary

Three feature flags have been set to `true` by default and there are no longer any in-progress forms that have them set to `false`. This means the flags are safe to remove, and this pull request removes them on the `vets-api` side.

## Related issue(s)

- [Main ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/86012)
- [Initial ticket for the discovery](https://github.com/department-of-veterans-affairs/va.gov-team/issues/81813)

## Testing done

N/A. As long as all the existing tests pass, this is good.

## Screenshots

N/A

## What areas of the site does it impact?

FSR Forms, specifically in-progress

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs