### PR TITLE
[DBEX] add enum, methods and scopes to Form526Submission

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1154,6 +1154,7 @@ spec/factories/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-
 spec/factories/form1095_bs.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/form526_job_statuses.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/form526_submissions.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/factories/form526_submission_remediations.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/form5655_submission.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/factories/form_submission_attempts.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/form_submissions.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -199,7 +199,7 @@ class Form526Submission < ApplicationRecord
   FLASHES = 'flashes'
   BIRLS_KEY = 'va_eauth_birlsfilenumber'
   SUBMIT_FORM_526_JOB_CLASSES = %w[SubmitForm526AllClaim SubmitForm526].freeze
-  MAX_PENDING_TIME = 7.days
+  MAX_PENDING_TIME = 3.days
 
   # Called when the DisabilityCompensation form controller is ready to hand off to the backend
   # submission process. Currently this passes directly to the retryable EVSS workflow, but if any

--- a/spec/factories/form526_submission_remediations.rb
+++ b/spec/factories/form526_submission_remediations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :form526_submission_remediation do
+    association :form526_submission
+    lifecycle { ['datetime -- context'] }
+    success { true }
+    ignored_as_duplicate { false }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
+  end
+end

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -265,4 +265,8 @@ FactoryBot.define do
   trait :with_accepted_backup_status do
     backup_submitted_claim_status { :accepted }
   end
+
+  trait :created_more_than_7_days_ago do
+    created_at { 8.days.ago }
+  end
 end

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     form_json do
       File.read("#{submissions_path}/only_526.json")
     end
+    backup_submitted_claim_status { nil }
   end
 
   trait :backup_path do
@@ -255,5 +256,13 @@ FactoryBot.define do
 
   trait :with_empty_auth_headers do
     auth_headers_json { { bogus: nil }.to_json }
+  end
+
+  trait :with_submitted_claim_id do
+    submitted_claim_id { 1 }
+  end
+
+  trait :with_accepted_backup_status do
+    backup_submitted_claim_status { :accepted }
   end
 end

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -261,12 +261,12 @@ FactoryBot.define do
   trait :with_submitted_claim_id do
     submitted_claim_id { 1 }
   end
-
+  spec/models/form526_submission_spec.rb
   trait :with_accepted_backup_status do
     backup_submitted_claim_status { :accepted }
   end
 
-  trait :created_more_than_7_days_ago do
-    created_at { 8.days.ago }
+  trait :created_more_than_3_days_ago do
+    created_at { 4.days.ago }
   end
 end

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -261,7 +261,7 @@ FactoryBot.define do
   trait :with_submitted_claim_id do
     submitted_claim_id { 1 }
   end
-  spec/models/form526_submission_spec.rb
+
   trait :with_accepted_backup_status do
     backup_submitted_claim_status { :accepted }
   end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Form526Submission do
     describe 'in_process' do
       let!(:in_process_submission1) { create(:form526_submission) }
       let!(:in_process_submission2) { create(:form526_submission, :backup_path) }
-      let!(:expired_submission) { create(:form526_submission, :backup_path, created_at: 25.hours.ago) }
+      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_7_days_ago) }
       let!(:backup_accepted_submission) { create(:form526_submission, :backup_path, :with_accepted_backup_status) }
       let!(:successful_submission) { create(:form526_submission, :with_submitted_claim_id) }
 
@@ -172,7 +172,7 @@ RSpec.describe Form526Submission do
       let!(:in_process_submission) { create(:form526_submission) }
       let!(:successful_submission) { create(:form526_submission, :with_submitted_claim_id) }
       let!(:rejected_submission) { create(:form526_submission, :backup_path, backup_submitted_claim_status: :rejected) }
-      let!(:expired_submission) { create(:form526_submission, :backup_path, created_at: 25.hours.ago) }
+      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_7_days_ago) }
       let!(:remediated_submission) do
         create(:form526_submission_remediation, form526_submission: subject)
         subject
@@ -1441,14 +1441,14 @@ RSpec.describe Form526Submission do
 
   describe '#in_process?' do
     context 'when submitted_claim_id and backup_submitted_claim_status are both nil' do
-      context 'and the record was created within the last 24 hours' do
+      context 'and the record was created within the last 7 days' do
         it 'returns true' do
           expect(subject).to be_in_process
         end
       end
 
-      context 'and the record was created more than 24 hours ago' do
-        subject { create(:form526_submission, created_at: 25.hours.ago) }
+      context 'and the record was created more than 7 days ago' do
+        subject { create(:form526_submission, :created_more_than_7_days_ago) }
 
         it 'returns false' do
           expect(subject).not_to be_in_process
@@ -1489,7 +1489,7 @@ RSpec.describe Form526Submission do
     end
 
     context 'when the submission is neither a success type nor in process' do
-      subject { create(:form526_submission, created_at: 25.hours.ago) }
+      subject { create(:form526_submission, :created_more_than_7_days_ago) }
 
       it 'returns true' do
         expect(subject).to be_failure_type

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Form526Submission do
     describe 'in_process' do
       let!(:in_process_submission1) { create(:form526_submission) }
       let!(:in_process_submission2) { create(:form526_submission, :backup_path) }
-      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_7_days_ago) }
+      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_3_days_ago) }
       let!(:backup_accepted_submission) { create(:form526_submission, :backup_path, :with_accepted_backup_status) }
       let!(:successful_submission) { create(:form526_submission, :with_submitted_claim_id) }
 
@@ -172,7 +172,7 @@ RSpec.describe Form526Submission do
       let!(:in_process_submission) { create(:form526_submission) }
       let!(:successful_submission) { create(:form526_submission, :with_submitted_claim_id) }
       let!(:rejected_submission) { create(:form526_submission, :backup_path, backup_submitted_claim_status: :rejected) }
-      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_7_days_ago) }
+      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_3_days_ago) }
       let!(:remediated_submission) do
         create(:form526_submission_remediation, form526_submission: subject)
         subject
@@ -1448,7 +1448,7 @@ RSpec.describe Form526Submission do
       end
 
       context 'and the record was created more than 7 days ago' do
-        subject { create(:form526_submission, :created_more_than_7_days_ago) }
+        subject { create(:form526_submission, :created_more_than_3_days_ago) }
 
         it 'returns false' do
           expect(subject).not_to be_in_process
@@ -1489,7 +1489,7 @@ RSpec.describe Form526Submission do
     end
 
     context 'when the submission is neither a success type nor in process' do
-      subject { create(:form526_submission, :created_more_than_7_days_ago) }
+      subject { create(:form526_submission, :created_more_than_3_days_ago) }
 
       it 'returns true' do
         expect(subject).to be_failure_type

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1441,13 +1441,13 @@ RSpec.describe Form526Submission do
 
   describe '#in_process?' do
     context 'when submitted_claim_id and backup_submitted_claim_status are both nil' do
-      context 'and the record was created within the last 7 days' do
+      context 'and the record was created within the last 3 days' do
         it 'returns true' do
           expect(subject).to be_in_process
         end
       end
 
-      context 'and the record was created more than 7 days ago' do
+      context 'and the record was created more than 3 days ago' do
         subject { create(:form526_submission, :created_more_than_3_days_ago) }
 
         it 'returns false' do


### PR DESCRIPTION
## Summary

- Adds to `Form526Submission` model (utility described in [526 State Repair Technical Design Document](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#b-add-backup_submitted_claim_status-enum-to-the-form526submission-model))
  - `backup_submitted_claim_status` enum with 3 allowed values: `:accepted`, `:rejected` and `nil` (default)
  - instance methods: `remediated?`, `success_type?`, `in_process?`, `failure_type?`, `duplicate?`
  - scopes: `success_type`, `in_process`, `failure_type`
- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/17254
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86438
- [526 State Repair Technical Design Document
](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#b-add-backup_submitted_claim_status-enum-to-the-form526submission-model)

## Testing done

- [x] *New code is covered by unit tests*
- Add to `form526_submission_spec`:
  - `backup_submitted_claim_status` validations
  - instance method tests
  - scope tests
- Create `form526_submission_remediation` factory
- Add traits to `form526_submission` factory

## What areas of the site does it impact?

Database records are never intended to be created by application code; they will be created manually by a developer, most likely via a script at the time of remediation.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
