### PR TITLE
Replace MebApi AMS serializers with JSONAPI serializers - Part 1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -742,6 +742,7 @@ config/initializers/freeze_schemas.rb @department-of-veterans-affairs/vfs-10-10 
 config/initializers/httpi.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/ial.rb @department-of-veterans-affairs/octo-identity
 config/initializers/inflections.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+config/initializers/jsonapi_serializer_blank_id_patch.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/kms_encrypted.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/loa.rb @department-of-veterans-affairs/octo-identity
 config/initializers/lockbox.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/initializers/jsonapi_serializer_blank_id_patch.rb
+++ b/config/initializers/jsonapi_serializer_blank_id_patch.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module FastJsonapi
+  module SerializationCore
+    class_methods do
+      def id_hash(id, record_type, default_return = false) # rubocop:disable Style/OptionalBooleanParameter
+        if id.present?
+          { id: id.to_s, type: record_type }
+        elsif id == ''
+          { id: '', type: record_type }
+        else
+          default_return ? { id: nil, type: record_type } : nil
+        end
+      end
+    end
+  end
+end

--- a/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
@@ -13,7 +13,7 @@ module MebApi
       def claimant_info
         response = automation_service.get_claimant_info('Chapter33')
 
-        render json: response, serializer: AutomationSerializer
+        render json: AutomationSerializer.new(response)
       end
 
       def eligibility
@@ -25,7 +25,7 @@ module MebApi
         response = claimant_response.status == 201 ? eligibility_response : claimant_response
         serializer = claimant_response.status == 201 ? EligibilitySerializer : ClaimantSerializer
 
-        render json: response, serializer:
+        render json: serializer.new(response)
       end
 
       def claim_status
@@ -36,7 +36,7 @@ module MebApi
         response = claimant_response.status == 201 ? claim_status_response : claimant_response
         serializer = claimant_response.status == 201 ? ClaimStatusSerializer : ClaimantSerializer
 
-        render json: response, serializer:
+        render json: serializer.new(response)
       end
 
       def claim_letter
@@ -125,7 +125,7 @@ module MebApi
 
       def duplicate_contact_info
         response = contact_info_service.check_for_duplicates(params[:emails], params[:phones])
-        render json: response, serializer: ContactInfoSerializer
+        render json: ContactInfoSerializer.new(response)
       end
 
       def exclusion_periods

--- a/modules/meb_api/app/serializers/automation_serializer.rb
+++ b/modules/meb_api/app/serializers/automation_serializer.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-class AutomationSerializer < ActiveModel::Serializer
-  attribute :claimant
-  attribute :service_data
+class AutomationSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+  attributes :claimant, :service_data
 end

--- a/modules/meb_api/app/serializers/claim_status_serializer.rb
+++ b/modules/meb_api/app/serializers/claim_status_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class ClaimStatusSerializer < ActiveModel::Serializer
-  attributes :claimant_id, :claim_service_id, :claim_status, :received_date
+class ClaimStatusSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+
+  attributes :claimant_id, :claim_service_id, :claim_status, :received_date
 end

--- a/modules/meb_api/app/serializers/claimant_serializer.rb
+++ b/modules/meb_api/app/serializers/claimant_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class ClaimantSerializer < ActiveModel::Serializer
-  attribute :claimant_id
+class ClaimantSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+
+  attribute :claimant_id
 end

--- a/modules/meb_api/app/serializers/contact_info_serializer.rb
+++ b/modules/meb_api/app/serializers/contact_info_serializer.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-class ContactInfoSerializer < ActiveModel::Serializer
-  attributes :phone
-  attributes :email
+class ContactInfoSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+  attributes :phone, :email
 end

--- a/modules/meb_api/app/serializers/eligibility_serializer.rb
+++ b/modules/meb_api/app/serializers/eligibility_serializer.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-class EligibilitySerializer < ActiveModel::Serializer
-  attributes :eligibility
+class EligibilitySerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+  attributes :eligibility
 end

--- a/modules/meb_api/spec/serializers/automation_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/automation_serializer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'dgi/automation/claimant_response'
 
-describe AutomationSerializer do
+describe AutomationSerializer, type: :serializer do
+  subject { serialize(automation_claimant_response, serializer_class: described_class) }
+
   let(:claimant) do
     {
       claimant_id: 600_010_259,
@@ -48,65 +50,18 @@ describe AutomationSerializer do
     MebApi::DGI::Automation::ClaimantResponse.new(201, response)
   end
 
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_automation_claimant_responses',
-        attributes: {
-          claimant: {
-            claimant_id: 600_010_259,
-            suffix: '',
-            date_of_birth: '1990-08-01',
-            first_name: 'Hector',
-            last_name: 'Allen',
-            middle_name: 'James',
-            notification_method: 'NONE',
-            contact_info: {
-              address_line1: '1291 Boston Post Rd',
-              address_line2: '',
-              city: 'Madison',
-              zipcode: '06443',
-              email_address: 'testing@test.com',
-              address_type: 'DOMESTIC',
-              mobile_phone_number: '1231231234',
-              home_phone_number: '1231231234',
-              country_code: 'US',
-              state_code: 'CT'
-            },
-            preferred_contact: nil
-          },
-          service_data: [
-            {
-              branch_of_service: 'Air Force',
-              begin_date: '2010-06-01',
-              end_date: '2020-06-01',
-              character_of_service: 'Honorable',
-              reason_for_separation: 'Expiration Term Of Service',
-              exclusion_periods: [],
-              training_periods: []
-            }
-          ]
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(automation_claimant_response,
-                                                     { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :claimant' do
-    expect(rendered_attributes[:claimant]).to eq expected_response[:data][:attributes][:claimant]
+    expect_data_eq(attributes['claimant'], claimant)
   end
 
   it 'includes :service_data' do
-    expect(rendered_attributes[:service_data]).to eq expected_response[:data][:attributes][:service_data]
+    expect_data_eq(attributes['service_data'], service_data)
   end
 end

--- a/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/claim_status_serializer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'dgi/status/status_response'
 
-describe ClaimStatusSerializer do
+describe ClaimStatusSerializer, type: :serializer do
+  subject { serialize(claim_status_response, serializer_class: described_class) }
+
   let(:claimant) { 600_000_001 }
   let(:claim_service_id) { 99_000_000_113_358_369 }
   let(:claim_status) { 'ELIGIBLE' }
@@ -18,44 +20,26 @@ describe ClaimStatusSerializer do
                       })
     MebApi::DGI::Status::StatusResponse.new(201, response)
   end
-
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_status_status_responses',
-        attributes: {
-          claimant_id: 600_000_001,
-          claim_service_id: 99_000_000_113_358_369,
-          claim_status: 'ELIGIBLE',
-          received_date: '2022-06-13'
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(claim_status_response, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :claimant_id' do
-    expect(rendered_attributes[:claimant_id]).to eq expected_response[:data][:attributes][:claimant_id]
+    expect(attributes['claimant_id']).to eq claimant
   end
 
   it 'includes :claim_service_id' do
-    expect(rendered_attributes[:claim_service_id]).to eq expected_response[:data][:attributes][:claim_service_id]
+    expect(attributes['claim_service_id']).to eq claim_service_id
   end
 
   it 'includes :claim_status' do
-    expect(rendered_attributes[:claim_status]).to eq expected_response[:data][:attributes][:claim_status]
+    expect(attributes['claim_status']).to eq 'ELIGIBLE'
   end
 
   it 'includes :received_date' do
-    expect(rendered_attributes[:received_date]).to eq expected_response[:data][:attributes][:received_date]
+    expect(attributes['received_date']).to eq received_date
   end
 end

--- a/modules/meb_api/spec/serializers/claimant_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/claimant_serializer_spec.rb
@@ -3,36 +3,22 @@
 require 'rails_helper'
 require 'dgi/claimant/claimant_response'
 
-describe ClaimantSerializer do
-  let(:claimant) { 600_010_259 }
+describe ClaimantSerializer, type: :serializer do
+  subject { serialize(claimant_response, serializer_class: described_class) }
 
+  let(:claimant) { 600_010_259 }
   let(:claimant_response) do
     response = double('response', body: { 'claimant_id' => claimant })
     MebApi::DGI::Claimant::ClaimantResponse.new(201, response)
   end
-
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_claimant_claimant_responses',
-        attributes: {
-          claimant_id: '600010259'
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(claimant_response, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :claimant_id' do
-    expect(rendered_attributes[:claimant_id]).to eq expected_response[:data][:attributes][:claimant_id]
+    expect(attributes['claimant_id']).to eq claimant.to_s
   end
 end

--- a/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
@@ -4,41 +4,29 @@ require 'rails_helper'
 require 'dgi/contact_info/response'
 
 describe ContactInfoSerializer do
+  subject { serialize(contact_info_response, serializer_class: described_class) }
+
+  let(:emails) { [{ address: 'test@test.com', dupe: 'false' }] }
+  let(:phones) { [{ number: '8013090123', dupe: 'false' }] }
   let(:contact_info_response) do
     response = double('response', body: {
-                        'emails' => [{ address: 'test@test.com', dupe: 'false' }],
-                        'phones' => [{ number: '8013090123', dupe: 'false' }]
+                        'emails' => emails,
+                        'phones' => phones
                       })
     MebApi::DGI::ContactInfo::Response.new(201, response)
   end
-
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_contact_info_responses',
-        attributes: {
-          phone: [{ number: '8013090123', dupe: 'false' }],
-          email: [{ address: 'test@test.com', dupe: 'false' }]
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(contact_info_response, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :phone' do
-    expect(rendered_attributes[:phone]).to eq expected_response[:data][:attributes][:phone]
+    expect_data_eq(attributes['phone'], phones)
   end
 
   it 'includes :email' do
-    expect(rendered_attributes[:email]).to eq expected_response[:data][:attributes][:email]
+    expect_data_eq(attributes['email'], emails)
   end
 end

--- a/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/contact_info_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'dgi/contact_info/response'
 
-describe ContactInfoSerializer do
+describe ContactInfoSerializer, type: :serializer do
   subject { serialize(contact_info_response, serializer_class: described_class) }
 
   let(:emails) { [{ address: 'test@test.com', dupe: 'false' }] }

--- a/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/eligibility_serializer_spec.rb
@@ -3,42 +3,28 @@
 require 'rails_helper'
 require 'dgi/eligibility/eligibility_response'
 
-describe EligibilitySerializer do
+describe EligibilitySerializer, type: :serializer do
+  subject { serialize(eligibility_response, serializer_class: described_class) }
+
+  let(:eligibility) do
+    [
+      { veteran_is_eligible: true, chapter: 'Chapter33' },
+      { veteran_is_eligible: false, chapter: 'Chapter30' },
+      { veteran_is_eligible: false, chapter: 'Chapter1606' }
+    ]
+  end
   let(:eligibility_response) do
-    response = double('response', body: [
-                        { veteran_is_eligible: true, chapter: 'Chapter33' },
-                        { veteran_is_eligible: false, chapter: 'Chapter30' },
-                        { veteran_is_eligible: false, chapter: 'Chapter1606' }
-                      ])
+    response = double('response', body: eligibility)
     MebApi::DGI::Eligibility::EligibilityResponse.new(201, response)
   end
-
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_eligibility_eligibility_responses',
-        attributes: {
-          eligibility: [
-            { veteran_is_eligible: true, chapter: 'Chapter33' },
-            { veteran_is_eligible: false, chapter: 'Chapter30' },
-            { veteran_is_eligible: false, chapter: 'Chapter1606' }
-          ]
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(eligibility_response, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :eligibility' do
-    expect(rendered_attributes[:eligibility]).to eq expected_response[:data][:attributes][:eligibility]
+    expect_data_eq(attributes['eligibility'], eligibility)
   end
 end

--- a/spec/support/serializer_spec_helper.rb
+++ b/spec/support/serializer_spec_helper.rb
@@ -24,9 +24,11 @@ module SerializerSpecHelper
   def determine_key_type(data)
     if data.is_a?(Array)
       first_element = data.find { |item| item.is_a?(Hash) }
-      return first_element.keys.first.is_a?(String) ? :string : :symbol if first_element
+      if first_element
+        first_element.keys.first.is_a?(String) ? :string : :symbol
+      end
     elsif data.is_a?(Hash)
-      return data.keys.first.is_a?(String) ? :string : :symbol
+      data.keys.first.is_a?(String) ? :string : :symbol
     end
   end
 

--- a/spec/support/serializer_spec_helper.rb
+++ b/spec/support/serializer_spec_helper.rb
@@ -14,6 +14,31 @@ module SerializerSpecHelper
     expect(serialized_time).to eq(time.iso8601(3))
   end
 
+  def expect_data_eq(serialized_data, data)
+    expect(serialized_data).to eq(normalize_data(data))
+  end
+
+  private
+
+  def normalize_data(data)
+    case data
+    when Hash
+      normalize_hash_keys(data)
+    when Array
+      data.map { |item| normalize_data(item) }
+    else
+      data
+    end
+  end
+
+  def normalize_hash_keys(hash)
+    if hash.keys.first.is_a?(String)
+      hash.deep_symbolize_keys
+    else
+      hash.deep_stringify_keys
+    end
+  end
+
   def serializer_with_ams(serializer_class, obj, opts = {})
     serializer = serializer_class.send(:new, obj, opts)
     adapter = ActiveModelSerializers::Adapter.create(serializer, opts)


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in modules/meb_api.
    - `EducationBenefitsController` related serializers 
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85754

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Screenshots

![Screenshot 2024-06-24 at 4 25 10 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/be3e656d-987e-4050-9cb4-bd72abfcc918)

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage