### PR TITLE
[FSR] 84473 - Defaulting fsr_5655_server_side_transform to true in dev envs

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -471,7 +471,7 @@ features:
   fsr_5655_server_side_transform:
     actor_type: user
     description: Update to use BE for business transform logic for Financial Status Report (FSR - 5655) form
-    enable_in_development: false
+    enable_in_development: true
   financial_status_report_debts_api_module:
     actor_type: user
     description: Points to debts-api module routes


### PR DESCRIPTION
## Summary
Defaulting `fsr_5655_server_side_transform` to `true`  now that the enpoint is active

- Undoing the previous falsey from here
department-of-veterans-affairs/vets-api/pull/17187

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#84473

- Feature flag implementation:
department-of-veterans-affairs/vets-website#30334
department-of-veterans-affairs/vets-api/pull/17107

- Using new endpoint PR
department-of-veterans-affairs/vets-website#30400

## Testing done
Local testing complete. `fsr_5655_server_side_transform` is false by default

## Screenshots
N/A

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
