### PR TITLE
Add action items to delay deploy workflow (part 2)

### DIFF
--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -50,7 +50,7 @@ jobs:
           action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-dev|ArgoCD dev>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml?query=branch%3Amaster|Build, Push, & Deploy> GitHub Action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>"
 
 
-          if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
+          if [ "${latest_sha:0:8}" == "${deployed_sha:0:7}" ]; then
             echo "${info_message} has been deployed."
             echo "dev_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
           elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
@@ -76,7 +76,7 @@ jobs:
           info_message="Latest commit (${latest_sha:0:8}, ${commit_time}) to staging"
           action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-staging|ArgoCD staging>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml?query=branch%3Amaster|Build, Push, & Deploy> GitHub Action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>"
 
-          if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
+          if [ "${latest_sha:0:8}" == "${deployed_sha:0:7}" ]; then
             echo "${info_message} has been deployed."
             echo "staging_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
           elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -57,7 +57,7 @@ jobs:
             echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
             echo "dev_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
           elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
-            echo "${info_message} has been delayed for more than 30 minutes."
+            echo "${info_message} has been delayed for more than 30 minutesssssssss."
             echo "Current commit on development is ${deployed_sha:0:8}."
             echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
             exit 1

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -44,6 +44,8 @@ jobs:
           commit_time=${{ env.commit_time }}
           deployed_sha=${{ env.dev_deployed_sha }}
           info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to development"
+          action_items="\n- [ArgoCD dev](https://argocd.vfs.va.gov/applications/vets-api-dev)\n- [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action\n- [Deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status)\n- [Latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/)."
+
 
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
@@ -54,11 +56,7 @@ jobs:
           elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on development is ${deployed_sha:0:8}."
-            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}."
-            echo ""
-            echo "- Check [ArgoCD dev](https://argocd.vfs.va.gov/applications/vets-api-dev) for errors."
-            echo "- Check the [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action for failures."
-            echo "- Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors." >> $GITHUB_OUTPUT
+            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."
@@ -73,6 +71,7 @@ jobs:
           commit_time=${{ env.commit_time }}
           deployed_sha=${{ env.staging_deployed_sha }}
           info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to staging"
+          action_items="\n- [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging)\n- [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action\n- [Deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status)\n- [Latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/)."
 
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
@@ -83,11 +82,7 @@ jobs:
           elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on staging is ${deployed_sha:0:8}."
-            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}."
-            echo ""
-            echo "- Check [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging) for errors."
-            echo "- Check the [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action for failures."
-            echo "- Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors." >> $GITHUB_OUTPUT
+            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -56,8 +56,8 @@ jobs:
           elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
             echo "dev_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
-          elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
-            echo "${info_message} has been delayed for more than 30 minutesssssssss."
+          elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on development is ${deployed_sha:0:8}."
             echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
             exit 1
@@ -82,7 +82,7 @@ jobs:
           elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
             echo "staging_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
-          elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
+          elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on staging is ${deployed_sha:0:8}."
             echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -54,11 +54,11 @@ jobs:
           elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on development is ${deployed_sha:0:8}."
-            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}." >> $GITHUB_OUTPUT
+            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}."
             echo ""
-            echo "Check [ArgoCD dev](https://argocd.vfs.va.gov/applications/vets-api-dev) for errors."
-            echo ""
-            echo "Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors."
+            echo "- Check [ArgoCD dev](https://argocd.vfs.va.gov/applications/vets-api-dev) for errors."
+            echo "- Check the [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action for failures."
+            echo "- Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors." >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."
@@ -83,11 +83,11 @@ jobs:
           elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on staging is ${deployed_sha:0:8}."
-            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}." >> $GITHUB_OUTPUT
+            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}."
             echo ""
-            echo "Check [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging) for errors."
-            echo ""
-            echo "Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors."
+            echo "- Check [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging) for errors."
+            echo "- Check the [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action for failures."
+            echo "- Check the [deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status) and [latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) for errors." >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -46,8 +46,8 @@ jobs:
           latest_sha=${{ env.latest_sha }}
           commit_time=${{ env.commit_time }}
           deployed_sha=${{ env.dev_deployed_sha }}
-          info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to development"
-          action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-dev|ArgoCD dev>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml|Build, Push, & Deploy> action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>."
+          info_message="Latest commit (${latest_sha:0:8}, ${commit_time}) to development"
+          action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-dev|ArgoCD dev>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml?query=branch%3Amaster|Build, Push, & Deploy> GitHub Action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>"
 
 
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
@@ -56,7 +56,7 @@ jobs:
           elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on development is ${deployed_sha:0:8}."
-            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
+            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}.\nCheck the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
           elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
             echo "dev_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
@@ -73,8 +73,8 @@ jobs:
           latest_sha=${{ env.latest_sha }}
           commit_time=${{ env.commit_time }}
           deployed_sha=${{ env.staging_deployed_sha }}
-          info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to staging"
-          action_items="\n- [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging)\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml|Build, Push, & Deploy> action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>."
+          info_message="Latest commit (${latest_sha:0:8}, ${commit_time}) to staging"
+          action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-staging|ArgoCD staging>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml?query=branch%3Amaster|Build, Push, & Deploy> GitHub Action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>"
 
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
@@ -82,7 +82,7 @@ jobs:
           elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on staging is ${deployed_sha:0:8}."
-            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
+            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}.\nCheck the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
           elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
             echo "staging_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
@@ -135,4 +135,5 @@ jobs:
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
           message: "Vets API Deployment Delay:"
           blocks: "[{\"type\": \"divider\"}, {\"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":scared_and_sweating_smiley: GitHub Action Runner Workflow failed! :scared_and_sweating_smiley:\n <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} Run #${{ github.run_number }}>\n\n*Development Summary:*\n${{ needs.check-deployment.outputs.development_summary }}\n\n*Staging Summary:*\n${{ needs.check-deployment.outputs.staging_summary }}\"}}, {\"type\": \"divider\"}]"
-          channel_id: "C039HRTHXDH"
+          # channel_id: "C039HRTHXDH"
+          channel_id: "C01TNTMKNKA"

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -1,9 +1,6 @@
 name: Deploy Delay Notifications
 
 on:
-  push:
-    branches:
-      - 'delay_deploy_gha'
   schedule:
     - cron: "*/10 * * * *" # Runs every 10 minutes
 
@@ -50,16 +47,16 @@ jobs:
           action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-dev|ArgoCD dev>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml?query=branch%3Amaster|Build, Push, & Deploy> GitHub Action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>"
 
 
-          if [ "${latest_sha:0:8}" == "${deployed_sha:0:7}" ]; then
+          if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
             echo "dev_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
-          elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
-            echo "${info_message} has been delayed for more than 30 minutes."
-            echo "Current commit on development is ${deployed_sha:0:8}."
-            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}.\nCheck the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
           elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
             echo "dev_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 30 minutes."
+            echo "Current commit on development is ${deployed_sha:0:8}."
+            echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}.\n\nCheck the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."
@@ -76,16 +73,16 @@ jobs:
           info_message="Latest commit (${latest_sha:0:8}, ${commit_time}) to staging"
           action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-staging|ArgoCD staging>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml?query=branch%3Amaster|Build, Push, & Deploy> GitHub Action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>"
 
-          if [ "${latest_sha:0:8}" == "${deployed_sha:0:7}" ]; then
+          if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
             echo "staging_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
-          elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
-            echo "${info_message} has been delayed for more than 30 minutes."
-            echo "Current commit on staging is ${deployed_sha:0:8}."
-            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}.\nCheck the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
           elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
             echo "staging_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 30 minutes."
+            echo "Current commit on staging is ${deployed_sha:0:8}."
+            echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}.\n\nCheck the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."
@@ -95,7 +92,7 @@ jobs:
   notify-on-failure:
     runs-on: ubuntu-latest
     needs: [check-deployment]
-    # if: ${{ failure() }}
+    if: ${{ failure() }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -135,5 +132,4 @@ jobs:
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
           message: "Vets API Deployment Delay:"
           blocks: "[{\"type\": \"divider\"}, {\"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":scared_and_sweating_smiley: GitHub Action Runner Workflow failed! :scared_and_sweating_smiley:\n <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} Run #${{ github.run_number }}>\n\n*Development Summary:*\n${{ needs.check-deployment.outputs.development_summary }}\n\n*Staging Summary:*\n${{ needs.check-deployment.outputs.staging_summary }}\"}}, {\"type\": \"divider\"}]"
-          # channel_id: "C039HRTHXDH"
-          channel_id: "C01TNTMKNKA"
+          channel_id: "C039HRTHXDH"

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -1,6 +1,9 @@
 name: Deploy Delay Notifications
 
 on:
+  push:
+    branches:
+      - 'delay_deploy_gha'
   schedule:
     - cron: "*/10 * * * *" # Runs every 10 minutes
 

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -53,13 +53,13 @@ jobs:
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
             echo "dev_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
-          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
-            echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
-            echo "dev_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
           elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on development is ${deployed_sha:0:8}."
             echo "dev_summary=${info_message} has been delayed for more than 30 minutes. Current commit on development is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
+            echo "dev_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."
@@ -79,13 +79,13 @@ jobs:
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."
             echo "staging_summary=${info_message} has been deployed." >> $GITHUB_OUTPUT
-          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
-            echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
-            echo "staging_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
           elif true || [ "$(date -d "${commit_time}" +%s)" -lt "$(date -d '30 minutes ago' +%s)" ]; then
             echo "${info_message} has been delayed for more than 30 minutes."
             echo "Current commit on staging is ${deployed_sha:0:8}."
             echo "staging_summary=${info_message} has been delayed for more than 30 minutes. Current commit on staging is ${deployed_sha:0:8}. Check the following list of items for errors: ${action_items}" >> $GITHUB_OUTPUT
+          elif [ "$(date -d "${commit_time}" +%s)" -gt "$(date -d '45 minutes ago' +%s)" ]; then
+            echo "${info_message} has been delayed for more than 45 minutes. Skipping notification."
+            echo "staging_summary=${info_message} has been delayed for more than 45 minutes. Skipping notification." >> $GITHUB_OUTPUT
             exit 1
           else
             echo "Awaiting deployment of ${info_message}."

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -47,7 +47,7 @@ jobs:
           commit_time=${{ env.commit_time }}
           deployed_sha=${{ env.dev_deployed_sha }}
           info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to development"
-          action_items="\n- [ArgoCD dev](https://argocd.vfs.va.gov/applications/vets-api-dev)\n- [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action\n- [Deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status)\n- [Latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/)."
+          action_items="\n- <https://argocd.vfs.va.gov/applications/vets-api-dev|ArgoCD dev>\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml|Build, Push, & Deploy> action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>."
 
 
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
@@ -74,7 +74,7 @@ jobs:
           commit_time=${{ env.commit_time }}
           deployed_sha=${{ env.staging_deployed_sha }}
           info_message="latest commit (${latest_sha:0:8}, ${commit_time}) to staging"
-          action_items="\n- [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging)\n- [Build, Push, & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action\n- [Deploy dashboard](https://www.va.gov/atlas/apps/vets-api/deploy_status)\n- [Latest commits](https://github.com/department-of-veterans-affairs/vets-api/commits/master/)."
+          action_items="\n- [ArgoCD staging](https://argocd.vfs.va.gov/applications/vets-api-staging)\n- <https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml|Build, Push, & Deploy> action\n- <https://www.va.gov/atlas/apps/vets-api/deploy_status|Deploy dashboard>\n- <https://github.com/department-of-veterans-affairs/vets-api/commits/master/|Latest commits>."
 
           if [ "${latest_sha:0:8}" == "${deployed_sha:0:8}" ]; then
             echo "${info_message} has been deployed."

--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -95,7 +95,7 @@ jobs:
   notify-on-failure:
     runs-on: ubuntu-latest
     needs: [check-deployment]
-    if: ${{ failure() }}
+    # if: ${{ failure() }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary

- Follow-up to https://github.com/department-of-veterans-affairs/vets-api/pull/17181. My messages weren't printing! As seen in this recent screenshot:
<img width="596" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/034d9263-d29b-4c1c-8d3c-363008255a7f">

They were showing up in the [message in the GHA](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/9649791424/job/26614017127), but not printing to Slack. 
- I also added a link to the Build, Push & Deploy actions.

## Testing done
I added this block to run on my branch:
```yaml
on:
  push:
    branches:
      - 'delay_deploy_gha'
```      
And saw the output in the channel. This is what it will look like: 
<img width="620" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/67b355b4-5c8f-4532-bf19-b137e05500d9">
 
