### PR TITLE
New feature flag for benefit selection page updates

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1085,6 +1085,10 @@ features:
     actor_type: user
     description: Flag to autofill datepicker for reliinquishment date
     enable_in_development: true
+  dgi_rudisill_hide_benefits_selection_step:
+    actor_type: user
+    description: Hides benefit selection page on original claims application.
+    enable_in_development: false
   show_forms_app:
     actor_type: user
     description: Enables the TOE form to be displayed.


### PR DESCRIPTION
## Summary
Adds new flipper for updating the benefit selection page on our team's original claim form.
[Vets-Website Pull Request](https://github.com/department-of-veterans-affairs/vets-website/pull/30644)

## Related issue(s)

![Screenshot 2024-07-02 at 10 31 52 AM](https://github.com/department-of-veterans-affairs/vets-api/assets/8945799/1a3b8622-362f-4260-a490-8732e5091d58)

## Testing done
Pull Request is just adding the new flag for the frontend enhancement

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
The feature flag will be used on the my-education-benefits-application on vets-website

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

