### PR TITLE
[DBEX] create Form526SubmissionRemediation model

### DIFF
--- a/db/migrate/20240621200006_create_form526_submission_remediations.rb
+++ b/db/migrate/20240621200006_create_form526_submission_remediations.rb
@@ -1,0 +1,12 @@
+class CreateForm526SubmissionRemediations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :form526_submission_remediations do |t|
+      t.references :form526_submission, null: false, foreign_key: true
+      t.text :lifecycle, array: true, default: []
+      t.boolean :success, default: true
+      t.boolean :ignored_as_duplicate, default: false
+
+      t.timestamps      
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_175759) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_21_200006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -681,6 +681,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_175759) do
     t.index ["bgjob_errors"], name: "index_form526_job_statuses_on_bgjob_errors", using: :gin
     t.index ["form526_submission_id"], name: "index_form526_job_statuses_on_form526_submission_id"
     t.index ["job_id"], name: "index_form526_job_statuses_on_job_id", unique: true
+  end
+
+  create_table "form526_submission_remediations", force: :cascade do |t|
+    t.bigint "form526_submission_id", null: false
+    t.text "lifecycle", default: [], array: true
+    t.boolean "success", default: true
+    t.boolean "ignored_as_duplicate", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["form526_submission_id"], name: "index_form526_submission_remediations_on_form526_submission_id"
   end
 
   create_table "form526_submissions", id: :serial, force: :cascade do |t|
@@ -1568,6 +1578,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_175759) do
   add_foreign_key "deprecated_user_accounts", "user_verifications"
   add_foreign_key "education_stem_automated_decisions", "user_accounts"
   add_foreign_key "evss_claims", "user_accounts"
+  add_foreign_key "form526_submission_remediations", "form526_submissions"
   add_foreign_key "form526_submissions", "user_accounts"
   add_foreign_key "form5655_submissions", "user_accounts"
   add_foreign_key "form_submission_attempts", "form_submissions"


### PR DESCRIPTION
## Summary

- Create `Form526SubmissionRemediation` model
- Allows for the tracking of remediation efforts, to include context data pertaining to actions taken
- Enables recording multiple remediations for a single submission
- This independent model facilitates providing instances with own state
- Subsequent PRs will implement model validations and methods
- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86438
- [526 State Repair Technical Design Document
](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#a-create-a-form526submissionremediation-model)

## Testing done

- Nothing to test

## What areas of the site does it impact?

Database records will never be created by application code. They will be created manually by a developer, most likely via a script at the time of remediation. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature