### PR TITLE
[397] Allowing sign in service JWT decoding to use multiple certs when decoding objects

### DIFF
--- a/app/services/sign_in/access_token_jwt_decoder.rb
+++ b/app/services/sign_in/access_token_jwt_decoder.rb
@@ -32,7 +32,7 @@ module SignIn
     def jwt_decode_access_token(with_validation)
       decoded_jwt = JWT.decode(
         access_token_jwt,
-        private_key,
+        decode_key_array,
         with_validation,
         {
           verify_expiration: with_validation,
@@ -48,8 +48,18 @@ module SignIn
       raise Errors::AccessTokenMalformedJWTError.new message: 'Access token JWT is malformed'
     end
 
-    def private_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key))
+    def decode_key_array
+      [public_key, public_key_old].compact
+    end
+
+    def public_key
+      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key
+    end
+
+    def public_key_old
+      return unless Settings.sign_in.jwt_old_encode_key
+
+      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)).public_key
     end
   end
 end

--- a/app/services/sign_in/service_account_access_token_jwt_decoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_decoder.rb
@@ -26,7 +26,7 @@ module SignIn
     def jwt_decode_service_account_access_token(with_validation)
       decoded_jwt = JWT.decode(
         service_account_access_token_jwt,
-        private_key,
+        decode_key_array,
         with_validation,
         {
           verify_expiration: with_validation,
@@ -44,8 +44,18 @@ module SignIn
       raise Errors::AccessTokenMalformedJWTError.new message: 'Service Account access token JWT is malformed'
     end
 
-    def private_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key))
+    def decode_key_array
+      [public_key, public_key_old].compact
+    end
+
+    def public_key
+      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key
+    end
+
+    def public_key_old
+      return unless Settings.sign_in.jwt_old_encode_key
+
+      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)).public_key
     end
   end
 end

--- a/app/services/sign_in/state_payload_jwt_decoder.rb
+++ b/app/services/sign_in/state_payload_jwt_decoder.rb
@@ -32,7 +32,7 @@ module SignIn
         with_validation = true
         decoded_jwt = JWT.decode(
           state_payload_jwt,
-          private_key,
+          decode_key_array,
           with_validation,
           {
             algorithm: Constants::Auth::JWT_ENCODE_ALGORITHM
@@ -46,8 +46,18 @@ module SignIn
       raise Errors::StatePayloadMalformedJWTError.new message: 'State JWT is malformed'
     end
 
-    def private_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key))
+    def decode_key_array
+      [public_key, public_key_old].compact
+    end
+
+    def public_key
+      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key
+    end
+
+    def public_key_old
+      return unless Settings.sign_in.jwt_old_encode_key
+
+      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)).public_key
     end
   end
 end


### PR DESCRIPTION
## Summary

- This PR adds the ability for sign in service token decoding, state payload decoding, and service account decoding to utilize a current and deprecated certificate in order to facilitate seamless cert rotation


## Related issue(s)

- https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/zh/397

## Testing done

- Authenticated with Sign in Service, rotated the `Settings.sign_in.jwt_encode_key` cert, confirmed the authentication (and access token) was still valid

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- Create an access token by authenticating with sign in service
- Update `settings.yml` so that `jwt_encode_key` has a new key, but `jwt_old_encode_key` points to the key that originally created the access token
- Access an authenticated endpoint to confirm the access token is still valid
