### PR TITLE
Fix invalid index `index_flipper_gates_on_feature_key_and_key_and_value`

### DIFF
--- a/db/migrate/20240628161151_re_add_index_on_flipper_gates.rb
+++ b/db/migrate/20240628161151_re_add_index_on_flipper_gates.rb
@@ -1,0 +1,8 @@
+class ReAddIndexOnFlipperGates < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :flipper_gates, name: :index_flipper_gates_on_feature_key_and_key_and_value, if_exists: true
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_180946) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_28_161151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- [PgHero](http://pghero-prod.vfs.va.gov/) listed `index_flipper_gates_on_feature_key_and_key_and_value` as an invalid index and recommended I recreate it. There should be no changes to the schema.

From PgHero:
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/ca33b198-4505-4cfb-8161-fe3d1715daf5)


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80648

## Testing done
- I ran `rails db:migrate` locally. 

## What areas of the site does it impact?
The `flipper_gates` table. re-adds the index.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

