### PR TITLE
add toggle for privacy policy

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -68,7 +68,7 @@ features:
     description: Allow list of medical care facilites to be fetched by way of the Facilities API.
   hca_submission_failure_email_va_notify:
     actor_type: user
-    description: Send HCA Submission Failure email using VANotify. 
+    description: Send HCA Submission Failure email using VANotify.
   ezr_prod_enabled:
     actor_type: user
     description: Enables access to the 10-10EZR application in prod for the purposes of conducting user reasearch
@@ -917,6 +917,9 @@ features:
   profile_show_payments_notification_setting:
     actor_type: user
     description: Show/Hide the payments section of notifications in profile
+  profile_show_privacy_policy:
+    actor_type: user
+    description: Show/Hide the privacy policy section on profile pages
   profile_show_pronouns_and_sexual_orientation:
     actor_type: user
     description: Show/hide Pronouns and Sexual Orientation fields on profile page


### PR DESCRIPTION
## Summary

- Adds a toggle for profile privacy policy work
- Also removed a trailing space on one toggle for cleanliness

Timeframe: toggle will be removed within a month of privacy statement being launched in production. Tentative date of removal would be end of August, depending on when final work lands in production. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85603

## Testing done

Test locally, just a single toggle being added

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Toggle added
- [x]  No error nor warning in the console.
