### PR TITLE
84764 Moving send_notification to travel claim base worker

### DIFF
--- a/modules/check_in/app/sidekiq/check_in/travel_claim_base_worker.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_base_worker.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module CheckIn
+  class TravelClaimBaseWorker
+    include Sidekiq::Job
+    include SentryLogging
+
+    sidekiq_options retry: false
+    def send_notification(opts = {})
+      notify_client = VaNotify::Service.new(Settings.vanotify.services.check_in.api_key)
+      phone_last_four = opts[:mobile_phone].delete('^0-9').last(4)
+
+      logger.info({
+                    message: "Sending travel claim notification to #{phone_last_four}, #{opts[:template_id]}",
+                    phone_last_four:,
+                    template_id: opts[:template_id]
+                  })
+      appt_date_in_mmm_dd_format = DateTime.strptime(opts[:appointment_date], '%Y-%m-%d').to_date.strftime('%b %d')
+
+      notify_client.send_sms(
+        phone_number: opts[:mobile_phone],
+        template_id: opts[:template_id],
+        sms_sender_id: 'oh'.casecmp?(opts[:facility_type]) ? Constants::OH_SMS_SENDER_ID : Constants::CIE_SMS_SENDER_ID,
+        personalisation: {
+          claim_number: opts[:claim_number],
+          appt_date: appt_date_in_mmm_dd_format
+        }
+      )
+    rescue => e
+      handle_error(e, opts)
+      raise e
+    end
+
+    def handle_error(ex, opts = {})
+      log_exception_to_sentry(
+        ex,
+        { phone_number: opts[:mobile_phone].delete('^0-9').last(4), template_id: opts[:template_id],
+          claim_number: opts[:claim_number] },
+        { error: :check_in_va_notify_job, team: 'check-in' }
+      )
+      StatsD.increment(Constants::STATSD_NOTIFY_ERROR)
+    end
+  end
+end

--- a/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
-require 'sidekiq'
-
 module CheckIn
-  class TravelClaimSubmissionWorker
-    include Sidekiq::Job
-    include SentryLogging
-
-    sidekiq_options retry: false
-
+  class TravelClaimSubmissionWorker < TravelClaimBaseWorker
     def perform(uuid, appointment_date)
       redis_client = TravelClaim::RedisClient.build
       mobile_phone = redis_client.patient_cell_phone(uuid:)
@@ -86,40 +79,5 @@ module CheckIn
       [claim_number, template_id]
     end
     # rubocop:enable Metrics/MethodLength
-
-    def send_notification(opts = {})
-      notify_client = VaNotify::Service.new(Settings.vanotify.services.check_in.api_key)
-      phone_last_four = opts[:mobile_phone].delete('^0-9').last(4)
-
-      logger.info({
-                    message: "Sending travel claim notification to #{phone_last_four}, #{opts[:template_id]}",
-                    phone_last_four:,
-                    template_id: opts[:template_id]
-                  })
-      appt_date_in_mmm_dd_format = DateTime.strptime(opts[:appointment_date], '%Y-%m-%d').to_date.strftime('%b %d')
-
-      notify_client.send_sms(
-        phone_number: opts[:mobile_phone],
-        template_id: opts[:template_id],
-        sms_sender_id: 'oh'.casecmp?(opts[:facility_type]) ? Constants::OH_SMS_SENDER_ID : Constants::CIE_SMS_SENDER_ID,
-        personalisation: {
-          claim_number: opts[:claim_number],
-          appt_date: appt_date_in_mmm_dd_format
-        }
-      )
-    rescue => e
-      handle_error(e, opts)
-      raise e
-    end
-
-    def handle_error(ex, opts = {})
-      log_exception_to_sentry(
-        ex,
-        { phone_number: opts[:mobile_phone].delete('^0-9').last(4), template_id: opts[:template_id],
-          claim_number: opts[:claim_number] },
-        { error: :check_in_va_notify_job, team: 'check-in' }
-      )
-      StatsD.increment(Constants::STATSD_NOTIFY_ERROR)
-    end
   end
 end


### PR DESCRIPTION
## Summary

- *Moving send_notification method to base class for using in new sidekiq job to call claim status api*

## Related issue(s)

- *https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/gh/department-of-veterans-affairs/va.gov-team/84764*

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
NA

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

