### PR TITLE
Log nil if there is no living_situation or other_reason in 20-10207

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -116,8 +116,8 @@ module SimpleFormsApi
       StatsD.increment("#{STATS_KEY}.#{identity}")
       Rails.logger.info('Simple forms api - 20-10207 submission user identity', identity:, confirmation_number:)
 
-      living_situations = data['living_situation'].select { |_, v| v }.keys.join(', ')
-      other_reasons = data['other_reasons'].select { |_, v| v }.keys.join(', ')
+      living_situations = data['living_situation']&.select { |_, v| v }.keys.join(', ')
+      other_reasons = data['other_reasons']&.select { |_, v| v }.keys.join(', ')
       Rails.logger.info('Simple forms api - 20-10207 submission living situations and other reasons for request',
                         living_situations:, other_reasons:)
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -116,8 +116,10 @@ module SimpleFormsApi
       StatsD.increment("#{STATS_KEY}.#{identity}")
       Rails.logger.info('Simple forms api - 20-10207 submission user identity', identity:, confirmation_number:)
 
-      living_situations = data['living_situation']&.select { |_, v| v }.keys.join(', ')
-      other_reasons = data['other_reasons']&.select { |_, v| v }.keys.join(', ')
+      living_situation_data = data['living_situation']
+      other_reasons_data = data['other_reasons']
+      living_situation = living_situation_data ? living_situation_data.select { |_, v| v }.keys.join(', ') : nil
+      other_reasons = other_reasons_data ? other_reasons_data.select { |_, v| v }.keys.join(', ') : nil
       Rails.logger.info('Simple forms api - 20-10207 submission living situations and other reasons for request',
                         living_situations:, other_reasons:)
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -118,7 +118,7 @@ module SimpleFormsApi
 
       living_situation_data = data['living_situation']
       other_reasons_data = data['other_reasons']
-      living_situation = living_situation_data ? living_situation_data.select { |_, v| v }.keys.join(', ') : nil
+      living_situations = living_situation_data ? living_situation_data.select { |_, v| v }.keys.join(', ') : nil
       other_reasons = other_reasons_data ? other_reasons_data.select { |_, v| v }.keys.join(', ') : nil
       Rails.logger.info('Simple forms api - 20-10207 submission living situations and other reasons for request',
                         living_situations:, other_reasons:)


### PR DESCRIPTION
## Summary
This PR will allow the logger to log the `living_situation` and `other_reason` in 20-10207, even if they are `nil`. Currently, we call `.select` on `nil` and that is raising an exception.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1417
