### PR TITLE
Fix invalid index `index_flipper_features_on_key`

### DIFF
--- a/db/migrate/20240627204058_re_add_index_on_flipper_features.rb
+++ b/db/migrate/20240627204058_re_add_index_on_flipper_features.rb
@@ -1,0 +1,8 @@
+class ReAddIndexOnFlipperFeatures < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :flipper_features, column: :key, name: :index_flipper_features_on_key, if_exists: true
+    add_index :flipper_features, :key, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_180946) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_27_204058) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -628,7 +628,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_25_180946) do
     t.datetime "updated_at", null: false
     t.datetime "flagged_value_updated_at"
     t.index ["ip_address", "representative_id", "flag_type", "flagged_value_updated_at"], name: "index_unique_constraint_fields", unique: true
-    t.index ["ip_address", "representative_id", "flag_type"], name: "index_unique_flagged_veteran_representative", unique: true
   end
 
   create_table "flipper_features", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -628,6 +628,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_204058) do
     t.datetime "updated_at", null: false
     t.datetime "flagged_value_updated_at"
     t.index ["ip_address", "representative_id", "flag_type", "flagged_value_updated_at"], name: "index_unique_constraint_fields", unique: true
+    t.index ["ip_address", "representative_id", "flag_type"], name: "index_unique_flagged_veteran_representative", unique: true
   end
 
   create_table "flipper_features", force: :cascade do |t|


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- [PgHero](http://pghero-prod.vfs.va.gov/) listed `index_flipper_features_on_key` as an invalid index and recommended I recreate it. There should be no changes to the schema.

From PgHero:
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/e381fd5c-b6ad-4c44-8c81-f1273641366f)


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80648

## Testing done
- I ran `rails db:migrate` locally. 

## What areas of the site does it impact?
The `flipper_features` table. re-adds the index.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

