### PR TITLE
Align flipper UI nav

### DIFF
--- a/lib/flipper/views/layout.erb
+++ b/lib/flipper/views/layout.erb
@@ -40,7 +40,7 @@
 
       <div class="vads-l-row">
         <nav>
-          <ul class="nav nav-underline mb-3 align-items-center">
+          <ul class="nav nav-underline mb-3 align-items-center" style="margin-left: -24px;">
             <% Flipper::UI.configuration.nav_items.each do |item| %>
               <ul class="vads-u-margin--0 vads-u-padding--0 nav-item">
                 <a href="<%= url_for(item[:href]) %>" class="nav-link<%= " active" if request.url.start_with?(url_for(item[:href])) %>">


### PR DESCRIPTION
## Summary

- Follow-up to  https://github.com/department-of-veterans-affairs/vets-api/pull/17159

During validation, @jennb33 called out the :eye-twitch: misalignment of the navigation. She recommended a negative margin and ✨ that worked!

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81501

## Testing done
See screenshots
✅ the alignment is consistent even with page re-sizing. 

## Screenshots
👎 **Before:**
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/8d983c0c-a3ce-405a-bb32-29f8bb394275)

✨ **After**
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/ebc47381-c10e-4f92-a884-ac8cbcac586a)

## What areas of the site does it impact?
Flipper UI
