### PR TITLE
[SIMPLE_FORMS] fix: add before_action to account for 422 errors

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -9,7 +9,7 @@ module SimpleFormsApi
     class UploadsController < ApplicationController
       skip_before_action :authenticate
       before_action :authenticate, if: :should_authenticate
-      before_action { authorize :mpi, :access_add_person_proxy? }, if: :form_is210966
+      before_action :mpi_proxy, if: :form_is210966
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {
@@ -78,6 +78,10 @@ module SimpleFormsApi
           'Simple forms api - unauthenticated user submitting form',
           { form_number: params[:form_number] }
         )
+      end
+
+      def mpi_proxy
+        authorize(:mpi, :access_add_person_proxy?)
       end
 
       private

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -9,7 +9,7 @@ module SimpleFormsApi
     class UploadsController < ApplicationController
       skip_before_action :authenticate
       before_action :authenticate, if: :should_authenticate
-      before_action { authorize :mpi, :access_add_person_proxy? }
+      before_action { authorize :mpi, :access_add_person_proxy? }, if: :form_is210966
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {
@@ -32,7 +32,7 @@ module SimpleFormsApi
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
 
-        response = if form_is210966 && icn && first_party?
+        response = if form_is210966 && first_party?
                      handle_210966_authenticated
                    elsif form_is264555_and_should_use_lgy_api
                      handle264555

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -9,6 +9,7 @@ module SimpleFormsApi
     class UploadsController < ApplicationController
       skip_before_action :authenticate
       before_action :authenticate, if: :should_authenticate
+      before_action { authorize :mpi, :access_add_person_proxy? }
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe 'Forms uploader', type: :request do
       let(:metadata_file) { "#{file_seed}.SimpleFormsApi.metadata.json" }
       let(:file_seed) { 'tmp/some-unique-simple-forms-file-seed' }
       let(:random_string) { 'some-unique-simple-forms-file-seed' }
+      let(:user) { build(:user_with_no_ids) }
 
       before do
+        sign_in_as(user)
         VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
         VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
         allow(Common::FileHelpers).to receive(:random_file_path).and_return(file_seed)
@@ -76,7 +78,7 @@ RSpec.describe 'Forms uploader', type: :request do
 
         context 'authenticated user' do
           before do
-            user = create(:user)
+            user = build(:user_with_no_ids)
             sign_in_as(user)
             create(:in_progress_form, user_uuid: user.uuid, form_id: data['form_number'])
           end
@@ -94,7 +96,7 @@ RSpec.describe 'Forms uploader', type: :request do
       context 'request with intent to file' do
         context 'authenticated' do
           before do
-            sign_in
+            sign_in_as(build(:user_with_no_ids))
             allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
             allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
           end
@@ -246,7 +248,7 @@ RSpec.describe 'Forms uploader', type: :request do
 
       context 'authenticated' do
         before do
-          sign_in
+          sign_in_as(build(:user_with_no_ids))
           allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
           allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
         end
@@ -698,7 +700,7 @@ RSpec.describe 'Forms uploader', type: :request do
         end
 
         before do
-          user = create(:user)
+          user = build(:user_with_no_ids)
           sign_in_as(user)
           allow_any_instance_of(User).to receive(:va_profile_email).and_return('abraham.lincoln@vets.gov')
           allow(VANotify::EmailJob).to receive(:perform_async)


### PR DESCRIPTION
## Summary
This PR represents an attempt to avoid `422` errors that are coming back from the Intent to File API. We believe that this before_action here is necessary to properly authorize users. Honestly, I don't entirely understand what calling this method does to the user to make it _not_ raise the error but this Slack thread hopefully sheds more light: https://dsva.slack.com/archives/C02CQP3RFFX/p1717704172086279