### PR TITLE
Replace AskVAApi AMS serializers with JSONAPI serializers

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/announcements/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/announcements/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Announcements
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :announcements
 

--- a/modules/ask_va_api/app/lib/ask_va_api/attachments/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/attachments/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Attachments
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :attachment
 

--- a/modules/ask_va_api/app/lib/ask_va_api/branch_of_service/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/branch_of_service/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module BranchOfService
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :branch_of_service
 

--- a/modules/ask_va_api/app/lib/ask_va_api/categories/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/categories/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Categories
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :categories
 

--- a/modules/ask_va_api/app/lib/ask_va_api/correspondences/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/correspondences/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Correspondences
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :correspondence
 

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Inquiries
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :inquiry
 

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/status/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/status/serializer.rb
@@ -3,7 +3,7 @@
 module AskVAApi
   module Inquiries
     module Status
-      class Serializer < ActiveModel::Serializer
+      class Serializer
         include JSONAPI::Serializer
         set_type :inquiry_status
 

--- a/modules/ask_va_api/app/lib/ask_va_api/optionset/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/optionset/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Optionset
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :optionsets
 

--- a/modules/ask_va_api/app/lib/ask_va_api/profile/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/profile/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Profile
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :profile
 

--- a/modules/ask_va_api/app/lib/ask_va_api/states/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/states/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module States
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :states
 

--- a/modules/ask_va_api/app/lib/ask_va_api/sub_topics/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/sub_topics/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module SubTopics
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :sub_topics
 

--- a/modules/ask_va_api/app/lib/ask_va_api/topics/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/topics/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Topics
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :topics
 

--- a/modules/ask_va_api/app/lib/ask_va_api/zipcodes/serializer.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/zipcodes/serializer.rb
@@ -2,7 +2,7 @@
 
 module AskVAApi
   module Zipcodes
-    class Serializer < ActiveModel::Serializer
+    class Serializer
       include JSONAPI::Serializer
       set_type :zipcodes
 

--- a/spec/support/serializer_spec_helper.rb
+++ b/spec/support/serializer_spec_helper.rb
@@ -3,12 +3,25 @@
 module SerializerSpecHelper
   def serialize(obj, opts = {})
     serializer_class = opts.delete(:serializer_class) || "#{obj.class.name}Serializer".constantize
+    if serializer_class.ancestors.include?(ActiveModel::Serializer)
+      serializer_with_ams(serializer_class, obj, opts)
+    else
+      serializer_with_jsonapi(serializer_class, obj, opts)
+    end
+  end
+
+  def expect_time_eq(serialized_time, time)
+    expect(serialized_time).to eq(time.iso8601(3))
+  end
+
+  def serializer_with_ams(serializer_class, obj, opts = {})
     serializer = serializer_class.send(:new, obj, opts)
     adapter = ActiveModelSerializers::Adapter.create(serializer, opts)
     adapter.to_json
   end
 
-  def expect_time_eq(serialized_time, time)
-    expect(serialized_time).to eq(time.iso8601(3))
+  def serializer_with_jsonapi(serializer_class, obj, opts = {})
+    serializer = serializer_class.new(obj, opts)
+    serializer.serializable_hash.to_json
   end
 end


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in modules/ask_va_api.
- Updated spec/support/serializer_spec_helper.rb to use AMS or JSON:API Serializers

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84405

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Screenshots

![Screenshot 2024-06-20 at 11 30 03 AM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/fe47415d-4cb8-44d3-80dc-018158cfdec4)

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage