### PR TITLE
Replace RepresentationManagement AMS serializers with JSONAPI serializers

### DIFF
--- a/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
@@ -15,7 +15,8 @@ module RepresentationManagement
 
           if flags.all?(&:valid?)
             flags.each(&:save!)
-            render json: flags, each_serializer: RepresentationManagement::FlaggedVeteranRepresentativeContactDataSerializer, status: :created # rubocop:disable Layout/LineLength
+            serializer = RepresentationManagement::FlaggedVeteranRepresentativeContactDataSerializer.new(flags)
+            render json: serializer, status: :created
           else
             raise ActiveRecord::Rollback, 'Invalid flags present'
           end

--- a/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_controller.rb
@@ -13,7 +13,7 @@ module RepresentationManagement
         if @active_poa.blank? || record.blank?
           render json: { data: {} }, status: :ok
         else
-          render json: record, serializer:, status: :ok
+          render json: serializer.new(record), status: :ok
         end
       end
 

--- a/modules/representation_management/app/serializers/representation_management/flagged_veteran_representative_contact_data_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/flagged_veteran_representative_contact_data_serializer.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module RepresentationManagement
-  class FlaggedVeteranRepresentativeContactDataSerializer < ActiveModel::Serializer
+  class FlaggedVeteranRepresentativeContactDataSerializer
+    include JSONAPI::Serializer
+
     attributes :ip_address, :representative_id, :flag_type, :flagged_value
   end
 end

--- a/modules/representation_management/app/serializers/representation_management/power_of_attorney/base_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/power_of_attorney/base_serializer.rb
@@ -2,20 +2,12 @@
 
 module RepresentationManagement
   module PowerOfAttorney
-    class BaseSerializer < ActiveModel::Serializer
-      attribute :address_line1
-      attribute :address_line2
-      attribute :address_line3
-      attribute :address_type
-      attribute :city
-      attribute :country_name
-      attribute :country_code_iso3
-      attribute :province
-      attribute :international_postal_code
-      attribute :state_code
-      attribute :zip_code
-      attribute :zip_suffix
-      attribute :phone
+    class BaseSerializer
+      include JSONAPI::Serializer
+
+      attributes :address_line1, :address_line2, :address_line3, :address_type,
+                 :city, :country_name, :country_code_iso3, :province,
+                 :international_postal_code, :state_code, :zip_code, :zip_suffix, :phone
     end
   end
 end

--- a/modules/representation_management/app/serializers/representation_management/power_of_attorney/organization_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/power_of_attorney/organization_serializer.rb
@@ -3,12 +3,13 @@
 module RepresentationManagement
   module PowerOfAttorney
     class OrganizationSerializer < BaseSerializer
-      attribute :type
-      attribute :name
+      include JSONAPI::Serializer
 
-      def type
+      attribute :type do
         'organization'
       end
+
+      attribute :name
     end
   end
 end

--- a/modules/representation_management/app/serializers/representation_management/power_of_attorney/representative_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/power_of_attorney/representative_serializer.rb
@@ -3,21 +3,15 @@
 module RepresentationManagement
   module PowerOfAttorney
     class RepresentativeSerializer < BaseSerializer
-      attribute :type
-      attribute :name
-      attribute :email
+      include JSONAPI::Serializer
 
-      def type
+      attribute :type do
         'representative'
       end
 
-      def name
-        object.full_name
-      end
-
-      def phone
-        object.phone_number
-      end
+      attribute :email
+      attribute :name, &:full_name
+      attribute :phone, &:phone_number
     end
   end
 end

--- a/modules/representation_management/spec/serializers/flagged_veteran_representative_contact_data_serializer_spec.rb
+++ b/modules/representation_management/spec/serializers/flagged_veteran_representative_contact_data_serializer_spec.rb
@@ -2,27 +2,26 @@
 
 require 'rails_helper'
 
-describe RepresentationManagement::FlaggedVeteranRepresentativeContactDataSerializer do
-  let(:contact_data) { build_stubbed(:flagged_veteran_representative_contact_data) }
+describe RepresentationManagement::FlaggedVeteranRepresentativeContactDataSerializer, type: :serializer do
+  subject { serialize(contact_data, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(contact_data, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:contact_data) { build_stubbed(:flagged_veteran_representative_contact_data) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :ip_address' do
-    expect(rendered_attributes[:ip_address]).to eq contact_data.ip_address
+    expect(attributes['ip_address']).to eq contact_data.ip_address
   end
 
   it 'includes :representative_id' do
-    expect(rendered_attributes[:representative_id]).to eq contact_data.representative_id
+    expect(attributes['representative_id']).to eq contact_data.representative_id
   end
 
   it 'includes :flag_type' do
-    expect(rendered_attributes[:flag_type]).to eq contact_data.flag_type
+    expect(attributes['flag_type']).to eq contact_data.flag_type
   end
 
   it 'includes :flagged_value' do
-    expect(rendered_attributes[:flagged_value]).to eq contact_data.flagged_value
+    expect(attributes['flagged_value']).to eq contact_data.flagged_value
   end
 end

--- a/modules/representation_management/spec/serializers/power_of_attorney/organization_serializer_spec.rb
+++ b/modules/representation_management/spec/serializers/power_of_attorney/organization_serializer_spec.rb
@@ -3,25 +3,24 @@
 require 'rails_helper'
 require_relative 'shared_base_power_of_attorney'
 
-describe RepresentationManagement::PowerOfAttorney::OrganizationSerializer do
-  let(:object) { build_stubbed(:organization) }
+describe RepresentationManagement::PowerOfAttorney::OrganizationSerializer, type: :serializer do
+  subject { serialize(object, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(object, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:object) { build_stubbed(:organization) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it_behaves_like 'power_of_attorney'
 
   it 'includes :type' do
-    expect(rendered_attributes[:type]).to eq 'organization'
+    expect(attributes['type']).to eq 'organization'
   end
 
   it 'includes :name' do
-    expect(rendered_attributes[:name]).to eq object.name
+    expect(attributes['name']).to eq object.name
   end
 
   it 'includes :phone' do
-    expect(rendered_attributes[:phone]).to eq object.phone
+    expect(attributes['phone']).to eq object.phone
   end
 end

--- a/modules/representation_management/spec/serializers/power_of_attorney/representative_serializer_spec.rb
+++ b/modules/representation_management/spec/serializers/power_of_attorney/representative_serializer_spec.rb
@@ -3,29 +3,28 @@
 require 'rails_helper'
 require_relative 'shared_base_power_of_attorney'
 
-describe RepresentationManagement::PowerOfAttorney::RepresentativeSerializer do
-  let(:object) { build_stubbed(:representative) }
+describe RepresentationManagement::PowerOfAttorney::RepresentativeSerializer, type: :serializer do
+  subject { serialize(object, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(object, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:object) { build_stubbed(:representative) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it_behaves_like 'power_of_attorney'
 
   it 'includes :type' do
-    expect(rendered_attributes[:type]).to eq 'representative'
+    expect(attributes['type']).to eq 'representative'
   end
 
   it 'includes :name' do
-    expect(rendered_attributes[:name]).to eq object.full_name
+    expect(attributes['name']).to eq object.full_name
   end
 
   it 'includes :email' do
-    expect(rendered_attributes[:email]).to eq object.email
+    expect(attributes['email']).to eq object.email
   end
 
   it 'includes :phone' do
-    expect(rendered_attributes[:phone]).to eq object.phone_number
+    expect(attributes['phone']).to eq object.phone_number
   end
 end

--- a/modules/representation_management/spec/serializers/power_of_attorney/shared_base_power_of_attorney.rb
+++ b/modules/representation_management/spec/serializers/power_of_attorney/shared_base_power_of_attorney.rb
@@ -4,55 +4,55 @@ require 'rails_helper'
 
 RSpec.shared_examples 'power_of_attorney' do
   it 'includes :address_line1' do
-    expect(rendered_attributes[:address_line1]).to eq object.address_line1
+    expect(attributes['address_line1']).to eq object.address_line1
   end
 
   it 'includes :address_line2' do
-    expect(rendered_attributes[:address_line2]).to eq object.address_line2
+    expect(attributes['address_line2']).to eq object.address_line2
   end
 
   it 'includes :address_line3' do
-    expect(rendered_attributes[:address_line3]).to eq object.address_line3
+    expect(attributes['address_line3']).to eq object.address_line3
   end
 
   it 'includes :address_type' do
-    expect(rendered_attributes[:address_type]).to eq object.address_type
+    expect(attributes['address_type']).to eq object.address_type
   end
 
   it 'includes :city' do
-    expect(rendered_attributes[:city]).to eq object.city
+    expect(attributes['city']).to eq object.city
   end
 
   it 'includes :country_name' do
-    expect(rendered_attributes[:country_name]).to eq object.country_name
+    expect(attributes['country_name']).to eq object.country_name
   end
 
   it 'includes :country_code_iso3' do
-    expect(rendered_attributes[:country_code_iso3]).to eq object.country_code_iso3
+    expect(attributes['country_code_iso3']).to eq object.country_code_iso3
   end
 
   it 'includes :province' do
-    expect(rendered_attributes[:province]).to eq object.province
+    expect(attributes['province']).to eq object.province
   end
 
   it 'includes :international_postal_code' do
-    expect(rendered_attributes[:international_postal_code]).to eq object.international_postal_code
+    expect(attributes['international_postal_code']).to eq object.international_postal_code
   end
 
   it 'includes :state_code' do
-    expect(rendered_attributes[:state_code]).to eq object.state_code
+    expect(attributes['state_code']).to eq object.state_code
   end
 
   it 'includes :zip_code' do
-    expect(rendered_attributes[:zip_code]).to eq object.zip_code
+    expect(attributes['zip_code']).to eq object.zip_code
   end
 
   it 'includes :zip_suffix' do
-    expect(rendered_attributes[:zip_suffix]).to eq object.zip_suffix
+    expect(attributes['zip_suffix']).to eq object.zip_suffix
   end
 
   # phone is on the organization and representative serializer spec
-  it 'includes :zip_suffix' do
-    expect(rendered_attributes.keys).to include(:phone)
+  it 'includes :phone' do
+    expect(attributes.keys).to include('phone')
   end
 end


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in `modules/representation_management`.
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86386

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage