### PR TITLE
8853: re-add facility error message for vaos non-index appointments e…

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -48,7 +48,7 @@ module VAOS
           appointment[:friendly_name] = clinic&.[](:service_name) if clinic&.[](:service_name)
         end
 
-        add_facility(appointment)
+        add_location(appointment)
 
         scrape_appt_comments_and_log_details(appointment, show_method_logging_name, PAP_COMPLIANCE_TELE)
 
@@ -67,7 +67,7 @@ module VAOS
           new_appointment[:friendly_name] = clinic&.[](:service_name) if clinic&.[](:service_name)
         end
 
-        add_facility(new_appointment)
+        add_location(new_appointment)
 
         scrape_appt_comments_and_log_details(new_appointment, create_method_logging_name, PAP_COMPLIANCE_TELE)
 
@@ -85,7 +85,7 @@ module VAOS
           updated_appointment[:friendly_name] = clinic&.[](:service_name) if clinic&.[](:service_name)
         end
 
-        add_facility(updated_appointment)
+        add_location(updated_appointment)
 
         serializer = VAOS::V2::VAOSSerializer.new
         serialized = serializer.serialize(updated_appointment, 'appointments')
@@ -104,7 +104,7 @@ module VAOS
           VAOS::V2::MobileFacilityService.new(current_user)
       end
 
-      def add_facility(appointment)
+      def add_location(appointment)
         return if appointment[:location_id].nil?
 
         appointment[:location] = mobile_facility_service.get_facility(appointment[:location_id]) || FACILITY_ERROR_MSG

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -19,8 +19,6 @@ module VAOS
       COMMENT = 'comment'
 
       def index
-        appointments
-
         appointments[:data].each do |appt|
           if include_params[:facilities] && appt[:location_id].present? && appt[:location].nil?
             appt[:location] = FACILITY_ERROR_MSG
@@ -50,10 +48,7 @@ module VAOS
           appointment[:friendly_name] = clinic&.[](:service_name) if clinic&.[](:service_name)
         end
 
-        unless appointment[:location_id].nil?
-          appointment[:location] =
-            mobile_facility_service.get_facility(appointment[:location_id])
-        end
+        add_facility(appointment)
 
         scrape_appt_comments_and_log_details(appointment, show_method_logging_name, PAP_COMPLIANCE_TELE)
 
@@ -72,9 +67,7 @@ module VAOS
           new_appointment[:friendly_name] = clinic&.[](:service_name) if clinic&.[](:service_name)
         end
 
-        unless new_appointment[:location_id].nil?
-          new_appointment[:location] = mobile_facility_service.get_facility(new_appointment[:location_id])
-        end
+        add_facility(new_appointment)
 
         scrape_appt_comments_and_log_details(new_appointment, create_method_logging_name, PAP_COMPLIANCE_TELE)
 
@@ -92,9 +85,7 @@ module VAOS
           updated_appointment[:friendly_name] = clinic&.[](:service_name) if clinic&.[](:service_name)
         end
 
-        unless updated_appointment[:location_id].nil?
-          updated_appointment[:location] = mobile_facility_service.get_facility(updated_appointment[:location_id])
-        end
+        add_facility(updated_appointment)
 
         serializer = VAOS::V2::VAOSSerializer.new
         serialized = serializer.serialize(updated_appointment, 'appointments')
@@ -111,6 +102,12 @@ module VAOS
       def mobile_facility_service
         @mobile_facility_service ||=
           VAOS::V2::MobileFacilityService.new(current_user)
+      end
+
+      def add_facility(appointment)
+        return if appointment[:location_id].nil?
+
+        appointment[:location] = mobile_facility_service.get_facility(appointment[:location_id]) || FACILITY_ERROR_MSG
       end
 
       def appointments


### PR DESCRIPTION
## Summary

Re-adds logic for setting a default location error message when an error was encountered fetching the upstream facility. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8853

## Testing done


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This should only impact appointment create/show/update by re-adding logic that was accidentally removed during a refactor.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback


