### PR TITLE
[API-37388] Unify monthly PACT and claim submissions

### DIFF
--- a/modules/claims_api/app/mailers/claims_api/submission_report_mailer.rb
+++ b/modules/claims_api/app/mailers/claims_api/submission_report_mailer.rb
@@ -12,7 +12,7 @@ module ClaimsApi
       rockwell.rice@oddball.io
     ].freeze
 
-    def build(date_from, date_to, pact_act_data, data)
+    def build(date_from, date_to, data)
       @date_from = date_from.in_time_zone('Eastern Time (US & Canada)').strftime('%a %D %I:%M %p')
       @date_to = date_to.in_time_zone('Eastern Time (US & Canada)').strftime('%a %D %I:%M %p')
       @data = { month: {} }
@@ -22,7 +22,6 @@ module ClaimsApi
       @itf_totals = data[:itf_totals]
       @ews_totals = data[:ews_totals]
 
-      pact_act_submissions(pact_act_data)
       @data.deep_symbolize_keys!
 
       template = File.read(path)
@@ -46,18 +45,6 @@ module ClaimsApi
         'submission_report_mailer',
         'submission_report.html.erb'
       )
-    end
-
-    def pact_act_submissions(pact_act_data)
-      return if pact_act_data.blank?
-
-      pact_act_data.pluck(:claim_type).uniq.sort.each do |kind|
-        @data[:month][kind] = {}
-        subs = pact_act_data.select { |sub| sub[:claim_type] == kind }
-        subs.pluck(:consumer_label).uniq.sort.each do |label|
-          @data[:month][kind][label] = subs.select { |sub| sub[:consumer_label] == label }.size
-        end
-      end
     end
   end
 end

--- a/modules/claims_api/app/sidekiq/claims_api/report_monthly_submissions.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/report_monthly_submissions.rb
@@ -38,13 +38,9 @@ module ClaimsApi
         hash[cid] += 1 if cid
       end
 
-      monthly_claims_by_cid_by_status.each do |cid, status_counts|
-        totals = status_counts.values.sum
-        status_counts[:totals] = totals
-        status_counts[:pact_count] = monthly_pact_claims_by_cid[cid]
-      end
-
       monthly_claims_by_cid_by_status.map do |cid, status_counts|
+        status_counts[:totals] = status_counts.values.sum
+        status_counts[:pact_count] = monthly_pact_claims_by_cid[cid]
         {
           ClaimsApi::CidMapper.new(cid:).name => status_counts.deep_symbolize_keys
         }

--- a/modules/claims_api/app/sidekiq/claims_api/report_monthly_submissions.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/report_monthly_submissions.rb
@@ -26,7 +26,7 @@ module ClaimsApi
 
     def monthly_claims_totals
       monthly_claims_consumers = ClaimsApi::AutoEstablishedClaim.where(created_at: @from..@to)
-      monthly_pact_claims = ClaimsApi::ClaimSubmission.where(created_at: @from..@to, claim_type: 'PACT',
+      monthly_pact_claims = ClaimsApi::ClaimSubmission.where(created_at: @from..@to,
                                                              claim_id: monthly_claims_consumers.pluck(:id))
 
       monthly_claims_by_cid_by_status = monthly_claims_consumers.group_by(&:cid).transform_values do |claims|

--- a/modules/claims_api/app/sidekiq/claims_api/report_monthly_submissions.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/report_monthly_submissions.rb
@@ -3,24 +3,51 @@
 module ClaimsApi
   class ReportMonthlySubmissions < ClaimsApi::ReportingBase
     def perform
-      if Settings.claims_api.report_enabled
-        @to = Time.zone.now
-        @from = 1.month.ago
-        pact_act_data = ClaimsApi::ClaimSubmission.where(created_at: @from..@to)
-        @claims_consumers = ClaimsApi::AutoEstablishedClaim.where(created_at: @from..@to).pluck(:cid).uniq
-        @poa_consumers = ClaimsApi::PowerOfAttorney.where(created_at: @from..@to).pluck(:cid).uniq
-        @itf_consumers = ClaimsApi::IntentToFile.where(created_at: @from..@to).pluck(:cid).uniq
-        @ews_consumers = ClaimsApi::EvidenceWaiverSubmission.where(created_at: @from..@to).pluck(:cid).uniq
+      return unless Settings.claims_api.report_enabled
 
-        ClaimsApi::SubmissionReportMailer.build(
-          @from,
-          @to,
-          pact_act_data,
-          consumer_claims_totals: monthly_claims_totals,
-          poa_totals:,
-          itf_totals:,
-          ews_totals:
-        ).deliver_now
+      @from = 1.month.ago
+      @to = Time.zone.now
+      @claims_consumers = ClaimsApi::AutoEstablishedClaim.where(created_at: @from..@to).pluck(:cid).uniq
+      @poa_consumers = ClaimsApi::PowerOfAttorney.where(created_at: @from..@to).pluck(:cid).uniq
+      @itf_consumers = ClaimsApi::IntentToFile.where(created_at: @from..@to).pluck(:cid).uniq
+      @ews_consumers = ClaimsApi::EvidenceWaiverSubmission.where(created_at: @from..@to).pluck(:cid).uniq
+
+      ClaimsApi::SubmissionReportMailer.build(
+        @from,
+        @to,
+        consumer_claims_totals: monthly_claims_totals,
+        poa_totals:,
+        itf_totals:,
+        ews_totals:
+      ).deliver_now
+    end
+
+    private
+
+    def monthly_claims_totals
+      monthly_claims_consumers = ClaimsApi::AutoEstablishedClaim.where(created_at: @from..@to)
+      monthly_pact_claims = ClaimsApi::ClaimSubmission.where(created_at: @from..@to, claim_type: 'PACT',
+                                                             claim_id: monthly_claims_consumers.pluck(:id))
+
+      monthly_claims_by_cid_by_status = monthly_claims_consumers.group_by(&:cid).transform_values do |claims|
+        claims.group_by(&:status).transform_values(&:count)
+      end
+
+      monthly_pact_claims_by_cid = monthly_pact_claims.each_with_object(Hash.new(0)) do |pact_claim, hash|
+        cid = monthly_claims_consumers.find { |claim| claim.id == pact_claim.claim_id }&.cid
+        hash[cid] += 1 if cid
+      end
+
+      monthly_claims_by_cid_by_status.each do |cid, status_counts|
+        totals = status_counts.values.sum
+        status_counts[:totals] = totals
+        status_counts[:pact_count] = monthly_pact_claims_by_cid[cid]
+      end
+
+      monthly_claims_by_cid_by_status.map do |cid, status_counts|
+        {
+          ClaimsApi::CidMapper.new(cid:).name => status_counts.deep_symbolize_keys
+        }
       end
     end
   end

--- a/modules/claims_api/app/sidekiq/claims_api/reporting_base.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/reporting_base.rb
@@ -51,21 +51,6 @@ module ClaimsApi
       end
     end
 
-    def monthly_claims_totals
-      @claims_consumers.map do |cid|
-        counts = ClaimsApi::AutoEstablishedClaim.where(created_at: @from..@to, cid:).group(:status).count
-        totals = counts.sum { |_k, v| v }.to_f
-
-        if totals.positive?
-          consumer_name = ClaimsApi::CidMapper.new(cid:).name
-          {
-            consumer_name => counts.merge(totals:)
-                                   .deep_symbolize_keys
-          }
-        end
-      end
-    end
-
     def poa_totals
       @poa_consumers.map do |cid|
         counts = ClaimsApi::PowerOfAttorney.where(created_at: @from..@to, cid:).group(:status).count

--- a/modules/claims_api/app/views/claims_api/_monthly_claims_status_table.html.erb
+++ b/modules/claims_api/app/views/claims_api/_monthly_claims_status_table.html.erb
@@ -6,6 +6,7 @@
         <th><%= status %></th>
         <% end %>
         <th>totals</th>
+        <th>pact</th>
     </tr>
   </thead>
   <tbody>
@@ -15,7 +16,8 @@
         <% ClaimsApi::AutoEstablishedClaim::ALL_STATUSES.map(&:to_sym).each do |status| %>
         <td class="right-align"><%= consumer.values.first[status] || 0 %></td>
         <% end %>
-        <td class="right-align"><%= consumer.values.first[:totals].to_i %></td>
+        <td class="right-align"><%= consumer.values.first[:totals] || 0 %></td>
+        <td class="right-align"><%= consumer.values.first[:pact_count] || 0 %></td>
       </tr>
     <% end if claims_consumers %>
   </tbody>

--- a/modules/claims_api/app/views/claims_api/submission_report_mailer/submission_report.html.erb
+++ b/modules/claims_api/app/views/claims_api/submission_report_mailer/submission_report.html.erb
@@ -49,22 +49,6 @@
   </head>
   <body>
     <h1><%= @date_from %> - <%= @date_to %> (Eastern Time)</h1>
-    <hr>
-    <h2>Monthly PACT Submissions</h2>
-    <% @data[:month].keys.each do |kind| %>
-      <table>
-        <tr>
-          <th>Consumer</th>
-          <th><%= kind %> submissions</th>
-        </tr>
-        <% @data[:month][kind].keys.each do |label| %>
-          <tr>
-            <td><%= label %></td>
-            <td><%= @data[:month][kind][label] %></td>
-          </tr>
-        <% end %>
-      </table>
-    <% end %>
     <hr />
     <h2>526EZ Claim Submissions</h2>
     <h3><span class="title">Per Consumer Status Counts</span></h3>

--- a/modules/claims_api/spec/mailers/report_monthly_submissions_spec.rb
+++ b/modules/claims_api/spec/mailers/report_monthly_submissions_spec.rb
@@ -10,12 +10,10 @@ RSpec.describe ClaimsApi::SubmissionReportMailer, type: [:mailer] do
 
       claim = create(:auto_established_claim, :status_established)
       ClaimsApi::ClaimSubmission.create claim:, claim_type: 'PACT', consumer_label: 'Consumer name here'
-      pact_act_data = ClaimsApi::ClaimSubmission.where(created_at: from..to)
 
       described_class.build(
         from,
         to,
-        pact_act_data,
         consumer_claims_totals: [],
         poa_totals: [],
         ews_totals: [],

--- a/modules/claims_api/spec/sidekiq/report_monthly_submissions_spec.rb
+++ b/modules/claims_api/spec/sidekiq/report_monthly_submissions_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ClaimsApi::ReportMonthlySubmissions, type: :job do
         expect(ClaimsApi::SubmissionReportMailer).to receive(:build).once.with(
           from,
           to,
-          consumer_claims_totals: expected_totals,
+          consumer_claims_totals: match_array(expected_totals),
           poa_totals: [],
           ews_totals: [],
           itf_totals: []

--- a/modules/claims_api/spec/sidekiq/report_monthly_submissions_spec.rb
+++ b/modules/claims_api/spec/sidekiq/report_monthly_submissions_spec.rb
@@ -9,26 +9,21 @@ RSpec.describe ClaimsApi::ReportMonthlySubmissions, type: :job do
 
   include_context 'shared reporting defaults'
 
-  describe '#perform' do
+  shared_examples 'sends mail with expected totals' do
+    before { send(claim_setup) }
+
     let(:from) { 1.month.ago }
     let(:to) { Time.zone.now }
-
-    before do
-      claim = create(:auto_established_claim, :status_established, cid: '0oa9uf05lgXYk6ZXn297')
-      ClaimsApi::ClaimSubmission.create claim:, claim_type: 'PACT', consumer_label: 'Consumer name here'
-    end
 
     it 'sends mail' do
       with_settings(Settings.claims_api,
                     report_enabled: true) do
         Timecop.freeze
-        pact_act_data = ClaimsApi::ClaimSubmission.where(created_at: from..to)
 
         expect(ClaimsApi::SubmissionReportMailer).to receive(:build).once.with(
           from,
           to,
-          pact_act_data,
-          consumer_claims_totals: monthly_claims_totals,
+          consumer_claims_totals: expected_totals,
           poa_totals: [],
           ews_totals: [],
           itf_totals: []
@@ -40,7 +35,73 @@ RSpec.describe ClaimsApi::ReportMonthlySubmissions, type: :job do
         Timecop.return
       end
     end
+  end
 
+  context 'with one claims consumer and one PACT claim' do
+    let(:claim_setup) { :setup_one_claim_one_pact_claim }
+    let(:expected_totals) { [{ 'VA TurboClaim' => { established: 1, totals: 1, pact_count: 1 } }] }
+
+    def setup_one_claim_one_pact_claim
+      claim = create(:auto_established_claim, :status_established, cid: '0oa9uf05lgXYk6ZXn297')
+      ClaimsApi::ClaimSubmission.create claim:, claim_type: 'PACT', consumer_label: 'Consumer name here'
+    end
+
+    it_behaves_like 'sends mail with expected totals'
+  end
+
+  context 'with one claims consumer and no PACT claims' do
+    let(:claim_setup) { :setup_one_claim_no_pact_claims }
+    let(:expected_totals) { [{ 'VA TurboClaim' => { established: 1, totals: 1, pact_count: 0 } }] }
+
+    def setup_one_claim_no_pact_claims
+      create(:auto_established_claim, :status_established, cid: '0oa9uf05lgXYk6ZXn297')
+    end
+
+    it_behaves_like 'sends mail with expected totals'
+  end
+
+  context 'with two claims consumers and one PACT claim' do
+    let(:claim_setup) { :setup_two_claims_one_pact_claim }
+    let(:expected_totals) do
+      [{ 'VA TurboClaim' => { established: 1, totals: 1, pact_count: 1 } },
+       { 'VA.gov' => { errored: 1, totals: 1, pact_count: 0 } }]
+    end
+
+    def setup_two_claims_one_pact_claim
+      claim = create(:auto_established_claim, :status_established, cid: '0oa9uf05lgXYk6ZXn297')
+      create(:auto_established_claim, :status_errored, cid: '0oagdm49ygCSJTp8X297')
+      ClaimsApi::ClaimSubmission.create claim:, claim_type: 'PACT', consumer_label: 'Consumer name here'
+    end
+
+    it_behaves_like 'sends mail with expected totals'
+  end
+
+  context 'with one claims consumer and multiple claims' do
+    let(:claim_setup) { :setup_one_consumer_multiple_claims }
+    let(:expected_totals) { [{ 'VA TurboClaim' => { established: 2, errored: 1, totals: 3, pact_count: 0 } }] }
+
+    def setup_one_consumer_multiple_claims
+      cid = '0oa9uf05lgXYk6ZXn297'
+      create(:auto_established_claim, :status_established, cid:)
+      create(:auto_established_claim, :status_established, cid:)
+      create(:auto_established_claim, :status_errored, cid:)
+    end
+
+    it_behaves_like 'sends mail with expected totals'
+  end
+
+  context 'no claims' do
+    let(:claim_setup) { :setup_no_claims }
+    let(:expected_totals) { [] }
+
+    def setup_no_claims
+      # no claims
+    end
+
+    it_behaves_like 'sends mail with expected totals'
+  end
+
+  context 'shared reporting behavior' do
     it_behaves_like 'shared reporting behavior'
   end
 
@@ -59,12 +120,5 @@ RSpec.describe ClaimsApi::ReportMonthlySubmissions, type: :job do
         )
       end
     end
-  end
-
-  # Expected value based on what is created in the before
-  def monthly_claims_totals
-    [
-      { 'VA TurboClaim' => { established: 1, totals: 1.0 } }
-    ]
   end
 end

--- a/spec/mailers/previews/claims_api_submission_report_mailer_preview.rb
+++ b/spec/mailers/previews/claims_api_submission_report_mailer_preview.rb
@@ -8,7 +8,6 @@ class ClaimsApiSubmissionReportMailerPreview < ActionMailer::Preview
     ClaimsApi::SubmissionReportMailer.build(
       from,
       to,
-      submissions,
       consumer_claims_totals: claims_totals,
       poa_totals:,
       ews_totals:,
@@ -18,32 +17,14 @@ class ClaimsApiSubmissionReportMailerPreview < ActionMailer::Preview
 
   private
 
-  def submissions
-    [
-      { id: 1, claim_id: '3a03bc5e-b77d-42c7-bad5-0fe3c334f852',
-        claim_type: 'PACT', consumer_label: 'Claims API Smoketesting - Local',
-        created_at: DateTime.now, updated_at: DateTime.now },
-      { id: 2, claim_id: '87f2c86a-9773-425a-9477-adcae4011e7b',
-        claim_type: 'PACT', consumer_label: 'Claims API Smoketesting - Local',
-        created_at: DateTime.now,
-        updated_at: DateTime.now },
-      { id: 3, claim_id: 'c3527ebb-710a-4806-9339-59dc846623c9',
-        claim_type: 'PACT', consumer_label: 'Claims API Smoketesting - Local - second consumer',
-        created_at: DateTime.now, updated_at: DateTime.now },
-      { id: 4, claim_id: '9096cd0e-0d97-4ee3-be3f-2279e47a81bc',
-        claim_type: 'PACT', consumer_label: 'Claims API Smoketesting - Local - third consumer',
-        created_at: DateTime.now, updated_at: DateTime.now }
-    ]
-  end
-
   def unsuccessful_claims_submissions
     [{ id: '019be853-fd70-4b65-b37b-c3f3842aaaca', status: 'errored', source: 'GDIT', created_at: 1.day.ago.to_s }]
   end
 
   def claims_totals
     [
-      { 'consumer 1' => { pending: 2, errored: 1, totals: 3 } },
-      { 'consumer 2' => { pending: 3, errored: 3, totals: 6 } }
+      { 'consumer 1' => { pending: 2, errored: 1, totals: 3, pact_count: 2 } },
+      { 'consumer 2' => { pending: 3, errored: 3, totals: 6, pact_count: 1 } }
     ]
   end
 


### PR DESCRIPTION
## Summary

In the monthly claims submissions email report:

- Remove the PACT Submissions table;
- Add a PACT column to the claims submission table.
  - The new PACT column shows the count of PACT claim submissions for a claims consumer over the past month.

## Related issue(s)

[API-37388](https://jira.devops.va.gov/browse/API-37388)

## Testing done

- [x] *New code is covered by unit tests*
- Previously, the monthly report showed all PACT claims in a separate table. Now, the report shows the number of PACT claims for each claim consumer in a new column on an existing table.
- New unit tests were added, but full integration testing should be done before merging.
- This feature is not behind a feature flag.

## Screenshots
**Before**
![pact-submissions-before](https://github.com/department-of-veterans-affairs/vets-api/assets/512195/77828b5e-d3f8-4e8e-b579-0b8753dddf1e)

---

**After**
![pact-submissions-after](https://github.com/department-of-veterans-affairs/vets-api/assets/512195/f30c137e-668e-484d-a3a4-51f34992d216)


## What areas of the site does it impact?
This change affects the monthly claims submissions email report and reporting base class.

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

This PR assumes:
- An entry in the `claims_api_claim_submissions` is a PACT claim;
- An entry in the `claims_api_auto_established_claims` is a claim that belongs to a consumer;
- Each claim consumer can have zero to many PACT claims.