### PR TITLE
Replace VBA Documents AMS serializers with JSONAPI serializers

### DIFF
--- a/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
@@ -15,8 +15,8 @@ module VBADocuments
         Rails.logger.info "Request from Consumer #{consumer} has #{params[ID_PARAM].size}" \
                           " total GUIDs and the first 5 are #{params[ID_PARAM].first(5)}"
         statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
-        render json: with_spoofed(statuses),
-               each_serializer: VBADocuments::V1::UploadSerializer
+        spoofed_statuses = with_spoofed(statuses)
+        render json: VBADocuments::V1::UploadSerializer.new(spoofed_statuses)
       end
 
       private

--- a/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
@@ -18,10 +18,8 @@ module VBADocuments
         )
         submission.metadata['version'] = 1
         submission.save!
-        render status: :accepted,
-               json: submission,
-               serializer: VBADocuments::V1::UploadSerializer,
-               render_location: true
+        options = { params: { render_location: true } }
+        render json: VBADocuments::V1::UploadSerializer.new(submission, options), status: :accepted
       end
 
       def show
@@ -42,9 +40,8 @@ module VBADocuments
           end
         end
 
-        render json: submission,
-               serializer: VBADocuments::V1::UploadSerializer,
-               render_location: false
+        options = { params: { render_location: false } }
+        render json: VBADocuments::V1::UploadSerializer.new(submission, options)
       end
 
       def download

--- a/modules/vba_documents/app/controllers/vba_documents/v2/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v2/reports_controller.rb
@@ -13,8 +13,8 @@ module VBADocuments
 
       def create
         statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
-        render json: with_spoofed(statuses),
-               each_serializer: VBADocuments::V2::UploadSerializer
+        spoofed_statuses = with_spoofed(statuses)
+        render json: VBADocuments::V2::UploadSerializer.new(spoofed_statuses)
       end
 
       private

--- a/modules/vba_documents/app/controllers/vba_documents/v2/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v2/uploads_controller.rb
@@ -39,10 +39,9 @@ module VBADocuments
             )
           end
         end
-        render status: :accepted,
-               json: submission,
-               serializer: VBADocuments::V2::UploadSerializer,
-               render_location: true
+
+        options = { params: { render_location: true } }
+        render json: VBADocuments::V2::UploadSerializer.new(submission, options), status: :accepted
       rescue JSON::ParserError => e
         raise Common::Exceptions::SchemaValidationErrors, ["invalid JSON. #{e.message}"] if e.is_a? JSON::ParserError
       end
@@ -66,9 +65,8 @@ module VBADocuments
           end
         end
 
-        render json: submission,
-               serializer: VBADocuments::V2::UploadSerializer,
-               render_location: false
+        options = { params: { render_location: false } }
+        render json: VBADocuments::V2::UploadSerializer.new(submission, options)
       end
 
       def download
@@ -111,7 +109,8 @@ module VBADocuments
           upload_model.update(status: 'error', code: 'DOC104', detail: e.message)
         end
         status = upload_model.status.eql?('error') ? 400 : 200
-        render json: upload_model, serializer: VBADocuments::V2::UploadSerializer, status:
+
+        render json: VBADocuments::V2::UploadSerializer.new(upload_model), status:
       end
       # rubocop:enable Metrics/MethodLength
 

--- a/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
@@ -3,58 +3,45 @@
 require 'vba_documents/pdf_inspector'
 
 module VBADocuments
-  class UploadSerializer < ActiveModel::Serializer
+  class UploadSerializer
+    include JSONAPI::Serializer
+
     MAX_DETAIL_DISPLAY_LENGTH = 200
 
-    type 'document_upload'
+    set_type :document_upload
+    set_id :guid
 
-    attributes :guid, :status, :code, :detail, :location, :updated_at, :uploaded_pdf
+    attributes :guid, :code, :updated_at
 
-    module ClassMethods
-      include PDFInspector::Constants
-      def scrub_unnecessary_keys(pdf_hash)
-        pdf_hash.delete(SOURCE_KEY.to_s)
-        pdf_hash.delete('submitted_line_of_business')
-
-        if pdf_hash['content'].present?
-          pdf_hash['content'].delete('sha256_checksum')
-          pdf_hash['content']['attachments']&.each { |attach_hash| attach_hash.delete('sha256_checksum') }
-        end
-
-        pdf_hash
-      end
-    end
-    extend ClassMethods
-
-    def id
-      object.guid
-    end
-
-    delegate :code, to: :object
-    delegate :detail, to: :object
-
-    def detail
+    attribute :detail do |object|
       detail = object.detail.to_s
-      detail = "#{detail[0..MAX_DETAIL_DISPLAY_LENGTH - 1]}..." if detail.length > MAX_DETAIL_DISPLAY_LENGTH
-      detail
+      detail.length > MAX_DETAIL_DISPLAY_LENGTH ? "#{detail[0..MAX_DETAIL_DISPLAY_LENGTH - 1]}..." : detail
     end
 
-    def uploaded_pdf
-      return nil unless object.uploaded_pdf
-
-      UploadSerializer.scrub_unnecessary_keys(object.uploaded_pdf)
+    attribute :uploaded_pdf do |object|
+      scrub_unnecessary_keys(object.uploaded_pdf) if object.uploaded_pdf
     end
 
-    def status
+    attribute :status do |object|
       object.status == 'vbms' ? 'success' : object.status
     end
 
-    def location
-      return nil unless @instance_options[:render_location]
-
-      object.get_location
+    attribute :location do |object, params|
+      object.get_location if params[:render_location]
     rescue => e
       raise Common::Exceptions::InternalServerError, e
+    end
+
+    def self.scrub_unnecessary_keys(pdf_hash)
+      pdf_hash.delete(PDFInspector::Constants::SOURCE_KEY.to_s)
+      pdf_hash.delete('submitted_line_of_business')
+
+      if pdf_hash['content'].present?
+        pdf_hash['content'].delete('sha256_checksum')
+        pdf_hash['content']['attachments']&.each { |attach_hash| attach_hash.delete('sha256_checksum') }
+      end
+
+      pdf_hash
     end
   end
 end

--- a/modules/vba_documents/app/serializers/vba_documents/v1/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/v1/upload_serializer.rb
@@ -3,7 +3,7 @@
 module VBADocuments
   module V1
     class UploadSerializer < VBADocuments::UploadSerializer
-      delegate :status, to: :object
+      attribute :status
     end
   end
 end

--- a/modules/vba_documents/spec/serializers/shared_upload_serializer.rb
+++ b/modules/vba_documents/spec/serializers/shared_upload_serializer.rb
@@ -56,7 +56,9 @@ RSpec.shared_examples 'VBADocuments::UploadSerializer' do
       allow(upload_submission).to receive(:get_location).and_return('http://another.fakesite.com/rewrittenpath')
     end
 
-    let(:response) { serialize(upload_submission, { serializer_class: described_class, render_location: true }) }
+    let(:response) do
+      serialize(upload_submission, { serializer_class: described_class, params: { render_location: true } })
+    end
     let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
 
     it 'includes :location' do
@@ -76,7 +78,7 @@ RSpec.shared_examples 'VBADocuments::UploadSerializer' do
     end
 
     it 'raises an internal server error' do
-      expect { serialize(upload_submission, { serializer_class: described_class, render_location: true }) }
+      expect { serialize(upload_submission, { serializer_class: described_class, params: { render_location: true } }) }
         .to raise_error(Common::Exceptions::InternalServerError, 'Internal server error')
     end
   end

--- a/modules/vba_documents/spec/serializers/v2/upload_serializer_spec.rb
+++ b/modules/vba_documents/spec/serializers/v2/upload_serializer_spec.rb
@@ -25,11 +25,11 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
       allow(Webhooks::Subscription).to receive(:get_observers_by_guid).and_return([double])
     end
 
-    let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
+    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
+    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
 
     it 'includes :observers' do
-      expect(attributes['observers']).to be_present
+      expect(attributes).to have_key('observers')
     end
   end
 
@@ -38,8 +38,8 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
       allow(Webhooks::Subscription).to receive(:get_observers_by_guid).and_return([])
     end
 
-    let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
+    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
+    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
 
     it 'does not include :observers' do
       expect(attributes).not_to have_key('observers')
@@ -51,8 +51,8 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
       allow(Settings.vba_documents).to receive(:v2_upload_endpoint_enabled).and_return(true)
     end
 
-    let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
+    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
+    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
 
     it 'does not include :location' do
       expect(attributes).not_to have_key('location')
@@ -64,11 +64,11 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
       allow(Settings.vba_documents).to receive(:v2_upload_endpoint_enabled).and_return(false)
     end
 
-    let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
+    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
+    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
 
     it 'includes :location' do
-      expect(attributes_location).to have_key('location')
+      expect(attributes).to have_key('location')
     end
   end
 end

--- a/modules/vba_documents/spec/serializers/v2/upload_serializer_spec.rb
+++ b/modules/vba_documents/spec/serializers/v2/upload_serializer_spec.rb
@@ -25,9 +25,6 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
       allow(Webhooks::Subscription).to receive(:get_observers_by_guid).and_return([double])
     end
 
-    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
-
     it 'includes :observers' do
       expect(attributes).to have_key('observers')
     end
@@ -37,9 +34,6 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
     before do
       allow(Webhooks::Subscription).to receive(:get_observers_by_guid).and_return([])
     end
-
-    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
 
     it 'does not include :observers' do
       expect(attributes).not_to have_key('observers')
@@ -51,9 +45,6 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
       allow(Settings.vba_documents).to receive(:v2_upload_endpoint_enabled).and_return(true)
     end
 
-    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
-
     it 'does not include :location' do
       expect(attributes).not_to have_key('location')
     end
@@ -63,9 +54,6 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
     before do
       allow(Settings.vba_documents).to receive(:v2_upload_endpoint_enabled).and_return(false)
     end
-
-    # let(:response) { serialize(upload_submission, serializer_class: described_class) }
-    # let(:attributes_location) { JSON.parse(response)['data']['attributes'] }
 
     it 'includes :location' do
       expect(attributes).to have_key('location')


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in `modules/vba_documents`.
- Refactoring `modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb` to remove the class method block
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86389

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage