### PR TITLE
[DBEX] refactor response handler & update spec

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -7,106 +7,8 @@ require 'logging/third_party_transaction'
 
 class Form526Submission < ApplicationRecord
   extend Logging::ThirdPartyTransaction::MethodWrapper
-  include AASM
   include SentryLogging
   include Form526ClaimFastTrackingConcern
-
-  # Documentation:
-  # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/implementation/form_526_state_machine.md
-  aasm do
-    after_all_transitions :log_status_change
-
-    state :unprocessed, initial: true
-    state :delivered_to_primary, :failed_primary_delivery, :rejected_by_primary,
-          :delivered_to_backup, :failed_backup_delivery, :rejected_by_backup,
-          :in_remediation, :finalized_as_successful, :unprocessable,
-          :processed_in_batch_remediation, :ignorable_duplicate
-
-    # - a submission has been delivered to our happy path
-    # - requires polling to finalize
-    event :deliver_to_primary do
-      transitions to: :delivered_to_primary
-    end
-
-    # - submission failed delivery to primary path for any reason
-    # - requires backup submission or remediation
-    event :fail_primary_delivery do
-      transitions to: :failed_primary_delivery
-    end
-
-    # - a successfully delivered submission has failed 3rd party validations on primary path
-    # - requires backup submission or remediation
-    event :reject_from_primary do
-      transitions to: :rejected_by_primary
-    end
-
-    # - a submission has been delivered to our backup path
-    # - requires polling to finalize
-    event :deliver_to_backup do
-      transitions to: :delivered_to_backup
-    end
-
-    # - a submission has failed to be delivered to our backup path
-    # - requires remediation
-    event :fail_backup_delivery do
-      transitions to: :failed_backup_delivery
-    end
-
-    # - a successfully delivered submission has failed 3rd party validations on backup path
-    # - requires remediation
-    event :reject_from_backup do
-      transitions to: :rejected_by_backup
-    end
-
-    # - Submission has entered a manual remediation flow, e.g. failsafe, paper submission
-    # - requires confirmation of success, e.g. polling or manual confirmation via audit
-    event :begin_remediation do
-      transitions to: :in_remediation
-    end
-
-    # - The only state that means we no longer own completion of this submission
-    # - There is nothing more to do.  E.G.
-    #   - VBMS has accepted and returned the applicable status to us via
-    #     lighthouse benefits intake API
-    #   - Manual remediation has been confirmed successful
-    #   - EVSS has received this submission and now owns it
-    event :finalize_success do
-      transitions to: :finalized_as_successful
-    end
-
-    # - a submission should be ignored
-    # - we probably want to avoid using this state
-    event :mark_as_unprocessable do
-      transitions to: :unprocessable
-    end
-
-    # A special state to indicate this was part of our remediation 'batching'
-    # process in 2023.  These were handled manually and are distinct from `in_remediation`
-    # in that they were not tracked at the time of remediation, but rather later in
-    # the 2024 526 State audit.
-    #
-    # This state is useful to us at the time of creation, but may be something
-    # to flatten to a simple `finalized_as_successful` in the future.
-    event :process_in_batch_remediation do
-      transitions to: :processed_in_batch_remediation
-    end
-
-    # A special state to indicate this was part of our remediation 'batching'
-    # process in 2023.  These submissions may have been processed or not, but
-    # we don't care because they have an earlier, successful duplicate.
-    #
-    # Duplicates are identified by comparing form_json, using this script:
-    # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/benefits/scripts/526/submission_deduper.rb
-    # The result of this script can be evaluated by a qualified stakeholder to make
-    # a judgement call on whether or not a submission is a 'perfect' duplicate.
-    #
-    # IF a submission is found to be an exact duplicate of another
-    # AND its duplicate was previously submitted / remediated successfully
-    # THEN we can ignore it as a duplicate
-    event :ignore_as_duplicate do
-      transitions to: :ignorable_duplicate
-    end
-  end
 
   wrap_with_logging(:start_evss_submission_job,
                     :enqueue_backup_submission,
@@ -161,7 +63,7 @@ class Form526Submission < ApplicationRecord
   enum submit_endpoint: { evss: 0, claims_api: 1, benefits_intake_api: 2 }
 
   scope :pending_backup_submissions, lambda {
-    where(aasm_state: 'delivered_to_backup')
+    where(submitted_claim_id: nil, backup_submitted_claim_status: nil)
       .where.not(backup_submitted_claim_id: nil)
   }
   scope :in_process, lambda {
@@ -180,16 +82,6 @@ class Form526Submission < ApplicationRecord
     where.not(id: in_process.select(:id))
          .where.not(id: success_type.select(:id))
   }
-
-  def log_status_change
-    log_hash = {
-      form_submission_id: id,
-      from_state: aasm.from_state,
-      to_state: aasm.to_state,
-      event: aasm.current_event
-    }
-    Rails.logger.info(log_hash)
-  end
 
   FORM_526 = 'form526'
   FORM_526_UPLOADS = 'form526_uploads'

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -67,7 +67,7 @@ class Form526Submission < ApplicationRecord
     # - The only state that means we no longer own completion of this submission
     # - There is nothing more to do.  E.G.
     #   - VBMS has accepted and returned the applicable status to us via
-    #     lighthouse benefits intack API
+    #     lighthouse benefits intake API
     #   - Manual remediation has been confirmed successful
     #   - EVSS has received this submission and now owns it
     event :finalize_success do

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -59,7 +59,6 @@ module EVSS
 
         # if no more unused birls to attempt submit with, give up, let vet know
         begin
-          submission.fail_primary_delivery!
           notify_enabled = Flipper.enabled?(:disability_compensation_pif_fail_notification)
           if submission && next_birls_jid.nil? && msg['error_message'] == 'PIF in use' && notify_enabled
             first_name = submission.get_first_name&.capitalize || 'Sir or Madam'
@@ -151,7 +150,6 @@ module EVSS
 
       def response_handler(response)
         submission.submitted_claim_id = response.claim_id
-        submission.deliver_to_primary!
         submission.save
       end
 
@@ -172,7 +170,6 @@ module EVSS
         # retry submitting the form for specific upstream errors
         retry_form526_error_handler!(submission, e)
       rescue => e
-        submission.fail_primary_delivery!
         non_retryable_error_handler(submission, e)
       end
 

--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -53,7 +53,7 @@ class Form526StatusPollingJob
         form_submission.finalize_success!
       else
         Rails.logger.warn('Unknown status returned from Benefits Intake API for 526 submission',
-                          status:, submission_id: submission.id)
+                          status:, submission_id: form_submission.id)
       end
       @total_handled += 1
     end

--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -40,8 +40,7 @@ class Form526StatusPollingJob
   def handle_response(response, batch_subs)
     response.body['data']&.each do |submission|
       status = submission.dig('attributes', 'status')
-      submission_guid = submission['id']
-      form_submission = batch_subs.find { |sub| sub.backup_submitted_claim_id == submission_guid }
+      form_submission = batch_subs.find { |sub| sub.backup_submitted_claim_id == submission['id'] }
 
       if %w[error expired].include? status
         log_result('failure')
@@ -52,8 +51,11 @@ class Form526StatusPollingJob
         log_result('success')
         form_submission.finalize_success!
       else
-        Rails.logger.warn('Unknown status returned from Benefits Intake API for 526 submission',
-                          status:, submission_id: form_submission.id)
+        Rails.logger.warn(
+          'Unknown status returned from Benefits Intake API for 526 submission',
+          status:,
+          submission_id: form_submission.id
+        )
       end
       @total_handled += 1
     end

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -19,10 +19,11 @@ FactoryBot.define do
   end
 
   trait :backup_path do
-    lighthouse_format_guid = "#{SecureRandom.hex(8)}-#{SecureRandom.hex(4)}-" \
-                             "#{SecureRandom.hex(4)}-#{SecureRandom.hex(4)}-" \
-                             "#{SecureRandom.hex(12)}"
-    backup_submitted_claim_id { lighthouse_format_guid }
+    backup_submitted_claim_id {
+      "#{SecureRandom.hex(8)}-#{SecureRandom.hex(4)}-" \
+        "#{SecureRandom.hex(4)}-#{SecureRandom.hex(4)}-" \
+        "#{SecureRandom.hex(12)}"
+    }
   end
 
   trait :with_everything do

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -260,7 +260,7 @@ FactoryBot.define do
   end
 
   trait :with_submitted_claim_id do
-    submitted_claim_id { 1 }
+    submitted_claim_id { SecureRandom.rand(900_000_000) }
   end
 
   trait :with_accepted_backup_status do

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -36,16 +36,16 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
     end
   end
 
-  context 'on failure' do
+  context 'catastrophic failure state' do
     describe 'when all retries are exhausted' do
-      let!(:form526_submission) { create(:form526_submission, aasm_state: 'failed_primary_delivery') }
+      let!(:form526_submission) { create(:form526_submission) }
       let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         args = { 'jid' => form526_job_status.job_id, 'args' => [form526_submission.id] }
         subject.within_sidekiq_retries_exhausted_block(args) do
           expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
-          expect(Rails).to receive(:logger).twice.and_call_original
+          expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload
         expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
@@ -59,7 +59,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
         allow(Settings.form526_backup).to receive_messages(submission_method: payload_method, enabled: true)
       end
 
-      let!(:submission) { create :form526_submission, :with_everything, aasm_state: 'failed_primary_delivery' }
+      let!(:submission) { create :form526_submission, :with_everything }
       let!(:upload_data) { submission.form[Form526Submission::FORM_526_UPLOADS] }
 
       context 'successfully' do
@@ -113,7 +113,6 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
                 expect(job_status.status).to eq('success')
                 submission = Form526Submission.last
                 expect(submission.backup_submitted_claim_id).not_to be(nil)
-                expect(submission.aasm_state).to eq('delivered_to_backup')
                 expect(submission.submit_endpoint).to eq('benefits_intake_api')
               end
             end
@@ -198,7 +197,6 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
               expect(job_status.status).to eq('success')
               submission = Form526Submission.last
               expect(submission.backup_submitted_claim_id).not_to be(nil)
-              expect(submission.aasm_state).to eq('delivered_to_backup')
             end
           end
         end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Form526Submission do
       end
     end
 
-    context 'when backup_submitted_claim_status is not accepted, rejected or nil' do
+    context 'when backup_submitted_claim_status is neither accepted, rejected nor nil' do
       it 'is invalid' do
         expect do
           subject.backup_submitted_claim_status = 'other_value'
@@ -99,39 +99,20 @@ RSpec.describe Form526Submission do
 
   describe 'scopes' do
     describe 'pending_backup_submissions' do
-      let!(:new_submission) { create(:form526_submission, aasm_state: 'unprocessed') }
-      let!(:failed_primary_submission) do
-        create(:form526_submission, aasm_state: 'failed_primary_delivery')
-      end
-      let!(:rejected_primary_submission) do
-        create(:form526_submission, aasm_state: 'rejected_by_primary')
-      end
-      let!(:complete_primary_submission) do
-        create(:form526_submission, aasm_state: 'delivered_to_primary')
-      end
-      let!(:failed_backup_submission) do
-        create(:form526_submission, aasm_state: 'failed_backup_delivery')
-      end
+      let!(:new_submission) { create(:form526_submission) }
       let!(:rejected_backup_submission) do
-        create(:form526_submission, aasm_state: 'rejected_by_backup')
+        create(:form526_submission, :backup_path, backup_submitted_claim_status: 'rejected')
       end
-      let!(:in_remediation_submission) do
-        create(:form526_submission, :backup_path, aasm_state: 'in_remediation')
+      let!(:accepted_backup_submission) do
+        create(:form526_submission, :backup_path, backup_submitted_claim_status: 'accepted')
       end
-      let!(:complete_submission) do
-        create(:form526_submission, :backup_path, aasm_state: 'finalized_as_successful')
-      end
-      let!(:delivered_backup_submission_a) do
-        create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
-      end
-      let!(:delivered_backup_submission_b) do
-        create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
-      end
+      let!(:backup_submission_a) { create(:form526_submission, :backup_path) }
+      let!(:backup_submission_b) { create(:form526_submission, :backup_path) }
 
       it 'returns records submitted to the backup path but lacking a decisive state' do
         expect(Form526Submission.pending_backup_submissions).to contain_exactly(
-          delivered_backup_submission_a,
-          delivered_backup_submission_b
+          backup_submission_a,
+          backup_submission_b
         )
       end
     end
@@ -194,43 +175,6 @@ RSpec.describe Form526Submission do
           subject.start_evss_submission_job
         end.to change(EVSS::DisabilityCompensationForm::SubmitForm526AllClaim.jobs, :size).by(1)
       end
-    end
-  end
-
-  describe 'state' do
-    let(:submission) { create(:form526_submission) }
-
-    it 'transitions states' do
-      expect(submission).to transition_from(:unprocessed)
-        .to(:delivered_to_primary).on_event(:deliver_to_primary)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:failed_primary_delivery).on_event(:fail_primary_delivery)
-      expect(submission).to transition_from(:failed_primary_delivery)
-        .to(:delivered_to_backup).on_event(:deliver_to_backup)
-      expect(submission).to transition_from(:rejected_by_primary)
-        .to(:delivered_to_backup).on_event(:deliver_to_backup)
-      expect(submission).to transition_from(:failed_primary_delivery)
-        .to(:failed_backup_delivery).on_event(:fail_backup_delivery)
-      expect(submission).to transition_from(:rejected_by_primary)
-        .to(:rejected_by_backup).on_event(:reject_from_backup)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:rejected_by_primary).on_event(:reject_from_primary)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:delivered_to_backup).on_event(:deliver_to_backup)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:failed_backup_delivery).on_event(:fail_backup_delivery)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:rejected_by_backup).on_event(:reject_from_backup)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:finalized_as_successful).on_event(:finalize_success)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:unprocessable).on_event(:mark_as_unprocessable)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:in_remediation).on_event(:begin_remediation)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:processed_in_batch_remediation).on_event(:process_in_batch_remediation)
-      expect(submission).to transition_from(:unprocessed)
-        .to(:ignorable_duplicate).on_event(:ignore_as_duplicate)
     end
   end
 

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -325,13 +325,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
         expect(Form526JobStatus.last.status).to eq 'success'
       end
 
-      it 'transitions to delivered_to_primary' do
-        subject.perform_async(submission.id)
-        described_class.drain
-        submission.reload
-        expect(submission.aasm_state).to eq('delivered_to_primary')
-      end
-
       it 'submits successfully without calling classification service' do
         subject.perform_async(submission.id)
         expect do
@@ -719,18 +712,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           subject.perform_async(submission.id)
           described_class.drain
           expect(Form526JobStatus.last.status).to eq Form526JobStatus::STATUS[:non_retryable_error]
-        end
-      end
-    end
-
-    describe 'form526 state transitioning' do
-      context 'with a non-retryable error' do
-        it 'transitions the submission to failure state' do
-          allow_any_instance_of(Form526Submission).to receive(:prepare_for_evss!).and_raise(StandardError)
-          subject.perform_async(submission.id)
-          described_class.drain
-          submission.reload
-          expect(submission.aasm_state).to eq 'failed_primary_delivery'
         end
       end
     end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb
@@ -33,21 +33,18 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
 
     context 'when all retries are exhausted' do
       let!(:form526_submission) { create(:form526_submission) }
-      let!(:form526_job_status) do
-        create(:form526_job_status, :non_retryable_error, form526_submission:, job_id: 1)
-      end
+      let!(:form526_job_status) { create(:form526_job_status, :non_retryable_error, form526_submission:, job_id: 1) }
 
-      it 'transitions the submission to a failure state' do
-        job_params = { 'jid' => form526_job_status.job_id, 'args' => [submission.id] }
+      it 'marks the job status as exhausted' do
+        job_params = { 'jid' => form526_job_status.job_id, 'args' => [form526_submission.id] }
         allow(Sidekiq::Form526JobStatusTracker::JobTracker).to receive(:send_backup_submission_if_enabled)
 
         subject.within_sidekiq_retries_exhausted_block(job_params) do
-          # block is required to use this functionality.  All we care about is
-          # the state of the submission after this exhaustion hook has run
+          # block is required to use this functionality
           true
         end
-        submission.reload
-        expect(submission.aasm_state).to eq 'failed_primary_delivery'
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
       end
     end
   end

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe Form526StatusPollingJob, type: :job do
       create(:form526_submission, :backup_path, aasm_state: 'finalized_as_successful')
     end
     let!(:delivered_backup_submission_a) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'a')
     end
     let!(:delivered_backup_submission_b) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'b')
     end
     let!(:delivered_backup_submission_c) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'c')
     end
     let!(:delivered_backup_submission_d) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'd')
     end
 
     describe 'submission to the bulk status report endpoint' do
@@ -130,6 +130,7 @@ RSpec.describe Form526StatusPollingJob, type: :job do
       it 'updates local state to reflect the returned statuses' do
         pending_claim_ids = Form526Submission.pending_backup_submissions.pluck(:backup_submitted_claim_id)
         response = double
+
         allow(response).to receive(:body).and_return(api_response)
         allow_any_instance_of(BenefitsIntakeService::Service)
           .to receive(:get_bulk_status_of_uploads)
@@ -139,7 +140,7 @@ RSpec.describe Form526StatusPollingJob, type: :job do
         Form526StatusPollingJob.new.perform
 
         expect(delivered_backup_submission_a.reload.aasm_state).to eq 'finalized_as_successful'
-        expect(delivered_backup_submission_b.reload.aasm_state).to eq 'finalized_as_successful'
+        expect(delivered_backup_submission_b.reload.aasm_state).to eq 'delivered_to_backup'
         expect(delivered_backup_submission_c.reload.aasm_state).to eq 'rejected_by_backup'
         expect(delivered_backup_submission_d.reload.aasm_state).to eq 'rejected_by_backup'
       end

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -4,39 +4,16 @@ require 'rails_helper'
 
 RSpec.describe Form526StatusPollingJob, type: :job do
   describe '#perform' do
-    let!(:new_submission) { create(:form526_submission, aasm_state: 'unprocessed') }
-    let!(:failed_primary_submission) do
-      create(:form526_submission, aasm_state: 'failed_primary_delivery')
-    end
-    let!(:rejected_primary_submission) do
-      create(:form526_submission, aasm_state: 'rejected_by_primary')
-    end
-    let!(:complete_primary_submission) do
-      create(:form526_submission, aasm_state: 'delivered_to_primary')
-    end
-    let!(:failed_backup_submission) do
-      create(:form526_submission, aasm_state: 'failed_backup_delivery')
+    let!(:new_submission) { create(:form526_submission) }
+    let!(:backup_submission_a) { create(:form526_submission, :backup_path) }
+    let!(:backup_submission_b) { create(:form526_submission, :backup_path) }
+    let!(:backup_submission_c) { create(:form526_submission, :backup_path) }
+    let!(:backup_submission_d) { create(:form526_submission, :backup_path) }
+    let!(:accepted_backup_submission) do
+      create(:form526_submission, :backup_path, backup_submitted_claim_status: 'accepted')
     end
     let!(:rejected_backup_submission) do
-      create(:form526_submission, aasm_state: 'rejected_by_backup')
-    end
-    let!(:in_remediation_submission) do
-      create(:form526_submission, :backup_path, aasm_state: 'in_remediation')
-    end
-    let!(:complete_submission) do
-      create(:form526_submission, :backup_path, aasm_state: 'finalized_as_successful')
-    end
-    let!(:delivered_backup_submission_a) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
-    end
-    let!(:delivered_backup_submission_b) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
-    end
-    let!(:delivered_backup_submission_c) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
-    end
-    let!(:delivered_backup_submission_d) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
+      create(:form526_submission, :backup_path, backup_submitted_claim_status: 'rejected')
     end
 
     describe 'submission to the bulk status report endpoint' do
@@ -46,10 +23,10 @@ RSpec.describe Form526StatusPollingJob, type: :job do
         allow(response).to receive(:body).and_return({ 'data' => [] })
 
         expect(pending_claim_ids).to contain_exactly(
-          delivered_backup_submission_a.backup_submitted_claim_id,
-          delivered_backup_submission_b.backup_submitted_claim_id,
-          delivered_backup_submission_c.backup_submitted_claim_id,
-          delivered_backup_submission_d.backup_submitted_claim_id
+          backup_submission_a.backup_submitted_claim_id,
+          backup_submission_b.backup_submitted_claim_id,
+          backup_submission_c.backup_submitted_claim_id,
+          backup_submission_d.backup_submitted_claim_id
         )
 
         expect_any_instance_of(BenefitsIntakeService::Service)
@@ -96,30 +73,30 @@ RSpec.describe Form526StatusPollingJob, type: :job do
         {
           'data' => [
             {
-              'id' => delivered_backup_submission_a.backup_submitted_claim_id,
+              'id' => backup_submission_a.backup_submitted_claim_id,
               'attributes' => {
-                'guid' => delivered_backup_submission_a.backup_submitted_claim_id,
+                'guid' => backup_submission_a.backup_submitted_claim_id,
                 'status' => 'vbms'
               }
             },
             {
-              'id' => delivered_backup_submission_b.backup_submitted_claim_id,
+              'id' => backup_submission_b.backup_submitted_claim_id,
               'attributes' => {
-                'guid' => delivered_backup_submission_b.backup_submitted_claim_id,
+                'guid' => backup_submission_b.backup_submitted_claim_id,
                 'status' => 'success'
               }
             },
             {
-              'id' => delivered_backup_submission_c.backup_submitted_claim_id,
+              'id' => backup_submission_c.backup_submitted_claim_id,
               'attributes' => {
-                'guid' => delivered_backup_submission_c.backup_submitted_claim_id,
+                'guid' => backup_submission_c.backup_submitted_claim_id,
                 'status' => 'error'
               }
             },
             {
-              'id' => delivered_backup_submission_d.backup_submitted_claim_id,
+              'id' => backup_submission_d.backup_submitted_claim_id,
               'attributes' => {
-                'guid' => delivered_backup_submission_d.backup_submitted_claim_id,
+                'guid' => backup_submission_d.backup_submitted_claim_id,
                 'status' => 'expired'
               }
             }
@@ -139,10 +116,10 @@ RSpec.describe Form526StatusPollingJob, type: :job do
 
         Form526StatusPollingJob.new.perform
 
-        expect(delivered_backup_submission_a.reload.aasm_state).to eq 'finalized_as_successful'
-        expect(delivered_backup_submission_b.reload.aasm_state).to eq 'delivered_to_backup'
-        expect(delivered_backup_submission_c.reload.aasm_state).to eq 'rejected_by_backup'
-        expect(delivered_backup_submission_d.reload.aasm_state).to eq 'rejected_by_backup'
+        expect(backup_submission_a.reload.backup_submitted_claim_status).to eq 'accepted'
+        expect(backup_submission_b.reload.backup_submitted_claim_status).to eq nil
+        expect(backup_submission_c.reload.backup_submitted_claim_status).to eq 'rejected'
+        expect(backup_submission_d.reload.backup_submitted_claim_status).to eq 'rejected'
       end
     end
   end

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe Form526StatusPollingJob, type: :job do
       create(:form526_submission, :backup_path, aasm_state: 'finalized_as_successful')
     end
     let!(:delivered_backup_submission_a) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'a')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
     end
     let!(:delivered_backup_submission_b) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'b')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
     end
     let!(:delivered_backup_submission_c) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'c')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
     end
     let!(:delivered_backup_submission_d) do
-      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup', backup_submitted_claim_id: 'd')
+      create(:form526_submission, :backup_path, aasm_state: 'delivered_to_backup')
     end
 
     describe 'submission to the bulk status report endpoint' do


### PR DESCRIPTION
## Summary

- Update Form 526 backup polling
  - correctly categorize 'success' responses as 'pending'
- Remove `aasm_state`, value updates and related legacy state machine references
  - replaced by `backup_submitted_claim_status` attribute
- Redefine `pending_backup_submissions` scope
- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86438
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86432
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86434
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86441  
- [526 State Repair Technical Design Document
](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#b-add-backup_submitted_claim_status-enum-to-the-form526submission-model)
 
## Testing done

- [x] *New code is covered by unit tests*
- applicable test updated to reflect logic concerning 'success' responses not altering backup submission status
- tests concerning transitions of `aasm_state` either removed or modified to reflect new paradigm that uses `backup_submitted_claims_status` to evaluate submission success 

## What areas of the site does it impact?

- Status polling of pending backup submissions for From 526EZ

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature