### PR TITLE
84351 api_auth_new StatsD "type" tag update

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -293,7 +293,7 @@ module V1
     end
 
     def new_stats(type, client_id)
-      tags = ["context:#{type}", VERSION_TAG, "client_id:#{client_id}"]
+      tags = ["type:#{type}", VERSION_TAG, "client_id:#{client_id}"]
       StatsD.increment(STATSD_SSO_NEW_KEY, tags:)
       Rails.logger.info("SSO_NEW_KEY, tags: #{tags}")
     end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .with(force_authn: true)
               expect { call_endpoint }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                             tags: ["context:#{type}", 'version:v1', 'client_id:vaweb'], **once)
+                                             tags: ["type:#{type}", 'version:v1', 'client_id:vaweb'], **once)
                 .and trigger_statsd_increment(described_class::STATSD_SSO_SAMLREQUEST_KEY, **once)
               expect(response).to have_http_status(:ok)
               expect(SAMLRequestTracker.keys.length).to eq(1)
@@ -142,7 +142,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'logs the USiP client application' do
                 expect { call_endpoint }
                   .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                               tags: ["context:#{type}", 'version:v1', 'client_id:vamobile'], **once)
+                                               tags: ["type:#{type}", 'version:v1', 'client_id:vamobile'], **once)
               end
             end
           end
@@ -159,7 +159,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
               expect { call_endpoint }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                             tags: ['context:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                             tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
 
               expect(response).to have_http_status(:ok)
               expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
@@ -181,7 +181,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['context:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -201,7 +201,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception when ial parameter is not 1 or 2' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['context:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -226,7 +226,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
               expect { call_endpoint }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                             tags: ['context:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                             tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
 
               expect(response).to have_http_status(:ok)
               expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
@@ -248,7 +248,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['context:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -268,7 +268,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['context:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -290,7 +290,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /sessions/idme_signup/new to SessionsController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['context:idme_signup', 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ['type:idme_signup', 'version:v1', 'client_id:vaweb'], **once)
             expect(response).to have_http_status(:ok)
             expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
                                   'originating_request_id' => nil, 'type' => 'signup')
@@ -303,7 +303,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /sessions/idme_signup_verified/new to SessionsController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['context:idme_signup_verified',
+                                           tags: ['type:idme_signup_verified',
                                                   'version:v1',
                                                   'client_id:vaweb'], **once)
             expect(response).to have_http_status(:ok)
@@ -318,7 +318,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /sessions/logingov_signup/new to SessionsController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['context:logingov_signup', 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ['type:logingov_signup', 'version:v1', 'client_id:vaweb'], **once)
             expect(response).to have_http_status(:ok)
             expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
                                   'originating_request_id' => nil, 'type' => 'signup')
@@ -331,7 +331,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /sessions/logingov_signup_verified/new to SessionsController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['context:logingov_signup_verified',
+                                           tags: ['type:logingov_signup_verified',
                                                   'version:v1',
                                                   'client_id:vaweb'], **once)
             expect(response).to have_http_status(:ok)
@@ -352,7 +352,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /v1/sessions/slo/new to SessionController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['context:slo', 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ['type:slo', 'version:v1', 'client_id:vaweb'], **once)
             expect(response).to have_http_status(:found)
           end
 
@@ -405,7 +405,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'does not delete cookies' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ["context:#{type}", 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ["type:#{type}", 'version:v1', 'client_id:vaweb'], **once)
             expect(response).to have_http_status(:ok)
             expect(cookies['vagov_saml_request_localhost']).not_to be_nil
           end


### PR DESCRIPTION
## Summary

- Updates `api_auth_new` StatsD with `type` tag (changed from `context`) to bring in line with previous log & metrics changes.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/16979
- https://github.com/department-of-veterans-affairs/vets-api/pull/17278

## Testing done

Perform a new SSOe authentication to see the updated log that has the same tags as the StatsD increment.
```ruby
Rails -- SSO_NEW_KEY, tags: ["type:idme_verified", "version:v1", "client_id:vaweb"]
```
- [x] *New code is covered by unit tests*
