### PR TITLE
Replace MebApi AMS serializers with JSONAPI serializers - Part 2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -743,6 +743,7 @@ config/initializers/freeze_schemas.rb @department-of-veterans-affairs/vfs-10-10 
 config/initializers/httpi.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/ial.rb @department-of-veterans-affairs/octo-identity
 config/initializers/inflections.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+config/initializers/jsonapi_serializer_blank_id_patch.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/kms_encrypted.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/loa.rb @department-of-veterans-affairs/octo-identity
 config/initializers/lockbox.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/initializers/jsonapi_serializer_blank_id_patch.rb
+++ b/config/initializers/jsonapi_serializer_blank_id_patch.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module FastJsonapi
+  module SerializationCore
+    class_methods do
+      def id_hash(id, record_type, default_return = false) # rubocop:disable Style/OptionalBooleanParameter
+        if id.present?
+          { id: id.to_s, type: record_type }
+        elsif id == ''
+          { id: '', type: record_type }
+        else
+          default_return ? { id: nil, type: record_type } : nil
+        end
+      end
+    end
+  end
+end

--- a/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
@@ -91,7 +91,7 @@ module MebApi
           }
         else
           response = enrollment_service.get_enrollment(claimant_id)
-          render json: response, serializer: EnrollmentSerializer
+          render json: EnrollmentSerializer.new(response)
         end
       end
 
@@ -119,7 +119,7 @@ module MebApi
           response = enrollment_service.submit_enrollment(
             params[:education_benefit], claimant_id
           )
-          render json: response, serializer: SubmitEnrollmentSerializer
+          render json: SubmitEnrollmentSerializer.new(response)
         end
       end
 
@@ -133,7 +133,7 @@ module MebApi
         claimant_id = claimant_response['claimant_id']
         exclusion_response = exclusion_period_service.get_exclusion_periods(claimant_id)
 
-        render json: exclusion_response, serializer: ExclusionPeriodSerializer
+        render json: ExclusionPeriodSerializer.new(exclusion_response)
       end
 
       private

--- a/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
@@ -41,13 +41,13 @@ module MebApi
       def claimant_info
         response = claimant_service.get_claimant_info('toe')
 
-        render json: response, serializer: ToeClaimantInfoSerializer
+        render json: ToeClaimantInfoSerializer.new(response)
       end
 
       def sponsors
         response = sponsor_service.post_sponsor
 
-        render json: response, serializer: SponsorsSerializer
+        render json: SponsorsSerializer.new(response)
       end
 
       def submit_claim

--- a/modules/meb_api/app/serializers/enrollment_serializer.rb
+++ b/modules/meb_api/app/serializers/enrollment_serializer.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-class EnrollmentSerializer < ActiveModel::Serializer
-  attribute :enrollment_verifications
-  attribute :last_certified_through_date
-  attribute :payment_on_hold
+class EnrollmentSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  attributes :enrollment_verifications, :last_certified_through_date, :payment_on_hold
+
+  set_id { '' }
 end

--- a/modules/meb_api/app/serializers/exclusion_period_serializer.rb
+++ b/modules/meb_api/app/serializers/exclusion_period_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class ExclusionPeriodSerializer < ActiveModel::Serializer
+class ExclusionPeriodSerializer
+  include JSONAPI::Serializer
+
   attribute :exclusion_periods
 
-  def id
-    nil
-  end
+  set_id { '' }
 end

--- a/modules/meb_api/app/serializers/sponsors_serializer.rb
+++ b/modules/meb_api/app/serializers/sponsors_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class SponsorsSerializer < ActiveModel::Serializer
+class SponsorsSerializer
+  include JSONAPI::Serializer
+
   attribute :sponsors
 
-  def id
-    nil
-  end
+  set_id { '' }
 end

--- a/modules/meb_api/app/serializers/submission_serializer.rb
+++ b/modules/meb_api/app/serializers/submission_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class SubmissionSerializer < ActiveModel::Serializer
+class SubmissionSerializer
+  include JSONAPI::Serializer
+
   attribute :education_benefit
 
-  def id
-    nil
-  end
+  set_id { '' }
 end

--- a/modules/meb_api/app/serializers/submit_enrollment_serializer.rb
+++ b/modules/meb_api/app/serializers/submit_enrollment_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class SubmitEnrollmentSerializer < ActiveModel::Serializer
+class SubmitEnrollmentSerializer
+  include JSONAPI::Serializer
+
   attribute :enrollment_certify_responses
 
-  def id
-    nil
-  end
+  set_id { '' }
 end

--- a/modules/meb_api/app/serializers/toe_claimant_info_serializer.rb
+++ b/modules/meb_api/app/serializers/toe_claimant_info_serializer.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-class ToeClaimantInfoSerializer < ActiveModel::Serializer
-  attribute :claimant
-  attribute :service_data
-  attribute :toe_sponsors
+class ToeClaimantInfoSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  attributes :claimant, :service_data, :toe_sponsors
+
+  set_id { '' }
 end

--- a/modules/meb_api/spec/serializers/enrollement_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/enrollement_serializer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'dgi/enrollment/enrollment_response'
 
-describe EnrollmentSerializer do
+describe EnrollmentSerializer, type: :serializer do
+  subject { serialize(eligibility_response, serializer_class: described_class) }
+
   let(:enrollment_verifications) do
     [{ 'verification_month' => 'January 2021',
        'certified_begin_date' => '2021-01-01',
@@ -19,58 +21,33 @@ describe EnrollmentSerializer do
        'verification_response' => 'NR',
        'created_date' => nil }]
   end
-
+  let(:last_certified_through_date) { '2021-01-01' }
+  let(:payment_on_hold) { true }
   let(:eligibility_response) do
-    response = double('response', status: 201, body: { 'enrollment_verifications' => enrollment_verifications })
+    response = double('response', status: 201, body: {
+                        'enrollment_verifications' => enrollment_verifications,
+                        'last_certified_through_date' => last_certified_through_date,
+                        'payment_on_hold' => payment_on_hold
+                      })
     MebApi::DGI::Enrollment::Response.new(response)
   end
 
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_enrollment_responses',
-        attributes: {
-          enrollment_verifications: [{
-            verification_month: 'January 2021', certified_begin_date: '2021-01-01',
-            certified_end_date: '2021-01-31', certified_through_date: nil, certification_method: nil,
-            enrollments: [
-              {
-                facility_name: 'UNIVERSITY OF HAWAII AT HILO',
-                begin_date: '2020-01-01',
-                end_date: '2021-01-01',
-                total_credit_hours: 17.0
-              }
-            ],
-            verification_response: 'NR', created_date: nil
-          }],
-          last_certified_through_date: nil,
-          payment_on_hold: nil
-        }
-      }
-    }.deep_stringify_keys
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(eligibility_response, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :enrollment_verifications' do
-    expect_enrollment_verifications = expected_response['data']['attributes']['enrollment_verifications']
-    expect(rendered_attributes[:enrollment_verifications]).to eq expect_enrollment_verifications
+    expect_data_eq(attributes['enrollment_verifications'], enrollment_verifications)
   end
 
   it 'includes :last_certified_through_date' do
-    expected_last_certified_through_date = expected_response['data']['attributes']['last_certified_through_date']
-    expect(rendered_attributes[:last_certified_through_date]).to eq expected_last_certified_through_date
+    expect(attributes['last_certified_through_date']).to eq last_certified_through_date
   end
 
   it 'includes :payment_on_hold' do
-    expect(rendered_attributes[:payment_on_hold]).to eq expected_response['data']['attributes']['payment_on_hold']
+    expect(attributes['payment_on_hold']).to eq payment_on_hold
   end
 end

--- a/modules/meb_api/spec/serializers/exclusion_period_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/exclusion_period_serializer_spec.rb
@@ -3,34 +3,22 @@
 require 'rails_helper'
 require 'dgi/exclusion_period/response'
 
-describe ExclusionPeriodSerializer do
-  let(:exclusion_period) do
-    response = double('response', status: 201, body: { 'exclusion_periods' => %w[ROTC NoPayDate] })
+describe ExclusionPeriodSerializer, type: :serializer do
+  subject { serialize(exclusion_period_response, serializer_class: described_class) }
+
+  let(:exclusion_periods) { %w[ROTC NoPayDate] }
+  let(:exclusion_period_response) do
+    response = double('response', status: 201, body: { 'exclusion_periods' => exclusion_periods })
     MebApi::DGI::ExclusionPeriod::Response.new(response)
   end
-
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_exclusion_period_responses',
-        attributes: {
-          exclusion_periods: %w[ROTC NoPayDate]
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(exclusion_period, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
-  it 'includes :exclusion_periods' do
-    expect(rendered_attributes[:exclusion_periods]).to eq expected_response[:data][:attributes][:exclusion_periods]
+  it 'includes :enrollment_verifications' do
+    expect_data_eq(attributes['exclusion_periods'], exclusion_periods)
   end
 end

--- a/modules/meb_api/spec/serializers/sponsors_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/sponsors_serializer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'dgi/forms/response/sponsor_response'
 
-describe SponsorsSerializer do
+describe SponsorsSerializer, type: :serializer do
+  subject { serialize(sponsors_response, serializer_class: described_class) }
+
   let(:sponsors) do
     [
       {
@@ -19,36 +21,14 @@ describe SponsorsSerializer do
     response = double('response', status: 201, body: sponsors)
     MebApi::DGI::Forms::Response::SponsorResponse.new(response)
   end
-
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_exclusion_period_responses',
-        attributes: {
-          sponsors: [
-            {
-              'first_name' => 'Rodrigo',
-              'last_name' => 'Diaz',
-              'sponsor_relationship' => 'Spouse',
-              'date_of_birth' => '06/12/1975'
-            }
-          ]
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(sponsors_response, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
-  it 'includes :sponsors' do
-    expect(rendered_attributes[:sponsors]).to eq expected_response[:data][:attributes][:sponsors]
+  it 'includes :enrollment_verifications' do
+    expect_data_eq(attributes['sponsors'], sponsors)
   end
 end

--- a/modules/meb_api/spec/serializers/submit_enrollment_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/submit_enrollment_serializer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'dgi/enrollment/submit_enrollment_response'
 
-describe SubmitEnrollmentSerializer do
+describe SubmitEnrollmentSerializer, type: :serializer do
+  subject { serialize(submit_enrollment_response, serializer_class: described_class) }
+
   let(:enrollment_certifys) do
     [
       { 'claimant_id' => 600_000_000, 'certified_period_begin_date' => '2020-02-01',
@@ -20,37 +22,14 @@ describe SubmitEnrollmentSerializer do
     MebApi::DGI::SubmitEnrollment::Response.new(response)
   end
 
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_exclusion_period_responses',
-        attributes: {
-          enrollment_certify_responses: [
-            { 'claimant_id' => 600_000_000, 'certified_period_begin_date' => '2020-02-01',
-              'certified_period_end_date' => '2020-02-31', 'certified_through_date' => '2022-01-31',
-              'certification_method' => 'MEB' },
-            { 'claimant_id' => 600_000_000, 'certified_period_begin_date' => '2020-01-01',
-              'certified_period_end_date' => '2020-01-31', 'certified_through_date' => '2022-01-31',
-              'certification_method' => 'MEB' }
-          ]
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(submit_enrollment_response,
-                                                     { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :enrollment_certify_responses' do
-    enrollment_certify_responses = expected_response[:data][:attributes][:enrollment_certify_responses]
-    expect(rendered_attributes[:enrollment_certify_responses]).to eq enrollment_certify_responses
+    expect_data_eq(attributes['enrollment_certify_responses'], enrollment_certifys)
   end
 end

--- a/modules/meb_api/spec/serializers/toe_claimant_info_serializer_spec.rb
+++ b/modules/meb_api/spec/serializers/toe_claimant_info_serializer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'dgi/forms/response/claimant_info_response'
 
-describe ToeClaimantInfoSerializer do
+describe ToeClaimantInfoSerializer, type: :serializer do
+  subject { serialize(claimant_response, serializer_class: described_class) }
+
   let(:claimant) do
     {
       claimant_id: 0,
@@ -32,65 +34,42 @@ describe ToeClaimantInfoSerializer do
     }
   end
 
+  let(:service_data) do
+    [
+      {
+        branch_of_service: 'Air Force',
+        begin_date: '2010-06-01',
+        end_date: '2020-06-01',
+        character_of_service: 'Honorable',
+        reason_for_separation: 'Expiration Term Of Service',
+        exclusion_periods: [],
+        training_periods: []
+      }
+    ]
+  end
+
   let(:claimant_response) do
-    body = { 'claimant' => claimant, 'service_data' => nil, 'toe_sponsors' => toe_sponsors }
+    body = { 'claimant' => claimant, 'service_data' => service_data, 'toe_sponsors' => toe_sponsors }
     response = double('response', body:)
     MebApi::DGI::Forms::ClaimantResponse.new(200, response)
   end
 
-  let(:expected_response) do
-    {
-      data: {
-        id: '',
-        type: 'meb_api_dgi_forms_claimant_responses',
-        attributes: {
-          claimant: {
-            claimant_id: 0,
-            suffix: nil,
-            date_of_birth: '1992-04-01',
-            first_name: 'Black',
-            last_name: 'Johnson',
-            middle_name: 'Jet',
-            notification_method: 'NONE',
-            contact_info: nil,
-            preferred_contact: nil
-          },
-          service_data: [],
-          toe_sponsors: {
-            transfer_of_entitlements: [
-              {
-                fist_name: 'SEAN',
-                second_name: 'JOHNSON',
-                sponsor_relationship: 'Child',
-                sponsor_va_id: 1_000_000_077,
-                date_of_birth: '1971-05-24'
-              }
-            ]
-          }
-        }
-      }
-    }
-  end
-
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(claimant_response,
-                                                     { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :claimant' do
-    expect(rendered_attributes[:claimant]).to eq expected_response[:data][:attributes][:claimant]
+    expect_data_eq(attributes['claimant'], claimant)
   end
 
   it 'includes :service_data' do
-    expect(rendered_attributes[:service_data]).to eq expected_response[:data][:attributes][:service_data]
+    expect_data_eq(attributes['service_data'], service_data)
   end
 
   it 'includes :toe_sponsors' do
-    expect(rendered_attributes[:toe_sponsors]).to eq expected_response[:data][:attributes][:toe_sponsors]
+    expect_data_eq(attributes['toe_sponsors'], toe_sponsors)
   end
 end

--- a/spec/support/serializer_spec_helper.rb
+++ b/spec/support/serializer_spec_helper.rb
@@ -14,6 +14,44 @@ module SerializerSpecHelper
     expect(serialized_time).to eq(time.iso8601(3))
   end
 
+  def expect_data_eq(serialized_data, data)
+    key_type = determine_key_type(serialized_data)
+    expect(serialized_data).to eq(normalize_data(data, key_type))
+  end
+
+  private
+
+  def determine_key_type(data)
+    if data.is_a?(Array)
+      first_element = data.find { |item| item.is_a?(Hash) }
+      if first_element
+        first_element.keys.first.is_a?(String) ? :string : :symbol
+      end
+    elsif data.is_a?(Hash)
+      data.keys.first.is_a?(String) ? :string : :symbol
+    end
+  end
+
+  def normalize_data(data, key_type)
+    case data
+    when Hash
+      normalize_hash_keys(data, key_type)
+    when Array
+      data.map { |item| normalize_data(item, key_type) }
+    else
+      data
+    end
+  end
+
+  def normalize_hash_keys(hash, key_type)
+    case key_type
+    when :string
+      hash.deep_stringify_keys
+    when :symbol
+      hash.deep_symbolize_keys
+    end
+  end
+
   def serializer_with_ams(serializer_class, obj, opts = {})
     serializer = serializer_class.send(:new, obj, opts)
     adapter = ActiveModelSerializers::Adapter.create(serializer, opts)


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in modules/meb_api.
    - `FormsController` related serializers 
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85754

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Screenshots

![Screenshot 2024-06-24 at 5 22 31 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/134282106/3a7136d0-265e-4014-b5a2-26f5ac29822e)

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage