### PR TITLE
Remove references to va_online_scheduling_status_improvement feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1171,10 +1171,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for display of clinic location on appointment detail page
-  va_online_scheduling_status_improvement:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for homepage status improvement
   va_online_scheduling_status_improvement_canceled:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Removing obsolete feature flag

## Related issue(s)

- Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Testing done

- Ensured existing tests pass

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

