### PR TITLE
Only trigger build & deploy if code checks pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
 jobs:
   build_and_push:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Build and Push
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
@@ -45,7 +46,7 @@ jobs:
           cache-to: type=inline
   deploy:
     needs: build_and_push
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: department-of-veterans-affairs/vets-api/.github/workflows/deploy-template.yml@master
     with:
       ecr_repository: "vets-api"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
     types: [completed]
 jobs:
   deploy:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: department-of-veterans-affairs/vets-api/.github/workflows/deploy-template.yml@master
     with:
       ecr_repository: "vets-api"


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

We were mistaken on the workflow run config for the GHA. For the following, on completed will run the build and deploy even if the Code checks fail. We only want these to run if the Code Checks runs are successful. This conditional logic was taken from the [Github docs.
](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#limiting-your-workflow-to-run-based-on-branches)
```  
  workflow_run:
    workflows: ["Code Checks"]
    branches: [master]
    types: [completed]
```

