### PR TITLE
add specs for streamlined long transform

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/additional_data_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/additional_data_calculator.rb
@@ -46,7 +46,8 @@ module DebtsApi
           return '' if filtered_expenses.blank?
 
           joined_expenses = filtered_expenses.map do |expense|
-            "#{expense['name']} ($#{dollars_cents(expense['amount'].to_f)})"
+            cash_str = dollars_cents(expense['amount'].to_f).gsub(/(\d)(?=(\d{3})+.\d{2}$)/, '\1,')
+            "#{expense['name']} ($#{cash_str})"
           end.join(', ')
 
           "Individual expense amount: #{joined_expenses}"

--- a/modules/debts_api/spec/fixtures/pre_submission_fsr/sw_long/minimal_asset_post_transform.json
+++ b/modules/debts_api/spec/fixtures/pre_submission_fsr/sw_long/minimal_asset_post_transform.json
@@ -155,7 +155,7 @@
       "pHCernerPatientId": "1005154223",
       "pHCernerAccountNumber": "1005154223",
       "pHIcnNumber": "1012845638V677813",
-      "pHAccountNumber": "0.00",
+      "pHAccountNumber": "0",
       "pHLargeFontIndcator": "0.00",
       "details": [
         {

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/full_transform_service_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/full_transform_service_spec.rb
@@ -197,5 +197,69 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::FullTransformService, type: :serv
         expect(transformed['streamlined']).to eq(post_transform_fsr['streamlined'])
       end
     end
+
+    context 'streamlined long FSR' do
+      let(:pre_transform_fsr_form_data) do
+        get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/sw_long/minimal_asset_pre_transform')
+      end
+      let(:post_transform_fsr) do
+        get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/sw_long/minimal_asset_post_transform')
+      end
+      let(:transformed) do
+        described_class.new(pre_transform_fsr_form_data).transform
+      end
+
+      it 'generates personalIdentification' do
+        expect(transformed['personalIdentification']).to eq(post_transform_fsr['personalIdentification'])
+      end
+
+      it 'generates personalData' do
+        expect(transformed['personalData']).to eq(post_transform_fsr['personalData'])
+      end
+
+      it 'generates income' do
+        expect(transformed['income']).to eq(post_transform_fsr['income'])
+      end
+
+      it 'generates expenses' do
+        expect(transformed['expenses']).to eq(post_transform_fsr['expenses'])
+      end
+
+      it 'generates discretionaryIncome' do
+        expect(transformed['discretionaryIncome']).to eq(post_transform_fsr['discretionaryIncome'])
+      end
+
+      it 'generates assets' do
+        expect(transformed['assets']).to eq(post_transform_fsr['assets'])
+      end
+
+      it 'generates installmentContractsAndOtherDebts' do
+        trans_installments = transformed['installmentContractsAndOtherDebts']
+        expect(trans_installments).to eq(post_transform_fsr['installmentContractsAndOtherDebts'])
+      end
+
+      it 'generates totalOfInstallmentContractsAndOtherDebts' do
+        trans_total_installments = transformed['totalOfInstallmentContractsAndOtherDebts']
+        expect(trans_total_installments).to eq(post_transform_fsr['totalOfInstallmentContractsAndOtherDebts'])
+      end
+
+      it 'generates additionalData' do
+        expect(transformed['additionalData']).to eq(post_transform_fsr['additionalData'])
+      end
+
+      it 'generates applicantCertifications' do
+        trans_sig = transformed['applicantCertifications']['veteranSignature']
+        expect(trans_sig).to eq(post_transform_fsr['applicantCertifications']['veteranSignature'])
+        expect(transformed['applicantCertifications']['veteranDateSigned']).to eq(Time.zone.today.strftime('%m/%d/%Y'))
+      end
+
+      it 'generates selectedDebtsAndCopays' do
+        expect(transformed['selectedDebtsAndCopays']).to eq(post_transform_fsr['selectedDebtsAndCopays'])
+      end
+
+      it 'generates streamlined' do
+        expect(transformed['streamlined']).to eq(post_transform_fsr['streamlined'])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
Add specs for the FSR full transform and react to them.

## Related issue(s)
[86849](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/86849)

## Testing done
Specs added

## What areas of the site does it impact?
It will eventually impact the FSR submission process
## Acceptance criteria
The full-transform accurately ports the FE's transform logic

