### PR TITLE
Add Unit Tests for Root AMS Serializers - Part 12

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1724,6 +1724,7 @@ spec/serializers/preferred_name_serializer_spec.rb @department-of-veterans-affai
 spec/serializers/preneed_attachment_serializer_spec.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/prescription_preference_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/prescription_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/serializers/rated_disabilities_serializer_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/receive_application_serializer_spec.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/shared_evss_claim_base_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/triage_team_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -417,7 +417,6 @@ app/serializers/preferred_name_serializer.rb @department-of-veterans-affairs/vfs
 app/serializers/preneed_attachment_serializer.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/prescription_preference_serializer.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/prescription_serializer.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/serializers/profile_photo_attachment_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/rated_disabilities_serializer.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/rating_info_serializer.rb @department-of-veterans-affairs/backend-review-group
 app/serializers/receive_application_serializer.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1194,6 +1193,7 @@ spec/factories/preneeds @department-of-veterans-affairs/mbs-core-team @departmen
 spec/factories/prescriptions.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/prescription_details.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/prescription_preferences.rb  @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/factories/rated_disabilities.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/representatives.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group
 spec/factories/rubysaml_settings.rb @department-of-veterans-affairs/octo-identity
 spec/factories/saml_attributes.rb @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1727,6 +1727,7 @@ spec/serializers/prescription_serializer_spec.rb @department-of-veterans-affairs
 spec/serializers/rated_disabilities_serializer_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/rating_info_serializer_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/serializers/receive_application_serializer_spec.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/serializers/saved_claim_serializer_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/shared_evss_claim_base_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/triage_team_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/user_serializer_spec.rb @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1728,6 +1728,7 @@ spec/serializers/rated_disabilities_serializer_spec.rb @department-of-veterans-a
 spec/serializers/rating_info_serializer_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/serializers/receive_application_serializer_spec.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/saved_claim_serializer_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/serializers/search_serializer_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/shared_evss_claim_base_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/triage_team_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/user_serializer_spec.rb @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1729,6 +1729,7 @@ spec/serializers/rating_info_serializer_spec.rb @department-of-veterans-affairs/
 spec/serializers/receive_application_serializer_spec.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/saved_claim_serializer_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/search_serializer_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/serializers/service_history_serializer_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/shared_evss_claim_base_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/triage_team_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/user_serializer_spec.rb @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1725,6 +1725,7 @@ spec/serializers/preneed_attachment_serializer_spec.rb @department-of-veterans-a
 spec/serializers/prescription_preference_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/prescription_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/rated_disabilities_serializer_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/serializers/rating_info_serializer_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/serializers/receive_application_serializer_spec.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/shared_evss_claim_base_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/triage_team_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/serializers/profile_photo_attachment_serializer.rb
+++ b/app/serializers/profile_photo_attachment_serializer.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class ProfilePhotoAttachmentSerializer < ActiveModel::Serializer
-  attribute :guid
-end

--- a/spec/factories/rated_disabilities.rb
+++ b/spec/factories/rated_disabilities.rb
@@ -4,14 +4,14 @@ require 'disability_compensation/responses/rated_disabilities_response'
 
 FactoryBot.define do
   factory :rated_disability, class: 'DisabilityCompensation::ApiProvider::RatedDisability' do
-    decision_code { "SVCCONNCTED" }
-    decision_text { "Service Connected" }
+    decision_code { 'SVCCONNCTED' }
+    decision_text { 'Service Connected' }
     diagnostic_code { 5238 }
     effective_date { DateTime.new(2018, 3, 27) }
     maximum_rating_percentage { nil }
-    name { "Diabetes mellitus0" }
-    rated_disability_id { "1" }
-    rating_decision_id { "0" }
+    name { 'Diabetes mellitus0' }
+    rated_disability_id { '1' }
+    rating_decision_id { '0' }
     rating_percentage { 50 }
     related_disability_date { DateTime.new(2024, 6, 18) }
     special_issues { [] }

--- a/spec/factories/rated_disabilities.rb
+++ b/spec/factories/rated_disabilities.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'disability_compensation/responses/rated_disabilities_response'
+
+FactoryBot.define do
+  factory :rated_disability, class: 'DisabilityCompensation::ApiProvider::RatedDisability' do
+    decision_code { "SVCCONNCTED" }
+    decision_text { "Service Connected" }
+    diagnostic_code { 5238 }
+    effective_date { DateTime.new(2018, 3, 27) }
+    maximum_rating_percentage { nil }
+    name { "Diabetes mellitus0" }
+    rated_disability_id { "1" }
+    rating_decision_id { "0" }
+    rating_percentage { 50 }
+    related_disability_date { DateTime.new(2024, 6, 18) }
+    special_issues { [] }
+
+    initialize_with { new(attributes) }
+  end
+
+  factory :rated_disabilities_response, class: 'DisabilityCompensation::ApiProvider::RatedDisabilitiesResponse' do
+    initialize_with { new(rated_disabilities: [build(:rated_disability)]) }
+  end
+end

--- a/spec/factories/va_profile/service_histories.rb
+++ b/spec/factories/va_profile/service_histories.rb
@@ -19,24 +19,24 @@ FactoryBot.define do
       deployments do
         [
           {
-            "deployment_sequence_number" => 1,
-            "deployment_begin_date" => "2004-11-15",
-            "deployment_end_date" => "2005-10-25",
-            "deployment_project_text" => "Overseas Contingency Operation (OCO)",
-            "deployment_project_code" => "9GF",
-            "deployment_termination_reason_text" => "Separation from personnel category or organization",
-            "deployment_termination_reason_code" => "S",
-            "deployment_locations" => [
+            'deployment_sequence_number' => 1,
+            'deployment_begin_date' => '2004-11-15',
+            'deployment_end_date' => '2005-10-25',
+            'deployment_project_text' => 'Overseas Contingency Operation (OCO)',
+            'deployment_project_code' => '9GF',
+            'deployment_termination_reason_text' => 'Separation from personnel category or organization',
+            'deployment_termination_reason_code' => 'S',
+            'deployment_locations' => [
               {
-                "deployment_location_sequence_number" => 2,
-                "deployment_country_text" => "Germany -- Added October 1990; formerly Germany, Berlin (BZ), German Democratic Republic (GC), and Germany, Federal Republic of (GE).",
-                "deployment_country_code" => "GM",
-                "deployment_location_body_of_water_text" => "DoD provided a NULL or blank value",
-                "deployment_location_body_of_water_code" => "DVN",
-                "deployment_location_begin_date" => "2005-04-12",
-                "deployment_location_end_date" => "2005-05-04",
-                "deployment_location_termination_reason_text" => "DoD provided a NULL or blank value",
-                "deployment_location_termination_reason_code" => "DVN"
+                'deployment_location_sequence_number' => 2,
+                'deployment_country_text' => 'Germany -- Added October 1990; formerly Germany, Berlin (BZ)',
+                'deployment_country_code' => 'GM',
+                'deployment_location_body_of_water_text' => 'DoD provided a NULL or blank value',
+                'deployment_location_body_of_water_code' => 'DVN',
+                'deployment_location_begin_date' => '2005-04-12',
+                'deployment_location_end_date' => '2005-05-04',
+                'deployment_location_termination_reason_text' => 'DoD provided a NULL or blank value',
+                'deployment_location_termination_reason_code' => 'DVN'
               }
             ]
           }

--- a/spec/factories/va_profile/service_histories.rb
+++ b/spec/factories/va_profile/service_histories.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'va_profile/models/service_history'
+
+FactoryBot.define do
+  factory :service_history, class: 'VAProfile::Models::ServiceHistory' do
+    begin_date { '2012-03-02' }
+    branch_of_service { 'Army' }
+    branch_of_service_code { 'A' }
+    character_of_discharge_code { 'A' }
+    deployments { [] }
+    end_date { '2018-10-31' }
+    personnel_category_type_code { 'N' }
+    service_type { 'Military Service' }
+    termination_reason_code { 'C' }
+    termination_reason_text { 'Completion of Active Service period' }
+
+    trait :with_deployments do
+      deployments do
+        [
+          {
+            "deployment_sequence_number" => 1,
+            "deployment_begin_date" => "2004-11-15",
+            "deployment_end_date" => "2005-10-25",
+            "deployment_project_text" => "Overseas Contingency Operation (OCO)",
+            "deployment_project_code" => "9GF",
+            "deployment_termination_reason_text" => "Separation from personnel category or organization",
+            "deployment_termination_reason_code" => "S",
+            "deployment_locations" => [
+              {
+                "deployment_location_sequence_number" => 2,
+                "deployment_country_text" => "Germany -- Added October 1990; formerly Germany, Berlin (BZ), German Democratic Republic (GC), and Germany, Federal Republic of (GE).",
+                "deployment_country_code" => "GM",
+                "deployment_location_body_of_water_text" => "DoD provided a NULL or blank value",
+                "deployment_location_body_of_water_code" => "DVN",
+                "deployment_location_begin_date" => "2005-04-12",
+                "deployment_location_end_date" => "2005-05-04",
+                "deployment_location_termination_reason_text" => "DoD provided a NULL or blank value",
+                "deployment_location_termination_reason_code" => "DVN"
+              }
+            ]
+          }
+        ]
+      end
+    end
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/serializers/preferred_name_serializer_spec.rb
+++ b/spec/serializers/preferred_name_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PreferredNameSerializer do
+describe PreferredNameSerializer, type: :serializer do
   subject { serialize(preferred_name_response, serializer_class: described_class) }
 
   let(:preferred_name_response) { build(:preferred_name_response) }

--- a/spec/serializers/rated_disabilities_serializer_spec.rb
+++ b/spec/serializers/rated_disabilities_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RatedDisabilitiesSerializer, type: :serializer do
+  subject { serialize(rated_disabilities_response, serializer_class: described_class) }
+
+  let(:rated_disabilities_response) { build(:rated_disabilities_response) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+  let(:links) { data['links'] }
+
+  it 'includes :id' do
+    expect(data['id']).to be_blank
+  end
+
+  it 'includes :rated_disabilities' do
+    expect(attributes['rated_disabilities'].size).to eq rated_disabilities_response.rated_disabilities.size
+  end
+
+  it 'includes :rated_disabilities with attributes' do
+    expected_attributes = rated_disabilities_response.rated_disabilities.first.attributes.keys.map(&:to_s)
+    expect(attributes['rated_disabilities'].first.keys).to eq expected_attributes
+  end
+end

--- a/spec/serializers/rating_info_serializer_spec.rb
+++ b/spec/serializers/rating_info_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'evss/disability_compensation_form/rating_info_response'
+
+describe RatingInfoSerializer, type: :serializer do
+  subject { serialize(rating_info_response, serializer_class: described_class) }
+
+  let(:rating_info_response) do
+    response = double('response', body: { user_percent_of_disability: 100 })
+    EVSS::DisabilityCompensationForm::RatingInfoResponse.new(200, response)
+  end
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  it 'includes :id' do
+    expect(data['id']).to be_blank
+  end
+
+  it 'includes :user_percent_of_disability' do
+    expect(attributes['user_percent_of_disability']).to eq rating_info_response[:user_percent_of_disability]
+  end
+
+  it 'includes :source_system' do
+    expect(attributes['source_system']).to eq 'EVSS'
+  end
+end

--- a/spec/serializers/saved_claim_serializer_spec.rb
+++ b/spec/serializers/saved_claim_serializer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SavedClaimSerializer, type: :serializer do
+  subject { serialize(saved_claim, serializer_class: described_class) }
+
+  let(:saved_claim) { build_stubbed(:burial_claim) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  it 'includes :id' do
+    expect(data['id']).to eq saved_claim.id.to_s
+  end
+
+  it 'includes :submitted_at' do
+    expect_time_eq(attributes['submitted_at'], saved_claim.submitted_at)
+  end
+
+  it 'includes :regional_office' do
+    expect(attributes['regional_office']).to eq saved_claim.regional_office
+  end
+
+  it 'includes :confirmation_number' do
+    expect(attributes['confirmation_number']).to eq saved_claim.confirmation_number
+  end
+
+  it 'includes :guid' do
+    expect(attributes['guid']).to eq saved_claim.guid
+  end
+
+  it 'includes :form' do
+    expect(attributes['form']).to eq saved_claim.form_id
+  end
+end

--- a/spec/serializers/search_serializer_spec.rb
+++ b/spec/serializers/search_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'search/response'
+
+describe SearchSerializer, type: :serializer do
+  subject { serialize(search_response, serializer_class: described_class) }
+
+  let(:search_attributes) { {body: {query: "benefits" }} }
+  let(:search_response) do
+    pagination = {current_page: 1, per_page: 10, total_pages: 9, total_entries: 85}
+    Search::ResultsResponse.new(200, pagination, search_attributes)
+  end
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  it 'includes :id' do
+    expect(data['id']).to be_blank
+  end
+
+  it 'includes :body' do
+    expect(attributes['body']).to eq search_attributes[:body].deep_stringify_keys
+  end
+end

--- a/spec/serializers/search_serializer_spec.rb
+++ b/spec/serializers/search_serializer_spec.rb
@@ -6,9 +6,9 @@ require 'search/response'
 describe SearchSerializer, type: :serializer do
   subject { serialize(search_response, serializer_class: described_class) }
 
-  let(:search_attributes) { {body: {query: "benefits" }} }
+  let(:search_attributes) { { body: { query: 'benefits' } } }
   let(:search_response) do
-    pagination = {current_page: 1, per_page: 10, total_pages: 9, total_entries: 85}
+    pagination = { current_page: 1, per_page: 10, total_pages: 9, total_entries: 85 }
     Search::ResultsResponse.new(200, pagination, search_attributes)
   end
   let(:data) { JSON.parse(subject)['data'] }

--- a/spec/serializers/service_history_serializer_spec.rb
+++ b/spec/serializers/service_history_serializer_spec.rb
@@ -6,8 +6,8 @@ describe ServiceHistorySerializer, type: :serializer do
   subject { serialize(service_history, serializer_class: described_class) }
 
   let(:service_history) do
-     histories = [build(:service_history, :with_deployments)]
-     JSON.parse(histories.to_json, symbolize_names: true)
+    histories = [build(:service_history, :with_deployments)]
+    JSON.parse(histories.to_json, symbolize_names: true)
   end
   let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }

--- a/spec/serializers/service_history_serializer_spec.rb
+++ b/spec/serializers/service_history_serializer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ServiceHistorySerializer, type: :serializer do
+  subject { serialize(service_history, serializer_class: described_class) }
+
+  let(:service_history) do
+     histories = [build(:service_history, :with_deployments)]
+     JSON.parse(histories.to_json, symbolize_names: true)
+  end
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  it 'includes :id' do
+    expect(data['id']).to be_blank
+  end
+
+  it 'includes :service_history' do
+    expect(attributes['service_history'].size).to eq service_history.size
+  end
+
+  it 'includes :service_history with attributes' do
+    expect(attributes['service_history'].first).to eq service_history.first.deep_stringify_keys
+  end
+end


### PR DESCRIPTION
## Summary

- Add test examples for missing attributes/specs
- Removed `ProfilePhotoAttachmentSerializer` 
    - I couldn't find where it's used and the controller it was used in previously was deleted

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83654

## Testing done

- [x] Add new tests

## Screenshots

![Screenshot 2024-06-18 at 5 10 44 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/c0867709-28f9-44ab-81b6-ac61151e96d7)

## Acceptance criteria

- [x] unit test coverage is 100%
