### PR TITLE
[DBEX] add backup_submitted_claim_status to Form526Submission

### DIFF
--- a/db/migrate/20240625180946_add_backup_submitted_claim_status_to_form526_submission.rb
+++ b/db/migrate/20240625180946_add_backup_submitted_claim_status_to_form526_submission.rb
@@ -1,0 +1,5 @@
+class AddBackupSubmittedClaimStatusToForm526Submission < ActiveRecord::Migration[7.1]
+  def change
+    add_column :form526_submissions, :backup_submitted_claim_status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_21_200006) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_180946) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -709,6 +709,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_21_200006) do
     t.string "backup_submitted_claim_id", comment: "*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.This column will be nil for all submissions where a backup submission is not generated.It will have the central mail id for submissions where a backup submission is submitted."
     t.string "aasm_state", default: "unprocessed"
     t.integer "submit_endpoint"
+    t.integer "backup_submitted_claim_status"
     t.index ["saved_claim_id"], name: "index_form526_submissions_on_saved_claim_id", unique: true
     t.index ["submitted_claim_id"], name: "index_form526_submissions_on_submitted_claim_id", unique: true
     t.index ["user_account_id"], name: "index_form526_submissions_on_user_account_id"


### PR DESCRIPTION
## Summary

- Adds `backup_submitted_claim_status` attribute to `Form526Submission`
- This enum will have 3 allowed values – `:accepted`, `:rejected` and `nil` (default)
- A subsequent PR will define the enum within the model
- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86438
- [526 State Repair Technical Design Document
](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#b-add-backup_submitted_claim_status-enum-to-the-form526submission-model)

## Testing done

- Nothing to test

## What areas of the site does it impact?

Database records will never be created by application code. They will be created manually by a developer, most likely via a script at the time of remediation.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
