### PR TITLE
Revert "CREATE UNIQUE INDEX flipper_features"

### DIFF
--- a/db/migrate/20240628195735_add_index_on_flipper_features.rb
+++ b/db/migrate/20240628195735_add_index_on_flipper_features.rb
@@ -1,9 +1,0 @@
-class AddIndexOnFlipperFeatures < ActiveRecord::Migration[7.1]
-  disable_ddl_transaction!
-
-  def change
-    safety_assured do
-      execute 'CREATE UNIQUE INDEX index_flipper_features_on_key ON public.flipper_features USING btree (key);'
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_28_195735) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_28_173854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -635,7 +635,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_195735) do
     t.string "key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
   create_table "flipper_gates", force: :cascade do |t|
@@ -1483,12 +1482,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_195735) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_profile_id"
-    t.date "cert_issue_date"
-    t.date "del_date"
-    t.date "date_last_certified"
     t.integer "bdn_clone_id"
     t.integer "bdn_clone_line"
     t.boolean "bdn_clone_active"
+    t.date "cert_issue_date"
+    t.date "del_date"
+    t.date "date_last_certified"
     t.index ["bdn_clone_active"], name: "index_vye_user_infos_on_bdn_clone_active"
     t.index ["bdn_clone_id"], name: "index_vye_user_infos_on_bdn_clone_id"
     t.index ["bdn_clone_line"], name: "index_vye_user_infos_on_bdn_clone_line"


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#17337

```
PG::UniqueViolation: ERROR:  could not create unique index "index_flipper_features_on_key"
DETAIL:  Key (key)=(mhv_secure_messaging_to_va_gov_release) is duplicated.
```