### PR TITLE
[SIMPLE_FORMS] feat: form-upload - update submit logic to account for extra values

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -7,28 +7,7 @@ module SimpleFormsApi
     class ScannedFormUploadsController < ApplicationController
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
-
-        confirmation_code = params[:confirmation_code]
-        attachment = PersistentAttachment.find_by(guid: confirmation_code)
-        file_path = attachment.to_pdf.to_s
-        raw_metadata = {
-          'veteranFirstName' => @current_user.first_name,
-          'veteranLastName' => @current_user.last_name,
-          'fileNumber' => @current_user.ssn,
-          'zipCode' => @current_user.address[:postal_code],
-          'source' => 'VA Platform Digital Forms',
-          'docType' => params[:form_number],
-          'businessLine' => 'CMP'
-        }
-        metadata = SimpleFormsApiSubmission::MetadataValidator.validate(raw_metadata)
-
-        status, confirmation_number = SimpleFormsApi::PdfUploader.new(
-          file_path,
-          metadata,
-          params[:form_number]
-        ).upload_to_benefits_intake(params)
-
-        render json: { confirmation_number:, status: }
+        render json: upload_response
       end
 
       def upload_scanned_form
@@ -38,6 +17,39 @@ module SimpleFormsApi
 
         attachment.save
         render json: attachment
+      end
+
+      private
+
+      def upload_response
+        file_path = find_attachment_path(params[:confirmation_code])
+        metadata = validated_metadata
+        status, confirmation_number = upload_pdf(file_path, metadata)
+
+        { confirmation_number:, status: }
+      end
+
+      def find_attachment_path(confirmation_code)
+        PersistentAttachment.find_by(guid: confirmation_code).to_pdf.to_s
+      end
+
+      def validated_metadata
+        raw_metadata = {
+          'veteranFirstName' => @current_user.first_name,
+          'veteranLastName' => @current_user.last_name,
+          'fileNumber' => params.dig(:options, :ssn) || @current_user.ssn,
+          'zipCode' => params.dig(:options, :zip_code) ||
+                       params.dig(:options, :va_file_number) ||
+                       @current_user.address[:postal_code],
+          'source' => 'VA Platform Digital Forms',
+          'docType' => params[:form_number],
+          'businessLine' => 'CMP'
+        }
+        SimpleFormsApiSubmission::MetadataValidator.validate(raw_metadata)
+      end
+
+      def upload_pdf(file_path, metadata)
+        SimpleFormsApi::PdfUploader.new(file_path, metadata, params[:form_number]).upload_to_benefits_intake(params)
       end
     end
   end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -37,9 +37,10 @@ module SimpleFormsApi
         raw_metadata = {
           'veteranFirstName' => @current_user.first_name,
           'veteranLastName' => @current_user.last_name,
-          'fileNumber' => params.dig(:options, :ssn) || @current_user.ssn,
+          'fileNumber' => params.dig(:options, :ssn) ||
+                          params.dig(:options, :va_file_number) ||
+                          @current_user.ssn,
           'zipCode' => params.dig(:options, :zip_code) ||
-                       params.dig(:options, :va_file_number) ||
                        @current_user.address[:postal_code],
           'source' => 'VA Platform Digital Forms',
           'docType' => params[:form_number],


### PR DESCRIPTION
## Summary

- This work allows for the front end to specify the user's ssn, va file number, and their zip code when they're not readily available within the current user's data

## Related issue(s)

- [Form Upload - Support LOA1 to edit SSN & Zip Code](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1388)

## Testing done

- [ ] *New code is covered by unit tests*
- Browser testing successful

## What areas of the site does it impact?

- Only form upload related logic

## Requested Feedback

Any