### PR TITLE
87253 - Handle STS timeouts in the MAP services controller

### DIFF
--- a/app/controllers/v0/map_services_controller.rb
+++ b/app/controllers/v0/map_services_controller.rb
@@ -11,7 +11,7 @@ module V0
       result = MAP::SecurityToken::Service.new.token(application: params[:application].to_sym, icn:, cache: false)
 
       render json: result, status: :ok
-    rescue Common::Client::Errors::ClientError
+    rescue Common::Client::Errors::ClientError, Common::Exceptions::GatewayTimeout
       render json: sts_client_error, status: :bad_gateway
     rescue MAP::SecurityToken::Errors::ApplicationMismatchError
       render json: application_mismatch_error, status: :bad_request


### PR DESCRIPTION
## Summary

This PR updates the MAP services controller to handle STS timeout errors by sending a bad gateway response.

## Related issue(s)

https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/87253

## Testing done

### Regression test

- Run the seeds script to add the chatbot service account config.
- Open the Rails console and generate an assertion.
```ruby
private_key = OpenSSL::PKey::RSA.new(
  File.read('spec/fixtures/sign_in/sts_client.pem')
)

payload = {
  'iss' => 'http://localhost:3978/api/messages',
  'sub' => 'vets.gov.user+0@gmail.com',
  'aud' => 'http://127.0.0.1:3000/v0/sign_in/token',
  'iat' => Time.now.to_i,
  'exp' => 10.days.from_now.to_i,
  'scopes' => ['http://localhost:3000/v0/map_services/chatbot/token'],
  'service_account_id' => '88a6d94a3182fd63279ea5565f26bcb4',
  'jti' => SecureRandom.hex,
  'user_attributes' => { 'icn' => 42 }
}

JWT.encode(payload, private_key, 'RS256')
```
- Using the Sign in Service postman collection, obtain a service account token.
  - Paste the generated assertion as the value for the `signed_service_account_assertion` collection variable.
  - Send the `token` request (located in the `Service Account Auth` collection.)
  - Save the returned token in the `service_account_access_token` collection variable.
- Create a new POST action for the `{{vets_api_env}}/v0/map_services/:application/token` endpoint.
- Set the application path variable as `chatbot` to test a successful response.
- Set-up the authorization header to include the `service_account_access_token` as a bearer token.
- Send the request.
- Verify the response includes the access token and expiration.


### Timeouts

- SImulate a timeout by adding `raise Net::ReadTimeout` to the STS configuration class.
```ruby
      def connection
        raise Net::ReadTimeout # Add this to force a timeout
        @connection ||= Faraday.new(
          base_path,
          headers: base_request_headers,
          request: request_options
        ) do |conn|
          conn.use :breakers
          conn.use Faraday::Response::RaiseError
          conn.response :betamocks if Settings.map_services.secure_token_service.mock
          conn.adapter Faraday.default_adapter
        end
      end
```
- Run the seeds script to add the chatbot service account config.
- Open the Rails console and generate an assertion.
```ruby
private_key = OpenSSL::PKey::RSA.new(
  File.read('spec/fixtures/sign_in/sts_client.pem')
)

payload = {
  'iss' => 'http://localhost:3978/api/messages',
  'sub' => 'vets.gov.user+0@gmail.com',
  'aud' => 'http://127.0.0.1:3000/v0/sign_in/token',
  'iat' => Time.now.to_i,
  'exp' => 10.days.from_now.to_i,
  'scopes' => ['http://localhost:3000/v0/map_services/chatbot/token'],
  'service_account_id' => '88a6d94a3182fd63279ea5565f26bcb4',
  'jti' => SecureRandom.hex,
  'user_attributes' => { 'icn' => 42 }
}

JWT.encode(payload, private_key, 'RS256')
```
- Using the Sign in Service postman collection, obtain a service account token.
  - Paste the generated assertion as the value for the `signed_service_account_assertion` collection variable.
  - Send the `token` request (located in the `Service Account Auth` collection.)
  - Save the returned token in the `service_account_access_token` collection variable.
- Create a new POST action for the `{{vets_api_env}}/v0/map_services/:application/token` endpoint.
- Set the application path variable as `chatbot` to test a successful response.
- Set-up the authorization header to include the `service_account_access_token` as a bearer token.
- Send the request.
- Verify the response returns status 502 bad gateway
- Verify the response body includes an error message:
```json
{
    "error": "server_error",
    "error_description": "STS failed to return a valid token."
}
```
- Verify the Rails logger logs the error:
```
2024-06-28 15:34:14.810685 E [449:puma srv tp 002 service.rb:23] Rails -- [MAP][SecurityToken][Service] token failed, gateway timeout -- { :application => :chatbot, :icn => 42 }
```

## Screenshots
Not relevant.

## What areas of the site does it impact?

Services that use the MAP STS request API.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None.
