### PR TITLE
Add links to resources in delay notification

### DIFF
--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -55,6 +55,10 @@ jobs:
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on development is ${deployed_sha:0:8}."
             echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}." >> $GITHUB_OUTPUT
+            echo ""
+            echo "Check [ArgoCD dev](https://argocd.vfs.va.gov/applications/vets-api-dev) for errors."
+            echo ""
+            echo "Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors."
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."
@@ -80,6 +84,10 @@ jobs:
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on staging is ${deployed_sha:0:8}."
             echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}." >> $GITHUB_OUTPUT
+            echo ""
+            echo "Check [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging) for errors."
+            echo ""
+            echo "Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors."
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."


### PR DESCRIPTION
## Summary
Eric built a workflow to notify the backend CoP if a vets-api commit has been merged but dev or staging hasn't deployed within a reasonable time. This PR adds some extra messaging around what to do if this message pops up. This will help Tier 2 support.

## Testing done

- None! I do not know if the formatting will look good or not. 

## Screenshots
Current message:
<img width="666" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/e87a6733-f705-46ba-bed4-4e540c63c54f">

## What areas of the site does it impact?
The message in #platform-cop-be-notifications when dev or staging hasn't been deployed after a commit merged. 

## Requested Feedback

What do you think of the spacing? Will the Slack formatting `[text](url)` render properly?? How's the wording?
