### PR TITLE
85680: Migrate Supplemental Claims Form 4142 to LH Benefits Intake API

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -308,6 +308,10 @@ features:
   decision_review_sc_status_updater_enabled:
     actor_type: user
     description: Enables the Supplemental Claim status update batch job
+  decision_review_sc_use_lighthouse_api_for_form4142:
+    actor_type: user
+    description: Use Lighthouse API to submit Form 21-4142 from Supplemental Claims
+    enable_in_development: true
   decision_review_icn_updater_enabled:
     actor_type: user
     description: Enables the ICN lookup job

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -246,6 +246,8 @@ lighthouse:
       access_token:
         client_id: ~
         rsa_key: ~
+  benefits_intake:
+      api_key: fake_api_key
 
 rrd:
   alerts:

--- a/lib/decision_review_v1/utilities/logging_utils.rb
+++ b/lib/decision_review_v1/utilities/logging_utils.rb
@@ -52,7 +52,7 @@ module DecisionReviewV1
       # rubocop:enable Metrics/ParameterLists
       # rubocop:enable Layout/LineLength
 
-      def parse_form412_response_to_log_msg(appeal_submission_id:, data:, bm: nil)
+      def parse_form412_response_to_log_msg(appeal_submission_id:, data:, uuid: nil, bm: nil)
         log_data = { message: 'Supplemental Claim 4142 submitted.',
                      lighthouse_submission: {
                        id: appeal_submission_id
@@ -60,7 +60,7 @@ module DecisionReviewV1
                      form_id: FORM4142_ID, parent_form_id: SUPP_CLAIM_FORM_ID,
                      response_body: data.body,
                      response_status: data.status }
-        log_data[:extracted_uuid] = extract_uuid_from_central_mail_message(data) if data.success?
+        log_data[:extracted_uuid] = extract_uuid_from_central_mail_message(data, uuid) if data.success?
         log_data[:meta] = benchmark_to_log_data_hash(bm) unless bm.nil?
         log_data
       end
@@ -109,7 +109,9 @@ module DecisionReviewV1
 
       private
 
-      def extract_uuid_from_central_mail_message(data)
+      def extract_uuid_from_central_mail_message(data, uuid)
+        return uuid unless uuid.nil?
+
         data.body[/(?<=\[).*?(?=\])/].split(': ').last
       end
 

--- a/spec/requests/v1/supplemental_claims_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims_controller_request_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe V1::SupplementalClaimsController do
   end
 
   describe '#create with 4142' do
+    before do
+      Flipper.disable :decision_review_sc_use_lighthouse_api_for_form4142
+    end
+
     def personal_information_logs
       PersonalInformationLog.where 'error_class like ?',
                                    'V1::SupplementalClaimsController#create exception % (SC_V1)'

--- a/spec/requests/v1/supplemental_claims_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims_controller_request_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe V1::SupplementalClaimsController do
   end
 
   describe '#create with 4142' do
+    subject do
+      post '/v1/supplemental_claims',
+           params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
+           headers:
+    end
+
     before do
       Flipper.disable :decision_review_sc_use_lighthouse_api_for_form4142
     end
@@ -106,12 +112,6 @@ RSpec.describe V1::SupplementalClaimsController do
     def personal_information_logs
       PersonalInformationLog.where 'error_class like ?',
                                    'V1::SupplementalClaimsController#create exception % (SC_V1)'
-    end
-
-    subject do
-      post '/v1/supplemental_claims',
-           params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
-           headers:
     end
 
     it 'creates a supplemental claim and queues a 4142 form when 4142 info is provided' do

--- a/spec/requests/v1/supplemental_claims_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims_controller_request_spec.rb
@@ -99,6 +99,11 @@ RSpec.describe V1::SupplementalClaimsController do
   end
 
   describe '#create with 4142' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'V1::SupplementalClaimsController#create exception % (SC_V1)'
+    end
+
     subject do
       post '/v1/supplemental_claims',
            params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
@@ -107,11 +112,6 @@ RSpec.describe V1::SupplementalClaimsController do
 
     before do
       Flipper.disable :decision_review_sc_use_lighthouse_api_for_form4142
-    end
-
-    def personal_information_logs
-      PersonalInformationLog.where 'error_class like ?',
-                                   'V1::SupplementalClaimsController#create exception % (SC_V1)'
     end
 
     it 'creates a supplemental claim and queues a 4142 form when 4142 info is provided' do

--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
         end
 
         it 'generates a 4142 PDF and sends it to Lighthouse API' do
-          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
-            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
-              with_settings(Settings.lighthouse.benefits_intake, api_key: 'fake_api_key') do
+          with_settings(Settings.lighthouse.benefits_intake, api_key: 'fake_api_key') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+              VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
                 expect do
                   form4142 = request_body['form4142']
                   payload = get_and_rejigger_required_info(

--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -47,27 +47,30 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
       context 'and feature flag is enabled' do
         before do
           Flipper.enable :decision_review_sc_use_lighthouse_api_for_form4142
+
+          VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
+          VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
+        end
+
+        after do
+          VCR.eject_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
+          VCR.eject_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
         end
 
         it 'generates a 4142 PDF and sends it to Lighthouse API' do
+
           with_settings(Settings.lighthouse.benefits_intake, api_key: 'fake_api_key') do
-            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
-              VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
-                expect do
-                  form4142 = request_body['form4142']
-                  payload = get_and_rejigger_required_info(
-                    request_body:, form4142:, user:
-                  )
-                  enc_payload = payload_encrypted_string(payload)
-                  subject.perform_async(appeal_submission.id, enc_payload, submitted_appeal_uuid)
-                  subject.drain
-                end.to trigger_statsd_increment('worker.decision_review.form4142_submit.success', times: 1)
-                  .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue',
-                                                times: 1)
-                  .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue',
-                                                times: 1)
-              end
-            end
+            expect do
+              form4142 = request_body['form4142']
+              payload = get_and_rejigger_required_info(
+                request_body:, form4142:, user:
+              )
+              enc_payload = payload_encrypted_string(payload)
+              subject.perform_async(appeal_submission.id, enc_payload, submitted_appeal_uuid)
+              subject.drain
+            end.to trigger_statsd_increment('worker.decision_review.form4142_submit.success', times: 1)
+              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue', times: 1)
+              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue', times: 1)
           end
         end
       end

--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -21,20 +21,54 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
     let(:request_body) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV') }
 
     context 'when form4142 data exists' do
-      it 'generates a 4142 PDF and sends it to central mail' do
-        VCR.use_cassette('central_mail/submit_4142') do
-          expect do
-            form4142 = request_body['form4142']
-            payload = get_and_rejigger_required_info(
-              request_body:, form4142:, user:
-            )
-            enc_payload = payload_encrypted_string(payload)
-            subject.perform_async(appeal_submission.id, enc_payload, submitted_appeal_uuid)
-            subject.drain
-          end.to trigger_statsd_increment('worker.decision_review.form4142_submit.success', times: 1)
-            .and trigger_statsd_increment('api.central_mail.upload.total', times: 1)
-            .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue', times: 1)
-            .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue', times: 1)
+      context 'and feature flag is disabled' do
+        before do
+          Flipper.disable :decision_review_sc_use_lighthouse_api_for_form4142
+        end
+
+        it 'generates a 4142 PDF and sends it to central mail' do
+          VCR.use_cassette('central_mail/submit_4142') do
+            expect do
+              form4142 = request_body['form4142']
+              payload = get_and_rejigger_required_info(
+                request_body:, form4142:, user:
+              )
+              enc_payload = payload_encrypted_string(payload)
+              subject.perform_async(appeal_submission.id, enc_payload, submitted_appeal_uuid)
+              subject.drain
+            end.to trigger_statsd_increment('worker.decision_review.form4142_submit.success', times: 1)
+              .and trigger_statsd_increment('api.central_mail.upload.total', times: 1)
+              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue', times: 1)
+              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue', times: 1)
+          end
+        end
+      end
+
+      context 'and feature flag is enabled' do
+        before do
+          Flipper.enable :decision_review_sc_use_lighthouse_api_for_form4142
+        end
+
+        it 'generates a 4142 PDF and sends it to Lighthouse API' do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              with_settings(Settings.lighthouse.benefits_intake, api_key: 'fake_api_key') do
+                expect do
+                  form4142 = request_body['form4142']
+                  payload = get_and_rejigger_required_info(
+                    request_body:, form4142:, user:
+                  )
+                  enc_payload = payload_encrypted_string(payload)
+                  subject.perform_async(appeal_submission.id, enc_payload, submitted_appeal_uuid)
+                  subject.drain
+                end.to trigger_statsd_increment('worker.decision_review.form4142_submit.success', times: 1)
+                  .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue',
+                                                times: 1)
+                  .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue',
+                                                times: 1)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary
The current process to upload Form 4142 as part of Supplemental Claim submissions are directly submitted to CMP. With this new feature in place the upload will be done through the Lighthouse Benefits Intake API.

- *This work is behind a feature toggle (flipper): YES*
`decision_review_sc_use_lighthouse_api_for_form4142`

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/85680

## Testing done
- [x] *New code is covered by unit tests*
- When the flipper is disabled, Form 4142 submissions for Supplemental Claims are directly submitted to CMP
- When the flipper is enabled, Form 4142 submissions for Supplemental Claims use the Lighthouse Benefits Intake API
- This will be first verified in staging, then the flipper will be enabled in production and monitored for any errors

## What areas of the site does it impact?
This impacts Form 4142 submission Sidekiq jobs for Supplemental Claims submissions.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
