### PR TITLE
87087 - Handle timeouts for calls to MAP STS

### DIFF
--- a/lib/map/security_token/service.rb
+++ b/lib/map/security_token/service.rb
@@ -19,6 +19,9 @@ module MAP
         token
       rescue Common::Client::Errors::ClientError => e
         parse_and_raise_error(e, icn, application)
+      rescue Common::Exceptions::GatewayTimeout => e
+        Rails.logger.error("#{config.logging_prefix} token failed, gateway timeout", application:, icn:)
+        raise e
       rescue Errors::ApplicationMismatchError => e
         Rails.logger.error(e.message, application:, icn:)
         raise e

--- a/spec/lib/map/security_token/service_spec.rb
+++ b/spec/lib/map/security_token/service_spec.rb
@@ -91,6 +91,22 @@ describe MAP::SecurityToken::Service do
         end
       end
 
+      context 'when request to STS times out' do
+        let(:expected_error) { Common::Exceptions::GatewayTimeout }
+        let(:expected_error_message) { 'Gateway timeout' }
+        let(:expected_logger_message) { "#{log_prefix} token failed, gateway timeout" }
+        let(:expected_log_values) { { application:, icn: } }
+
+        before do
+          stub_request(:post, 'https://veteran.apps-staging.va.gov/sts/oauth/v1/token').to_raise(Net::ReadTimeout)
+        end
+
+        it 'raises an gateway timeout error and creates a log' do
+          expect(Rails.logger).to receive(:error).with(expected_logger_message, expected_log_values)
+          expect { subject }.to raise_exception(expected_error, expected_error_message)
+        end
+      end
+
       context 'and response is successful' do
         let(:expected_log_message) { "#{log_prefix} token success" }
         let(:expected_log_payload) { { application:, icn:, cached_response: false } }


### PR DESCRIPTION
## Summary

This PR handles gateway timeouts to the MAP STS service.

## Related issue(s)

https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/87087

## Testing done

Unit specs.

## Screenshots

Not relevant.

## What areas of the site does it impact?

Any service that requests MAP STS token.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None.
