### PR TITLE
[DBEX] add tests & cassette for LH 526 validate endpoint

### DIFF
--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -135,17 +135,12 @@ module BenefitsClaims
     # @param [hash] options: options to override aud_claim_url, params, and auth_params
     # @option options [hash] :body_only only return the body from the request
     #
-    # NOTE: this method is similar to submit526.  The
-    # only difference is the path and endpoint values
+    # NOTE: This method is similar to submit526. The only difference is the path and endpoint values
     #
-    def validate526(body,
-                    lighthouse_client_id = nil,
-                    lighthouse_rsa_key_path = nil,
-                    options = {})
-
-      endpoint  = '{icn}/526/validate'
-      path      = "#{@icn}/526/validate"
-      body      = prepare_submission_body(body)
+    def validate526(body, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
+      endpoint = '{icn}/526/validate'
+      path = "#{@icn}/526/validate"
+      body = prepare_submission_body(body)
 
       response = config.post(
         path,
@@ -161,7 +156,6 @@ module BenefitsClaims
       handle_error(e, lighthouse_client_id, endpoint)
     end
 
-    ######################################
     private
 
     def build_request_body(body)

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe BenefitsClaims::Service do
 
         context 'when posting to the /validate endpoint' do
           it 'when given a full request body, posts to the Lighthouse API' do
-            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do # change cassette
+            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do
               raw_response = @service.validate526({ data: { attributes: {} } }, '', '', { body_only: true })
               response_json = JSON.parse(raw_response)
               expect(response_json.dig('data', 'attributes', 'status')).to eq('valid')
@@ -168,7 +168,7 @@ RSpec.describe BenefitsClaims::Service do
           end
 
           it 'when given only the form data in the request body, posts to the Lighthouse API' do
-            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do # change cassette
+            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do
               raw_response = @service.validate526({}, '', '', { body_only: true })
               response_json = JSON.parse(raw_response)
               expect(response_json.dig('data', 'attributes', 'status')).to eq('valid')
@@ -176,7 +176,7 @@ RSpec.describe BenefitsClaims::Service do
           end
 
           it 'returns only the response body' do
-            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do # change cassette
+            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do
               body = @service.validate526({ data: { attributes: {} } }, '', '', { body_only: true })
               response_json = JSON.parse(body)
               expect(response_json.dig('data', 'attributes', 'status')).to eq('valid')

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -113,47 +113,83 @@ RSpec.describe BenefitsClaims::Service do
                              })
         end
 
-        it 'when given a full request body, posts to the Lighthouse API' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
-            response = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
-            response_json = JSON.parse(response)
-            expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
-            expect(response_json['data']['attributes']['claimId']).to eq('12345678')
+        context 'when posting to the default /synchronous endpoint' do
+          it 'when given a full request body, posts to the Lighthouse API' do
+            VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
+              response = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
+              response_json = JSON.parse(response)
+              expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+              expect(response_json['data']['attributes']['claimId']).to eq('12345678')
+            end
+          end
+
+          it 'when given only the form data in the request body, posts to the Lighthouse API' do
+            VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
+              response = @service.submit526({}, '', '', { body_only: true })
+              response_json = JSON.parse(response)
+              expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+              expect(response_json['data']['attributes']['claimId']).to eq('12345678')
+            end
+          end
+
+          it 'returns only the response body' do
+            VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
+              body = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
+              response_json = JSON.parse(body)
+              expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
+              expect(response_json['data']['attributes']['claimId']).to eq('12345678')
+            end
+          end
+
+          it 'returns the whole response' do
+            VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
+              raw_response = @service.submit526({}, '', '', { body_only: false })
+              claim_id = JSON.parse(raw_response.body).dig('data', 'attributes', 'claimId').to_i
+              raw_response_struct = OpenStruct.new({
+                                                     body: { claim_id: },
+                                                     status: raw_response.status
+                                                   })
+              response = EVSS::DisabilityCompensationForm::FormSubmitResponse
+                         .new(raw_response_struct.status, raw_response_struct)
+
+              expect(response.status).to eq(200)
+              expect(response.claim_id).to eq(claim_id)
+            end
           end
         end
 
-        it 'when given a only the form data in the request body, posts to the Lighthouse API' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
-            response = @service.submit526({}, '', '', { body_only: true })
-            response_json = JSON.parse(response)
-            expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
-            expect(response_json['data']['attributes']['claimId']).to eq('12345678')
+        context 'when posting to the /validate endpoint' do
+          it 'when given a full request body, posts to the Lighthouse API' do
+            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do # change cassette
+              raw_response = @service.validate526({ data: { attributes: {} } }, '', '', { body_only: true })
+              response_json = JSON.parse(raw_response)
+              expect(response_json.dig('data', 'attributes', 'status')).to eq('valid')
+            end
           end
-        end
 
-        it 'returns only the response body' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
-            body = @service.submit526({ data: { attributes: {} } }, '', '', { body_only: true })
-            response_json = JSON.parse(body)
-            expect(response_json['data']['id']).to eq('46285849-9d82-4001-8572-2323d521eb8c')
-            expect(response_json['data']['attributes']['claimId']).to eq('12345678')
+          it 'when given only the form data in the request body, posts to the Lighthouse API' do
+            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do # change cassette
+              raw_response = @service.validate526({}, '', '', { body_only: true })
+              response_json = JSON.parse(raw_response)
+              expect(response_json.dig('data', 'attributes', 'status')).to eq('valid')
+            end
           end
-        end
 
-        it 'returns the whole response' do
-          VCR.use_cassette('lighthouse/benefits_claims/submit526/200_synchronous_response') do
-            raw_response = @service.submit526({}, '', '', { body_only: false })
+          it 'returns only the response body' do
+            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do # change cassette
+              body = @service.validate526({ data: { attributes: {} } }, '', '', { body_only: true })
+              response_json = JSON.parse(body)
+              expect(response_json.dig('data', 'attributes', 'status')).to eq('valid')
+            end
+          end
 
-            claim_id = JSON.parse(raw_response.body).dig('data', 'attributes', 'claimId').to_i
-            raw_response_struct = OpenStruct.new({
-                                                   body: { claim_id: },
-                                                   status: raw_response.status
-                                                 })
-            response = EVSS::DisabilityCompensationForm::FormSubmitResponse
-                       .new(raw_response_struct.status, raw_response_struct)
-
-            expect(response.status).to eq(200)
-            expect(response.claim_id).to eq(claim_id)
+          it 'returns the whole response' do
+            VCR.use_cassette('lighthouse/benefits_claims/validate526/200_synchronous_response') do
+              raw_response = @service.validate526({}, '', '', { body_only: false })
+              response_json = JSON.parse(raw_response.body)
+              expect(raw_response.status).to eq(200)
+              expect(response_json.dig('data', 'attributes', 'status')).to eq('valid')
+            end
           end
         end
 

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/validate526/200_synchronous_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/validate526/200_synchronous_response.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://sandbox-api.va.gov/services/claims/v2/veterans/123498767V234859/526/validate
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Authorization:
+          - Bearer blahblahblah
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Tue, 28 Feb 2023 21:02:39 GMT
+        Content-Type:
+          - text/html; charset=utf-8
+        Connection:
+          - keep-alive
+        X-Ratelimit-Remaining-Minute:
+          - "59"
+        X-Ratelimit-Limit-Minute:
+          - "60"
+        Ratelimit-Remaining:
+          - "59"
+        Ratelimit-Limit:
+          - "60"
+        Ratelimit-Reset:
+          - "25"
+        Etag:
+          - W/"6571c42e57529000188d704a3cd1f46a"
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Vary:
+          - Origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Git-Sha:
+          - b20885293917fd081d24899644d2718d2ab4ccf9
+        X-Github-Repository:
+          - https://github.com/department-of-veterans-affairs/vets-api
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - d687047e-5004-43c1-babb-c2f52f2fda40
+        X-Runtime:
+          - "3.569014"
+        X-Xss-Protection:
+          - 1; mode=block
+        Access-Control-Allow-Origin:
+          - "*"
+        X-Kong-Upstream-Latency:
+          - "3573"
+        X-Kong-Proxy-Latency:
+          - "24"
+        Via:
+          - kong/3.0.2
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        Cache-Control:
+          - no-cache, no-store
+        Pragma:
+          - no-cache
+        Transfer-Encoding:
+          - chunked
+      body:
+        encoding: ASCII-8BIT
+        string: '{"data": {"type": "claims_api_auto_established_claim_validation", "attributes": {"status": "valid"}}}'
+    recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary

Adds tests for the `validate526` method in the Lighthouse `BenefitsClaims::Service` class. The service method is configured to submit the content of a `Form526Submission` to the corresponding Benefits Claims API Disability Compensation Claims `/validate` endpoint, and follows the pattern established by the `submit526` service method. 

A synchronous method, `form_content_valid?`, previously added to the `Form526Submission` model in [16887](https://github.com/department-of-veterans-affairs/vets-api/pull/16887), calls the `validate526` method to confirm if the form content is valid based on the response returned from a submission to the `/validate` endpoint.

- *This work is behind a feature toggle (flipper): ~YES~/**NO*** 
- **Responsible team:** Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82149
- https://github.com/department-of-veterans-affairs/vets-api/pull/16887

## Testing done

- [x] *New code is covered by unit tests*
  - *Previous implementation of the `validate526` method did not include spec tests*
  - *Tests added include the same as implemented for the `submit526` method, with the exception of the generate PDF option*
  - *A new VCR cassette file, based on the content of the successful 200 response YAML file used to test `submit526`, was added, replacing the response body content with the example value for a successful response posted to `/veterans/{veteranID}/526/validate` as provided in the [Benefits Claims API Developer Docs](https://developer.va.gov/explore/api/benefits-claims/docs?version=current)*
  - *Running `bers spec/lib/lighthouse/benefits_claims/service_spec.rb` locally from the terminal, in the `vets-api` directory, should output `17 examples, 0 failures` at the time of this writing; the examples include the 4 newly added tests*

## What areas of the site does it impact?

- Form 526EZ

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
