### PR TITLE
[86435] adds lock_all & unlock_all tasks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1601,6 +1601,7 @@ spec/rakelib/jobs_spec.rb @department-of-veterans-affairs/govcio-vfep-codereview
 spec/rakelib/piilog_repl @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/rakelib/piilog_repl/piilog_helpers_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/rakelib/vet360_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/rakelib/user_credential_spec.rb @department-of-veterans-affairs/octo-identity
 rakelib/prod/user_credential.rake @department-of-veterans-affairs/octo-identity
 spec/requests/admin_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/appeals_request_spec.rb @department-of-veterans-affairs/backend-review-group

--- a/rakelib/prod/user_credential.rake
+++ b/rakelib/prod/user_credential.rake
@@ -3,95 +3,70 @@
 desc 'Lock and unlock user credentials'
 namespace :user_credential do
   task :lock, %i[type credential_id requested_by] => :environment do |_, args|
-    namespace = 'UserCredential::Lock'
-    validate_args(args)
-    type = args[:type]
-    credential_id = args[:credential_id]
-    context = { type:, credential_id:, requested_by: args[:requested_by] }
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task start, context: #{context.to_json}")
-    user_verification = UserVerification.where(["#{type}_uuid = ?", credential_id]).first
-    user_verification.lock!
-    context[:locked] = user_verification.locked
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task complete, context: #{context.to_json}")
-    puts "#{namespace} complete - #{type}_uuid: #{credential_id}"
-  rescue => e
-    puts "#{namespace} failed - #{e.message}"
+    run_task(:lock, args)
   end
 
   task :unlock, %i[type credential_id requested_by] => :environment do |_, args|
-    namespace = 'UserCredential::Unlock'
-    validate_args(args)
-    type = args[:type]
-    credential_id = args[:credential_id]
-    context = { type:, credential_id:, requested_by: args[:requested_by] }
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task start, context: #{context.to_json}")
-    user_verification = UserVerification.where(["#{type}_uuid = ?", credential_id]).first
-    user_verification.unlock!
-    context[:locked] = user_verification.locked
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task complete, context: #{context.to_json}")
-    puts "#{namespace} complete - #{type}_uuid: #{credential_id}"
-  rescue => e
-    puts "#{namespace} failed - #{e.message}"
+    run_task(:unlock, args)
   end
 
   task :lock_all, %i[icn requested_by] => :environment do |_, args|
-    namespace = 'UserCredential::LockAll'
-    validate_icn_args(args)
-    icn = args[:icn]
-    context = { icn:, requested_by: args[:requested_by] }
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task start, context: #{context.to_json}")
-    user_account = UserAccount.find_by(icn:)
-    user_account.user_verifications.each do |user_verification|
-      user_verification.lock!
-      uv_context = { type: user_verification.credential_type, credential_id: user_verification.credential_identifier,
-                     locked: user_verification.locked }
-      log_to_stdout(level: 'info',
-                    message: "[#{namespace}] credential locked, context: #{context.merge(uv_context).to_json}")
-      puts "#{namespace} credential locked - #{uv_context[:type]}_uuid: #{uv_context[:credential_id]}"
-    end
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task complete, context: #{context.to_json}")
-    puts "#{namespace} complete - ICN: #{icn}"
-  rescue => e
-    puts "#{namespace} failed - #{e.message}"
+    run_task(:lock_all, args, all_credentials: true)
   end
 
   task :unlock_all, %i[icn requested_by] => :environment do |_, args|
-    namespace = 'UserCredential::UnlockAll'
-    validate_icn_args(args)
-    icn = args[:icn]
-    context = { icn:, requested_by: args[:requested_by] }
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task start, context: #{context.to_json}")
-    user_account = UserAccount.find_by(icn:)
-    user_account.user_verifications.each do |user_verification|
-      user_verification.unlock!
-      uv_context = { type: user_verification.credential_type, credential_id: user_verification.credential_identifier,
-                     locked: user_verification.locked }
-      log_to_stdout(level: 'info',
-                    message: "[#{namespace}] credential unlocked, context: #{context.merge(uv_context).to_json}")
-      puts "#{namespace} credential unlocked - #{uv_context[:type]}_uuid: #{uv_context[:credential_id]}"
+    run_task(:unlock_all, args, all_credentials: true)
+  end
+
+  def run_task(action, args, all_credentials: false)
+    validate_args(args, all_credentials)
+    namespace = "UserCredential::#{action.to_s.camelize}"
+    action = %i[lock lock_all].include?(action) ? :lock : :unlock
+    context = build_context(args)
+    log_message(level: 'info', message: "[#{namespace}] rake task start, context: #{context.to_json}")
+
+    if all_credentials
+      UserAccount.find_by(icn: args[:icn]).user_verifications.each do |user_verification|
+        update_credential(user_verification, action, namespace, context)
+      end
+    else
+      user_verification = UserVerification.where(["#{args[:type]}_uuid = ?", args[:credential_id]]).first
+      update_credential(user_verification, action, namespace, context)
     end
-    log_to_stdout(level: 'info', message: "[#{namespace}] rake task complete, context: #{context.to_json}")
-    puts "#{namespace} complete - ICN: #{icn}"
+    log_message(level: 'info', message: "[#{namespace}] rake task complete, context: #{context.to_json}")
   rescue => e
-    puts "#{namespace} failed - #{e.message}"
+    log_message(level: 'error', message: "#{namespace} failed - #{e.message}")
   end
 
-  def validate_args(args)
-    raise 'Missing required arguments' if args[:type].blank? ||
-                                          args[:credential_id].blank? ||
-                                          args[:requested_by].blank?
+  def validate_args(args, all_credentials)
+    missing_args = all_credentials ? %i[icn requested_by] : %i[type credential_id requested_by]
+    raise 'Missing required arguments' unless args.values_at(*missing_args).all?
   end
 
-  def validate_icn_args(args)
-    raise 'Missing required arguments' if args[:icn].blank? ||
-                                          args[:requested_by].blank?
+  def build_context(args)
+    { icn: args[:icn],
+      type: args[:type],
+      credential_id: args[:credential_id],
+      requested_by: args[:requested_by] }.compact
   end
 
-  def log_to_stdout(level:, message:)
-    `echo "#{log_message(level:, message:).to_json.dump}" >> /proc/1/fd/1` if Rails.env.production?
+  def update_credential(user_verification, action, namespace, context)
+    action == :lock ? user_verification.lock! : user_verification.unlock!
+    credential_context = context.merge({ type: user_verification.credential_type,
+                                         credential_id: user_verification.credential_identifier,
+                                         locked: user_verification.locked }).compact
+    log_message(level: 'info', message: "[#{namespace}] credential #{action}, context: #{credential_context.to_json}")
   end
 
   def log_message(level:, message:)
+    if Rails.env.production?
+      `echo "#{datadog_log(level:, message:).to_json.dump}" >> /proc/1/fd/1`
+    else
+      puts message
+    end
+  end
+
+  def datadog_log(level:, message:)
     {
       level:,
       message:,

--- a/rakelib/prod/user_credential.rake
+++ b/rakelib/prod/user_credential.rake
@@ -20,8 +20,8 @@ namespace :user_credential do
 
   def run_task(action, args, all_credentials: false)
     namespace = "UserCredential::#{action.to_s.camelize}"
-    validate_args(args, all_credentials)
     action = %i[lock lock_all].include?(action) ? :lock : :unlock
+    validate_args(args, all_credentials)
     context = build_context(args)
     log_message(level: 'info', message: "[#{namespace}] rake task start, context: #{context.to_json}")
 
@@ -52,7 +52,7 @@ namespace :user_credential do
   end
 
   def update_credential(user_verification, action, namespace, context)
-    action == :lock ? user_verification.lock! : user_verification.unlock!
+    user_verification.send("#{action}!")
     credential_context = context.merge({ type: user_verification.credential_type,
                                          credential_id: user_verification.credential_identifier,
                                          locked: user_verification.locked }).compact

--- a/rakelib/prod/user_credential.rake
+++ b/rakelib/prod/user_credential.rake
@@ -19,8 +19,8 @@ namespace :user_credential do
   end
 
   def run_task(action, args, all_credentials: false)
-    validate_args(args, all_credentials)
     namespace = "UserCredential::#{action.to_s.camelize}"
+    validate_args(args, all_credentials)
     action = %i[lock lock_all].include?(action) ? :lock : :unlock
     context = build_context(args)
     log_message(level: 'info', message: "[#{namespace}] rake task start, context: #{context.to_json}")
@@ -35,12 +35,13 @@ namespace :user_credential do
     end
     log_message(level: 'info', message: "[#{namespace}] rake task complete, context: #{context.to_json}")
   rescue => e
-    log_message(level: 'error', message: "#{namespace} failed - #{e.message}")
+    log_message(level: 'error', message: "[#{namespace}] failed - #{e.message}")
   end
 
   def validate_args(args, all_credentials)
     missing_args = all_credentials ? %i[icn requested_by] : %i[type credential_id requested_by]
     raise 'Missing required arguments' unless args.values_at(*missing_args).all?
+    raise 'Invalid type' if SignIn::Constants::Auth::CSP_TYPES.exclude?(args[:type]) && !all_credentials
   end
 
   def build_context(args)

--- a/spec/rakelib/user_credential_spec.rb
+++ b/spec/rakelib/user_credential_spec.rb
@@ -57,7 +57,10 @@ describe 'user_credential rake tasks' do # rubocop:disable RSpec/DescribeClass
       let(:action) { 'lock' }
       let(:locked) { true }
 
-      before { user_verification.unlock! }
+      before do
+        user_verification.unlock!
+        task.reenable
+      end
 
       it 'locks the credential & return the credential type & uuid when successful' do
         expect(user_verification.locked).to be_falsey

--- a/spec/rakelib/user_credential_spec.rb
+++ b/spec/rakelib/user_credential_spec.rb
@@ -3,12 +3,13 @@
 require 'rails_helper'
 require 'rake'
 
-describe 'user_credential rake tasks' do
+describe 'user_credential rake tasks' do # rubocop:disable RSpec/DescribeClass
   let(:user_account) { create(:user_account) }
-  let!(:logingov_user_verification) { create(:logingov_user_verification, user_account:) }
-  let!(:idme_user_verification) { create(:idme_user_verification, user_account:) }
+  let(:icn) { user_account.icn }
   let(:type) { 'logingov' }
-  let(:credential_id) { logingov_user_verification.credential_identifier }
+  let(:user_verification) { create(:logingov_user_verification, user_account:) }
+  let(:linked_user_verification) { create(:idme_user_verification, user_account:) }
+  let(:credential_id) { user_verification.credential_identifier }
   let(:requested_by) { 'some-name' }
 
   before :all do
@@ -16,18 +17,65 @@ describe 'user_credential rake tasks' do
     Rake::Task.define_task(:environment)
   end
 
-  shared_examples 'credential lock & unlock' do
-    describe 'user_credential:lock' do
-      let(:task) { Rake::Task['user_credential:lock'] }
+  describe 'user_credential:lock' do
+    let(:task) { Rake::Task['user_credential:lock'] }
 
-      it 'should lock user credential' do
-        expect { task.invoke(type, credential_id, requested_by) }
-          .to output(/UserCredential::Lock complete - #{type}_uuid: #{credential_id}/).to_stdout
-      end
+    before { user_verification.unlock! }
+
+    it 'locks the credential & return the credential type & uuid when successful' do
+      expect(user_verification.locked).to be_falsey
+      expect { task.invoke(type, credential_id, requested_by) }
+        .to output(/UserCredential::Lock complete - #{type}_uuid: #{credential_id}/).to_stdout
+      expect(user_verification.reload.locked).to be_truthy
     end
   end
 
-  context 'when the credential type is logingov' do
-    it_behaves_like 'credential lock & unlock'
+  describe 'user_credential:unlock' do
+    let(:task) { Rake::Task['user_credential:unlock'] }
+
+    before { user_verification.lock! }
+
+    it 'unlocks the credential & return the credential type & uuid when successful' do
+      expect(user_verification.locked).to be_truthy
+      expect { task.invoke(type, credential_id, requested_by) }
+        .to output(/UserCredential::Unlock complete - #{type}_uuid: #{credential_id}/).to_stdout
+      expect(user_verification.reload.locked).to be_falsey
+    end
+  end
+
+  describe 'user_credential:lock_all' do
+    let(:task) { Rake::Task['user_credential:lock_all'] }
+
+    before do
+      user_verification.unlock!
+      linked_user_verification.unlock!
+    end
+
+    it 'locks all credentials for a user account & return the ICN when successful' do
+      expect(user_verification.locked).to be_falsey
+      expect(linked_user_verification.locked).to be_falsey
+      expect { task.invoke(icn, requested_by) }
+        .to output(/UserCredential::LockAll complete - ICN: #{icn}/).to_stdout
+      expect(user_verification.reload.locked).to be_truthy
+      expect(linked_user_verification.reload.locked).to be_truthy
+    end
+  end
+
+  describe 'user_credential:unlock_all' do
+    let(:task) { Rake::Task['user_credential:unlock_all'] }
+
+    before do
+      user_verification.lock!
+      linked_user_verification.lock!
+    end
+
+    it 'unlocks all credentials for a user account & return the ICN when successful' do
+      expect(user_verification.locked).to be_truthy
+      expect(linked_user_verification.locked).to be_truthy
+      expect { task.invoke(icn, requested_by) }
+        .to output(/UserCredential::UnlockAll complete - ICN: #{icn}/).to_stdout
+      expect(user_verification.reload.locked).to be_falsey
+      expect(linked_user_verification.reload.locked).to be_falsey
+    end
   end
 end

--- a/spec/rakelib/user_credential_spec.rb
+++ b/spec/rakelib/user_credential_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+describe 'user_credential rake tasks' do
+  let(:user_account) { create(:user_account) }
+  let!(:logingov_user_verification) { create(:logingov_user_verification, user_account:) }
+  let!(:idme_user_verification) { create(:idme_user_verification, user_account:) }
+  let(:type) { 'logingov' }
+  let(:credential_id) { logingov_user_verification.credential_identifier }
+  let(:requested_by) { 'some-name' }
+
+  before :all do
+    Rake.application.rake_require '../rakelib/prod/user_credential'
+    Rake::Task.define_task(:environment)
+  end
+
+  shared_examples 'credential lock & unlock' do
+    describe 'user_credential:lock' do
+      let(:task) { Rake::Task['user_credential:lock'] }
+
+      it 'should lock user credential' do
+        expect { task.invoke(type, credential_id, requested_by) }
+          .to output(/UserCredential::Lock complete - #{type}_uuid: #{credential_id}/).to_stdout
+      end
+    end
+  end
+
+  context 'when the credential type is logingov' do
+    it_behaves_like 'credential lock & unlock'
+  end
+end


### PR DESCRIPTION
## Summary

- Updates `user_credential` Rake task to include `lock_all` and `unlock_all` tasks; these tasks use an ICN to look up the corresponding `UserAccount`, using it to lock or unlock all of that account's `UserVerifications`.
- Each individual lock/unlock action on a UserVerification will now result in a Rails log, as well as a log signifying the start or end of a job.
  - Updated all Rails logs to only be written in production environments

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86453

## Testing done

- [x] Unit specs added to cover rake task
- To test, confirm you have two `UserVerifications` with the same `user_account_uuid`:
```ruby
UserVerification.all =>
[ #<UserVerification:0x00007078990a0f00
  id: 1,
  user_account_id: "937b6c00-a8d7-4506-9b7f-7ddacd283c39",
  idme_uuid: nil,
  logingov_uuid: "eb172e31-36a0-4266-aa7b-b44c939e6850",
  mhv_uuid: nil,
  dslogon_uuid: nil,
  verified_at: Mon, 01 Jul 2024 17:10:07.677429000 UTC +00:00,
  created_at: Mon, 01 Jul 2024 17:10:07.700539000 UTC +00:00,
  updated_at: Mon, 01 Jul 2024 18:32:01.177650000 UTC +00:00,
  backing_idme_uuid: nil,
  locked: false>,
 #<UserVerification:0x00007078990a0b40
  id: 4,
  user_account_id: "937b6c00-a8d7-4506-9b7f-7ddacd283c39",
  idme_uuid: "a5f2d966f3356f76b63989122ee4a70d",
  logingov_uuid: nil,
  mhv_uuid: nil,
  dslogon_uuid: nil,
  verified_at: nil,
  created_at: Mon, 01 Jul 2024 17:38:39.591926000 UTC +00:00,
  updated_at: Mon, 01 Jul 2024 18:32:01.181662000 UTC +00:00,
  backing_idme_uuid: nil,
  locked: false>] 
  ```
  - Use the `user_account_id` to look up the parent `UserAccount` and obtain its ICN, then call the Rake task. You can also test the original `lock` & `unlock` tasks by passing the CSP type & credential_id.
```zsh
# escape brackets in zsh
> bundle exec rake user_credential:lock_all\[1012667122V019349,john_bramley\]
[UserCredential::LockAll] rake task start, context: {"icn":"1012667122V019349","requested_by":"john_bramley"}
[UserCredential::LockAll] credential lock, context: {"icn":"1012667122V019349","requested_by":"john_bramley","type":"logingov","credential_id":"eb172e31-36a0-4266-aa7b-b44c939e6850","locked":true}
[UserCredential::LockAll] credential lock, context: {"icn":"1012667122V019349","requested_by":"john_bramley","type":"idme","credential_id":"a5f2d966f3356f76b63989122ee4a70d","locked":true}
[UserCredential::LockAll] rake task complete, context: {"icn":"1012667122V019349","requested_by":"john_bramley"}

# original single-credential lock & unlock
> bundle exec rake user_credential:lock\[logingov,eb172e31-36a0-4266-aa7b-b44c939e6850,john_bramley\]
[UserCredential::Lock] rake task start, context: {"type":"logingov","credential_id":"eb172e31-36a0-4266-aa7b-b44c939e6850","requested_by":"john_bramley"}
[UserCredential::Lock] credential lock, context: {"type":"logingov","credential_id":"eb172e31-36a0-4266-aa7b-b44c939e6850","requested_by":"john_bramley","locked":true}
[UserCredential::Lock] rake task complete, context: {"type":"logingov","credential_id":"eb172e31-36a0-4266-aa7b-b44c939e6850","requested_by":"john_bramley"}
  ```