### PR TITLE
Replace COVID Vaccine AMS serializers with JSONAPI serializers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -742,6 +742,7 @@ config/initializers/freeze_schemas.rb @department-of-veterans-affairs/vfs-10-10 
 config/initializers/httpi.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/ial.rb @department-of-veterans-affairs/octo-identity
 config/initializers/inflections.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+config/initializers/jsonapi_serializer_blank_id_patch.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/kms_encrypted.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/loa.rb @department-of-veterans-affairs/octo-identity
 config/initializers/lockbox.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/initializers/jsonapi_serializer_blank_id_patch.rb
+++ b/config/initializers/jsonapi_serializer_blank_id_patch.rb
@@ -6,8 +6,10 @@ module FastJsonapi
       def id_hash(id, record_type, default_return = false) # rubocop:disable Style/OptionalBooleanParameter
         if id.present?
           { id: id.to_s, type: record_type }
+        elsif id == ''
+          { id: '', type: record_type }
         else
-          default_return ? { id: '', type: record_type } : nil
+          default_return ? { id: nil, type: record_type } : nil
         end
       end
     end

--- a/config/initializers/jsonapi_serializer_blank_id_patch.rb
+++ b/config/initializers/jsonapi_serializer_blank_id_patch.rb
@@ -3,7 +3,7 @@
 module FastJsonapi
   module SerializationCore
     class_methods do
-      def id_hash(id, record_type, default_return = false)
+      def id_hash(id, record_type, default_return = false) # rubocop:disable Style/OptionalBooleanParameter
         if id.present?
           { id: id.to_s, type: record_type }
         else

--- a/config/initializers/jsonapi_serializer_blank_id_patch.rb
+++ b/config/initializers/jsonapi_serializer_blank_id_patch.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FastJsonapi
+  module SerializationCore
+    class_methods do
+      def id_hash(id, record_type, default_return = false)
+        if id.present?
+          { id: id.to_s, type: record_type }
+        else
+          default_return ? { id: '', type: record_type } : nil
+        end
+      end
+    end
+  end
+end

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
@@ -15,7 +15,7 @@ module CovidVaccine
                                                                             raw_form_data: })
         audit_log(raw_form_data)
         CovidVaccine::ExpandedRegistrationEmailJob.perform_async(record.id) if raw_form_data['email_address'].present?
-        render json: record, serializer: CovidVaccine::V0::ExpandedRegistrationSerializer, status: :created
+        render json: CovidVaccine::V0::ExpandedRegistrationSerializer.new(record), status: :created
       end
 
       private

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -18,14 +18,14 @@ module CovidVaccine
                                                                     raw_form_data: })
 
         CovidVaccine::SubmissionJob.perform_async(record.id, user_type)
-        render json: record, serializer: CovidVaccine::V0::RegistrationSummarySerializer, status: :created
+        render json: CovidVaccine::V0::RegistrationSummarySerializer.new(record), status: :created
       end
 
       def show
         submission = CovidVaccine::V0::RegistrationSubmission.for_user(current_user).last
         raise Common::Exceptions::RecordNotFound, nil if submission.blank?
 
-        render json: submission, serializer: CovidVaccine::V0::RegistrationSubmissionSerializer
+        render json: CovidVaccine::V0::RegistrationSubmissionSerializer.new(submission)
       end
 
       def opt_out

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/expanded_registration_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/expanded_registration_serializer.rb
@@ -2,12 +2,12 @@
 
 module CovidVaccine
   module V0
-    class ExpandedRegistrationSerializer < ActiveModel::Serializer
+    class ExpandedRegistrationSerializer
+      include JSONAPI::Serializer
+
       attribute :created_at
 
-      def id
-        nil
-      end
+      set_id { '' }
     end
   end
 end

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
@@ -5,7 +5,9 @@ module CovidVaccine
     class RegistrationSubmissionSerializer
       include JSONAPI::Serializer
 
-      set_id(&:sid)
+      set_id do |object|
+        object&.sid || ''
+      end
 
       attribute :created_at
 

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
@@ -2,25 +2,43 @@
 
 module CovidVaccine
   module V0
-    class RegistrationSubmissionSerializer < ActiveModel::Serializer
-      attribute :created_at
-      attribute :vaccine_interest
-      attribute :zip_code
-      attribute :zip_code_details
-      attribute :phone
-      attribute :email
-      attribute :first_name
-      attribute :last_name
-      attribute :birth_date
+    class RegistrationSubmissionSerializer
+      include JSONAPI::Serializer
 
-      def id
-        object.sid
+      set_id &:sid
+
+      attribute :created_at
+
+      attribute :vaccine_interest do |object|
+        object.raw_form_data['vaccine_interest']
       end
 
-      %i[vaccine_interest zip_code zip_code_details phone email first_name last_name birth_date].each do |attr|
-        define_method attr do
-          object.raw_form_data[attr.to_s]
-        end
+      attribute :zip_code do |object|
+        object.raw_form_data['zip_code']
+      end
+
+      attribute :zip_code_details do |object|
+        object.raw_form_data['zip_code_details']
+      end
+
+      attribute :phone do |object|
+        object.raw_form_data['phone']
+      end
+
+      attribute :email do |object|
+        object.raw_form_data['email']
+      end
+
+      attribute :first_name do |object|
+        object.raw_form_data['first_name']
+      end
+
+      attribute :last_name do |object|
+        object.raw_form_data['last_name']
+      end
+
+      attribute :birth_date do |object|
+        object.raw_form_data['birth_date']
       end
     end
   end

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
@@ -5,7 +5,7 @@ module CovidVaccine
     class RegistrationSubmissionSerializer
       include JSONAPI::Serializer
 
-      set_id &:sid
+      set_id(&:sid)
 
       attribute :created_at
 

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
@@ -2,19 +2,19 @@
 
 module CovidVaccine
   module V0
-    class RegistrationSummarySerializer < ActiveModel::Serializer
-      attribute :created_at
-      attribute :vaccine_interest
-      attribute :zip_code
+    class RegistrationSummarySerializer
+      include JSONAPI::Serializer
 
-      def id
-        nil
+      set_id { '' }
+
+      attribute :created_at
+
+      attribute :vaccine_interest do |object|
+        object.raw_form_data['vaccine_interest']
       end
 
-      %i[vaccine_interest zip_code].each do |attr|
-        define_method attr do
-          object.raw_form_data[attr.to_s]
-        end
+      attribute :zip_code do |object|
+        object.raw_form_data['zip_code']
       end
     end
   end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/expanded_registration_serializer_spec.rb
@@ -2,19 +2,18 @@
 
 require 'rails_helper'
 
-describe CovidVaccine::V0::ExpandedRegistrationSerializer do
-  let(:submission) { build_stubbed(:covid_vax_expanded_registration) }
+describe CovidVaccine::V0::ExpandedRegistrationSerializer, type: :serializer do
+  subject { serialize(submission, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(submission, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:submission) { build_stubbed(:covid_vax_expanded_registration) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :created_at' do
-    expect(rendered_attributes[:created_at]).to eq submission.created_at
+    expect_time_eq(attributes['created_at'], submission.created_at)
   end
 end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
@@ -2,51 +2,51 @@
 
 require 'rails_helper'
 
-describe CovidVaccine::V0::RegistrationSubmissionSerializer do
-  let(:registration) { build_stubbed(:covid_vax_registration) }
+describe CovidVaccine::V0::RegistrationSubmissionSerializer, type: :serializer do
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(registration, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  subject { serialize(registration, serializer_class: described_class) }
+
+  let(:registration) { build_stubbed(:covid_vax_registration) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq registration.sid
+    expect(data['id']).to eq registration.sid
   end
 
   it 'includes :created_at' do
-    expect(rendered_attributes[:created_at]).to eq registration.created_at
+    expect_time_eq(attributes['created_at'], registration.created_at)
   end
 
   it 'includes :vaccine_interest' do
-    expect(rendered_attributes[:vaccine_interest]).to eq registration.raw_form_data['vaccine_interest']
+    expect(attributes['vaccine_interest']).to eq registration.raw_form_data['vaccine_interest']
   end
 
   it 'includes :zip_code' do
-    expect(rendered_attributes[:zip_code]).to eq registration.raw_form_data['zip_code']
+    expect(attributes['zip_code']).to eq registration.raw_form_data['zip_code']
   end
 
   it 'includes :zip_code_details' do
-    expect(rendered_attributes[:zip_code_details]).to eq registration.raw_form_data['zip_code_details']
+    expect(attributes['zip_code_details']).to eq registration.raw_form_data['zip_code_details']
   end
 
   it 'includes :phone' do
-    expect(rendered_attributes[:phone]).to eq registration.raw_form_data['phone']
+    expect(attributes['phone']).to eq registration.raw_form_data['phone']
   end
 
   it 'includes :email' do
-    expect(rendered_attributes[:email]).to eq registration.raw_form_data['email']
+    expect(attributes['email']).to eq registration.raw_form_data['email']
   end
 
   it 'includes :first_name' do
-    expect(rendered_attributes[:first_name]).to eq registration.raw_form_data['first_name']
+    expect(attributes['first_name']).to eq registration.raw_form_data['first_name']
   end
 
   it 'includes :last_name' do
-    expect(rendered_attributes[:last_name]).to eq registration.raw_form_data['last_name']
+    expect(attributes['last_name']).to eq registration.raw_form_data['last_name']
   end
 
   it 'includes :birth_date' do
-    expect(rendered_attributes[:birth_date]).to eq registration.raw_form_data['birth_date']
+    expect(attributes['birth_date']).to eq registration.raw_form_data['birth_date']
   end
 end

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_submission_serializer_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe CovidVaccine::V0::RegistrationSubmissionSerializer, type: :serializer do
-
   subject { serialize(registration, serializer_class: described_class) }
 
   let(:registration) { build_stubbed(:covid_vax_registration) }

--- a/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_summary_serializer_spec.rb
+++ b/modules/covid_vaccine/spec/serializers/covid_vaccines/v0/registration_summary_serializer_spec.rb
@@ -2,27 +2,26 @@
 
 require 'rails_helper'
 
-describe CovidVaccine::V0::RegistrationSummarySerializer do
-  let(:registration) { build_stubbed(:covid_vax_registration) }
+describe CovidVaccine::V0::RegistrationSummarySerializer, type: :serializer do
+  subject { serialize(registration, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(registration, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:registration) { build_stubbed(:covid_vax_registration) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :created_at' do
-    expect(rendered_attributes[:created_at]).to eq registration.created_at
+    expect_time_eq(attributes['created_at'], registration.created_at)
   end
 
   it 'includes :vaccine_interest' do
-    expect(rendered_attributes[:vaccine_interest]).to eq registration.raw_form_data['vaccine_interest']
+    expect(attributes['vaccine_interest']).to eq registration.raw_form_data['vaccine_interest']
   end
 
   it 'includes :zip_code' do
-    expect(rendered_attributes[:zip_code]).to eq registration.raw_form_data['zip_code']
+    expect(attributes['zip_code']).to eq registration.raw_form_data['zip_code']
   end
 end


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in modules/covid_vaccine.
- Add `jsonapi_serializer_blank_id_patch.rb`
    - the default functionality of jsonapi-serializer doesn't allow for empty strings for id, so I patched FastJsonapi::SerializationCore so it would allow it via `set_id` (e.g. `set_id { '' }`)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86384

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Screenshots
![Screenshot 2024-06-24 at 1 47 50 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/88c55796-2985-4029-9800-e8066305125f)


## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage
