### PR TITLE
provider name on cancelled cc appt

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -208,7 +208,9 @@ module VAOS
         if avs_applicable?(appointment) && Flipper.enabled?(AVS_FLIPPER, user)
           fetch_avs_and_update_appt_body(appointment)
         end
-        find_and_merge_provider_name(appointment) if appointment[:kind] == 'cc' && appointment[:status] == 'proposed'
+        if appointment[:kind] == 'cc' && (appointment[:status] == 'proposed' || appointment[:status] == 'cancelled')
+          find_and_merge_provider_name(appointment)
+        end
       end
 
       def find_and_merge_provider_name(appointment)

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointments_200_cc_cancelled.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointments_200_cc_cancelled.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vaos/v1/patients/1012846043V576341/appointments?end=2022-12-01T19:45:00Z&pageSize=0&start=2022-01-01T19:25:00Z
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Nov 2021 19:56:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.12.1
+      B3:
+      - fb5e01cb7d2f4995-d9e83a83cc4e7326-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 661c259
+      X-Vamf-Timestamp:
+      - '2021-11-01T15:35:46+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"68254","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/hsrm/id","value":"13009"}],"kind":"cc","status":"cancelled","serviceType":"audiology-routineexam","serviceTypes":[{"text":"audiology-routineexam"}],"patientIcn":"1012845331V153043","locationId":"983","practitioners":[{"identifier":[{"system":"http://hl7.org/fhir/sid/us-npi","value":"1528231610"}],"address":{"type":"physical","line":["1106WNewHavenAve"],"city":"Melbourne","state":"FL","postalCode":"32904","text":"1106WNewHavenAve,Melbourne,FL,32904"}}],"created":"2022-09-15T15:18:00Z","requestedPeriods":[{"start":"2022-09-20T06:00:00Z"}],"contact":{"telecom":[{"type":"phone","value":"3174485062"},{"type":"email","value":"Aarathi.poldass@va.gov"}]},"preferredTimesForPhoneCall":["Morning"],"preferredLocation":{"city":"PalmBay","state":"FL"},"preferredLanguage":"English","cancellable":true,"extension":{"ccLocation":{"address":{}},"ccRequestedCancellation":false,"hsrmTaskId":"13009"},"location":{"id":"983","type":"appointments","attributes":{"id":"983","vistaSite":"983","vastParent":"983","type":"va_facilities","name":"CheyenneVAMedicalCenter","classification":"VAMedicalCenter(VAMC)","timezone":{"timeZoneId":"America/Denver"},"lat":39.744507,"long":-104.830956,"website":"https://www.denver.va.gov/locations/directions.asp","phone":{"main":"307-778-7550","fax":"307-778-7381","pharmacy":"866-420-6337","afterHours":"307-778-7550","patientAdvocate":"307-778-7550x7517","mentalHealthClinic":"307-778-7349","enrollmentCoordinator":"307-778-7550x7579"},"physicalAddress":{"type":"physical","line":["2360EastPershingBoulevard"],"city":"Cheyenne","state":"WY","postalCode":"82001-5356"},"mobile":false,"healthService":["Audiology","Cardiology","DentalServices","EmergencyCare","Gastroenterology","Gynecology","MentalHealthCare","Nutrition","Ophthalmology","Optometry","Orthopedics","Podiatry","PrimaryCare","SpecialtyCare","UrgentCare","Urology","WomensHealth"],"operatingStatus":{"code":"NORMAL"}}}},{"id":"68355","identifier":[{"system":"http://med.va.gov/fhir/urn/vaos/hsrm/id","value":"13011"}],"kind":"cc","status":"cancelled","serviceType":"audiology-routineexam","serviceTypes":[{"text":"audiology-routineexam"}],"reasonCode":{"text":"kjh"},"patientIcn":"1012845331V153043","locationId":"983","practitioners":[{"identifier":[{"system":"http://hl7.org/fhir/sid/us-npi","value":"1528231610"}],"address":{"type":"physical","line":["1106WNewHavenAve"],"city":"Melbourne","state":"FL","postalCode":"32904","text":"1106WNewHavenAve,Melbourne,FL,32904"}}],"created":"2022-09-16T17:00:00Z","requestedPeriods":[{"start":"2022-09-29T06:00:00Z"}],"contact":{"telecom":[{"type":"phone","value":"3179087069"},{"type":"email","value":"apoldass@lts.com"}]},"preferredTimesForPhoneCall":["Morning"],"preferredLocation":{"city":"PalmBay","state":"FL"},"preferredLanguage":"English","cancellable":true,"extension":{"ccLocation":{"address":{}},"ccRequestedCancellation":false,"hsrmTaskId":"13011","ccTreatingSpecialty":"string"},"location":{"id":"983","type":"appointments","attributes":{"id":"983","vistaSite":"983","vastParent":"983","type":"va_facilities","name":"CheyenneVAMedicalCenter","classification":"VAMedicalCenter(VAMC)","timezone":{"timeZoneId":"America/Denver"},"lat":39.744507,"long":-104.830956,"website":"https://www.denver.va.gov/locations/directions.asp","phone":{"main":"307-778-7550","fax":"307-778-7381","pharmacy":"866-420-6337","afterHours":"307-778-7550","patientAdvocate":"307-778-7550x7517","mentalHealthClinic":"307-778-7349","enrollmentCoordinator":"307-778-7550x7579"},"physicalAddress":{"type":"physical","line":["2360EastPershingBoulevard"],"city":"Cheyenne","state":"WY","postalCode":"82001-5356"},"mobile":false,"healthService":["Audiology","Cardiology","DentalServices","EmergencyCare","Gastroenterology","Gynecology","MentalHealthCare","Nutrition","Ophthalmology","Optometry","Orthopedics","Podiatry","PrimaryCare","SpecialtyCare","UrgentCare","Urology","WomensHealth"],"operatingStatus":{"code":"NORMAL"}}}}]}'
+  recorded_at: Thu, 04 Nov 2021 19:56:46 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Summary

- Quick fix to ensure that provider name info is made available on a cc appt that is cancelled

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83900