### PR TITLE
[API-37195] Add Tyler to Benefits Claims API email reports

### DIFF
--- a/modules/claims_api/app/mailers/claims_api/submission_report_mailer.rb
+++ b/modules/claims_api/app/mailers/claims_api/submission_report_mailer.rb
@@ -10,6 +10,7 @@ module ClaimsApi
       kayla.watanabe@adhocteam.us
       matthew.christianson@adhocteam.us
       rockwell.rice@oddball.io
+      tyler.coleman@oddball.io
     ].freeze
 
     def build(date_from, date_to, pact_act_data, data)

--- a/modules/claims_api/app/mailers/claims_api/unsuccessful_report_mailer.rb
+++ b/modules/claims_api/app/mailers/claims_api/unsuccessful_report_mailer.rb
@@ -15,6 +15,7 @@ module ClaimsApi
       robert.perea-martinez@adhocteam.us
       rockwell.rice@oddball.io
       stone_christopher@bah.com
+      tyler.coleman@oddball.io
       zachary.goldfine@va.gov
     ].freeze
 

--- a/modules/claims_api/spec/mailers/report_monthly_submissions_spec.rb
+++ b/modules/claims_api/spec/mailers/report_monthly_submissions_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe ClaimsApi::SubmissionReportMailer, type: [:mailer] do
           kayla.watanabe@adhocteam.us
           matthew.christianson@adhocteam.us
           rockwell.rice@oddball.io
+          tyler.coleman@oddball.io
         ]
       )
     end

--- a/modules/claims_api/spec/mailers/unsuccessful_report_mailer_spec.rb
+++ b/modules/claims_api/spec/mailers/unsuccessful_report_mailer_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe ClaimsApi::UnsuccessfulReportMailer, type: [:mailer] do
           robert.perea-martinez@adhocteam.us
           rockwell.rice@oddball.io
           stone_christopher@bah.com
+          tyler.coleman@oddball.io
           zachary.goldfine@va.gov
         ]
       )


### PR DESCRIPTION
_See also: https://github.com/department-of-veterans-affairs/vets-api/pull/17155. Opening a new PR now that I can commit within the repo._

## Summary

Adds Tyler, a new addition to Team DASH, to email report recipient list and tests.

## Related issue(s)

[API-37195](https://jira.devops.va.gov/browse/API-37195)

## Testing done

- [x] *New code is covered by unit tests*

    Low-risk change. Can verify whether Tyler gets emails or not after merging.

## Screenshots
_Note: Optional_

N/A

## What areas of the site does it impact?

Benefits Claims API email report recipient list and tests.

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

N/A
