### PR TITLE
Check for participant_id for ITF API

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -157,7 +157,7 @@ module SimpleFormsApi
       end
 
       def use_itf_api_for_210966_form?
-        form_is210966 && icn && first_party?
+        form_is210966 && participant_id && icn && first_party?
       end
 
       def form_is264555_and_should_use_lgy_api
@@ -167,6 +167,10 @@ module SimpleFormsApi
 
       def should_authenticate
         true unless UNAUTHENTICATED_FORMS.include? params[:form_number]
+      end
+
+      def participant_id
+        @current_user&.participant_id
       end
 
       def icn

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Forms uploader', type: :request do
       end
 
       context 'request with intent to file' do
-        context 'authenticated' do
+        context 'authenticated but without participant_id' do
           before do
             sign_in
             allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
@@ -278,6 +278,7 @@ RSpec.describe 'Forms uploader', type: :request do
         before do
           sign_in
           allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
+          allow_any_instance_of(User).to receive(:participant_id).and_return('fake-participant-id')
           allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
         end
 
@@ -731,6 +732,7 @@ RSpec.describe 'Forms uploader', type: :request do
           user = create(:user)
           sign_in_as(user)
           allow_any_instance_of(User).to receive(:va_profile_email).and_return('abraham.lincoln@vets.gov')
+          allow_any_instance_of(User).to receive(:participant_id).and_return('fake-participant-id')
           allow(VANotify::EmailJob).to receive(:perform_async)
         end
 


### PR DESCRIPTION
## Summary
This PR adds a check for `participant_id` before using the Intent to File API. It turns out the `icn` is necessary, too, but insufficient.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/87481
