### PR TITLE
CREATE UNIQUE INDEX flipper_features

### DIFF
--- a/db/migrate/20240628195735_add_index_on_flipper_features.rb
+++ b/db/migrate/20240628195735_add_index_on_flipper_features.rb
@@ -1,0 +1,9 @@
+class AddIndexOnFlipperFeatures < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      execute 'CREATE UNIQUE INDEX index_flipper_features_on_key ON public.flipper_features USING btree (key);'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_180946) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_28_195735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -635,6 +635,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_195735) do
     t.string "key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
   create_table "flipper_gates", force: :cascade do |t|
@@ -1482,12 +1483,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_195735) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_profile_id"
-    t.integer "bdn_clone_id"
-    t.integer "bdn_clone_line"
-    t.boolean "bdn_clone_active"
     t.date "cert_issue_date"
     t.date "del_date"
     t.date "date_last_certified"
+    t.integer "bdn_clone_id"
+    t.integer "bdn_clone_line"
+    t.boolean "bdn_clone_active"
     t.index ["bdn_clone_active"], name: "index_vye_user_infos_on_bdn_clone_active"
     t.index ["bdn_clone_id"], name: "index_vye_user_infos_on_bdn_clone_id"
     t.index ["bdn_clone_line"], name: "index_vye_user_infos_on_bdn_clone_line"


### PR DESCRIPTION
## Summary
- Follow-up to #17331 

This is a second attempt. First attempt https://github.com/department-of-veterans-affairs/vets-api/pull/17320 resulted in the error when db migrate was run in dev and staging:
```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  could not create unique index "index_flipper_features_on_key" (ActiveRecord::RecordNotUnique)
DETAIL:  Key (key)=(drupal_footer) is duplicated.
```
In this PR, we're only adding in index.  
- *This work is behind a feature toggle (flipper): NO*
- [PgHero](http://pghero-prod.vfs.va.gov/) listed `index_flipper_features_on_key` as an invalid index and recommended I recreate it. There should be no changes to the schema.

From PgHero:
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10993987/e381fd5c-b6ad-4c44-8c81-f1273641366f)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80648

## Testing done
- [x] Run `rails db:migrate` locally after pulling in master. 

## What areas of the site does it impact?
The `flipper_features` table.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
