### PR TITLE
Revert "delete unused features"

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -734,6 +734,10 @@ features:
   mhv_helpdesk_information_enabled:
     actor_type: user
     description: Enables the MHV helpdesk information
+  mhv_secure_messaging_to_va_gov_release:
+    actor_type: user
+    description: Enables/disables Secure Messaging Patient on VA.gov (intial transition from MHV to VA.gov)
+    enable_in_development: true
   mhv_secure_messaging_to_phase_1:
     actor_type: user
     description: Enables/disables Secure Messaging Phase 1 on VA.gov
@@ -1402,6 +1406,9 @@ features:
   virtual_agent_fetch_jwt_token:
     actor_type: user
     description: Enable the fetching of a JWT token to access MAP environment
+  drupal_footer:
+    actor_type: user
+    description: If enabled, pulls Drupal data to populate most of the global footer
   virtual_agent_lighthouse_claims:
     actor_type: user
     description: Use lighthouse instead of EVSS to view benefit claims for virtual agent chatbot application
@@ -1527,3 +1534,4 @@ features:
   toggle_vye_application:
     actor_type: user
     description: Enable VYE
+    


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#17342

See https://dsva.slack.com/archives/CBU0KDSB1/p1719840613675229

>This [PR](https://github.com/department-of-veterans-affairs/vets-api/pull/17342) removed a feature flag mhv_secure_messaging_to_va_gov_release which was not supposed to be removed as it is still [being used.](https://github.com/department-of-veterans-affairs/vets-website/blob/2fec2708bf1041b71f7afadf35339fa0502140c5/src/applications/mhv-secure-messaging/containers/App.jsx#L39) Currently it is blocking access to My Health - Messages in staging. Please revert ASAP to prevent from deploying to production