### PR TITLE
[API-34409] Skip BGS calls in lower environments for POA requests

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -693,6 +693,10 @@ features:
     actor_type: user
     description: Enables ability to log letter discrepancies between evss and lighthouse
     enable_in_development: true
+  lighthouse_claims_v2_poa_requests_skip_bgs:
+    actor_type: user
+    description: Enable/disable skipping BGS calls for POA Requests
+    enable_in_development: true
   loop_pages:
     actor_type: user
     description: Enable new list loop pattern

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -25,8 +25,8 @@ module ClaimsApi
 
           bgs_form_attributes = build_bgs_attributes(form_attributes)
 
-          # skip the BGS API calls in sandbox to prevent 3rd parties from creating data in external systems
-          unless sandbox?
+          # skip the BGS API calls in lower environments to prevent 3rd parties from creating data in external systems
+          unless Flipper.enabled?(:lighthouse_claims_v2_poa_requests_skip_bgs)
             ClaimsApi::PowerOfAttorneyRequestService::Orchestrator.new(target_veteran.participant_id,
                                                                        bgs_form_attributes.deep_symbolize_keys,
                                                                        user_profile&.profile&.participant_id,
@@ -107,10 +107,6 @@ module ClaimsApi
               'organizationName' => @organization.name
             }
           }
-        end
-
-        def sandbox?
-          Settings.claims_api.claims_error_reporting.environment_name&.downcase.eql? 'sandbox'
         end
       end
     end

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -23,15 +23,15 @@ module ClaimsApi
                   @claims_api_forms_validation_errors
           end
 
-          bgs_form_attributes = form_attributes.deep_merge(veteran_data)
-          bgs_form_attributes.deep_merge!(claimant_data) if user_profile&.status == :ok
-          bgs_form_attributes.deep_merge!(representative_data)
-          bgs_form_attributes.deep_merge!(organization_data) if @organization
+          bgs_form_attributes = build_bgs_attributes(form_attributes)
 
-          ClaimsApi::PowerOfAttorneyRequestService::Orchestrator.new(target_veteran.participant_id,
-                                                                     bgs_form_attributes.deep_symbolize_keys,
-                                                                     user_profile&.profile&.participant_id,
-                                                                     :poa).submit_request
+          # skip the BGS API calls in sandbox to prevent 3rd parties from creating data in external systems
+          unless sandbox?
+            ClaimsApi::PowerOfAttorneyRequestService::Orchestrator.new(target_veteran.participant_id,
+                                                                       bgs_form_attributes.deep_symbolize_keys,
+                                                                       user_profile&.profile&.participant_id,
+                                                                       :poa).submit_request
+          end
 
           # return only the form information consumers provided
           render json: { data: { attributes: form_attributes } }, status: :created
@@ -57,6 +57,15 @@ module ClaimsApi
           # organization is not required. An attorney or claims agent appointment request would not have an accredited
           #   organization to associate with.
           @organization = ::Veteran::Service::Organization.find_by(poa: poa_code)
+        end
+
+        def build_bgs_attributes(form_attributes)
+          bgs_form_attributes = form_attributes.deep_merge(veteran_data)
+          bgs_form_attributes.deep_merge!(claimant_data) if user_profile&.status == :ok
+          bgs_form_attributes.deep_merge!(representative_data)
+          bgs_form_attributes.deep_merge!(organization_data) if @organization
+
+          bgs_form_attributes
         end
 
         def veteran_data
@@ -98,6 +107,10 @@ module ClaimsApi
               'organizationName' => @organization.name
             }
           }
+        end
+
+        def sandbox?
+          Settings.claims_api.claims_error_reporting.environment_name&.downcase.eql? 'sandbox'
         end
       end
     end

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_new_poa_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_new_poa_request_spec.rb
@@ -144,20 +144,45 @@ RSpec.describe 'Power Of Attorney Request Controller', type: :request do
                           'power_of_attorney', 'request_representative', 'valid.json').read
         end
 
-        it 'responds with created status and the original request body' do
-          VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
-            mock_ccg(scopes) do |auth_header|
-              # the final return from BGS does not matter at this point in time, the calls need only to succeed
-              allow_any_instance_of(ClaimsApi::PowerOfAttorneyRequestService::Orchestrator)
-                .to receive(:submit_request)
-                .and_return(true)
+        context 'sandbox environment' do
+          let(:request_body) do
+            Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                            'power_of_attorney', 'request_representative', 'valid_no_claimant.json').read
+          end
 
-              post request_path, params: request_body, headers: auth_header
+          it 'does not call the Orchestrator' do
+            with_settings(Settings.claims_api.claims_error_reporting, environment_name: 'sandbox') do
+              mock_ccg(scopes) do |auth_header|
+                expect_any_instance_of(ClaimsApi::PowerOfAttorneyRequestService::Orchestrator)
+                  .not_to receive(:submit_request)
 
-              response_body = JSON.parse(response.body)
+                post request_path, params: request_body, headers: auth_header
 
-              expect(response).to have_http_status(:created)
-              expect(response_body).to eq(JSON.parse(request_body))
+                response_body = JSON.parse(response.body)
+
+                expect(response).to have_http_status(:created)
+                expect(response_body).to eq(JSON.parse(request_body))
+              end
+            end
+          end
+        end
+
+        context 'non-sandbox environment' do
+          it 'responds with created status and the original request body' do
+            VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
+              mock_ccg(scopes) do |auth_header|
+                # the final return from BGS does not matter at this point in time, the calls need only to succeed
+                allow_any_instance_of(ClaimsApi::PowerOfAttorneyRequestService::Orchestrator)
+                  .to receive(:submit_request)
+                  .and_return(true)
+
+                post request_path, params: request_body, headers: auth_header
+
+                response_body = JSON.parse(response.body)
+
+                expect(response).to have_http_status(:created)
+                expect(response_body).to eq(JSON.parse(request_body))
+              end
             end
           end
         end


### PR DESCRIPTION
## Summary

- This pr adds a feature flag to the new poa request controller to skip BGS calls in lower environments

## Related issue(s)

- [API-34409](https://jira.devops.va.gov/browse/API-34409)

## Testing done

- [x] *New code is covered by unit tests*
- Tested locally in Postman. Manually update the feature flag and compare requests. When `true`, the request should take ~0.5s instead of 20-30s and there should be no activity in the BGS forward proxy terminal.

## What areas of the site does it impact?
Impacts POA requests in environments where this flag is set to `true`

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature