### PR TITLE
85953 - 1010 EZ/EZR Add specs around TERA questions in enrollment system

### DIFF
--- a/spec/lib/hca/enrollment_system_spec.rb
+++ b/spec/lib/hca/enrollment_system_spec.rb
@@ -909,6 +909,100 @@ describe HCA::EnrollmentSystem do
     ]
   )
 
+  describe '#veteran_to_tera' do
+    test_method(
+      described_class,
+      'veteran_to_tera',
+      [
+        [
+          { 'hasTeraResponse' => false },
+          {}
+        ],
+        [
+          {
+            'hasTeraResponse' => true
+          },
+          {
+            'supportOperationsInd' => false
+          }
+        ],
+        [
+          {
+            'hasTeraResponse' => true,
+            'combatOperationService' => true
+          },
+          {
+            'supportOperationsInd' => true
+          }
+        ],
+        [
+          {
+            'hasTeraResponse' => true,
+            'gulfWarService' => true,
+            'gulfWarStartDate' => '1993-16-08',
+            'gulfWarEndDate' => '1994-16-07'
+          },
+          {
+            'supportOperationsInd' => false,
+            'gulfWarHazard' => {
+              'gulfWarHazardInd' => true,
+              'fromDate' => '08/16/1993',
+              'toDate' => '07/16/1994'
+            }
+          }
+        ]
+      ]
+    )
+  end
+
+  describe '#veteran_to_toxic_exposure' do
+    test_method(
+      described_class,
+      'veteran_to_toxic_exposure',
+      [
+        [
+          {},
+          {}
+        ],
+        [
+          {
+            'exposureToAirPollutants' => 'true',
+            'toxicExposureStartDate' => '1980-16-08',
+            'toxicExposureEndDate' => '1989-13-08'
+          },
+          {
+            'toxicExposure' => {
+              'exposureCategories' => {
+                'exposureCategory' => ['Air Pollutants']
+              },
+              'otherText' => nil,
+              'fromDate' => '08/16/1980',
+              'toDate' => '08/13/1989'
+            }
+          }
+        ],
+        [
+          {
+            'exposureToOther' => 'true',
+            'otherToxicExposure' => 'other exposure text value here',
+            'toxicExposureStartDate' => '1980-16-08',
+            'toxicExposureEndDate' => '1989-13-08'
+          },
+          {
+            'toxicExposure' => {
+              'exposureCategories' => {
+                'exposureCategory' => ['Other']
+              },
+              'otherText' => 'other exposure text value here',
+              'fromDate' => '08/16/1980',
+              'toDate' => '08/13/1989'
+            }
+          }
+        ]
+      ]
+    )
+  end
+
   test_method(
     described_class,
     'veteran_to_financials_info',


### PR DESCRIPTION

## Summary

- This work is behind a feature toggle (flipper): NO
- Add specs around the existing TERA logic in the `enrollment_system.rb` as they were not being fully tested. These tests will hopefully allow for future refactors to try to make the `enrollment_system.rb` simpler and easier to understand without introducing any regressions. 
- 1010 Health Apps and it is used by the 1010 EZ and 1010 EZR form

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85953

## Testing done

- The only code changes are adding tests

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
1010 EZ and 1010 EZR

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

