### PR TITLE
update error handling on backend submit to send proper HTTP response codes

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -23,12 +23,12 @@ module IvcChampva
 
           status, error_message = FileUploader.new(form_id, metadata, file_paths, attachment_ids, true).handle_uploads
 
-          render json: build_json(Array(status), error_message), status: status
+          render json: build_json(Array(status), error_message), status:
         rescue => e
           puts 'An unknown error occurred while uploading document(s).'
           Rails.logger.error "Error: #{e.message}"
           Rails.logger.error e.backtrace.join("\n")
-          render json: build_json([500, error_message], error_message), status: 500
+          render json: build_json([500, error_message], error_message), status: :internal_server_error
         end
       end
 

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -23,11 +23,12 @@ module IvcChampva
 
           status, error_message = FileUploader.new(form_id, metadata, file_paths, attachment_ids, true).handle_uploads
 
-          render json: build_json(Array(status), error_message)
+          render json: build_json(Array(status), error_message), status: status
         rescue => e
           puts 'An unknown error occurred while uploading document(s).'
           Rails.logger.error "Error: #{e.message}"
           Rails.logger.error e.backtrace.join("\n")
+          render json: build_json([500, error_message], error_message), status: 500
         end
       end
 


### PR DESCRIPTION
## Summary

This fixes an issue where all response codes returned form a form submission to IVC module result in either a 200 regardless of whether or not they should, or fail to send back the actual response and thus produce a `204 no content`, which slips through the frontend code check as a false positive (as it's in the 200 range). 

This PR updates the usage of `render` to explicitly include the proper response code, which allows the frontend (platform code) to respond to errors appropriately without needing to be modified.

- Updated usage of `render` in ivc module's `uploads_controller.rb`

### Before changes:

Previously, if we got an error on submit, we fell into a catch block that did not explicitly produce an HTTP response object. We just logged to the rails console and returned a 200 later down the line. This gave us a false positive on the backend. Here's a demonstration of dividing by zero to force what should be a 500:
| | |
|-|-|
|Division by zero in the BE code to force us into the rescue block|![Screenshot 2024-06-24 at 16 43 35](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/5113c37f-b97a-49ad-8070-7a8d5927de76)|
|Error appropriately logged to Rails console|![Screenshot 2024-06-24 at 16 27 48](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/ed23a7a6-3f39-4457-ba6c-78edf779bc7b)|
|204 returned to front end because no explicit HTTP response is set in the rescue block (a 500 would have been appropriate)|![Screenshot 2024-06-24 at 16 26 23](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/bfa5c784-3fb9-4781-bba6-92176f6c7f89)|
|204 is in the 200-code range, so it produces a success screen for the user (BAD)|![Screenshot 2024-06-24 at 16 25 21](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/5365ef13-d5aa-424a-8e63-11b11adff09f)|

### After changes made to `render`

| | |
|-|-|
|Division by zero in the BE code to force us into the rescue block where an explicit 500 status is set|![Screenshot 2024-06-24 at 16 49 05](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/6d894038-e3f5-4f7a-af0b-b5ef147a94fc)|
|Error appropriately logged to Rails console|![Screenshot 2024-06-24 at 16 27 48](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/ed23a7a6-3f39-4457-ba6c-78edf779bc7b)|
|500 returned to front end because of explicit HTTP response set in the rescue block|![Screenshot 2024-06-24 at 16 28 47](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/4ff82039-fef9-474a-9aed-a827e743a78b)|
|Front end informs user submission failed and stops the process|![Screenshot 2024-06-24 at 16 28 59](https://github.com/department-of-veterans-affairs/vets-api/assets/18408628/884dd4c1-4f4c-4fa7-8c6b-0b9df187f522)|

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
