### PR TITLE
Add Logingov all_email attribute to Sign-in Service

### DIFF
--- a/app/services/sign_in/authentication_service_retriever.rb
+++ b/app/services/sign_in/authentication_service_retriever.rb
@@ -41,7 +41,7 @@ module SignIn
     end
 
     def logingov_auth_service
-      @logingov_auth_service ||= Logingov::Service.new
+      @logingov_auth_service ||= Logingov::Service.new(optional_scopes: logingov_optional_scopes)
     end
 
     def mock_auth_service
@@ -50,6 +50,12 @@ module SignIn
         @mock_auth_service.type = type
         @mock_auth_service
       end
+    end
+
+    def logingov_optional_scopes
+      return [] if client_config.blank?
+
+      client_config.access_token_attributes & Logingov::Service::OPTIONAL_SCOPES
     end
   end
 end

--- a/app/services/sign_in/constants/access_token.rb
+++ b/app/services/sign_in/constants/access_token.rb
@@ -11,7 +11,7 @@ module SignIn
       ].freeze
 
       ISSUER = 'va.gov sign in'
-      USER_ATTRIBUTES = %w[first_name last_name email].freeze
+      USER_ATTRIBUTES = %w[first_name last_name email all_emails].freeze
     end
   end
 end

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -6,6 +6,7 @@ module SignIn
                 :idme_uuid,
                 :logingov_uuid,
                 :credential_email,
+                :all_credential_emails,
                 :verified_icn,
                 :edipi,
                 :mhv_correlation_id,
@@ -18,6 +19,7 @@ module SignIn
       @idme_uuid = user_attributes[:idme_uuid]
       @logingov_uuid = user_attributes[:logingov_uuid]
       @credential_email = user_attributes[:csp_email]
+      @all_credential_emails = user_attributes[:all_csp_emails]
       @edipi = user_attributes[:edipi]
       @mhv_correlation_id = user_attributes[:mhv_correlation_id]
       @verified_icn = verified_icn
@@ -103,7 +105,8 @@ module SignIn
     def access_token_attributes
       { first_name:,
         last_name:,
-        email: credential_email }.compact
+        email: credential_email,
+        all_emails: all_credential_emails }.compact
     end
 
     def needs_accepted_terms_of_use?

--- a/lib/sign_in/logingov/service.rb
+++ b/lib/sign_in/logingov/service.rb
@@ -9,14 +9,34 @@ module SignIn
     class Service < Common::Client::Base
       configuration Configuration
 
-      SCOPE = 'profile profile:verified_at address email social_security_number openid'
+      DEFAULT_SCOPES = [
+        PROFILE_SCOPE = 'profile',
+        VERIFIED_AT_SCOPE = 'profile:verified_at',
+        ADDRESS_SCOPE = 'address',
+        EMAIL_SCOPE = 'email',
+        OPENID_SCOPE = 'openid',
+        SSN_SCOPE = 'social_security_number'
+      ].freeze
+
+      OPTIONAL_SCOPES = [ALL_EMAILS_SCOPE = 'all_emails'].freeze
+
+      attr_reader :optional_scopes
+
+      def initialize(optional_scopes: [])
+        @optional_scopes = valid_optional_scopes(optional_scopes)
+        super()
+      end
 
       def render_auth(state: SecureRandom.hex,
                       acr: Constants::Auth::LOGIN_GOV_IAL1,
                       operation: Constants::Auth::AUTHORIZE)
+
         Rails.logger.info('[SignIn][Logingov][Service] Rendering auth, ' \
-                          "state: #{state}, acr: #{acr}, operation: #{operation}")
-        RedirectUrlGenerator.new(redirect_uri: auth_url, params_hash: auth_params(acr, state)).perform
+                          "state: #{state}, acr: #{acr}, operation: #{operation}, " \
+                          "optional_scopes: #{optional_scopes}")
+
+        scope = (DEFAULT_SCOPES + optional_scopes).join(' ')
+        RedirectUrlGenerator.new(redirect_uri: auth_url, params_hash: auth_params(acr, state, scope)).perform
       end
 
       def render_logout(client_logout_redirect_uri)
@@ -43,6 +63,7 @@ module SignIn
       def user_info(token)
         response = perform(:get, config.userinfo_path, nil, { 'Authorization' => "Bearer #{token}" })
         log_credential(response.body) if config.log_credential
+
         OpenStruct.new(response.body)
       rescue Common::Client::Errors::ClientError => e
         raise_client_error(e, 'UserInfo')
@@ -59,6 +80,7 @@ module SignIn
           last_name: user_info.family_name,
           address: normalize_address(user_info.address),
           csp_email: user_info.email,
+          all_csp_emails: user_info.all_emails,
           multifactor: true,
           service_name: config.service_name,
           authn_context: get_authn_context(credential_level.current_ial),
@@ -68,7 +90,7 @@ module SignIn
 
       private
 
-      def auth_params(acr, state)
+      def auth_params(acr, state, scope)
         {
           acr_values: acr,
           client_id: config.client_id,
@@ -76,7 +98,7 @@ module SignIn
           prompt: config.prompt,
           redirect_uri: config.redirect_uri,
           response_type: config.response_type,
-          scope: SCOPE,
+          scope:,
           state:
         }
       end
@@ -207,6 +229,10 @@ module SignIn
 
       def random_seed
         @random_seed ||= SecureRandom.hex
+      end
+
+      def valid_optional_scopes(optional_scopes)
+        optional_scopes.to_a & OPTIONAL_SCOPES
       end
     end
   end

--- a/modules/mocked_authentication/spec/lib/credential/service_spec.rb
+++ b/modules/mocked_authentication/spec/lib/credential/service_spec.rb
@@ -109,6 +109,7 @@ describe MockedAuthentication::Credential::Service do
     let(:birth_date) { 'some-birth-date' }
     let(:ssn) { 'some-ssn' }
     let(:email) { 'some-email' }
+    let(:all_emails) { [email] }
     let(:user_uuid) { 'some-user-uuid' }
     let(:street) { "some-street\nsome-second-line-street" }
     let(:postal_code) { 'some-postal-code' }
@@ -128,6 +129,7 @@ describe MockedAuthentication::Credential::Service do
                          sub: user_uuid,
                          iss:,
                          email:,
+                         all_emails:,
                          email_verified: true,
                          given_name: first_name,
                          family_name: last_name,
@@ -155,6 +157,7 @@ describe MockedAuthentication::Credential::Service do
           max_ial: IAL::TWO,
           service_name: type,
           csp_email: email,
+          all_csp_emails: all_emails,
           multifactor:,
           authn_context:,
           auto_uplevel:

--- a/spec/factories/sign_in/code_containers.rb
+++ b/spec/factories/sign_in/code_containers.rb
@@ -10,7 +10,8 @@ FactoryBot.define do
     user_attributes do
       { first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name,
-        email: Faker::Internet.email }
+        email: Faker::Internet.email,
+        all_emails: [Faker::Internet.email] }
     end
   end
 end

--- a/spec/factories/sign_in/o_auth_sessions.rb
+++ b/spec/factories/sign_in/o_auth_sessions.rb
@@ -14,7 +14,8 @@ FactoryBot.define do
     user_attributes do
       { first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name,
-        email: Faker::Internet.email }.to_json
+        email: Faker::Internet.email,
+        all_emails: [Faker::Internet.email] }.to_json
     end
   end
 end

--- a/spec/factories/sign_in/validated_credentials.rb
+++ b/spec/factories/sign_in/validated_credentials.rb
@@ -10,7 +10,8 @@ FactoryBot.define do
     user_attributes do
       { first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name,
-        email: Faker::Internet.email }
+        email: Faker::Internet.email,
+        all_emails: [Faker::Internet.email] }
     end
     device_sso { false }
 

--- a/spec/services/sign_in/authentication_service_retriever_spec.rb
+++ b/spec/services/sign_in/authentication_service_retriever_spec.rb
@@ -30,8 +30,32 @@ RSpec.describe SignIn::AuthenticationServiceRetriever do
         let(:type) { SignIn::Constants::Auth::LOGINGOV }
         let(:expected_credential_service) { SignIn::Logingov::Service }
 
-        it 'returns expected credential service object' do
-          expect(subject).to be_a(expected_credential_service)
+        context 'and client config does not have optional scopes' do
+          it 'returns expected credential service object' do
+            expect(subject).to be_a(expected_credential_service)
+          end
+        end
+
+        context 'and client config has optional scopes' do
+          let(:client_config) { create(:client_config, authentication:, access_token_attributes:) }
+
+          context 'and optional scopes are valid' do
+            let(:access_token_attributes) { %w[all_emails] }
+            let(:expected_optional_scopes) { %w[all_emails] }
+
+            it 'sets optional scopes variable to returned credential service object' do
+              expect(subject.optional_scopes).to eq(expected_optional_scopes)
+            end
+          end
+
+          context 'and optional scopes are invalid' do
+            let(:access_token_attributes) { %w[first_name] }
+            let(:expected_optional_scopes) { [] }
+
+            it 'does not set optional_scopes' do
+              expect(subject.optional_scopes).to eq(expected_optional_scopes)
+            end
+          end
         end
       end
 

--- a/spec/services/sign_in/session_refresher_spec.rb
+++ b/spec/services/sign_in/session_refresher_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SignIn::SessionRefresher do
       let(:client_config) do
         create(:client_config, anti_csrf:, refresh_token_duration:, access_token_attributes:, enforced_terms:)
       end
-      let(:access_token_attributes) { %w[first_name last_name email] }
+      let(:access_token_attributes) { %w[first_name last_name email all_emails] }
       let(:anti_csrf) { false }
       let(:refresh_token_duration) { SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES }
       let(:enforced_terms) { nil }

--- a/spec/services/sign_in/session_spawner_spec.rb
+++ b/spec/services/sign_in/session_spawner_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SignIn::SessionSpawner do
     end
     let(:client_id) { 'some-client-id' }
     let(:refresh_token_duration) { SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES }
-    let(:access_token_attributes) { %w[first_name last_name email] }
+    let(:access_token_attributes) { %w[first_name last_name email all_emails] }
     let(:enforced_terms) { nil }
     let(:device_sso) { false }
 

--- a/spec/services/sign_in/token_exchanger_spec.rb
+++ b/spec/services/sign_in/token_exchanger_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe SignIn::TokenExchanger, type: :model do
               let(:actor_token_type) { SignIn::Constants::Urn::DEVICE_SECRET }
               let(:new_client_config) do
                 create(:client_config,
-                       access_token_attributes: %i[first_name last_name email],
+                       access_token_attributes: %i[first_name last_name email all_emails],
                        shared_sessions:,
                        enforced_terms: nil)
               end

--- a/spec/services/sign_in/user_code_map_creator_spec.rb
+++ b/spec/services/sign_in/user_code_map_creator_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SignIn::UserCodeMapCreator do
       {
         logingov_uuid:,
         csp_email:,
+        all_csp_emails:,
         first_name:,
         last_name:
       }
@@ -35,6 +36,7 @@ RSpec.describe SignIn::UserCodeMapCreator do
     let(:logingov_uuid) { SecureRandom.hex }
     let(:icn) { 'some-icn' }
     let(:csp_email) { 'some-csp-email' }
+    let(:all_csp_emails) { [csp_email] }
     let(:service_name) { SignIn::Constants::Auth::LOGINGOV }
     let(:auth_broker) { SignIn::Constants::Auth::BROKER_CODE }
     let!(:user_verification) { create(:logingov_user_verification, logingov_uuid:) }
@@ -49,7 +51,7 @@ RSpec.describe SignIn::UserCodeMapCreator do
     let(:enforced_terms) { SignIn::Constants::Auth::VA_TERMS }
     let(:device_sso) { true }
     let(:scope) { SignIn::Constants::Auth::DEVICE_SSO }
-    let(:expected_user_attributes) { { first_name:, last_name:, email: csp_email } }
+    let(:expected_user_attributes) { { first_name:, last_name:, email: csp_email, all_emails: all_csp_emails } }
 
     before do
       allow(SecureRandom).to receive(:uuid).and_return(login_code)

--- a/spec/support/vcr_cassettes/identity/logingov_200_responses.yml
+++ b/spec/support/vcr_cassettes/identity/logingov_200_responses.yml
@@ -128,8 +128,8 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{ "access_token" : "mHO_gU3WooLm0xoDxIAulw", "token_type" : "Bearer", "expires_in" : 900, "id_token" : "eyJraWQiOiJmNWNlMTIzOWUzOWQzZGE4MzZmOTYzYmNjZDg1Zjg1ZDU3ZDQzMzVjZmRjNmExNzAzOWYyNzQzNjFhMThiMTNjIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJlYmYyZTZlZC01M2I2LTQwOWQtYTMwYS1jYzk4YWUyYWRjMDEiLCJpc3MiOiJodHRwczovL2lkcC5pbnQuaWRlbnRpdHlzYW5kYm94Lmdvdi8iLCJlbWFpbCI6ImpvZS5uaXF1ZXR0ZStsZ292aWFsMkBvZGRiYWxsLmlvIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImdpdmVuX25hbWUiOiJqb2VpYWwyIiwiZmFtaWx5X25hbWUiOiJ0ZXN0bGFzdG5hbWUiLCJiaXJ0aGRhdGUiOiIxOTgwLTA4LTE2Iiwic29jaWFsX3NlY3VyaXR5X251bWJlciI6IjEwMjk5ODc3NSIsImFkZHJlc3MiOnsiZm9ybWF0dGVkIjoiMjI4IE4gU3BlbmNlciBSZFxuUGF4dG9uLCBNQSAwMTYxMiIsInN0cmVldF9hZGRyZXNzIjoiMjI4IE4gU3BlbmNlciBSZCIsImxvY2FsaXR5IjoiUGF4dG9uIiwicmVnaW9uIjoiTUEiLCJwb3N0YWxfY29kZSI6IjAxNjEyIn0sInZlcmlmaWVkX2F0IjoxNjM2NDc4Nzg1LCJpYWwiOiJodHRwOi8vaWRtYW5hZ2VtZW50Lmdvdi9ucy9hc3N1cmFuY2UvaWFsLzIiLCJhYWwiOiJ1cm46Z292OmdzYTphYzpjbGFzc2VzOnNwOlBhc3N3b3JkUHJvdGVjdGVkVHJhbnNwb3J0OmR1byIsImFjciI6Imh0dHA6Ly9pZG1hbmFnZW1lbnQuZ292L25zL2Fzc3VyYW5jZS9pYWwvMiIsIm5vbmNlIjoiYzY0YzBjNzcyYjdiNDM1ZDdkZWVhMTM1ZDY3NDg2ZjgiLCJhdWQiOiJodHRwczovL3NxYS5lYXV0aC52YS5nb3YvaXNhbS9zcHMvc2FtbDIwc3Avc2FtbDIwIiwianRpIjoibW9rQ2xwV1FRSWZVdzNMTG1MM0F6dyIsImF0X2hhc2giOiJ4aW9Ubk9aVEFaZ2w5N0FqSHJ0Q0xBIiwiY19oYXNoIjoiWDdNMG00SnRwQlJDQTZzNk5jb243ZyIsImV4cCI6MTY5MjY2MzkzOCwiaWF0IjoxNjkyNjYzMDM4LCJuYmYiOjE2OTI2NjMwMzh9.pvy7yGYMewc-nLvcO7C-Wu1DIk58HaUSo9FloN8mOEuNPk8WqmXeV7el0jMUi7nwe_fyUn-yqvaGp7wJ11a3gAHbYGJWrfDfp4_nl6sL0B5ZX6wwlK-lppcSJcLMEQQbXW4LO8SzGSfQP07Mzp5IH35WTF3FZVaE-xBekGI4jj4dnsuCYGE13cOQpYMpfmJPKm4Pzpe6L257Mjzim50ufXSHlmxdxD5ldx_tA1AktRXtfHszrXXh7zdO2zmRvLe4VqZc13G1NJxP4HfNh_FPWJ5--Jn_BKp5HqroETr02Ubl2T0dzYqlH8qd3Z2_4cxblwkix6W8uo6VaoKYbZkDSQ" }'
-    http_version: 
+      string: '{ "access_token": "mHO_gU3WooLm0xoDxIAulw", "token_type": "Bearer", "expires_in": 900, "id_token": "eyJraWQiOiJmNWNlMTIzOWUzOWQzZGE4MzZmOTYzYmNjZDg1Zjg1ZDU3ZDQzMzVjZmRjNmExNzAzOWYyNzQzNjFhMThiMTNjIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJlYmYyZTZlZC01M2I2LTQwOWQtYTMwYS1jYzk4YWUyYWRjMDEiLCJpc3MiOiJodHRwczovL2lkcC5pbnQuaWRlbnRpdHlzYW5kYm94Lmdvdi8iLCJlbWFpbCI6ImpvZS5uaXF1ZXR0ZStsZ292aWFsMkBvZGRiYWxsLmlvIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImdpdmVuX25hbWUiOiJqb2VpYWwyIiwiZmFtaWx5X25hbWUiOiJ0ZXN0bGFzdG5hbWUiLCJiaXJ0aGRhdGUiOiIxOTgwLTA4LTE2Iiwic29jaWFsX3NlY3VyaXR5X251bWJlciI6IjEwMjk5ODc3NSIsImFkZHJlc3MiOnsiZm9ybWF0dGVkIjoiMjI4IE4gU3BlbmNlciBSZFxuUGF4dG9uLCBNQSAwMTYxMiIsInN0cmVldF9hZGRyZXNzIjoiMjI4IE4gU3BlbmNlciBSZCIsImxvY2FsaXR5IjoiUGF4dG9uIiwicmVnaW9uIjoiTUEiLCJwb3N0YWxfY29kZSI6IjAxNjEyIn0sInZlcmlmaWVkX2F0IjoxNjM2NDc4Nzg1LCJpYWwiOiJodHRwOi8vaWRtYW5hZ2VtZW50Lmdvdi9ucy9hc3N1cmFuY2UvaWFsLzIiLCJhYWwiOiJ1cm46Z292OmdzYTphYzpjbGFzc2VzOnNwOlBhc3N3b3JkUHJvdGVjdGVkVHJhbnNwb3J0OmR1byIsImFjciI6Imh0dHA6Ly9pZG1hbmFnZW1lbnQuZ292L25zL2Fzc3VyYW5jZS9pYWwvMiIsIm5vbmNlIjoiYzY0YzBjNzcyYjdiNDM1ZDdkZWVhMTM1ZDY3NDg2ZjgiLCJhdWQiOiJodHRwczovL3NxYS5lYXV0aC52YS5nb3YvaXNhbS9zcHMvc2FtbDIwc3Avc2FtbDIwIiwianRpIjoibW9rQ2xwV1FRSWZVdzNMTG1MM0F6dyIsImF0X2hhc2giOiJ4aW9Ubk9aVEFaZ2w5N0FqSHJ0Q0xBIiwiY19oYXNoIjoiWDdNMG00SnRwQlJDQTZzNk5jb243ZyIsImV4cCI6MTY5MjY2MzkzOCwiaWF0IjoxNjkyNjYzMDM4LCJuYmYiOjE2OTI2NjMwMzh9.pvy7yGYMewc-nLvcO7C-Wu1DIk58HaUSo9FloN8mOEuNPk8WqmXeV7el0jMUi7nwe_fyUn-yqvaGp7wJ11a3gAHbYGJWrfDfp4_nl6sL0B5ZX6wwlK-lppcSJcLMEQQbXW4LO8SzGSfQP07Mzp5IH35WTF3FZVaE-xBekGI4jj4dnsuCYGE13cOQpYMpfmJPKm4Pzpe6L257Mjzim50ufXSHlmxdxD5ldx_tA1AktRXtfHszrXXh7zdO2zmRvLe4VqZc13G1NJxP4HfNh_FPWJ5--Jn_BKp5HqroETr02Ubl2T0dzYqlH8qd3Z2_4cxblwkix6W8uo6VaoKYbZkDSQ" }'
+    http_version:
   recorded_at: Thu, 23 Dec 2021 16:09:22 GMT
 - request:
     method: get
@@ -179,10 +179,11 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{ "sub" : "12345678-0990-10a1-f038-2839ab281f90", "iss" : "https://idp.int.identitysandbox.gov/",
-                 "email" : "user@test.com", "email_verified" : true, "given_name" : "Bob", "family_name" : "User",
-                 "birthdate" : "1993-01-01", "social_security_number" : "999-11-9999", "address" : { "formatted" : "1 Microsoft Way\nApt 3\nBayside, NY 11364",
-                 "street_address" : "1 Microsoft Way\nApt 3", "locality" : "Bayside", "region" : "NY", "postal_code" : "11364" }, "verified_at" : 1635465286 }'
-    http_version: 
+      string: '{ "sub": "12345678-0990-10a1-f038-2839ab281f90", "iss": "https://idp.int.identitysandbox.gov/",
+                 "email": "user@test.com", "email_verified": true, "all_emails": ["user@test.com", "user@secondaryemail.com"],
+                 "given_name": "Bob", "family_name": "User", "birthdate": "1993-01-01", "social_security_number": "999-11-9999",
+                 "address": { "formatted": "1 Microsoft Way\nApt 3\nBayside, NY 11364", "street_address": "1 Microsoft Way\nApt 3",
+                 "locality": "Bayside", "region": "NY", "postal_code": "11364" }, "verified_at": 1635465286 }'
+    http_version:
   recorded_at: Thu, 23 Dec 2021 16:09:22 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Summary
- Re-do of https://github.com/department-of-veterans-affairs/vets-api/pull/17301
- Add Logingov `all_emails` attribute to Sign-in Service. Restrict to clients who have `all_emails` in their client configs `access_token_attributes`.
- We may want to move this to a new column on `client_configs` in the future

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83797
- https://github.com/department-of-veterans-affairs/vets-api/pull/17301

## Testing done
- Add `all_emails` to `vaweb` client_config
  ```ruby
  SignIn::ClientConfig.find_by(client_id: 'vaweb').update(access_token_attributes: ['all_emails'])
  ```
- Sign in with `logingov` using `oauth=true`
- In the rails console find your `OAuthSession.user_attributes`
   ```ruby
  JSON.parse(SignIn::OAuthSession.last.user_attributes)
   ```
- You should see `all_emails` in `user_attributes`
   ```ruby
   {"email"=>"vets.gov.user+0@gmail.com", "all_emails"=>["vets.gov.user+0@gmail.com"]
   ```

## What areas of the site does it impact?
Sign-in Service, Authentication

