### PR TITLE
Log primary and hyphenated diagnostic codes for Max CFI metrics

### DIFF
--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -47,7 +47,7 @@ module ClaimFastTracking
       when 6300..6399
         :infectious_disease
       when ->(dc) { dc % 100 == 99 }
-        :unlisted_condition
+        :analogous_code
       else
         :primary_max_rating
       end

--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -33,23 +33,25 @@ module ClaimFastTracking
       rated_disabilities.each do |dis|
         Rails.logger.info('Max CFI rated disability',
                           diagnostic_code: dis&.diagnostic_code,
-                          diagnostic_code_type: diagnostic_code_type(dis&.diagnostic_code),
+                          diagnostic_code_type: diagnostic_code_type(dis),
                           hyphenated_diagnostic_code: dis&.hyphenated_diagnostic_code)
       end
     end
 
-    def self.diagnostic_code_type(diagnostic_code)
-      case diagnostic_code
+    def self.diagnostic_code_type(rated_disability)
+      case rated_disability&.diagnostic_code
       when nil
         :missing_diagnostic_code
       when 7200..7399
         :digestive_system
       when 6300..6399
         :infectious_disease
-      when ->(dc) { dc % 100 == 99 }
-        :analogous_code
       else
-        :primary_max_rating
+        if (rated_disability&.hyphenated_diagnostic_code || 0) % 100 == 99
+          :analogous_code
+        else
+          :primary_max_rating
+        end
       end
     end
 

--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -39,13 +39,14 @@ module ClaimFastTracking
     end
 
     def self.diagnostic_code_type(diagnostic_code)
-      if diagnostic_code.nil?
+      case diagnostic_code
+      when nil
         :missing_diagnostic_code
-      elsif diagnostic_code.between?(7200, 7399)
+      when 7200..7399
         :digestive_system
-      elsif diagnostic_code.between?(6300, 6399)
+      when 6300..6399
         :infectious_disease
-      elsif diagnostic_code % 100 == 99
+      when ->(dc) { dc % 100 == 99 }
         :unlisted_condition
       else
         :primary_max_rating

--- a/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider.rb
+++ b/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider.rb
@@ -42,6 +42,7 @@ class LighthouseRatedDisabilitiesProvider
           decision_code: decision_code_transform(rated_disability['decision']),
           decision_text: rated_disability['decision'],
           diagnostic_code: rated_disability['diagnostic_type_code'].to_i,
+          hyphenated_diagnostic_code: rated_disability['hyph_diagnostic_type_code'].presence&.to_i,
           effective_date: rated_disability['effective_date'],
           rated_disability_id: rated_disability['disability_rating_id'],
           rating_decision_id: 0,

--- a/lib/disability_compensation/responses/rated_disabilities_response.rb
+++ b/lib/disability_compensation/responses/rated_disabilities_response.rb
@@ -16,6 +16,7 @@ module DisabilityCompensation
       attribute :decision_code, String
       attribute :decision_text, String
       attribute :diagnostic_code, Integer
+      attribute :hyphenated_diagnostic_code, Integer
       attribute :name, String
       attribute :effective_date, DateTime
       attribute :rated_disability_id, String

--- a/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
+++ b/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider'
 
 RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
   describe 'annotate_disabilities' do
@@ -138,6 +139,73 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
           end
         end
       end
+    end
+  end
+
+  describe 'log_hyphenated_diagnostic_codes' do
+    subject { described_class.log_hyphenated_diagnostic_codes(rated_disabilities) }
+
+    before { allow(Rails.logger).to receive(:info) }
+
+    let(:rated_disabilities) do
+      disabilities_data.map { |dis| DisabilityCompensation::ApiProvider::RatedDisability.new(**dis) }
+    end
+    let(:disabilities_data) do
+      [
+        { name: 'Tinnitus', diagnostic_code: 6260, rating_percentage: 10 },
+        { name: 'Pancreatitis, chronic', diagnostic_code: 7347, rating_percentage: 30 },
+        { name: 'Postop tonsillectomy', diagnostic_code: 6599, hyphenated_diagnostic_code: 6516, rating_percentage: 30 }
+      ]
+    end
+
+    it 'sends the correct output to Rails log' do
+      subject
+      expect(Rails.logger).to have_received(:info).with(
+        'Max CFI rated disability',
+        { diagnostic_code: 6260, diagnostic_code_type: :primary_max_rating, hyphenated_diagnostic_code: nil }
+      )
+      expect(Rails.logger).to have_received(:info).with(
+        'Max CFI rated disability',
+        { diagnostic_code: 7347, diagnostic_code_type: :digestive_system, hyphenated_diagnostic_code: nil }
+      )
+      expect(Rails.logger).to have_received(:info).with(
+        'Max CFI rated disability',
+        { diagnostic_code: 6599, diagnostic_code_type: :unlisted_condition, hyphenated_diagnostic_code: 6516 }
+      )
+    end
+  end
+
+  describe 'diagnostic_code_type' do
+    subject { described_class.diagnostic_code_type(diagnostic_code) }
+
+    context 'when diagnostic code is nil' do
+      let(:diagnostic_code) { nil }
+
+      it { is_expected.to eq(:missing_diagnostic_code) }
+    end
+
+    context 'when diagnostic code is in the digestive system range' do
+      let(:diagnostic_code) { 7329 }
+
+      it { is_expected.to eq(:digestive_system) }
+    end
+
+    context 'when diagnostic code is in the infectious disease range' do
+      let(:diagnostic_code) { 6354 }
+
+      it { is_expected.to eq(:infectious_disease) }
+    end
+
+    context 'when diagnostic code is an unlisted condition' do
+      let(:diagnostic_code) { 6599 }
+
+      it { is_expected.to eq(:unlisted_condition) }
+    end
+
+    context 'when diagnostic code does not invoke any hyphenated logic' do
+      let(:diagnostic_code) { 6260 }
+
+      it { is_expected.to eq(:primary_max_rating) }
     end
   end
 end

--- a/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
+++ b/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
       [
         { name: 'Tinnitus', diagnostic_code: 6260, rating_percentage: 10 },
         { name: 'Pancreatitis, chronic', diagnostic_code: 7347, rating_percentage: 30 },
-        { name: 'Postop tonsillectomy', diagnostic_code: 6599, hyphenated_diagnostic_code: 6516, rating_percentage: 30 }
+        { name: 'Postop tonsillectomy', diagnostic_code: 6516, hyphenated_diagnostic_code: 6599, rating_percentage: 30 }
       ]
     end
 
@@ -170,13 +170,18 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
       )
       expect(Rails.logger).to have_received(:info).with(
         'Max CFI rated disability',
-        { diagnostic_code: 6599, diagnostic_code_type: :analogous_code, hyphenated_diagnostic_code: 6516 }
+        { diagnostic_code: 6516, diagnostic_code_type: :analogous_code, hyphenated_diagnostic_code: 6599 }
       )
     end
   end
 
   describe 'diagnostic_code_type' do
-    subject { described_class.diagnostic_code_type(diagnostic_code) }
+    subject { described_class.diagnostic_code_type(rated_disability) }
+
+    let(:rated_disability) do
+      DisabilityCompensation::ApiProvider::RatedDisability.new(diagnostic_code:, hyphenated_diagnostic_code:)
+    end
+    let(:hyphenated_diagnostic_code) { nil }
 
     context 'when diagnostic code is nil' do
       let(:diagnostic_code) { nil }
@@ -197,7 +202,8 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
     end
 
     context 'when diagnostic code is for an unlisted condition requiring an analogous code' do
-      let(:diagnostic_code) { 6599 }
+      let(:hyphenated_diagnostic_code) { 6599 }
+      let(:diagnostic_code) { 6516 }
 
       it { is_expected.to eq(:analogous_code) }
     end

--- a/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
+++ b/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
       )
       expect(Rails.logger).to have_received(:info).with(
         'Max CFI rated disability',
-        { diagnostic_code: 6599, diagnostic_code_type: :unlisted_condition, hyphenated_diagnostic_code: 6516 }
+        { diagnostic_code: 6599, diagnostic_code_type: :analogous_code, hyphenated_diagnostic_code: 6516 }
       )
     end
   end
@@ -196,10 +196,10 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
       it { is_expected.to eq(:infectious_disease) }
     end
 
-    context 'when diagnostic code is an unlisted condition' do
+    context 'when diagnostic code is for an unlisted condition requiring an analogous code' do
       let(:diagnostic_code) { 6599 }
 
-      it { is_expected.to eq(:unlisted_condition) }
+      it { is_expected.to eq(:analogous_code) }
     end
 
     context 'when diagnostic code does not invoke any hyphenated logic' do

--- a/spec/support/schemas/rated_disability_base.json
+++ b/spec/support/schemas/rated_disability_base.json
@@ -22,6 +22,9 @@
     "diagnostic_code": {
       "type": "integer"
     },
+    "hyphenated_diagnostic_code": {
+      "type": ["integer", "null"]
+    },
     "name": {
       "type": "string"
     },

--- a/spec/support/schemas_camelized/rated_disability_base.json
+++ b/spec/support/schemas_camelized/rated_disability_base.json
@@ -22,6 +22,9 @@
     "diagnosticCode": {
       "type": "integer"
     },
+    "hyphenatedDiagnosticCode": {
+      "type": ["integer", "null"]
+    },
     "name": {
       "type": "string"
     },


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This PR adds Rails logging of primary and hyphenated diagnostic codes seen in the 526 flow, for visibility in DataDog.
- I'm on the Employee Experience team, and we work closely with the Disability Experience team who maintains 526.

## Related issue(s)
- department-of-veterans-affairs/abd-vro#2865

## Testing done
- [x] *New code is covered by unit tests*
- Old behavior: no Rails logging of diagnostic codes
- New rspec examples added to cover logging behavior as well as logic for making sense of primary and hyphenated diagnostic codes
- EE team will confirm in DataDog (staging) that diagnostic codes are being logged correctly before adding code to make use of them.

## What areas of the site does it impact?
* No user-facing impact

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
