### PR TITLE
85849: Add user tracking for DataDog

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -57,6 +57,7 @@ module IvcChampva
         applicant_rounded_number = total_applicants_count.positive? ? total_applicants_count.ceil : total_applicants_count.floor
 
         form = form_class.new(parsed_form_data)
+        form.track_user_identity
 
         attachment_ids = generate_attachment_ids(form_id, applicant_rounded_number)
         attachment_ids.concat(supporting_document_ids(parsed_form_data))

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -4,6 +4,7 @@ module IvcChampva
   class VHA1010d
     ADDITIONAL_PDF_KEY = 'applicants'
     ADDITIONAL_PDF_COUNT = 3
+    STATS_KEY = 'api.ivc_champva_form.10_10d'
 
     include Virtus.model(nullify_blank: true)
     include Attachments
@@ -39,6 +40,12 @@ module IvcChampva
 
     def submission_date_config
       { should_stamp_date?: false }
+    end
+
+    def track_user_identity
+      identity = data['certifier_role']
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('IVC ChampVA Forms - 10-10D Submission User Identity', identity:)
     end
 
     def method_missing(_, *args)

--- a/modules/ivc_champva/lib/tasks/forms.rake
+++ b/modules/ivc_champva/lib/tasks/forms.rake
@@ -47,6 +47,13 @@ namespace :ivc_champva do
       end
     SUB_DATE_CONFIG
 
+    track_user_identity_method = <<-TRACK_USER_CONFIG
+      def track_user_identity
+        # Add STATS_KEY to top of file
+        # Copy other data from 10-10D
+      end
+    TRACK_USER_CONFIG
+
     method_missing_method = <<-METHOD_MISSING
     def method_missing(_, *args)
       args&.first
@@ -85,6 +92,8 @@ namespace :ivc_champva do
       f.puts metadata_method
 
       f.puts submission_date_config_method
+
+      f.puts track_user_identity_method
 
       f.puts method_missing_method
 

--- a/modules/ivc_champva/spec/fixtures/form_json/vha_10_10d.json
+++ b/modules/ivc_champva/spec/fixtures/form_json/vha_10_10d.json
@@ -1,5 +1,6 @@
 {
   "form_number": "10-10D",
+  "certifier_role": "applicant",
   "primary_contact_info": {
     "name": {
       "first": "Veteran",

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe IvcChampva::VHA1010d do
     }
   end
   let(:vha1010d) { described_class.new(data) }
+  let(:logger) { instance_spy(Logger) }
+
+  before { allow(Rails.logger).to receive(:info) }
+
+  describe '#track_user_identity' do
+    it 'returns the right data' do
+      fixture_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', 'vha_10_10d.json')
+      data = JSON.parse(fixture_path.read)
+
+      described_class.new(data).track_user_identity
+
+      expect(Rails.logger).to have_received(:info)
+        .with('IVC ChampVA Forms - 10-10D Submission User Identity', { identity: 'applicant' })
+    end
+  end
 
   describe '#metadata' do
     it 'returns metadata for the form' do


### PR DESCRIPTION
Add tags to forms so we can track which applicant type is filling out each form (for 10-10d).

This ticket should split out the signer type ("I’m applying for benefits for myself", "I’m a Veteran applying for benefits for my spouse or dependents", "I’m a representative applying for benefits on behalf of someone else")


## Summary

- Add `track_user_identity` to model 10-10D (Rest to follow)
- Add new method to forms.rake for new forms
- Update 10-10D Rspec test
- Updated uploads_controller to trigger new method

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85849

## Testing done

- [x] Rspec
- Have to test DD once on staging