### PR TITLE
[AVS] update AVS id validation

### DIFF
--- a/modules/avs/app/controllers/avs/v0/avs_controller.rb
+++ b/modules/avs/app/controllers/avs/v0/avs_controller.rb
@@ -88,7 +88,7 @@ module Avs
       end
 
       def validate_sid?(sid)
-        /^([A-F0-9]){32}$/.match(sid)
+        /^[[:xdigit:]]{30,40}$/.match(sid)
       end
 
       def normalize_icn(icn)

--- a/modules/avs/spec/request/v0/avs_request_spec.rb
+++ b/modules/avs/spec/request/v0/avs_request_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe 'V0::Avs', type: :request do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it 'returns error when sid is too short' do
+      get '/avs/v0/avs/3e8535e743ce63ed333ebbbb67626'
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'returns error when sid is too long' do
+      get '/avs/v0/avs/5e68a88a158a70da31e48c0bf02243545e68a88a1'
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'returns error when sid is not in hex format' do
+      get '/avs/v0/avs/5e68a88a158a70da31e48c0bf0224354z'
+      expect(response).to have_http_status(:bad_request)
+    end
+
     it 'returns empty response found when AVS not found for sid' do
       VCR.use_cassette('avs/show/not_found') do
         get '/avs/v0/avs/9A7AF40B2BC2471EA116891839113253'


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- During production validation, requests for a new AVS were returning an error for an invalid ID. After validating with the upstream system owner, I learned that the IDs can be of variable length. This PR updates the validation to accept lengths from 30-40 characters.

## Related issue(s)

- https://dsva.slack.com/archives/C04UBETRY8N/p1719591085143669

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
- AVS module only

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
