### PR TITLE
Update PegaController JSON render to move status: outside

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -18,14 +18,12 @@ module IvcChampva
             if valid_keys?(data)
               update_data(data['form_uuid'], data['file_names'], data['status'], data['case_id'])
             else
-              { status: 500, error: 'Invalid JSON keys' }
+              { json: { error_message: 'Invalid JSON keys' }, status: :bad_request }
             end
 
-          json_response = JSON.generate(response)
-
-          render json: json_response
+          render json: response[:json], status: response[:status]
         rescue JSON::ParserError => e
-          render json: JSON.generate({ status: 500, error: "JSON parsing error: #{e.message}" })
+          render json: { error_message: "JSON parsing error: #{e.message}" }, status: :internal_server_error
         end
       end
 
@@ -45,12 +43,11 @@ module IvcChampva
           ivc_forms_by_email = ivc_forms.select { |record| record.email.present? }.group_by(&:email)
           send_emails(ivc_forms_by_email) if ivc_forms_by_email.present?
 
-          { status: 200 }
+          { json: {}, status: :ok }
         else
-          {
-            status: 202,
-            error: "No form(s) found with the form_uuid: #{form_uuid} and/or the file_names: #{file_names}."
-          }
+          { json:
+          { error_message: "No form(s) found with the form_uuid: #{form_uuid} and/or the file_names: #{file_names}." },
+            status: :accepted }
         end
       end
 

--- a/modules/ivc_champva/spec/requests/v1/pega_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/pega_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Pega callback', type: :request do
 
       it 'returns HTTP status 200' do
         post '/ivc_champva/v1/forms/status_updates', params: invalid_payload
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it 'returns an error message' do


### PR DESCRIPTION
Update JSON rendering for calls to our endpoint via Pega. Previously it was being lumped into JSON generate and not outputting like a regular status.


## Summary

- Update JSON renders to actually use their status instead of a defacto 200
- Update test

## Testing done

- [x] Rspec

