### PR TITLE
Move MPI call to SignUpServiceUpdaterJob

### DIFF
--- a/app/services/terms_of_use/decliner.rb
+++ b/app/services/terms_of_use/decliner.rb
@@ -23,11 +23,8 @@ module TermsOfUse
 
     def perform!
       terms_of_use_agreement.declined!
-      if mpi_profile.sec_id
-        update_sign_up_service
-      else
-        Rails.logger.info('[TermsOfUse] [Decliner] Sign Up Service not updated due to user missing sec_id', { icn: })
-      end
+
+      update_sign_up_service
       Logger.new(terms_of_use_agreement:).perform
 
       terms_of_use_agreement
@@ -42,26 +39,13 @@ module TermsOfUse
     end
 
     def update_sign_up_service
-      Rails.logger.info('[TermsOfUse] [Decliner] attr_package key', { icn:, attr_package_key: })
-      SignUpServiceUpdaterJob.perform_async(attr_package_key)
+      Rails.logger.info('[TermsOfUse] [Decliner] update_sign_up_service', { icn: })
+      SignUpServiceUpdaterJob.perform_async(user_account.id, version)
     end
 
     def log_and_raise_decliner_error(error)
       Rails.logger.error("[TermsOfUse] [Decliner] Error: #{error.message}", { user_account_id: user_account&.id })
       raise Errors::DeclinerError, error.message
-    end
-
-    def signature_name
-      "#{mpi_profile.given_names.first} #{mpi_profile.family_name}"
-    end
-
-    def mpi_profile
-      @mpi_profile ||= MPI::Service.new.find_profile_by_identifier(identifier: icn,
-                                                                   identifier_type: MPI::Constants::ICN)&.profile
-    end
-
-    def attr_package_key
-      @attr_package_key ||= Sidekiq::AttrPackage.create(icn:, signature_name:, version:, expires_in: 72.hours)
     end
   end
 end

--- a/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
+++ b/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
@@ -10,21 +10,13 @@ module TermsOfUse
     sidekiq_options retry_for: 48.hours
 
     sidekiq_retries_exhausted do |job, exception|
-      attr_package_key = job['args'].first
-      attrs = Sidekiq::AttrPackage.find(attr_package_key)
-
-      icn = attrs&.dig(:icn)
-      version = attrs&.dig(:version)
-
-      agreement = TermsOfUseAgreement.joins(:user_account)
-                                     .where(user_account: { icn: })
-                                     .where(agreement_version: version)
-                                     .last
+      user_account = UserAccount.find_by(id: job['args'].first)
+      version = job['args'].second
+      agreement = user_account.terms_of_use_agreements.where(agreement_version: version).last if user_account.present?
 
       payload = {
-        icn:,
+        icn: user_account&.icn,
         version:,
-        attr_package_key:,
         response: agreement&.response,
         response_time: agreement&.created_at&.iso8601,
         exception_message: exception.message
@@ -33,18 +25,15 @@ module TermsOfUse
       Rails.logger.warn('[TermsOfUse][SignUpServiceUpdaterJob] retries exhausted', payload)
     end
 
-    attr_reader :icn, :signature_name, :version
+    attr_reader :user_account_uuid, :version
 
-    def perform(attr_package_key)
-      attrs = Sidekiq::AttrPackage.find(attr_package_key)
+    def perform(user_account_uuid, version)
+      @user_account_uuid = user_account_uuid
+      @version = version
 
-      @icn = attrs[:icn]
-      @signature_name = attrs[:signature_name]
-      @version = attrs[:version]
+      return unless sec_id?
 
       terms_of_use_agreement.accepted? ? accept : decline
-
-      Sidekiq::AttrPackage.delete(attr_package_key)
     end
 
     private
@@ -57,8 +46,33 @@ module TermsOfUse
       MAP::SignUp::Service.new.agreements_decline(icn:)
     end
 
+    def sec_id?
+      return true if mpi_profile.sec_id.present?
+
+      Rails.logger.info('[TermsOfUse][SignUpServiceUpdaterJob] Sign Up Service not updated due to user missing sec_id',
+                        { icn: })
+      false
+    end
+
+    def user_account
+      @user_account ||= UserAccount.find(user_account_uuid)
+    end
+
+    def icn
+      @icn ||= user_account.icn
+    end
+
     def terms_of_use_agreement
-      UserAccount.find_by(icn:).terms_of_use_agreements.where(agreement_version: version).last
+      user_account.terms_of_use_agreements.where(agreement_version: version).last
+    end
+
+    def signature_name
+      "#{mpi_profile.given_names.first} #{mpi_profile.family_name}"
+    end
+
+    def mpi_profile
+      @mpi_profile ||= MPI::Service.new.find_profile_by_identifier(identifier: icn,
+                                                                   identifier_type: MPI::Constants::ICN)&.profile
     end
   end
 end


### PR DESCRIPTION
## Summary

- This moves the MPI profile call inside the SignUpServiceUpdaterJob
- Removes use of sidekiq attr package since the args we are passing to sidekiq aren't PII anymore

## Related issue(s)
- https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/zh/369

## Testing
- Test accepting and declining terms of use
- Confirm TermsOfUseAgreements are being created in rails console
   ```ruby
   TermsOfUseAgreement.last
   ```
- check that jobs are getting queued in sidekiq:
  - Go to http://localhost:3000/sidekiq/queues/default
  - You should see `TermsOfUse::SignUpServiceUpdaterJob` being queued up    
    <img width="915" alt="Screenshot 2024-06-28 at 11 15 22 AM" src="https://github.com/department-of-veterans-affairs/vets-api/assets/10853209/88be8bb9-91ce-48c8-9d64-a66eac0f60ed">

  
## What areas of the site does it impact?
Terms of use, authentication

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

