### PR TITLE
Obfuscate filenames in Form526DocumentUploadFailureEmail with Xs

### DIFF
--- a/app/models/supporting_evidence_attachment.rb
+++ b/app/models/supporting_evidence_attachment.rb
@@ -37,7 +37,10 @@ class SupportingEvidenceAttachment < FormAttachment
     filename_without_extension = original_filename.gsub(FILENAME_EXTENSION_MATCHER, '')
 
     if filename_without_extension.length > 5
-      obfuscated_portion = filename_without_extension[3..-3].gsub(OBFUSCATED_CHARACTER_MATCHER, '*')
+      # Obfuscate with the letter 'X'; we cannot obfuscate with special characters such as an asterisk,
+      # as these filenames appear in VA Notify Mailers and their templating engine uses markdown.
+      # Therefore, special characters can be interpreted as markdown and introduce formatting issues in the mailer
+      obfuscated_portion = filename_without_extension[3..-3].gsub(OBFUSCATED_CHARACTER_MATCHER, 'X')
       filename_without_extension[0..2] + obfuscated_portion + filename_without_extension[-2..] + extension
     else
       original_filename

--- a/spec/models/supporting_evidence_attachment_spec.rb
+++ b/spec/models/supporting_evidence_attachment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SupportingEvidenceAttachment, type: :model do
         end
 
         it 'obscures all but the first 3 and last 2 characters of the filename' do
-          expect(attachment.obscured_filename).to eq('MyS*******le.pdf')
+          expect(attachment.obscured_filename).to eq('MySXXXXXXXle.pdf')
         end
       end
 
@@ -27,7 +27,7 @@ RSpec.describe SupportingEvidenceAttachment, type: :model do
         end
 
         it 'obscures the filename' do
-          expect(attachment.obscured_filename).to eq('MyS**********23.pdf')
+          expect(attachment.obscured_filename).to eq('MySXXXXXXXXXX23.pdf')
         end
       end
 
@@ -40,7 +40,7 @@ RSpec.describe SupportingEvidenceAttachment, type: :model do
         end
 
         it 'does not obscure the underscores' do
-          expect(attachment.obscured_filename).to eq('MyS*********_*23.pdf')
+          expect(attachment.obscured_filename).to eq('MySXXXXXXXXX_X23.pdf')
         end
       end
 
@@ -53,7 +53,7 @@ RSpec.describe SupportingEvidenceAttachment, type: :model do
         end
 
         it 'does not obscure the dashes' do
-          expect(attachment.obscured_filename).to eq('MyS*********-*23.pdf')
+          expect(attachment.obscured_filename).to eq('MySXXXXXXXXX-X23.pdf')
         end
       end
 
@@ -67,7 +67,7 @@ RSpec.describe SupportingEvidenceAttachment, type: :model do
         end
 
         it 'obsucres the filename properly' do
-          expect(attachment.obscured_filename).to eq('MyS*****.*****23.pdf')
+          expect(attachment.obscured_filename).to eq('MySXXXXX.XXXXX23.pdf')
         end
       end
 
@@ -80,7 +80,7 @@ RSpec.describe SupportingEvidenceAttachment, type: :model do
         end
 
         it 'preserves the whitespace' do
-          expect(attachment.obscured_filename).to eq('My ****** **le.pdf')
+          expect(attachment.obscured_filename).to eq('My XXXXXX XXle.pdf')
         end
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe SupportingEvidenceAttachment, type: :model do
       end
 
       it 'obscures the original filename' do
-        expect(attachment.obscured_filename).to eq('Fil**23.pdf')
+        expect(attachment.obscured_filename).to eq('FilXX23.pdf')
       end
     end
   end

--- a/spec/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526DocumentUploadFailureEma
       form526_submission.created_at.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.')
     end
 
-    let(:obscured_filename) { 'sm_***e1.jpg' }
+    let(:obscured_filename) { 'sm_XXXe1.jpg' }
 
     it 'dispatches a failure notification email with an obscured filename' do
       expect(notification_client).to receive(:send_email).with(


### PR DESCRIPTION
## Summary

In https://github.com/department-of-veterans-affairs/vets-api/commit/dc0971632ad7c542ca4fe66f2e5c7ca30120bdf6, we added a new VA Notify mailer to send to a Veteran when a document they uploaded as evidence to support a Form 526 claim failed when we tried to upload it to EVSS. We needed to obscure a portion of the filename since it could contain PII and the mailer is not the most secure method of communicating with a veteran. Initially this was implemented with asterisks obscuring a portion of the filename.

This PR alters the filename masking  to obfuscate with the letter 'X' instead of an asterisk. It was discovered in testing we cannot obfuscate with special characters such as an asterisk, as these filenames appear in VA Notify Mailers and their templating engine uses markdown. Therefore, special characters can be interpreted as markdown and introduce formatting issues in the mailer:

<img width="747" alt="Screenshot 2024-06-20 at 1 54 31 PM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/8537428/1b331b1b-6621-4c44-a173-f1cdab005bf5">

I'm on the Benefits Disability team


## Related issue(s)
N/A

## Testing done

- [X] *New code is covered by unit tests*
This will be tested in staging as the initial implementation was to ensure the formatting issue is fixed and to obtain a screenshot for the privacy officer approval process and product guide




## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [X]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

N/A