### PR TITLE
Quick fix avs link safe check

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -290,7 +290,7 @@ module VAOS
 
         avs_resp = avs_service.get_avs_by_appointment(station_no, appt_ien)
 
-        return nil if avs_resp.body.empty? || !avs_resp.body.first.is_a?(Hash)
+        return nil if avs_resp.body.empty? || !(avs_resp.body.is_a?(Array) && avs_resp.body.first.is_a?(Hash))
 
         data = avs_resp.body.first.with_indifferent_access
 

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -290,7 +290,7 @@ module VAOS
 
         avs_resp = avs_service.get_avs_by_appointment(station_no, appt_ien)
 
-        return nil if avs_resp.body.empty?
+        return nil if avs_resp.body.empty? || !avs_resp.body.first.is_a?(Hash)
 
         data = avs_resp.body.first.with_indifferent_access
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1145,6 +1145,14 @@ describe VAOS::V2::AppointmentsService do
         end
       end
     end
+
+    context 'with non-hash body' do
+      it 'returns nil' do
+        VCR.use_cassette('vaos/v2/appointments/avs-search-error', match_requests_on: %i[method path query]) do
+          expect(subject.send(:get_avs_link, appt)).to eq(nil)
+        end
+      end
+    end
   end
 
   describe '#fetch_avs_and_update_appt_body' do

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/avs-search-error.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/avs-search-error.yml
@@ -1,0 +1,22 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://something.fake.va.gov/avs-by-appointment/500/9876543
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - Server
+        Date:
+          - Mon, 29 Jun 2020 15:46:52 GMT
+        Content-Type:
+          - application/json
+      body:
+        encoding: UTF-8
+        string: |-
+          "<HTML Internal Server Error>"
+    recorded_at: Thu, 10 Aug 2023 16:45:03 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Summary

- This is a quick fix to more gracefully handle responses returned to vets-api from the avs service, checking if the response is a hash before parsing it.

## Testing done

- Tested new logic
- Ran regression tests
