### PR TITLE
[84351] updates SSOe login tags to use CSP "type"

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -301,7 +301,7 @@ module V1
     def login_stats(status, error = nil)
       type = url_service.tracker.payload_attr(:type)
       client_id = url_service.tracker.payload_attr(:application)
-      tags = ["context:#{type}", VERSION_TAG, "client_id:#{client_id}"]
+      tags = ["type:#{type}", VERSION_TAG, "client_id:#{client_id}"]
       case status
       when :success
         StatsD.increment(STATSD_LOGIN_NEW_USER_KEY, tags: [VERSION_TAG]) if type == 'signup'

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -619,7 +619,7 @@ RSpec.describe V1::SessionsController, type: :controller do
                                               'context:http://idmanagement.gov/ns/assurance/loa/1/vets',
                                               'version:v1'])
           .and trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE,
-                                        tags: ['context:idme', 'version:v1', 'client_id:vaweb', 'error:102'])
+                                        tags: ['type:idme', 'version:v1', 'client_id:vaweb', 'error:102'])
           .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_FAILED_KEY,
                                         tags: ['error:multiple_edipis', 'version:v1'])
 
@@ -629,7 +629,7 @@ RSpec.describe V1::SessionsController, type: :controller do
       context 'USiP user' do
         it 'logs the USiP client application' do
           SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: 'vamobile' })
-          login_failed_tags = ['context:idme', 'version:v1', 'client_id:vamobile', 'error:102']
+          login_failed_tags = ['type:idme', 'version:v1', 'client_id:vamobile', 'error:102']
 
           expect { call_endpoint }
             .to trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE, tags: login_failed_tags)
@@ -724,7 +724,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           end
 
           it 'logs the USiP client application' do
-            callback_tags = ['context:idme', 'version:v1', 'client_id:vamobile']
+            callback_tags = ['type:idme', 'version:v1', 'client_id:vamobile']
 
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_SUCCESS, tags: callback_tags, **once)
@@ -1050,7 +1050,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           )
           callback_tags = ['status:failure', 'context:unknown', 'version:v1']
           callback_failed_tags = ['error:clicked_deny', 'version:v1']
-          login_failed_tags = ['context:idme', 'version:v1', 'client_id:vaweb', 'error:001']
+          login_failed_tags = ['type:idme', 'version:v1', 'client_id:vaweb', 'error:001']
 
           expect { call_endpoint }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
@@ -1064,7 +1064,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         context 'USiP user' do
           it 'logs the USiP client application' do
             SAMLRequestTracker.create(uuid: multi_error_uuid, payload: { type: 'idme', application: 'vamobile' })
-            login_failed_tags = ['context:idme', 'version:v1', 'client_id:vamobile', 'error:001']
+            login_failed_tags = ['type:idme', 'version:v1', 'client_id:vamobile', 'error:001']
 
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE, tags: login_failed_tags)


### PR DESCRIPTION
## Summary

- Followup to https://github.com/department-of-veterans-affairs/vets-api/pull/16979
- Updates the following SSOe auth StatsD entries to use CSP `type` instead of `context`:
  - 'api_auth_login_success'
  - 'api_auth_login_failure'
  - 'api_auth_latency'
  - 'api_auth_new_user'
- Rails log `LOGIN_STATUS_FAILURE' is also updated.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84351

## Testing done

- [x] *New code is covered by unit tests*

