### PR TITLE
83081 - Ensure JSON responses for STS calls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,6 +96,7 @@ Metrics/MethodLength:
     - 'spec/support/form1010cg_helpers/build_claim_data_for.rb'
     - 'spec/simplecov_helper.rb'
     - 'app/sidekiq/education_form/create_daily_spool_files.rb'
+    - 'lib/map/security_token/service.rb'
     - 'Dangerfile'
 
 Metrics/ClassLength:

--- a/lib/map/security_token/configuration.rb
+++ b/lib/map/security_token/configuration.rb
@@ -86,8 +86,9 @@ module MAP
         ) do |conn|
           conn.use :breakers
           conn.use Faraday::Response::RaiseError
-          conn.response :betamocks if Settings.map_services.secure_token_service.mock
           conn.adapter Faraday.default_adapter
+          conn.response :json, content_type: /\bjson/
+          conn.response :betamocks if Settings.map_services.secure_token_service.mock
         end
       end
     end

--- a/lib/map/security_token/service.rb
+++ b/lib/map/security_token/service.rb
@@ -17,6 +17,10 @@ module MAP
         end
         Rails.logger.info("#{config.logging_prefix} token success", { application:, icn:, cached_response: })
         token
+      rescue Common::Client::Errors::ParsingError => e
+        Rails.logger.error("#{config.logging_prefix} token failed, parsing error", application:, icn:,
+                                                                                   context: e.message)
+        raise e
       rescue Common::Client::Errors::ClientError => e
         parse_and_raise_error(e, icn, application)
       rescue Common::Exceptions::GatewayTimeout => e

--- a/lib/map/security_token/service.rb
+++ b/lib/map/security_token/service.rb
@@ -42,7 +42,7 @@ module MAP
 
       def parse_and_raise_error(e, icn, application)
         status = e.status
-        parse_body = e.body.present? ? JSON.parse(e.body) : {}
+        parse_body = e.body.presence || {}
         context = { error: parse_body['error'] }
         message = "#{config.logging_prefix} token failed, client error"
 
@@ -51,7 +51,7 @@ module MAP
       end
 
       def parse_response(response, application, icn)
-        response_body = JSON.parse(response.body)
+        response_body = response.body
 
         {
           access_token: response_body['access_token'],

--- a/spec/lib/map/security_token/service_spec.rb
+++ b/spec/lib/map/security_token/service_spec.rb
@@ -107,6 +107,19 @@ describe MAP::SecurityToken::Service do
         end
       end
 
+      context 'when response is malformed',
+              vcr: { cassette_name: 'map/security_token_service_200_malformed_response' } do
+        let(:expected_error) { Common::Client::Errors::ParsingError }
+        let(:expected_error_message) { "unexpected token at 'Not valid JSON'" }
+        let(:expected_logger_message) { "#{log_prefix} token failed, parsing error" }
+        let(:expected_log_values) { { application:, icn:, context: expected_error_message } }
+
+        it 'raises an gateway timeout error and creates a log' do
+          expect(Rails.logger).to receive(:error).with(expected_logger_message, expected_log_values)
+          expect { subject }.to raise_exception(expected_error, expected_error_message)
+        end
+      end
+
       context 'and response is successful' do
         let(:expected_log_message) { "#{log_prefix} token success" }
         let(:expected_log_payload) { { application:, icn:, cached_response: false } }

--- a/spec/support/vcr_cassettes/map/security_token_service_200_malformed_response.yml
+++ b/spec/support/vcr_cassettes/map/security_token_service_200_malformed_response.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://veteran.apps-staging.va.gov/sts/oauth/v1/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=c7d6e0fc9a39&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=eyJhbGciOiJSUzUxMiJ9.eyJyb2xlIjoidmV0ZXJhbiIsInBhdGllbnRfaWQiOiJzb21lLWljbiIsInBhdGllbnRfaWRfdHlwZSI6ImljbiIsInN1YiI6ImM3ZDZlMGZjOWEzOSIsImp0aSI6IjIwODllOWFlLTZiNDctNGJkNy05NzNiLTczMzM4NjgzYTVkYiIsImlzcyI6ImM3ZDZlMGZjOWEzOSIsImF1ZCI6Imh0dHBzOi8vZ29vZ2xlLmNvbS9zdHMvb2F1dGgvdjEvdG9rZW4iLCJuYmYiOjE2OTI5MjE5NjcsImV4cCI6MTY5MjkyMjI2N30.VXzWaXBjk83TNA39VTApJQSG9inwyUioYouGXeqkEWicSP3oLb-CNFpkEgkMNccz6SpAlYIJ_KYKRFAA1rQv8Gp5LzIv_YM2WFJUYxpF02-fAhYzl6SkOLwD86Yto6a8JbFrNPL9uYxG1vmTZgl_vk2dmNFpnQ3gf8bXc2GOBAM2gc3tzNjv1M18dVtObX6zw7ZG7drxw7itzZnkDLTU9217XyOgSFQvA0czRiiRcfsXb6LIB7A1k7MpQy6KA3UDBQ7sbuXkaFZiJo2tSDG3PXScTHBtqmqejCt68906wiBf_ACeI4TQPH4ogoTrnfb9oprQyKp8xMlwwKYAMih12g
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - allow-from https://nextgenid-mbetenantworkflow.azurewebsites.net
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - frame-ancestors https://nextgenid-mbetenantworkflow.azurewebsites.net
+      Etag:
+      - W/"dba68a519b00d7f452e79971a398650f"
+      X-Request-Id:
+      - 5b1d220c-4b01-4409-b9a5-367ab3c99ca9
+      X-Runtime:
+      - '0.026178'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Node:
+      - sandbox-core-02.idmeinc.net
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Content-Length:
+      - '14658'
+      Connection:
+      - keep-alive
+      Server-Timing:
+      - ak_p; desc="1690401366974_1752320020_1303469004_11342_12901_31_-_-";dur=1
+      - cdn-cache; desc=MISS
+      - edge; dur=68
+      - origin; dur=46
+    body:
+      encoding: UTF-8
+      string: 'Not valid JSON'
+  recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary

This PR changes the STS client configuration to send the header for JSON responses. It also modifies the STS client service to remove manual JSON parsing as this is no longer necessary due to the configuration change.

## Related issue(s)

https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/83081

## Testing done

* Open the mockdata for the token endpoint (`/vets-api-mockdata/map/secure_token_service/token.yml`)
* Modify the response body to return anything that isn't valid JSON.
* Open a rails console.
* Require the STS service.
```ruby
require 'map/security_token/service'
```
* Call the service with a valid application parameter and any value for ICN:
```ruby
MAP::SecurityToken::Service.new.token(application: :sign_up_service, icn: 'bar')
```
* Verify the the service object logs an error message
```
2024-06-28 12:14:16.319435 E [62210:12280 service.rb:21] Rails -- [MAP][SecurityToken][Service] token failed, parsing error -- { :application => :sign_up_service, :icn => "bar", :context => "unexpected token at 'Gobbeldygook'" }
```
* Verify the service object reraises the exception
```
lib/common/client/base.rb:126:in `rescue in request': unexpected token at 'Gobbeldygook' (Common::Client::Errors::ParsingError)
```

## Screenshots

Not relevant.

## What areas of the site does it impact?

Any service that uses the STS client to request tokens.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None.
