### PR TITLE
Fix Settings Updates on bin/setup

### DIFF
--- a/bin/lib/vets-api/setups/base.rb
+++ b/bin/lib/vets-api/setups/base.rb
@@ -111,7 +111,7 @@ module VetsApi
 
       def save_settings(settings)
         File.open('config/settings.local.yml', 'a') do |file|
-          file.puts settings.to_yaml.tr('---', '')
+          file.puts settings.to_yaml.sub(/^---\n/, '')
         end
       end
     end

--- a/bin/lib/vets-api/setups/docker.rb
+++ b/bin/lib/vets-api/setups/docker.rb
@@ -19,18 +19,23 @@ module VetsApi
       private
 
       def configuring_clamav_antivirus
-        print 'Configuring ClamAV in local settings...'
-        file_path = 'config/settings.local.yml'
-        data = YAML.load_file(file_path)
+        print 'Updating settings.local.yml...'
+        settings_path = 'config/settings.local.yml'
+        settings_file = File.read(settings_path)
+        settings = YAML.safe_load(settings_file, permitted_classes: [Symbol])
+        settings.delete('clamav')
 
-        data['clamav'] = {
+        settings['clamav'] = {
           'mock' => true,
           'host' => 'clamav',
           'port' => '3310'
         }
 
-        File.write(file_path, data.to_yaml)
+        updated_yaml = settings.to_yaml
+        updated_content = settings_file.gsub(/clamav:.*?(?=\n\w|\Z)/m,
+                                             updated_yaml.match(/clamav:.*?(?=\n\w|\Z)/m).to_s)
 
+        File.write(settings_path, updated_content)
         puts 'Done'
       end
 

--- a/bin/lib/vets-api/setups/docker.rb
+++ b/bin/lib/vets-api/setups/docker.rb
@@ -19,7 +19,7 @@ module VetsApi
       private
 
       def configuring_clamav_antivirus
-        print 'Updating settings.local.yml...'
+        print 'Configuring ClamAV in local settings...'
         settings_path = 'config/settings.local.yml'
         settings_file = File.read(settings_path)
         settings = YAML.safe_load(settings_file, permitted_classes: [Symbol])

--- a/bin/lib/vets-api/setups/hybrid.rb
+++ b/bin/lib/vets-api/setups/hybrid.rb
@@ -83,7 +83,7 @@ module VetsApi
 
       def save_settings(settings)
         File.open('config/settings.local.yml', 'a') do |file|
-          file.puts settings.to_yaml.tr('---', '')
+          file.puts settings.to_yaml.sub(/^---\n/, '')
         end
       end
     end

--- a/bin/lib/vets-api/setups/native.rb
+++ b/bin/lib/vets-api/setups/native.rb
@@ -3,6 +3,7 @@
 require 'yaml'
 require 'fileutils'
 require_relative 'rails'
+require 'pry'
 
 module VetsApi
   module Setups
@@ -41,7 +42,14 @@ module VetsApi
           settings.delete(key) if settings.key?(key)
         end
 
-        File.write(settings_path, YAML.dump(settings).tr('---', ''))
+        lines = File.readlines(settings_path)
+        updated_lines = lines.reject do |line|
+          hybrid_keys.any? { |key| line.strip.start_with?("#{key}:") }
+        end
+        File.open(settings_path, 'w') do |file|
+          file.puts updated_lines
+        end
+
         puts 'Done'
       end
 

--- a/bin/lib/vets-api/setups/rails.rb
+++ b/bin/lib/vets-api/setups/rails.rb
@@ -20,7 +20,7 @@ module VetsApi
       end
 
       def configuring_clamav_antivirus
-        print 'Updating settings.local.yml...'
+        print 'Configuring ClamAV in local settings...'
         settings_path = 'config/settings.local.yml'
         settings_file = File.read(settings_path)
         settings = YAML.safe_load(settings_file, permitted_classes: [Symbol])

--- a/bin/lib/vets-api/setups/rails.rb
+++ b/bin/lib/vets-api/setups/rails.rb
@@ -19,16 +19,10 @@ module VetsApi
         puts 'Done'
       end
 
+      # rubocop:disable Metrics/MethodLength
       def configuring_clamav_antivirus
         print 'Configuring ClamAV in local settings...'
         settings_path = 'config/settings.local.yml'
-        data = YAML.load_file(settings_path)
-
-        new_clamav_config = {
-          'mock' => true,
-          'host' => '0.0.0.0',
-          'port' => '33100'
-        }
 
         lines = File.readlines(settings_path)
         in_clamav_section = false
@@ -38,11 +32,11 @@ module VetsApi
             line
           elsif in_clamav_section
             if line.strip.start_with?('mock:')
-              "  mock: #{new_clamav_config['mock']}\n"
+              "  mock: #{desired_clamav_config['mock']}\n"
             elsif line.strip.start_with?('host:')
-              "  host: #{new_clamav_config['host']}\n"
+              "  host: #{desired_clamav_config['host']}\n"
             elsif line.strip.start_with?('port:')
-              "  port: '#{new_clamav_config['port']}'\n"
+              "  port: '#{desired_clamav_config['port']}'\n"
             elsif line =~ /^\s*[a-z]/
               in_clamav_section = false
               line
@@ -60,6 +54,7 @@ module VetsApi
 
         puts 'Done'
       end
+      # rubocop:enable Metrics/MethodLength
 
       def install_pdftk
         if pdftk_installed?
@@ -97,6 +92,14 @@ module VetsApi
 
       def pdftk_installed?
         ShellCommand.run_quiet('pdftk --help')
+      end
+
+      def desired_clamav_config
+        {
+          'mock' => true,
+          'host' => '0.0.0.0',
+          'port' => '33100'
+        }
       end
     end
   end


### PR DESCRIPTION
## Summary

- Update the setting changes to keep comments and prevent hyphens from being removed

## Related issue(s)

- n/a

## Testing done

- [x] manual testing

## Acceptance criteria

- [x] `settings.local.yml` has comments after running bin/setup native|hybrid
- [x] `settings.local.yml` has hyphens but not the `---` at the top of the file