### PR TITLE
Run deploy workflow after build_and_push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,14 @@ jobs:
           cache-from: type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY
           cache-to: type=inline
   deploy:
+    needs: build_and_push
     if: github.ref == 'refs/heads/master'
     uses: department-of-veterans-affairs/vets-api/.github/workflows/deploy-template.yml@master
     with:
       ecr_repository: "vets-api"
       manifests_directory: "vets-api"
       auto_deploy_envs: "dev staging prod sandbox"
-      commit_sha: ${{ github.sha }} 
+      commit_sha: ${{ github.sha }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Deploy should not be ran until build_and_push finishes to prevent the following error.
<img width="734" alt="Screenshot 2024-06-24 at 10 53 55 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/32692924/252b3b36-dc60-4e9c-be68-f4b150a2fcaa">
