### PR TITLE
Replace VA Forms AMS serializers with JSONAPI serializers

### DIFF
--- a/modules/va_forms/app/controllers/va_forms/v0/forms_controller.rb
+++ b/modules/va_forms/app/controllers/va_forms/v0/forms_controller.rb
@@ -20,31 +20,26 @@ module VAForms
       end
 
       def search_by_form_number
-        render json: Form.search_by_form_number(params[:query]),
-               serializer: ActiveModel::Serializer::CollectionSerializer,
-               each_serializer: VAForms::FormListSerializer
+        forms = Form.search_by_form_number(params[:query])
+        render json: VAForms::FormListSerializer.new(forms)
       end
 
       def search_by_text(query)
-        render json: Form.search(query),
-               serializer: ActiveModel::Serializer::CollectionSerializer,
-               each_serializer: VAForms::FormListSerializer
+        forms = Form.search(query)
+        render json: VAForms::FormListSerializer.new(forms)
       end
 
       def return_all
-        render json: Form.return_all,
-               serializer: ActiveModel::Serializer::CollectionSerializer,
-               each_serializer: VAForms::FormListSerializer
+        forms = Form.return_all
+        render json: VAForms::FormListSerializer.new(forms)
       end
 
       def show
         forms = Form.find_by form_name: params[:id]
         if forms.present?
-          render json: forms,
-                 serializer: VAForms::FormDetailSerializer
+          render json: VAForms::FormDetailSerializer.new(forms)
         else
-          render json: { errors: [{ detail: 'Form not found' }] },
-                 status: :not_found
+          render json: { errors: [{ detail: 'Form not found' }] }, status: :not_found
         end
       end
     end

--- a/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
+++ b/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 module VAForms
-  class FormDetailSerializer < ActiveModel::Serializer
-    type :va_form
+  class FormDetailSerializer
+    include JSONAPI::Serializer
+
+    set_type :va_form
+    set_id :row_id
 
     attributes :form_name, :url, :title, :first_issued_on,
                :last_revision_on, :created_at, :pages, :sha256, :valid_pdf,
                :form_usage, :form_tool_intro, :form_tool_url, :form_details_url,
                :form_type, :language, :deleted_at, :related_forms,
-               :benefit_categories, :va_form_administration, :versions
+               :benefit_categories, :va_form_administration
 
-    def id
-      object.row_id
-    end
-
-    def versions
+    attribute :versions do |object|
       object.change_history&.dig('versions') || []
     end
   end

--- a/modules/va_forms/app/serializers/va_forms/form_list_serializer.rb
+++ b/modules/va_forms/app/serializers/va_forms/form_list_serializer.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module VAForms
-  class FormListSerializer < ActiveModel::Serializer
-    type :va_form
+  class FormListSerializer
+    include JSONAPI::Serializer
+
+    set_type :va_form
+    set_id :row_id
 
     attributes :form_name, :url, :title, :first_issued_on,
                :last_revision_on, :pages, :sha256, :last_sha256_change, :valid_pdf,
                :form_usage, :form_tool_intro, :form_tool_url, :form_details_url,
                :form_type, :language, :deleted_at, :related_forms, :benefit_categories,
                :va_form_administration
-
-    def id
-      object.row_id
-    end
   end
 end


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in `modules/va_forms`.
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86388

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage