### PR TITLE
Replace ClaimsApi AMS serializers with JSONAPI serializers - Part 2

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -34,8 +34,7 @@ module ClaimsApi
           else
             ClaimsApi::IntentToFile.create!(status: ClaimsApi::IntentToFile::SUBMITTED, cid: token.payload['cid'])
 
-            render json: bgs_response,
-                   serializer: ClaimsApi::IntentToFileSerializer
+            render json: ClaimsApi::IntentToFileSerializer.new(bgs_response)
           end
         end
 
@@ -65,7 +64,7 @@ module ClaimsApi
             raise ::Common::Exceptions::ResourceNotFound.new(detail: message)
           end
 
-          render json: bgs_active, serializer: ClaimsApi::IntentToFileSerializer
+          render json: ClaimsApi::IntentToFileSerializer.new(bgs_active)
         end
 
         # POST to validate 0966 submission payload.

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -60,7 +60,7 @@ module ClaimsApi
           end
 
           claims_v1_logging('poa_submit', message: "poa_submit complete, poa: #{power_of_attorney&.id}")
-          render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
+          render json: ClaimsApi::PowerOfAttorneySerializer.new(power_of_attorney)
         end
 
         # PUT to upload a wet-signed 2122 form.
@@ -82,7 +82,7 @@ module ClaimsApi
           # If upload is successful, then the PoaUpater job is also called to update the code in BGS.
           ClaimsApi::PoaVBMSUploadJob.perform_async(@power_of_attorney.id)
 
-          render json: @power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
+          render json: ClaimsApi::PowerOfAttorneySerializer.new(@power_of_attorney)
         end
 
         # GET the current status of a previous POA change request.
@@ -91,7 +91,7 @@ module ClaimsApi
         def status
           find_poa_by_id
 
-          render json: @power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
+          render json: ClaimsApi::PowerOfAttorneySerializer.new(@power_of_attorney)
         end
 
         # GET current POA for a Veteran.

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
@@ -34,7 +34,9 @@ module ClaimsApi
             )
           end
 
-          render json: poa, serializer: ClaimsApi::PowerOfAttorneySerializer, key_transform: :camel_lower
+          serialized_response = ClaimsApi::PowerOfAttorneySerializer.new(poa).serializable_hash
+          serialized_response[:data][:type] = serialized_response[:data][:type].to_s.camelize(:lower)
+          render json: serialized_response.deep_transform_keys! { |key| key.to_s.camelize(:lower).to_sym }
         end
 
         private

--- a/modules/claims_api/app/serializers/claims_api/intent_to_file_serializer.rb
+++ b/modules/claims_api/app/serializers/claims_api/intent_to_file_serializer.rb
@@ -1,31 +1,28 @@
 # frozen_string_literal: true
 
 module ClaimsApi
-  class IntentToFileSerializer < ActiveModel::Serializer
-    attribute :creation_date
-    attribute :expiration_date
-    attribute :type
-    attribute :status
+  class IntentToFileSerializer
+    include JSONAPI::Serializer
 
-    type :intent_to_file
+    set_type :intent_to_file
 
-    def id
+    set_id do |object|
       object[:intent_to_file_id]
     end
 
-    def type
-      ClaimsApi::IntentToFile::ITF_TYPES_TO_BGS_TYPES.key(object[:itf_type_cd])
-    end
-
-    def creation_date
+    attribute :creation_date do |object|
       object[:create_dt]
     end
 
-    def expiration_date
+    attribute :expiration_date do |object|
       object[:exprtn_dt]
     end
 
-    def status
+    attribute :type do |object|
+      ClaimsApi::IntentToFile::ITF_TYPES_TO_BGS_TYPES.key(object[:itf_type_cd])
+    end
+
+    attribute :status do |object|
       object[:itf_status_type_cd]&.downcase
     end
   end

--- a/modules/claims_api/app/serializers/claims_api/power_of_attorney_serializer.rb
+++ b/modules/claims_api/app/serializers/claims_api/power_of_attorney_serializer.rb
@@ -11,7 +11,7 @@ module ClaimsApi
     attributes :date_request_accepted, :previous_poa
 
     attribute :representative do |object|
-      object.representative.deep_transform_keys! { |k| k.underscore }
+      object.representative.deep_transform_keys!(&:underscore)
     end
 
     # "Uploaded" is an internal-only status indicating that the POA PDF

--- a/modules/claims_api/app/serializers/claims_api/power_of_attorney_serializer.rb
+++ b/modules/claims_api/app/serializers/claims_api/power_of_attorney_serializer.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
 module ClaimsApi
-  class PowerOfAttorneySerializer < ActiveModel::Serializer
-    attributes :status, :date_request_accepted, :representative, :previous_poa
+  class PowerOfAttorneySerializer
+    include JSONAPI::Serializer
+
+    set_type :claims_api_power_of_attorneys
+    set_id :id
+    set_key_transform :underscore
+
+    attributes :date_request_accepted, :previous_poa
+
+    attribute :representative do |object|
+      object.representative.deep_transform_keys! { |k| k.underscore }
+    end
 
     # "Uploaded" is an internal-only status indicating that the POA PDF
     # was uploaded to VBMS, but we did not make it to updating BGS.
     # For external consistency, return as "Updated"
-    def status
+    attribute :status do |object|
       if object[:status] == ClaimsApi::PowerOfAttorney::UPLOADED
         ClaimsApi::PowerOfAttorney::UPDATED
       else

--- a/modules/claims_api/spec/serializers/intent_to_file_serializer_spec.rb
+++ b/modules/claims_api/spec/serializers/intent_to_file_serializer_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-describe ClaimsApi::IntentToFileSerializer do
+describe ClaimsApi::IntentToFileSerializer, type: :serializer do
+  include SerializerSpecHelper
+
   # based on ClaimsApi::V1::Forms::IntentToFileController#active bgs_active
+  subject { serialize(bgs_response, serializer_class: described_class) }
+
   let(:bgs_response) do
     {
       create_dt: '2020-06-05T11:24:28-05:00',
@@ -25,26 +29,27 @@ describe ClaimsApi::IntentToFileSerializer do
       submtr_applcn_type_cd: 'VETS.GOV'
     }
   end
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(bgs_response, { serializer: described_class }).as_json
+  it 'includes :id' do
+    expect(data['id']).to eq bgs_response[:intent_to_file_id]
   end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 
   it 'includes :creation_date' do
-    expect(rendered_attributes[:creation_date]).to eq bgs_response[:create_dt]
+    expect(attributes['creation_date']).to eq bgs_response[:create_dt]
   end
 
   it 'includes :expiration_date' do
-    expect(rendered_attributes[:expiration_date]).to eq bgs_response[:exprtn_dt]
+    expect(attributes['expiration_date']).to eq bgs_response[:exprtn_dt]
   end
 
   it 'includes :type' do
     itf_to_bgs_types = ClaimsApi::IntentToFile::ITF_TYPES_TO_BGS_TYPES
-    expect(rendered_attributes[:type]).to eq itf_to_bgs_types.key(bgs_response[:itf_type_cd])
+    expect(attributes['type']).to eq itf_to_bgs_types.key(bgs_response[:itf_type_cd])
   end
 
   it 'includes :status' do
-    expect(rendered_attributes[:status]).to eq bgs_response[:itf_status_type_cd]&.downcase
+    expect(attributes['status']).to eq bgs_response[:itf_status_type_cd]&.downcase
   end
 end

--- a/modules/claims_api/spec/serializers/power_of_attorney_serializer_spec.rb
+++ b/modules/claims_api/spec/serializers/power_of_attorney_serializer_spec.rb
@@ -2,42 +2,43 @@
 
 require 'rails_helper'
 
-describe ClaimsApi::PowerOfAttorneySerializer do
+describe ClaimsApi::PowerOfAttorneySerializer, type: :serializer do
+  include SerializerSpecHelper
+
+  subject { serialize(poa_submission, serializer_class: described_class) }
+
   let(:poa_submission) { build(:power_of_attorney, status: ClaimsApi::PowerOfAttorney::UPLOADED) }
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(poa_submission, { serializer: described_class }).as_json
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  it 'includes :id' do
+    expect(data['id']).to eq poa_submission.id.to_s
   end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 
   it 'includes :date_request_accepted' do
-    expect(rendered_attributes[:date_request_accepted]).to eq poa_submission.date_request_accepted
+    expect(attributes['date_request_accepted']).to eq poa_submission.date_request_accepted
   end
 
   it 'includes :representative' do
-    expect(rendered_attributes[:representative]).to eq poa_submission.representative
+    expect(attributes['representative']).to eq poa_submission.representative
   end
 
   it 'includes :previous_poa' do
-    expect(rendered_attributes[:previous_poa]).to eq poa_submission.previous_poa
+    expect(attributes['previous_poa']).to eq poa_submission.previous_poa
   end
 
   context 'when a POA submission has a status property of "uploaded"' do
     it 'transforms status to "updated"' do
       expect(poa_submission[:status]).to eq(ClaimsApi::PowerOfAttorney::UPLOADED)
-      expect(rendered_attributes[:status]).to eq(ClaimsApi::PowerOfAttorney::UPDATED)
+      expect(attributes['status']).to eq(ClaimsApi::PowerOfAttorney::UPDATED)
     end
   end
 
   context 'when a POA submission does not have a status property of "uploaded"' do
-    let(:submitted_poa_submission) { build(:power_of_attorney) }
-    let(:submitted_rendered_hash) do
-      ActiveModelSerializers::SerializableResource.new(submitted_poa_submission,
-                                                       { serializer: described_class }).as_json
-    end
-    let(:submitted_rendered_attributes) { submitted_rendered_hash[:data][:attributes] }
+    let(:poa_submission) { build(:power_of_attorney) }
 
     it 'includes :status from poa_submission' do
-      expect(submitted_rendered_attributes[:status]).to eq(submitted_poa_submission.status)
+      expect(poa_submission['status']).to eq(poa_submission.status)
     end
   end
 end


### PR DESCRIPTION
This PR is related to https://github.com/department-of-veterans-affairs/vets-api/pull/17210 but should be reviewed first

## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in modules/claims_api.
    - `IntentToFileSerializer` and  `PowerOfAttorneySerializer`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85753

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Screenshots

![Screenshot 2024-06-24 at 10 41 27 AM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/d6b75c1c-a963-4079-9582-c6fc02e7fba5)

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage