### PR TITLE
Use ecr for ruby image

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -25,6 +25,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2.0.1
+        with:
+          mask-password: true
+
       - name: Setup Environment
         run: |
           echo "VETS_API_USER_ID=$(id -u)" >> $GITHUB_ENV

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -43,6 +43,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2.0.1
+        with:
+          mask-password: true
+
       - name: Setup Environment
         run: |
           echo "VETS_API_USER_ID=$(id -u)" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.4-slim-bookworm AS rubyimg
+FROM public.ecr.aws/docker/library/ruby:3.2.4-slim-bookworm AS rubyimg
 FROM rubyimg AS modules
 
 WORKDIR /tmp

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   redis:
-    image: redis:6.2-alpine
+    image: public.ecr.aws/docker/library/redis:6.2-alpine
   postgres:
     image: mdillon/postgis:11-alpine
     command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200


### PR DESCRIPTION
## Summary

Use ECR for our Ruby image. We'll need follow-up stories for making sure we're are properly authenticated with AWS, but for now this gets us away from rate limiting on Docker hub.

Sanity check for the images:
```
$ docker pull  public.ecr.aws/docker/library/ruby:3.2-slim-bookworm
3.2-slim-bookworm: Pulling from docker/library/ruby
559a76444520: Already exists 
fe68faa3e9a4: Already exists 
0e01272b679f: Already exists 
2715e4f77bd3: Already exists 
69e9afc1f947: Already exists 
Digest: sha256:de26aa754986a356f0feaeaac37a674a8cb3a5e6617d6a22721b246d41061fb7
Status: Downloaded newer image for public.ecr.aws/docker/library/ruby:3.2-slim-bookworm
public.ecr.aws/docker/library/ruby:3.2-slim-bookworm
$ docker pull  ruby:3.2-slim-bookworm
3.2-slim-bookworm: Pulling from library/ruby
Digest: sha256:de26aa754986a356f0feaeaac37a674a8cb3a5e6617d6a22721b246d41061fb7
Status: Downloaded newer image for ruby:3.2-slim-bookworm
docker.io/library/ruby:3.2-slim-bookworm
$ docker images | grep book
ruby                                                              3.2-slim-bookworm                          942fd439a18b   2 months ago     204MB
public.ecr.aws/docker/library/ruby                                3.2-slim-bookworm                          942fd439a18b   2 months ago     204MB
```
