### PR TITLE
Toxic Exposure: populate other hazard description to hazard_exposed_to in multipleExposures array

### DIFF
--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -272,7 +272,8 @@ module EVSS
         end
         if values_present(toxic_exposure_source['otherHerbicideLocations'])
           multiple_exposures +=
-            transform_multiple_exposures_other_details(toxic_exposure_source['otherHerbicideLocations'])
+            transform_multiple_exposures_other_details(toxic_exposure_source['otherHerbicideLocations'],
+                                                       MULTIPLE_EXPOSURES_TYPE[:herbicide])
         end
         if toxic_exposure_source['otherExposureDetails'].present?
           multiple_exposures += transform_multiple_exposures(toxic_exposure_source['otherExposureDetails'],
@@ -280,7 +281,8 @@ module EVSS
         end
         if values_present(toxic_exposure_source['specifyOtherExposures'])
           multiple_exposures +=
-            transform_multiple_exposures_other_details(toxic_exposure_source['specifyOtherExposures'])
+            transform_multiple_exposures_other_details(toxic_exposure_source['specifyOtherExposures'],
+                                                       MULTIPLE_EXPOSURES_TYPE[:hazard])
         end
 
         toxic_exposure_target.multiple_exposures = multiple_exposures
@@ -313,14 +315,18 @@ module EVSS
         end
       end
 
-      def transform_multiple_exposures_other_details(details)
+      def transform_multiple_exposures_other_details(details, multiple_exposures_type)
         obj = Requests::MultipleExposures.new(
           exposure_dates: Requests::Dates.new
         )
 
         obj.exposure_dates.begin_date = convert_date_no_day(details['startDate']) if details['startDate'].present?
         obj.exposure_dates.end_date = convert_date_no_day(details['endDate']) if details['endDate'].present?
-        obj.exposure_location = details['description'] if details['description'].present?
+        if multiple_exposures_type == MULTIPLE_EXPOSURES_TYPE[:hazard]
+          obj.hazard_exposed_to = details['description'] if details['description'].present?
+        elsif details['description'].present?
+          obj.exposure_location = details['description']
+        end
 
         [obj]
       end

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -356,7 +356,9 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(result[0].exposure_dates.end_date).to eq('1992-01')
       expect(result[0].exposure_location).to eq('Cambodia at Mimot or Krek, Kampong Cham Province')
 
-      result = transformer.send(:transform_multiple_exposures_other_details, data['otherHerbicideLocations'])
+      result = transformer.send(:transform_multiple_exposures_other_details, data['otherHerbicideLocations'],
+                                EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform::
+                                    MULTIPLE_EXPOSURES_TYPE[:herbicide])
       expect(result[0].exposure_dates.begin_date).to eq('1991-03')
       expect(result[0].exposure_dates.end_date).to eq('1992-01')
       expect(result[0].exposure_location).to eq('other location 1, other location 2 etc')
@@ -367,6 +369,13 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(result[0].exposure_dates.begin_date).to eq('1991-03')
       expect(result[0].exposure_dates.end_date).to eq('1992-01')
       expect(result[0].hazard_exposed_to).to eq('Asbestos')
+
+      result = transformer.send(:transform_multiple_exposures_other_details, data['specifyOtherExposures'],
+                                EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform::
+                                    MULTIPLE_EXPOSURES_TYPE[:hazard])
+      expect(result[0].exposure_dates.begin_date).to eq('1991-03')
+      expect(result[0].exposure_dates.end_date).to eq('1992-01')
+      expect(result[0].hazard_exposed_to).to eq('Lead, burn pits')
 
       no_location_dates = data.merge({
                                        'gulfWar1990Details' => {


### PR DESCRIPTION
This PR populates the `hazard_exposed_to` field with the "specify other hazard" value of the `multipleExposures` array of the Lighthouse request. Previously it had been erroneously populated to `exposure_location`

## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
Disability Benefits Experience Team 1 (DBEX-TREX 🦖 =rawr=)
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
Toxic Exposure: multipleExposures/exposureDates - Submit fails when beginDate and endDate are nil#[85775](https://app.zenhub.com/workspaces/disability-experience-63dbdb0a401c4400119d3a44/issues/gh/department-of-veterans-affairs/va.gov-team/85775)
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
