### PR TITLE
Add all_credential_emails to OAuthSessions

### DIFF
--- a/db/migrate/20240627161450_add_all_credential_emails_to_o_auth_sessions.rb
+++ b/db/migrate/20240627161450_add_all_credential_emails_to_o_auth_sessions.rb
@@ -1,0 +1,5 @@
+class AddAllCredentialEmailsToOAuthSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :oauth_sessions, :all_credential_emails, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_180946) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_27_161450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -941,6 +941,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_25_180946) do
     t.text "user_attributes_ciphertext"
     t.text "encrypted_kms_key"
     t.string "hashed_device_secret"
+    t.string "all_credential_emails", default: [], array: true
     t.index ["handle"], name: "index_oauth_sessions_on_handle", unique: true
     t.index ["hashed_device_secret"], name: "index_oauth_sessions_on_hashed_device_secret"
     t.index ["hashed_refresh_token"], name: "index_oauth_sessions_on_hashed_refresh_token", unique: true


### PR DESCRIPTION
## Summary
- Add all_credential_emails to OAuthSessions

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83797
- https://github.com/department-of-veterans-affairs/vets-api/pull/17301

## What areas of the site does it impact?
Authentication
