### PR TITLE
Add logging for 0966 bug

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -100,7 +100,7 @@ module SimpleFormsApi
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
         Rails.logger.info(
           'Simple forms api - 21-0966 Benefits Claims Intent to File API error, reverting to filling a PDF and sending it to Central Mail',
-          { error: e, current_user_participant_id: @current_user.participant_id }
+          { error: e, current_user_participant_id: @current_user.participant_id, current_user_account_uuid: @current_user.user_account_uuid }
         )
         prepare_params_for_central_mail
         submit_form_to_central_mail

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -98,7 +98,7 @@ module SimpleFormsApi
         json_for210966(confirmation_number, expiration_date, existing_intents)
       rescue Common::Exceptions::UnprocessableEntity => e
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
-        prepare_params_for_central_mail_and_log_error
+        prepare_params_for_central_mail_and_log_error(e)
         submit_form_to_central_mail
       end
 
@@ -191,7 +191,7 @@ module SimpleFormsApi
         json
       end
 
-      def prepare_params_for_central_mail_and_log_error
+      def prepare_params_for_central_mail_and_log_error(e)
         params['veteran_full_name'] ||= {
           'first' => params['full_name']['first'],
           'last' => params['full_name']['last']

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -98,16 +98,7 @@ module SimpleFormsApi
         json_for210966(confirmation_number, expiration_date, existing_intents)
       rescue Common::Exceptions::UnprocessableEntity => e
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
-        Rails.logger.info(
-          'Simple forms api - 21-0966 Benefits Claims Intent to File API error,' \
-          'reverting to filling a PDF and sending it to Central Mail',
-          {
-            error: e,
-            current_user_participant_id: @current_user.participant_id,
-            current_user_account_uuid: @current_user.user_account_uuid
-          }
-        )
-        prepare_params_for_central_mail
+        prepare_params_for_central_mail_and_log_error
         submit_form_to_central_mail
       end
 
@@ -200,13 +191,22 @@ module SimpleFormsApi
         json
       end
 
-      def prepare_params_for_central_mail
+      def prepare_params_for_central_mail_and_log_error
         params['veteran_full_name'] ||= {
           'first' => params['full_name']['first'],
           'last' => params['full_name']['last']
         }
         params['veteran_id'] ||= { 'ssn' => params['ssn'] }
         params['veteran_mailing_address'] ||= { 'postal_code' => @current_user.address[:postal_code] || '00000' }
+        Rails.logger.info(
+          'Simple forms api - 21-0966 Benefits Claims Intent to File API error,' \
+          'reverting to filling a PDF and sending it to Central Mail',
+          {
+            error: e,
+            current_user_participant_id: @current_user.participant_id,
+            current_user_account_uuid: @current_user.user_account_uuid
+          }
+        )
       end
 
       def json_for210966(confirmation_number, expiration_date, existing_intents)

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -96,8 +96,12 @@ module SimpleFormsApi
         end
 
         json_for210966(confirmation_number, expiration_date, existing_intents)
-      rescue Common::Exceptions::UnprocessableEntity
+      rescue Common::Exceptions::UnprocessableEntity => e
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
+        Rails.logger.info(
+          'Simple forms api - 21-0966 Benefits Claims Intent to File API error, reverting to filling a PDF and sending it to Central Mail',
+          { error: e, current_user_participant_id: @current_user.participant_id }
+        )
         prepare_params_for_central_mail
         submit_form_to_central_mail
       end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -200,10 +200,10 @@ module SimpleFormsApi
         params['veteran_mailing_address'] ||= { 'postal_code' => @current_user.address[:postal_code] || '00000' }
         Rails.logger.info(
           'Simple forms api - 21-0966 Benefits Claims Intent to File API error,' \
-          'reverting to filling a PDF and sending it to Central Mail',
+          'reverting to filling a PDF and sending it to Benefits Intake API',
           {
             error: e,
-            current_user_participant_id: @current_user.participant_id,
+            is_current_user_participant_id_present: @current_user.participant_id ? true : false,
             current_user_account_uuid: @current_user.user_account_uuid
           }
         )

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -99,8 +99,13 @@ module SimpleFormsApi
       rescue Common::Exceptions::UnprocessableEntity => e
         # There is an authentication issue with the Intent to File API so we revert to sending a PDF to Central Mail
         Rails.logger.info(
-          'Simple forms api - 21-0966 Benefits Claims Intent to File API error, reverting to filling a PDF and sending it to Central Mail',
-          { error: e, current_user_participant_id: @current_user.participant_id, current_user_account_uuid: @current_user.user_account_uuid }
+          'Simple forms api - 21-0966 Benefits Claims Intent to File API error,' \
+          'reverting to filling a PDF and sending it to Central Mail',
+          {
+            error: e,
+            current_user_participant_id: @current_user.participant_id,
+            current_user_account_uuid: @current_user.user_account_uuid
+          }
         )
         prepare_params_for_central_mail
         submit_form_to_central_mail


### PR DESCRIPTION
## Summary
This PR adds a line of logging whenever the Intent API raises an exception. It will tell us the error itself and the current user's participant_id, which may be `nil`.