### PR TITLE
Implement fallback for when Intent API is down

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -104,9 +104,7 @@ module SimpleFormsApi
         } }
       rescue Common::Exceptions::UnprocessableEntity
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
-        params['veteran_full_name'] ||= { 'first' => params['full_name']['first'], 'last' => params['full_name']['last'] }
-        params['veteran_id'] ||= { 'ssn' => params['ssn'] }
-        params['veteran_mailing_address'] ||= { 'postal_code' => @current_user.address[:postal_code] || '00000' }
+        prepare_params_for_central_mail
         submit_form_to_central_mail
       end
 
@@ -201,6 +199,15 @@ module SimpleFormsApi
         json[:expiration_date] = 1.year.from_now if form_id == 'vba_21_0966'
 
         json
+      end
+
+      def prepare_params_for_central_mail
+        params['veteran_full_name'] ||= {
+          'first' => params['full_name']['first'],
+          'last' => params['full_name']['last']
+        }
+        params['veteran_id'] ||= { 'ssn' => params['ssn'] }
+        params['veteran_mailing_address'] ||= { 'postal_code' => @current_user.address[:postal_code] || '00000' }
       end
     end
   end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -95,7 +95,7 @@ module SimpleFormsApi
           ).send
         end
 
-        json_for_210966(confirmation_number, expiration_date, existing_intents)
+        json_for210966(confirmation_number, expiration_date, existing_intents)
       rescue Common::Exceptions::UnprocessableEntity
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
         prepare_params_for_central_mail
@@ -204,7 +204,7 @@ module SimpleFormsApi
         params['veteran_mailing_address'] ||= { 'postal_code' => @current_user.address[:postal_code] || '00000' }
       end
 
-      def json_for_210966(confirmation_number, expiration_date, existing_intents)
+      def json_for210966(confirmation_number, expiration_date, existing_intents)
         { json: {
           confirmation_number:,
           expiration_date:,

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -157,7 +157,7 @@ module SimpleFormsApi
       end
 
       def use_itf_api_for_210966_form?
-        form_is210966 && loa3 && icn && first_party?
+        form_is210966 && icn && first_party?
       end
 
       def form_is264555_and_should_use_lgy_api
@@ -167,10 +167,6 @@ module SimpleFormsApi
 
       def should_authenticate
         true unless UNAUTHENTICATED_FORMS.include? params[:form_number]
-      end
-
-      def loa3
-        @current_user&.loa&.[](:current) == 3
       end
 
       def icn

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -95,13 +95,7 @@ module SimpleFormsApi
           ).send
         end
 
-        { json: {
-          confirmation_number:,
-          expiration_date:,
-          compensation_intent: existing_intents['compensation'],
-          pension_intent: existing_intents['pension'],
-          survivor_intent: existing_intents['survivor']
-        } }
+        210966_json(confirmation_number, expiration_date, existing_intents)
       rescue Common::Exceptions::UnprocessableEntity
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
         prepare_params_for_central_mail
@@ -208,6 +202,16 @@ module SimpleFormsApi
         }
         params['veteran_id'] ||= { 'ssn' => params['ssn'] }
         params['veteran_mailing_address'] ||= { 'postal_code' => @current_user.address[:postal_code] || '00000' }
+      end
+
+      def 210966_json(confirmation_number, expiration_date, existing_intents)
+        { json: {
+          confirmation_number:,
+          expiration_date:,
+          compensation_intent: existing_intents['compensation'],
+          pension_intent: existing_intents['pension'],
+          survivor_intent: existing_intents['survivor']
+        } }
       end
     end
   end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -95,7 +95,7 @@ module SimpleFormsApi
           ).send
         end
 
-        210966_json(confirmation_number, expiration_date, existing_intents)
+        json_for_210966(confirmation_number, expiration_date, existing_intents)
       rescue Common::Exceptions::UnprocessableEntity
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
         prepare_params_for_central_mail
@@ -204,7 +204,7 @@ module SimpleFormsApi
         params['veteran_mailing_address'] ||= { 'postal_code' => @current_user.address[:postal_code] || '00000' }
       end
 
-      def 210966_json(confirmation_number, expiration_date, existing_intents)
+      def json_for_210966(confirmation_number, expiration_date, existing_intents)
         { json: {
           confirmation_number:,
           expiration_date:,

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -148,8 +148,6 @@ RSpec.describe 'Forms uploader', type: :request do
 
               post '/simple_forms_api/v1/simple_forms', params: data
 
-              puts response.inspect
-
               expect(response).to have_http_status(:ok)
             end
           end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -125,21 +125,29 @@ RSpec.describe 'Forms uploader', type: :request do
           context 'fails to go to Lighthouse Benefits Claims API because of UnprocessableEntity error' do
             before do
               VCR.insert_cassette('lighthouse/benefits_claims/intent_to_file/422_response')
-              expect_any_instance_of(SimpleFormsApi::PdfUploader).to receive(:upload_to_benefits_intake).and_call_original
+              expect_any_instance_of(SimpleFormsApi::PdfUploader).to receive(
+                :upload_to_benefits_intake
+              ).and_call_original
             end
-      
+
             after do
               VCR.eject_cassette('lighthouse/benefits_claims/intent_to_file/422_response')
             end
-      
+
             it 'catches the exception and sends a PDF to Central Mail instead' do
-              fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
-              'vba_21_0966-min.json')
+              fixture_path = Rails.root.join(
+                'modules',
+                'simple_forms_api',
+                'spec',
+                'fixtures',
+                'form_json',
+                'vba_21_0966-min.json'
+              )
               data = JSON.parse(fixture_path.read)
               data['preparer_identification'] = 'VETERAN'
-      
+
               post '/simple_forms_api/v1/simple_forms', params: data
-      
+
               expect(response).to have_http_status(:ok)
             end
           end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -123,6 +123,8 @@ RSpec.describe 'Forms uploader', type: :request do
           end
 
           context 'fails to go to Lighthouse Benefits Claims API because of UnprocessableEntity error' do
+            skip 'restore this test when we figure out why it fails on CI but passes locally'
+
             before do
               VCR.insert_cassette('lighthouse/benefits_claims/intent_to_file/422_response')
               expect_any_instance_of(SimpleFormsApi::PdfUploader).to receive(

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -147,8 +147,6 @@ RSpec.describe 'Forms uploader', type: :request do
               data['preparer_identification'] = 'VETERAN'
 
               post '/simple_forms_api/v1/simple_forms', params: data
-
-              expect(response).to have_http_status(:ok)
             end
           end
         end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Forms uploader', type: :request do
               VCR.insert_cassette('lighthouse/benefits_claims/intent_to_file/422_response')
               expect_any_instance_of(SimpleFormsApi::PdfUploader).to receive(
                 :upload_to_benefits_intake
-              )
+              ).and_return([:ok, 'confirmation number'])
             end
 
             after do

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Forms uploader', type: :request do
               VCR.insert_cassette('lighthouse/benefits_claims/intent_to_file/422_response')
               expect_any_instance_of(SimpleFormsApi::PdfUploader).to receive(
                 :upload_to_benefits_intake
-              ).and_call_original
+              )
             end
 
             after do
@@ -147,6 +147,8 @@ RSpec.describe 'Forms uploader', type: :request do
               data['preparer_identification'] = 'VETERAN'
 
               post '/simple_forms_api/v1/simple_forms', params: data
+
+              expect(response).to have_http_status(:ok)
             end
           end
         end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -123,13 +123,8 @@ RSpec.describe 'Forms uploader', type: :request do
           end
 
           context 'fails to go to Lighthouse Benefits Claims API because of UnprocessableEntity error' do
-            skip 'restore this test when we figure out why it fails on CI but passes locally'
-
             before do
               VCR.insert_cassette('lighthouse/benefits_claims/intent_to_file/422_response')
-              expect_any_instance_of(SimpleFormsApi::PdfUploader).to receive(
-                :upload_to_benefits_intake
-              ).and_return([:ok, 'confirmation number'])
             end
 
             after do
@@ -137,6 +132,9 @@ RSpec.describe 'Forms uploader', type: :request do
             end
 
             it 'catches the exception and sends a PDF to Central Mail instead' do
+              expect_any_instance_of(SimpleFormsApi::PdfUploader).to receive(
+                :upload_to_benefits_intake
+              ).and_return([:ok, 'confirmation number'])
               fixture_path = Rails.root.join(
                 'modules',
                 'simple_forms_api',

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -148,6 +148,8 @@ RSpec.describe 'Forms uploader', type: :request do
 
               post '/simple_forms_api/v1/simple_forms', params: data
 
+              puts response.inspect
+
               expect(response).to have_http_status(:ok)
             end
           end

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/intent_to_file/422_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/intent_to_file/422_response.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/claims/v2/veterans/123498767V234859/intent-to-file/compensation
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 422
+      message: Unprocessable entity
+    headers:
+      Date:
+      - Wed, 26 Jun 2024 13:44:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '65'
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      Ratelimit-Reset:
+      - '49'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Limit:
+      - '120'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Git-Sha:
+      - 87b5a2f2d08bc05205824e885d812aae2248f275
+      X-Github-Repository:
+      - https://github.com/department-of-veterans-affairs/vets-api
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 395ec00b-b8ff-4efb-8953-9cf5befc199b
+      X-Runtime:
+      - '0.153940'
+      X-Xss-Protection:
+      - '0'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"title":"Unprocessable entity","detail":"Unprocessable entity"}]}'
+  recorded_at: Wed, 26 Jun 2024 13:44:12 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary
This PR implements a fallback while we continue figuring out why the Intent API is returning `422`s. This will redirect those submissions back to the PDF -> Central Mail route rather than try the Intent API.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/86870

## Testing done

- [X] *New code is covered by unit tests*
