### PR TITLE
Replace MyHealth AMS serializers with JSONAPI serializers - Part 1

### DIFF
--- a/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
@@ -5,7 +5,7 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::EvidenceSubmissionSerializer, type: :serializer do
   subject do
-    serialize(evidence_submission, { serializer_class: described_class, render_location: })
+    serialize(evidence_submission, serializer_class: described_class, params: { render_location: })
   end
 
   let(:evidence_submission) { build_stubbed(:evidence_submission_v0) }

--- a/modules/claims_api/spec/serializers/claim_detail_serializer_spec.rb
+++ b/modules/claims_api/spec/serializers/claim_detail_serializer_spec.rb
@@ -23,7 +23,7 @@ describe ClaimsApi::ClaimDetailSerializer, type: :serializer do
   let(:claim_data) { claim.data }
 
   context 'when uuid is passed in' do
-    subject { serialize(claim, { serializer_class: described_class, uuid: }) }
+    subject { serialize(claim, { serializer_class: described_class, params: { uuid: } }) }
 
     it 'includes :id from :uuid' do
       expect(data['id']).to eq uuid

--- a/modules/my_health/app/controllers/my_health/v1/all_triage_teams_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/all_triage_teams_controller.rb
@@ -13,10 +13,7 @@ module MyHealth
         resource = resource.sort(params.permit(:sort)[:sort])
 
         # Even though this is a collection action we are not going to paginate
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: AllTriageTeamsSerializer,
-               meta: resource.metadata
+        render json: AllTriageTeamsSerializer.new(resource.data, { meta: resource.metadata })
       end
     end
   end

--- a/modules/my_health/app/controllers/my_health/v1/health_records_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/health_records_controller.rb
@@ -15,9 +15,7 @@ module MyHealth
       def eligible_data_classes
         resource = client.get_eligible_data_classes
 
-        render json: resource.data,
-               serializer: EligibleDataClassesSerializer,
-               meta: resource.metadata
+        render json: EligibleDataClassesSerializer.new(resource.data, { meta: resource.metadata })
       end
 
       def create

--- a/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
@@ -95,8 +95,7 @@ module MyHealth
       def categories
         resource = client.get_categories
 
-        render json: resource,
-               serializer: CategorySerializer
+        render json: CategorySerializer.new(resource)
       end
 
       def signature

--- a/modules/my_health/app/serializers/my_health/v1/all_triage_teams_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/all_triage_teams_serializer.rb
@@ -2,17 +2,14 @@
 
 module MyHealth
   module V1
-    class AllTriageTeamsSerializer < ActiveModel::Serializer
-      def id
-        object.triage_team_id
-      end
+    class AllTriageTeamsSerializer
+      include JSONAPI::Serializer
 
-      attribute :triage_team_id
-      attribute :name
-      attribute :station_number
-      attribute :blocked_status
-      attribute :preferred_team
-      attribute :relationship_type
+      set_type :all_triage_teams
+      set_id :triage_team_id
+
+      attributes :triage_team_id, :name, :station_number,
+                 :blocked_status, :preferred_team, :relationship_type
     end
   end
 end

--- a/modules/my_health/app/serializers/my_health/v1/category_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/category_serializer.rb
@@ -2,12 +2,13 @@
 
 module MyHealth
   module V1
-    class CategorySerializer < ActiveModel::Serializer
-      def id
-        object.category_id
-      end
+    class CategorySerializer
+      include JSONAPI::Serializer
 
-      attribute(:message_category_type)
+      set_type :categories
+      set_id :category_id
+
+      attribute :message_category_type
     end
   end
 end

--- a/modules/my_health/app/serializers/my_health/v1/eligible_data_classes_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/eligible_data_classes_serializer.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require 'digest'
-
 module MyHealth
   module V1
-    class EligibleDataClassesSerializer < ActiveModel::Serializer
-      type 'eligible_data_classes'
-      attribute :data_classes
+    class EligibleDataClassesSerializer
+      include JSONAPI::Serializer
 
-      def data_classes
+      set_type :eligible_data_classes
+      set_id { '' }
+
+      attribute :data_classes do |object|
         object.map(&:name)
-      end
-
-      def id
-        nil
       end
     end
   end

--- a/modules/my_health/spec/serializer/v1/all_triage_teams_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/all_triage_teams_serializer_spec.rb
@@ -3,39 +3,38 @@
 require 'rails_helper'
 require_relative '../../factories/all_triage_teams'
 
-describe MyHealth::V1::AllTriageTeamsSerializer do
-  let(:triage_team) { build_stubbed(:all_triage_team) }
+describe MyHealth::V1::AllTriageTeamsSerializer, type: :serializer do
+  subject { serialize(triage_team, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(triage_team, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:triage_team) { build_stubbed(:all_triage_team) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq triage_team.triage_team_id.to_s
+    expect(data['id']).to eq triage_team.triage_team_id.to_s
   end
 
   it 'includes :triage_team_id' do
-    expect(rendered_attributes[:triage_team_id]).to eq triage_team.triage_team_id
+    expect(attributes['triage_team_id']).to eq triage_team.triage_team_id
   end
 
   it 'includes :name' do
-    expect(rendered_attributes[:name]).to eq triage_team.name
+    expect(attributes['name']).to eq triage_team.name
   end
 
   it 'includes :station_number' do
-    expect(rendered_attributes[:station_number]).to eq triage_team.station_number
+    expect(attributes['station_number']).to eq triage_team.station_number
   end
 
   it 'includes :blocked_status' do
-    expect(rendered_attributes[:blocked_status]).to eq triage_team.blocked_status
+    expect(attributes['blocked_status']).to eq triage_team.blocked_status
   end
 
   it 'includes :preferred_team' do
-    expect(rendered_attributes[:preferred_team]).to eq triage_team.preferred_team
+    expect(attributes['preferred_team']).to eq triage_team.preferred_team
   end
 
   it 'includes :relationship_type' do
-    expect(rendered_attributes[:relationship_type]).to eq triage_team.relationship_type
+    expect(attributes['relationship_type']).to eq triage_team.relationship_type
   end
 end

--- a/modules/my_health/spec/serializer/v1/category_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/category_serializer_spec.rb
@@ -2,19 +2,18 @@
 
 require 'rails_helper'
 
-describe MyHealth::V1::CategorySerializer do
-  let(:category) { build_stubbed(:category) }
+describe MyHealth::V1::CategorySerializer, type: :serializer do
+  subject { serialize(category, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(category, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:category) { build_stubbed(:category) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq category.category_id.to_s
+    expect(data['id']).to eq category.category_id.to_s
   end
 
   it 'includes :message_category_type' do
-    expect(rendered_attributes[:message_category_type]).to eq category.message_category_type
+    expect(attributes['message_category_type']).to eq category.message_category_type
   end
 end

--- a/modules/my_health/spec/serializer/v1/eligible_data_classes_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/eligible_data_classes_serializer_spec.rb
@@ -3,19 +3,18 @@
 require 'rails_helper'
 require 'bb/generate_report_request_form'
 
-describe MyHealth::V1::EligibleDataClassesSerializer do
-  let(:eligible_data_classes) { build_list(:eligible_data_class, 3) }
+describe MyHealth::V1::EligibleDataClassesSerializer, type: :serializer do
+  subject { serialize(eligible_data_classes, { serializer_class: described_class, is_collection: false }) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(eligible_data_classes, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:eligible_data_classes) { build_list(:eligible_data_class, 3) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to be_blank
+    expect(data['id']).to be_blank
   end
 
   it 'includes :data_classes' do
-    expect(rendered_attributes[:data_classes]).to eq eligible_data_classes.map(&:name)
+    expect(attributes['data_classes']).to eq eligible_data_classes.map(&:name)
   end
 end

--- a/spec/support/serializer_spec_helper.rb
+++ b/spec/support/serializer_spec_helper.rb
@@ -59,7 +59,7 @@ module SerializerSpecHelper
   end
 
   def serializer_with_jsonapi(serializer_class, obj, opts = {})
-    serializer = serializer_class.new(obj, { params: opts })
+    serializer = serializer_class.new(obj, opts)
     serializer.serializable_hash.to_json
   end
 end


### PR DESCRIPTION
## Summary

- Update serializer options in SerializerSpecHealth
    - This required a trivial change to AppealsApi::EvidenceSubmission spec and  ClaimsApi::ClaimDetailSerializer spec
- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in `modules/my_health`.
    - `AllTriageTeamsSerializer`, `CategorySerializer`, `EligibleDataClassesSerializer`
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86385

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage