### PR TITLE
Replace MyHealth AMS serializers with JSONAPI serializers - Part 2

### DIFF
--- a/modules/my_health/app/controllers/concerns/my_health/json_api_pagination_links.rb
+++ b/modules/my_health/app/controllers/concerns/my_health/json_api_pagination_links.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module MyHealth
+  module Concerns
+    module MyHealth
+      module JsonApiPaginationLinks
+        extend ActiveSupport::Concern
+
+        private
+
+        def pagination_links(collection)
+          total_size = collection.try(:size) || collection.data.size
+          per_page = pagination_params[:per_page].try(:to_i) || total_size
+          current_page = pagination_params[:page].try(:to_i) || 1
+          total_pages = (total_size.to_f / per_page).ceil
+
+          {
+            self: build_page_url(current_page, per_page),
+            first: build_page_url(1, per_page),
+            prev: prev_link(current_page, per_page),
+            next: next_link(current_page, per_page, total_pages),
+            last: build_page_url(total_pages, per_page)
+          }
+        end
+
+        def prev_link(current_page, per_page)
+          return nil if current_page <= 1
+
+          build_page_url(current_page - 1, per_page)
+        end
+
+        def next_link(current_page, per_page, total_pages)
+          return nil if current_page >= total_pages
+
+          build_page_url(current_page + 1, per_page)
+        end
+
+        def build_page_url(page_number, per_page)
+          url_params = {
+            page: page_number,
+            per_page:,
+            query_parameters: request.query_parameters
+          }
+          path_partial = URI.parse(request.original_url).path
+          url = "#{base_path}#{path_partial}?#{url_params.to_query}"
+          URI.parse(url).to_s
+        end
+
+        def base_path
+          "#{Rails.application.config.protocol}://#{Rails.application.config.hostname}"
+        end
+      end
+    end
+  end
+end

--- a/modules/my_health/app/controllers/concerns/my_health/json_api_pagination_links.rb
+++ b/modules/my_health/app/controllers/concerns/my_health/json_api_pagination_links.rb
@@ -1,55 +1,51 @@
 # frozen_string_literal: true
 
 module MyHealth
-  module Concerns
-    module MyHealth
-      module JsonApiPaginationLinks
-        extend ActiveSupport::Concern
+  module JsonApiPaginationLinks
+    extend ActiveSupport::Concern
 
-        private
+    private
 
-        def pagination_links(collection)
-          total_size = collection.try(:size) || collection.data.size
-          per_page = pagination_params[:per_page].try(:to_i) || total_size
-          current_page = pagination_params[:page].try(:to_i) || 1
-          total_pages = (total_size.to_f / per_page).ceil
+    def pagination_links(collection)
+      total_size = collection.try(:size) || collection.data.size
+      per_page = pagination_params[:per_page].try(:to_i) || total_size
+      current_page = pagination_params[:page].try(:to_i) || 1
+      total_pages = (total_size.to_f / per_page).ceil
 
-          {
-            self: build_page_url(current_page, per_page),
-            first: build_page_url(1, per_page),
-            prev: prev_link(current_page, per_page),
-            next: next_link(current_page, per_page, total_pages),
-            last: build_page_url(total_pages, per_page)
-          }
-        end
+      {
+        self: build_page_url(current_page, per_page),
+        first: build_page_url(1, per_page),
+        prev: prev_link(current_page, per_page),
+        next: next_link(current_page, per_page, total_pages),
+        last: build_page_url(total_pages, per_page)
+      }
+    end
 
-        def prev_link(current_page, per_page)
-          return nil if current_page <= 1
+    def prev_link(current_page, per_page)
+      return nil if current_page <= 1
 
-          build_page_url(current_page - 1, per_page)
-        end
+      build_page_url(current_page - 1, per_page)
+    end
 
-        def next_link(current_page, per_page, total_pages)
-          return nil if current_page >= total_pages
+    def next_link(current_page, per_page, total_pages)
+      return nil if current_page >= total_pages
 
-          build_page_url(current_page + 1, per_page)
-        end
+      build_page_url(current_page + 1, per_page)
+    end
 
-        def build_page_url(page_number, per_page)
-          url_params = {
-            page: page_number,
-            per_page:,
-            query_parameters: request.query_parameters
-          }
-          path_partial = URI.parse(request.original_url).path
-          url = "#{base_path}#{path_partial}?#{url_params.to_query}"
-          URI.parse(url).to_s
-        end
+    def build_page_url(page_number, per_page)
+      url_params = {
+        page: page_number,
+        per_page:,
+        query_parameters: request.query_parameters
+      }
+      path_partial = URI.parse(request.original_url).path
+      url = "#{base_path}#{path_partial}?#{url_params.to_query}"
+      URI.parse(url).to_s
+    end
 
-        def base_path
-          "#{Rails.application.config.protocol}://#{Rails.application.config.hostname}"
-        end
-      end
+    def base_path
+      "#{Rails.application.config.protocol}://#{Rails.application.config.hostname}"
     end
   end
 end

--- a/modules/my_health/app/controllers/my_health/v1/folders_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/folders_controller.rb
@@ -5,7 +5,7 @@ require_relative '../../concerns/my_health/json_api_pagination_links'
 module MyHealth
   module V1
     class FoldersController < SMController
-      include MyHealth::Concerns::MyHealth::JsonApiPaginationLinks
+      include MyHealth::JsonApiPaginationLinks
 
       def index
         resource = client.get_folders(@current_user.uuid, use_cache?)

--- a/modules/my_health/app/controllers/my_health/v1/folders_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/folders_controller.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
+require_relative '../../concerns/my_health/json_api_pagination_links'
+
 module MyHealth
   module V1
     class FoldersController < SMController
+      include MyHealth::Concerns::MyHealth::JsonApiPaginationLinks
+
       def index
         resource = client.get_folders(@current_user.uuid, use_cache?)
+        links = pagination_links(resource)
         resource = resource.paginate(**pagination_params)
 
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: MyHealth::V1::FolderSerializer,
-               meta: resource.metadata
+        options = { meta: resource.metadata, links: }
+        render json: MyHealth::V1::FolderSerializer.new(resource.data, options)
       end
 
       def show
@@ -18,9 +21,7 @@ module MyHealth
         resource = client.get_folder(id)
         raise Common::Exceptions::RecordNotFound, id if resource.blank?
 
-        render json: resource,
-               serializer: MyHealth::V1::FolderSerializer,
-               meta: resource.metadata
+        render json: MyHealth::V1::FolderSerializer.new(resource, { meta: resource.metadata })
       end
 
       def create
@@ -28,11 +29,7 @@ module MyHealth
         raise Common::Exceptions::ValidationErrors, folder unless folder.valid?
 
         resource = client.post_create_folder(folder.name)
-
-        render json: resource,
-               serializer: MyHealth::V1::FolderSerializer,
-               meta: resource.metadata,
-               status: :created
+        render json: MyHealth::V1::FolderSerializer.new(resource, { meta: resource.metadata }), status: :created
       end
 
       def update
@@ -40,11 +37,7 @@ module MyHealth
         raise Common::Exceptions::ValidationErrors, folder unless folder.valid?
 
         resource = client.post_rename_folder(params[:id], folder.name)
-
-        render json: resource,
-               serializer: MyHealth::V1::FolderSerializer,
-               meta: resource.metadata,
-               status: :created
+        render json: MyHealth::V1::FolderSerializer.new(resource, { meta: resource.metadata }), status: :created
       end
 
       def destroy

--- a/modules/my_health/app/controllers/my_health/v1/health_records_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/health_records_controller.rb
@@ -6,10 +6,7 @@ module MyHealth
       def refresh
         resource = client.get_extract_status
 
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: ExtractStatusSerializer,
-               meta: resource.metadata
+        render json: ExtractStatusSerializer.new(resource.data, { meta: resource.metadata })
       end
 
       def eligible_data_classes

--- a/modules/my_health/app/controllers/my_health/v1/triage_teams_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/triage_teams_controller.rb
@@ -13,10 +13,7 @@ module MyHealth
         resource = resource.sort(params.permit(:sort)[:sort])
 
         # Even though this is a collection action we are not going to paginate
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: TriageTeamSerializer,
-               meta: resource.metadata
+        render json: TriageTeamSerializer.new(resource.data, { meta: resource.metadata })
       end
     end
   end

--- a/modules/my_health/app/serializers/my_health/v1/extract_status_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/extract_status_serializer.rb
@@ -2,13 +2,12 @@
 
 module MyHealth
   module V1
-    class ExtractStatusSerializer < ActiveModel::Serializer
-      attribute :id
-      attribute :extract_type
-      attribute :last_updated
-      attribute :status
-      attribute :created_on
-      attribute :station_number
+    class ExtractStatusSerializer
+      include JSONAPI::Serializer
+
+      set_type :extract_status
+
+      attributes :extract_type, :last_updated, :status, :created_on, :station_number
     end
   end
 end

--- a/modules/my_health/app/serializers/my_health/v1/folder_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/folder_serializer.rb
@@ -2,18 +2,17 @@
 
 module MyHealth
   module V1
-    class FolderSerializer < ActiveModel::Serializer
-      # include MyHealth::Engine.routes.url_helpers
+    class FolderSerializer
+      include JSONAPI::Serializer
 
-      attribute :id
+      set_type :folders
+      attributes :name, :count, :unread_count, :system_folder
 
-      attribute(:folder_id) { object.id }
-      attribute :name
-      attribute :count
-      attribute :unread_count
-      attribute :system_folder
+      attribute :folder_id, &:id
 
-      link(:self) { MyHealth::UrlHelper.new.v1_folder_url(object.id) }
+      link :self do |object|
+        MyHealth::UrlHelper.new.v1_folder_url(object.id)
+      end
     end
   end
 end

--- a/modules/my_health/app/serializers/my_health/v1/triage_team_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/triage_team_serializer.rb
@@ -2,15 +2,12 @@
 
 module MyHealth
   module V1
-    class TriageTeamSerializer < ActiveModel::Serializer
-      def id
-        object.triage_team_id
-      end
+    class TriageTeamSerializer
+      include JSONAPI::Serializer
 
-      attribute :triage_team_id
-      attribute :name
-      attribute :relation_type
-      attribute :preferred_team
+      set_type :triage_teams
+      set_id :triage_team_id
+      attributes :triage_team_id, :name, :relation_type, :preferred_team
     end
   end
 end

--- a/modules/my_health/spec/request/v1/folders_request_spec.rb
+++ b/modules/my_health/spec/request/v1/folders_request_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Folders Integration', type: :request do
     describe '#index' do
       it 'responds to GET #index' do
         VCR.use_cassette('sm_client/folders/gets_a_collection_of_folders') do
-          get '/my_health/v1/messaging/folders'
+          get '/my_health/v1/messaging/folders', params: { page: 3, per_page: 5 }
         end
 
         expect(response).to be_successful
@@ -58,7 +58,7 @@ RSpec.describe 'Folders Integration', type: :request do
 
       it 'responds to GET #index when camel-inflected' do
         VCR.use_cassette('sm_client/folders/gets_a_collection_of_folders') do
-          get '/my_health/v1/messaging/folders', headers: inflection_header
+          get '/my_health/v1/messaging/folders', headers: inflection_header, params: { page: 3, per_page: 5 }
         end
 
         expect(response).to be_successful

--- a/modules/my_health/spec/serializer/v1/extract_status_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/extract_status_serializer_spec.rb
@@ -3,35 +3,34 @@
 require 'rails_helper'
 require 'bb/generate_report_request_form'
 
-describe MyHealth::V1::ExtractStatusSerializer do
-  let(:extract_status) { build(:extract_status) }
+describe MyHealth::V1::ExtractStatusSerializer, type: :serializer do
+  subject { serialize(extract_status, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(extract_status, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:extract_status) { build(:extract_status) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq extract_status.id
+    expect(data['id']).to eq extract_status.id.to_s
   end
 
   it 'includes :extract_type' do
-    expect(rendered_attributes[:extract_type]).to eq extract_status.extract_type
+    expect(attributes['extract_type']).to eq extract_status.extract_type
   end
 
   it 'includes :last_updated' do
-    expect(rendered_attributes[:last_updated]).to eq extract_status.last_updated
+    expect_time_eq(attributes['last_updated'], extract_status.last_updated)
   end
 
   it 'includes :status' do
-    expect(rendered_attributes[:status]).to eq extract_status.status
+    expect(attributes['status']).to eq extract_status.status
   end
 
   it 'includes :created_on' do
-    expect(rendered_attributes[:created_on]).to eq extract_status.created_on
+    expect_time_eq(attributes['created_on'], extract_status.created_on)
   end
 
   it 'includes :station_number' do
-    expect(rendered_attributes[:station_number]).to eq extract_status.station_number
+    expect(attributes['station_number']).to eq extract_status.station_number
   end
 end

--- a/modules/my_health/spec/serializer/v1/folder_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/folder_serializer_spec.rb
@@ -2,40 +2,40 @@
 
 require 'rails_helper'
 
-describe MyHealth::V1::FolderSerializer do
-  let(:folder) { build_stubbed(:folder) }
+describe MyHealth::V1::FolderSerializer, type: :serializer do
+  subject { serialize(folder, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(folder, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:folder) { build_stubbed(:folder) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+  let(:links) { data['links'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq folder.id.to_s
+    expect(data['id']).to eq folder.id.to_s
   end
 
   it 'includes :folder_id' do
-    expect(rendered_attributes[:folder_id]).to eq folder.id
+    expect(attributes['folder_id']).to eq folder.id
   end
 
   it 'includes :name' do
-    expect(rendered_attributes[:name]).to eq folder.name
+    expect(attributes['name']).to eq folder.name
   end
 
   it 'includes :count' do
-    expect(rendered_attributes[:count]).to eq folder.count
+    expect(attributes['count']).to eq folder.count
   end
 
   it 'includes :unread_count' do
-    expect(rendered_attributes[:unread_count]).to eq folder.unread_count
+    expect(attributes['unread_count']).to eq folder.unread_count
   end
 
   it 'includes :system_folder' do
-    expect(rendered_attributes[:system_folder]).to eq folder.system_folder
+    expect(attributes['system_folder']).to eq folder.system_folder
   end
 
-  it 'includes :download link' do
+  it 'includes :self link' do
     expected_url = MyHealth::UrlHelper.new.v1_folder_url(folder.id)
-    expect(rendered_hash[:data][:links][:self]).to eq expected_url
+    expect(links['self']).to eq expected_url
   end
 end

--- a/modules/my_health/spec/serializer/v1/triage_teams_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/triage_teams_serializer_spec.rb
@@ -3,31 +3,30 @@
 require 'rails_helper'
 require_relative '../../factories/all_triage_teams'
 
-describe MyHealth::V1::TriageTeamSerializer do
-  let(:triage_team) { build_stubbed(:triage_team) }
+describe MyHealth::V1::TriageTeamSerializer, type: :serializer do
+  subject { serialize(triage_team, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(triage_team, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:triage_team) { build_stubbed(:triage_team) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq triage_team.triage_team_id.to_s
+    expect(data['id']).to eq triage_team.triage_team_id.to_s
   end
 
   it 'includes :triage_team_id' do
-    expect(rendered_attributes[:triage_team_id]).to eq triage_team.triage_team_id
+    expect(attributes['triage_team_id']).to eq triage_team.triage_team_id
   end
 
   it 'includes :name' do
-    expect(rendered_attributes[:name]).to eq triage_team.name
+    expect(attributes['name']).to eq triage_team.name
   end
 
   it 'includes :relation_type' do
-    expect(rendered_attributes[:relation_type]).to eq triage_team.relation_type
+    expect(attributes['relation_type']).to eq triage_team.relation_type
   end
 
   it 'includes :preferred_team' do
-    expect(rendered_attributes[:preferred_team]).to eq triage_team.preferred_team
+    expect(attributes['preferred_team']).to eq triage_team.preferred_team
   end
 end


### PR DESCRIPTION
**Note**: `modules/my_health/app/controllers/my_health/v1/health_records_controller.rb` has not test coverage via request specs 

**Note**:  It's also unclear based on the specs whether the FoldersController#index call is using `links` or `meta` for pagination. The codeowners should address that in the spec. `links` is require, but pagination in the spec is checked only against `meta`  

## Summary

- Added `JsonApiPaginationLinks` which is used in creating the "links" object of the response
- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in `modules/my_health`.
    - `FoldersController`, `ExtractStatusSerializer`, `TriageTeamSerializer`
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86385

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage