### PR TITLE
[DBEX] create Form526SubmissionRemediation model with lifecycle tracking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -259,6 +259,7 @@ app/models/form1010cg/submission.rb @department-of-veterans-affairs/vfs-10-10 @d
 app/models/form1095_b.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/form526_job_status.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/form526_submission.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/form526_submission_remediation.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/form_attachment.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/form_profile.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/form_profiles @department-of-veterans-affairs/my-education-benefits  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1525,6 +1525,7 @@ spec/models/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-
 spec/models/form1095_b_spec.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form526_job_status_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form526_submission_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/models/form526_submission_remediation_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form_attachment_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form_profile_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form_submission_spec.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -153,6 +153,7 @@ class Form526Submission < ApplicationRecord
              inverse_of: false
 
   has_many :form526_job_statuses, dependent: :destroy
+  has_many :form526_submission_remediations, dependent: :destroy
   belongs_to :user_account, dependent: nil, optional: true
 
   validates(:auth_headers_json, presence: true)

--- a/app/models/form526_submission_remediation.rb
+++ b/app/models/form526_submission_remediation.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Form526SubmissionRemediation < ApplicationRecord
+  belongs_to :form526_submission
+
+  validates :lifecycle, presence: true, if: :new_or_changed?
+  validate :validate_context_on_create_update
+  validate :ensure_success_if_ignored_as_duplicate
+
+  before_create :initialize_lifecycle
+
+  STATSD_KEY_PREFIX = 'form526_submission_remediation'
+
+  def mark_as_unsuccessful(context)
+    self.success = false
+    if add_context_to_lifecycle(context)
+      save!
+      log_to_datadog(context)
+    end
+  end
+
+  private
+
+  def initialize_lifecycle
+    self.lifecycle ||= []
+  end
+
+  def validate_context_on_create_update
+    errors.add(:base, 'Context required for create/update actions') if lifecycle.empty? || lifecycle.last.blank?
+  end
+
+  def ensure_success_if_ignored_as_duplicate
+    errors.add(:success, 'must be true if ignored as duplicate') if ignored_as_duplicate && !success
+  end
+
+  def log_to_datadog(context)
+    StatsD.increment("#{STATSD_KEY_PREFIX} marked as unsuccessful: #{context}")
+  end
+
+  def add_context_to_lifecycle(context)
+    if context.is_a?(String) && context.strip.present?
+      self.lifecycle << "#{Time.current.strftime('%Y-%m-%d %H:%M:%S')} -- #{context}"
+      true
+    else
+      errors.add(:base, 'Context must be a non-empty string')
+      false
+    end
+  end
+
+  def new_or_changed?
+    new_record? || changed?
+  end
+end

--- a/spec/models/form526_submission_remediation_spec.rb
+++ b/spec/models/form526_submission_remediation_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Form526SubmissionRemediation, type: :model do
+  subject do
+    described_class.new(form526_submission:, lifecycle: [])
+  end
+
+  let(:form526_submission) { create(:form526_submission) }
+  let(:remediate_context) { 'Failed remediation' }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:form526_submission) }
+  end
+
+  describe 'validations' do
+    context 'lifecycle validation' do
+      it 'is invalid without context on create' do
+        expect(subject).not_to be_valid
+      end
+
+      it 'is invalid without context on update' do
+        subject.mark_as_unsuccessful(remediate_context)
+        subject.lifecycle << ''
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context 'ignored_as_duplicate validation' do
+      before do
+        subject.mark_as_unsuccessful(remediate_context)
+      end
+
+      it 'is invalid if ignored_as_duplicate is true and success is false' do
+        subject.ignored_as_duplicate = true
+        subject.success = false
+        expect(subject).not_to be_valid
+      end
+
+      it 'is valid if ignored_as_duplicate is true and success is true' do
+        subject.ignored_as_duplicate = true
+        subject.success = true
+        expect(subject).to be_valid
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    describe '#mark_as_unsuccessful' do
+      let(:timestamped_context) { "#{Time.current.strftime('%Y-%m-%d %H:%M:%S')} -- #{remediate_context}" }
+
+      it 'transitions the record to success: false' do
+        subject.mark_as_unsuccessful(remediate_context)
+        expect(subject.success).to be false
+      end
+
+      it 'adds timestamped context to lifecycle' do
+        subject.mark_as_unsuccessful(remediate_context)
+        expect(subject.lifecycle.last).to match(timestamped_context)
+      end
+
+      it 'logs the change to Datadog' do
+        allow(StatsD).to receive(:increment)
+
+        subject.mark_as_unsuccessful(remediate_context)
+
+        expect(StatsD).to have_received(:increment).with(
+          "#{Form526SubmissionRemediation::STATSD_KEY_PREFIX} marked as unsuccessful: #{remediate_context}"
+        )
+      end
+
+      it 'adds an error if context is not a non-empty string and does not update lifecycle' do
+        subject.save
+        original_lifecycle = subject.lifecycle.dup
+        subject.mark_as_unsuccessful('')
+
+        expect(subject.errors[:base]).to include('Context must be a non-empty string')
+        expect(subject.lifecycle).to eq(original_lifecycle)
+      end
+    end
+  end
+end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Form526Submission do
   end
   let(:submit_endpoint) { nil }
 
+  describe 'associations' do
+    it { is_expected.to have_many(:form526_submission_remediations) }
+  end
+
   describe 'submit_endpoint enum' do
     context 'when submit_endpoint is evss' do
       let(:submit_endpoint) { 'evss' }


### PR DESCRIPTION
## Summary

- Add `Form526SubmissionRemediation` model with associations and validations
- Add reciprocal association to `Form526Submission` model
- Construct `lifecycle` attribute as an array of hashes with timestamp and context
- Implement `mark_as_unsuccessful` method to update `success` and log context
- Ensure context validation in `add_context_to_lifecycle` method
- Include model validations for `form526_submission_id` and `lifecycle `context
- Subsequent PR will add scopes to `Form526Submission` model
- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86438
- [526 State Repair Technical Design Document
](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#a-create-a-form526submissionremediation-model)
- https://github.com/department-of-veterans-affairs/vets-api/pull/17208

## Testing done

- [x] *New code is covered by unit tests*
- Add spec to test associations, validations, and `mark_as_unsuccessful` method
- Ensure specs cover context validation and `lifecycle` updates

## What areas of the site does it impact?

Database records will never be created by application code. They will be created manually by a developer, most likely via a script at the time of remediation. 

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
