### PR TITLE
DROP INDEX index_flipper_features_on_key

### DIFF
--- a/db/migrate/20240628173854_drop_index_on_flipper_features.rb
+++ b/db/migrate/20240628173854_drop_index_on_flipper_features.rb
@@ -2,6 +2,8 @@ class DropIndexOnFlipperFeatures < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    execute 'DROP INDEX CONCURRENTLY index_flipper_features_on_key;'
+    safety_assured do
+      execute 'DROP INDEX CONCURRENTLY index_flipper_features_on_key;'
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -885,7 +885,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_173854) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "case_id"
-    t.index ["form_uuid"], name: "index_ivc_champva_forms_on_form_uuid"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
@@ -1482,12 +1481,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_173854) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_profile_id"
-    t.date "cert_issue_date"
-    t.date "del_date"
-    t.date "date_last_certified"
     t.integer "bdn_clone_id"
     t.integer "bdn_clone_line"
     t.boolean "bdn_clone_active"
+    t.date "cert_issue_date"
+    t.date "del_date"
+    t.date "date_last_certified"
     t.index ["bdn_clone_active"], name: "index_vye_user_infos_on_bdn_clone_active"
     t.index ["bdn_clone_id"], name: "index_vye_user_infos_on_bdn_clone_id"
     t.index ["bdn_clone_line"], name: "index_vye_user_infos_on_bdn_clone_line"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -885,6 +885,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_173854) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "case_id"
+    t.index ["form_uuid"], name: "index_ivc_champva_forms_on_form_uuid"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Summary
This is a second attempt. First attempt https://github.com/department-of-veterans-affairs/vets-api/pull/17320 resulted in the error when db migrate was run in dev and staging:
```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  could not create unique index "index_flipper_features_on_key" (ActiveRecord::RecordNotUnique)
DETAIL:  Key (key)=(drupal_footer) is duplicated.
```
In this PR, we've separated out the commands. 
- *This work is behind a feature toggle (flipper): NO*
- [PgHero](http://pghero-prod.vfs.va.gov/) listed `index_flipper_features_on_key` as an invalid index and recommended I recreate it. There should be no changes to the schema.

From PgHero:
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/e381fd5c-b6ad-4c44-8c81-f1273641366f)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80648

## Testing done
- I ran `rails db:migrate` locally. 

## What areas of the site does it impact?
The `flipper_features` table.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

