### PR TITLE
Replace VYE AMS serializers with JSONAPI serializers

### DIFF
--- a/modules/vye/app/controllers/vye/v1/user_infos_controller.rb
+++ b/modules/vye/app/controllers/vye/v1/user_infos_controller.rb
@@ -8,11 +8,11 @@ module Vye
       def show
         authorize user_info, policy_class: Vye::UserInfoPolicy
 
-        render json: user_info,
-               serializer: Vye::UserInfoSerializer,
-               adapter: :json,
-               api_key: api_key?,
-               include: %i[latest_address pending_documents verifications pending_verifications].freeze
+        options = {
+          params: { api_key: api_key? },
+          include: %i[latest_address pending_documents verifications pending_verifications]
+        }
+        render json: Vye::UserInfoSerializer.new(user_info, options)
       end
 
       private

--- a/modules/vye/app/serializers/vye/address_change_serializer.rb
+++ b/modules/vye/app/serializers/vye/address_change_serializer.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 module Vye
-  class AddressChangeSerializer < ActiveModel::Serializer
-    attributes(
-      :veteran_name,
-      :address1,
-      :address2,
-      :address3,
-      :address4,
-      :address5,
-      :city,
-      :state,
-      :zip_code,
-      :origin
-    )
+  class AddressChangeSerializer
+    include JSONAPI::Serializer
+
+    attributes :veteran_name, :address1, :address2, :address3, :address4, :address5,
+               :city, :state, :zip_code, :origin
   end
 end

--- a/modules/vye/app/serializers/vye/pending_document_serializer.rb
+++ b/modules/vye/app/serializers/vye/pending_document_serializer.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Vye
-  class PendingDocumentSerializer < ActiveModel::Serializer
+  class PendingDocumentSerializer
+    include JSONAPI::Serializer
+
     attributes :doc_type, :queue_date
   end
 end

--- a/modules/vye/app/serializers/vye/user_info_serializer.rb
+++ b/modules/vye/app/serializers/vye/user_info_serializer.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
 module Vye
-  class UserInfoSerializer < ActiveModel::Serializer
-    attributes(
-      :rem_ent,
-      :cert_issue_date,
-      :del_date,
-      :date_last_certified,
-      :payment_amt,
-      :indicator
-    )
+  class UserInfoSerializer
+    include JSONAPI::Serializer
 
-    attribute :zip_code, if: -> { instance_options[:api_key] }
+    attributes :rem_ent, :cert_issue_date, :del_date, :date_last_certified,
+               :payment_amt, :indicator
+
+    attribute :zip_code do |object, params|
+      object.zip_code if params[:api_key]
+    end
 
     has_one :latest_address, serializer: Vye::AddressChangeSerializer
-    has_many :pending_documents, serializer: Vye::PendingDocumentSerializer
-    has_many :verifications, serializer: Vye::VerificationSerializer
-    has_many :pending_verifications, serializer: Vye::VerificationSerializer
+    has_many :pending_documents, serializer: Vye::PendingDocumentSerializer, &:pending_documents
+    has_many :verifications, serializer: Vye::VerificationSerializer, &:verifications
+    has_many :pending_verifications, serializer: Vye::VerificationSerializer, &:pending_verifications
   end
 end

--- a/modules/vye/app/serializers/vye/verification_serializer.rb
+++ b/modules/vye/app/serializers/vye/verification_serializer.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 module Vye
-  class VerificationSerializer < ActiveModel::Serializer
-    attributes(
-      :award_id,
-      :act_begin, :act_end,
-      :transact_date,
-      :monthly_rate, :number_hours, :source_ind
-    )
+  class VerificationSerializer
+    include JSONAPI::Serializer
+
+    attributes :award_id, :act_begin, :act_end, :transact_date,
+               :monthly_rate, :number_hours, :source_ind
   end
 end


### PR DESCRIPTION
## Summary

- Replace ActiveModelSerializers (AMS) with JSON:API Serializers in `modules/vye`.
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87046

## Testing done

- [x] updated serializers spec for jsonapi-serializer

## Acceptance Criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage