### PR TITLE
8855: fix appointments helper syntax error

### DIFF
--- a/modules/mobile/app/helpers/mobile/appointments_helper.rb
+++ b/modules/mobile/app/helpers/mobile/appointments_helper.rb
@@ -17,7 +17,7 @@ module Mobile
 
     def backfill_location(appointment)
       unless appointment[:clinic].nil?
-        clinic = vaos_mobile_facility_service.get_clinic(station_id: [:location_id], clinic_id: appointment[:clinic])
+        clinic = vaos_mobile_facility_service.get_clinic(appointment[:location_id], appointment[:clinic])
         appointment[:service_name] = clinic&.[](:service_name)
         appointment[:physical_location] = clinic&.[](:physical_location) if clinic&.[](:physical_location)
       end


### PR DESCRIPTION
## Summary
Fixes an issue that was accidentally created in recent work. Only one endpoint uses this code and it is not currently in use. The syntax issue was not found by testing because the method being called is mocked in the specs.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8855

## Testing done


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None. This endpoint isn't in use. I'm just cleaning up after myself.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
