### PR TITLE
Check for LOA3 on 21-0966 to send to ITF API

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -177,7 +177,7 @@ module SimpleFormsApi
       end
 
       def loa3
-        @current_user&.loa&[:current] == 3
+        @current_user&.loa&.[](:current) == 3
       end
 
       def icn

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -9,7 +9,7 @@ module SimpleFormsApi
     class UploadsController < ApplicationController
       skip_before_action :authenticate
       before_action :authenticate, if: :should_authenticate
-      before_action :mpi_proxy, if: :form_is210966_and_should_use_itf_api
+      before_action :mpi_proxy, if: :use_itf_api_for_210966_form?
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {
@@ -32,7 +32,7 @@ module SimpleFormsApi
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
 
-        response = if form_is210966_and_should_use_itf_api
+        response = if use_itf_api_for_210966_form?
                      handle_210966_authenticated
                    elsif form_is264555_and_should_use_lgy_api
                      handle264555
@@ -163,7 +163,7 @@ module SimpleFormsApi
         params[:form_number] == '21-0966'
       end
 
-      def form_is210966_and_should_use_itf_api
+      def use_itf_api_for_210966_form?
         form_is210966 && loa3 && icn && first_party?
       end
 

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -32,7 +32,7 @@ module SimpleFormsApi
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
 
-        response = if form_is210966 && first_party?
+        response = if form_is210966 && loa3 && icn && first_party?
                      handle_210966_authenticated
                    elsif form_is264555_and_should_use_lgy_api
                      handle264555
@@ -170,6 +170,10 @@ module SimpleFormsApi
 
       def should_authenticate
         true unless UNAUTHENTICATED_FORMS.include? params[:form_number]
+      end
+
+      def loa3
+        @current_user&.loa&[:current] == 3
       end
 
       def icn

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -9,7 +9,7 @@ module SimpleFormsApi
     class UploadsController < ApplicationController
       skip_before_action :authenticate
       before_action :authenticate, if: :should_authenticate
-      before_action :mpi_proxy, if: :form_is210966
+      before_action :mpi_proxy, if: :form_is210966_and_should_use_itf_api
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {
@@ -32,7 +32,7 @@ module SimpleFormsApi
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
 
-        response = if form_is210966 && loa3 && icn && first_party?
+        response = if form_is210966_and_should_use_itf_api
                      handle_210966_authenticated
                    elsif form_is264555_and_should_use_lgy_api
                      handle264555
@@ -161,6 +161,10 @@ module SimpleFormsApi
 
       def form_is210966
         params[:form_number] == '21-0966'
+      end
+
+      def form_is210966_and_should_use_itf_api
+        form_is210966 && loa3 && icn && first_party?
       end
 
       def form_is264555_and_should_use_lgy_api


### PR DESCRIPTION
## Summary
This is a stopgap measure because we're getting lots of failures on this form. I don't totally understand what's going on with LOA3 vs ICN vs EDIPI etc but I want to send less traffic to the Intent to File API. Hopefully if the user passes the mpi proxy, has an ICN and is LOA3 then there should not be an error at the ITF API.
