### PR TITLE
[384] Adding unauthenticated 'current_status' route for terms of use agreement controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,7 +372,9 @@ Rails.application.routes.draw do
       post 'document_upload'
     end
 
-    get 'terms_of_use_agreements/:icn/current_status', to: 'terms_of_use_agreements#current_status'
+    unless Settings.vsp_environment == 'production'
+      get 'terms_of_use_agreements/:icn/current_status', to: 'terms_of_use_agreements#current_status'
+    end
     get 'terms_of_use_agreements/:version/latest', to: 'terms_of_use_agreements#latest'
     post 'terms_of_use_agreements/:version/accept', to: 'terms_of_use_agreements#accept'
     post 'terms_of_use_agreements/:version/accept_and_provision', to: 'terms_of_use_agreements#accept_and_provision'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,6 +372,7 @@ Rails.application.routes.draw do
       post 'document_upload'
     end
 
+    get 'terms_of_use_agreements/:icn/current_status', to: 'terms_of_use_agreements#current_status'
     get 'terms_of_use_agreements/:version/latest', to: 'terms_of_use_agreements#latest'
     post 'terms_of_use_agreements/:version/accept', to: 'terms_of_use_agreements#accept'
     post 'terms_of_use_agreements/:version/accept_and_provision', to: 'terms_of_use_agreements#accept_and_provision'

--- a/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
+++ b/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
@@ -23,6 +23,46 @@ RSpec.describe V0::TermsOfUseAgreementsController, type: :controller do
     allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(find_profile_response)
   end
 
+  describe 'GET #current_status' do
+    subject { get :current_status, params: { icn: } }
+
+    it 'returns ok status' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'when a terms of use agreement exists for the authenticated user' do
+      let!(:terms_of_use_acceptance) do
+        create(:terms_of_use_agreement, user_account:, response: terms_response, agreement_version:)
+      end
+
+      context 'and terms of use agreement has been accepted' do
+        let(:terms_response) { 'accepted' }
+
+        it 'returns accepted status' do
+          subject
+          expect(JSON.parse(response.body)['agreement_status']).to eq(terms_response)
+        end
+      end
+
+      context 'and terms of use agreement has been declined' do
+        let(:terms_response) { 'declined' }
+
+        it 'returns declined status' do
+          subject
+          expect(JSON.parse(response.body)['agreement_status']).to eq(terms_response)
+        end
+      end
+    end
+
+    context 'when a terms of use agreement does not exist for the authenticated user' do
+      it 'returns nil status' do
+        subject
+        expect(JSON.parse(response.body)['agreement_status']).to eq(nil)
+      end
+    end
+  end
+
   describe 'GET #latest' do
     subject { get :latest, params: { version: agreement_version, terms_code: } }
 


### PR DESCRIPTION


## Summary

- This PR adds a route to the terms of use agreement controller to allow for an unauthenticated way to see if an ICN has accepted or declined a latest terms of use

## Related issue(s)

- https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/zh/384

## Testing done

- [ ] Called route with existing and non-existing ICN, proved that it returned applicable terms of use agreement status


## What areas of the site does it impact?
Terms of Use

## Acceptance criteria

- [ ]  Curl this route with existing and made up ICN values: localhost:3000/v0/terms_of_use_agreements/123456789V123456/current_status
