### PR TITLE
API-37741: Add Gia Antoniades to Appeals and Benefits Intake Email Reports

### DIFF
--- a/modules/appeals_api/config/mailinglists/error_report_daily.yml
+++ b/modules/appeals_api/config/mailinglists/error_report_daily.yml
@@ -1,9 +1,9 @@
 common:
    - michael.hobson@adhocteam.us
    - michel.mcdonald@adhocteam.us
-   - casey.williams@adhocteam.us
    - kristen.brown@adhocteam.us
    - matt.kelly@adhocteam.us
+   - gia.antoniades@adhocteam.us
 development:
 staging:
 sandbox:

--- a/modules/appeals_api/config/mailinglists/error_report_weekly.yml
+++ b/modules/appeals_api/config/mailinglists/error_report_weekly.yml
@@ -1,9 +1,9 @@
 common:
    - michael.hobson@adhocteam.us
    - michel.mcdonald@adhocteam.us
-   - casey.williams@adhocteam.us
    - kristen.brown@adhocteam.us
    - matt.kelly@adhocteam.us
+   - gia.antoniades@adhocteam.us
 development:
 staging:
 sandbox:

--- a/modules/appeals_api/config/mailinglists/report_daily.yml
+++ b/modules/appeals_api/config/mailinglists/report_daily.yml
@@ -1,9 +1,9 @@
 common:
    - michael.hobson@adhocteam.us
    - michel.mcdonald@adhocteam.us
-   - casey.williams@adhocteam.us
    - kristen.brown@adhocteam.us
    - matt.kelly@adhocteam.us
+   - gia.antoniades@adhocteam.us
 development:
 staging:
 sandbox:

--- a/modules/appeals_api/config/mailinglists/report_weekly.yml
+++ b/modules/appeals_api/config/mailinglists/report_weekly.yml
@@ -1,9 +1,9 @@
 common:
    - michael.hobson@adhocteam.us
    - michel.mcdonald@adhocteam.us
-   - casey.williams@adhocteam.us
    - kristen.brown@adhocteam.us
    - matt.kelly@adhocteam.us
+   - gia.antoniades@adhocteam.us
 development:
 staging:
 sandbox:

--- a/modules/appeals_api/config/mailinglists/stats_report_monthly.yml
+++ b/modules/appeals_api/config/mailinglists/stats_report_monthly.yml
@@ -1,8 +1,8 @@
 common:
-  - casey.williams@adhocteam.us
   - michel.mcdonald@adhocteam.us
   - kristen.brown@adhocteam.us
   - matt.kelly@adhocteam.us
+  - gia.antoniades@adhocteam.us
 development:
 staging:
 production:

--- a/modules/vba_documents/app/mailers/vba_documents/monthly_report_recipients.yml
+++ b/modules/vba_documents/app/mailers/vba_documents/monthly_report_recipients.yml
@@ -1,12 +1,12 @@
 common:
   - 'kristen.brown@adhocteam.us'
   - 'michael.hobson@adhocteam.us'
-  - 'casey.williams@adhocteam.us'
   - 'michel.mcdonald@adhocteam.us'
   - 'emily.goodrich@oddball.io'
   - 'melinda.cuerda@adhocteam.us'
   - 'heather.roy@adhocteam.us'
   - 'matt.kelly@adhocteam.us'
+  - 'gia.antoniades@adhocteam.us'
 dev:
 staging:
 sandbox:

--- a/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_recipients.yml
+++ b/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_recipients.yml
@@ -1,12 +1,12 @@
 common:
   - 'kristen.brown@adhocteam.us'
   - 'michael.hobson@adhocteam.us'
-  - 'casey.williams@adhocteam.us'
   - 'michel.mcdonald@adhocteam.us'
   - 'emily.goodrich@oddball.io'
   - 'melinda.cuerda@adhocteam.us'
   - 'heather.roy@adhocteam.us'
   - 'matt.kelly@adhocteam.us'
+  - 'gia.antoniades@adhocteam.us'
 dev:
 staging:
 sandbox:


### PR DESCRIPTION
## Summary
- *This work is behind a feature toggle (flipper): NO*
- This PR updates the recipients lists for the Appeals and Benefits Intake emails reports to add Gia Antoniades and remove Casey Williams. 

## Related issue(s)
- [API-37741](https://jira.devops.va.gov/browse/API-37741)
![screencapture-jira-devops-va-gov-browse-API-37741-2024-06-26-12_00_52](https://github.com/department-of-veterans-affairs/vets-api/assets/11942904/ceae3c10-74a6-4ce6-8cf1-fded4e2a0ff0)

## Testing done
- [ ] *New code is covered by unit tests* – N/A, no new code, config change only
- Ran a couple of the email generation jobs locally to ensure that the new recipients list was correct.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the recipients list for the emails sent in the `vba_documents` and `appeals_api` modules only.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A, config change only
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested.
