### PR TITLE
[API-37793] Raise a `GatewayTimeout` exception when needed

### DIFF
--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -22,7 +22,15 @@ module ClaimsApi
       body = { data: { claimId: claim_id, fileNumber: file_number } }
       ClaimsApi::Logger.log('benefits_documents',
                             detail: "calling benefits documents search for claimId #{claim_id}")
-      client.post('documents/search', body)&.body&.deep_symbolize_keys
+      res = client.post('documents/search', body)&.body
+
+      raise ::Common::Exceptions::GatewayTimeout.new(detail: "Gateway timeout. #{res}") unless res.is_a?(Hash)
+
+      res.deep_symbolize_keys
+    rescue ::Common::Exceptions::GatewayTimeout => e
+      ClaimsApi::Logger.log('benefits_documents',
+                            detail: "/search failure for claimId #{claim_id}, #{e.message}")
+      raise
     rescue => e
       ClaimsApi::Logger.log('benefits_documents',
                             detail: "/search failure for claimId #{claim_id}, #{e.message}")

--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -56,16 +56,10 @@ module ClaimsApi
 
       res = res.deep_symbolize_keys
       request_id = res&.dig(:data, :requestId)
-      ClaimsApi::Logger.log(
-        'benefits_documents',
-        detail: "Successfully uploaded #{doc_type == 'L122' ? 'claim' : 'supporting'} doc to BD",
-        claim_id: claim.id, request_id:
-      )
-      res
-    rescue ::Common::Exceptions::GatewayTimeout => e
       ClaimsApi::Logger.log('benefits_documents',
-                            detail: "/upload failure for claimId #{claim&.id}, #{e.message}")
-      raise
+                            detail: "Successfully uploaded #{doc_type == 'L122' ? 'claim' : 'supporting'} doc to BD",
+                            claim_id: claim.id, request_id:)
+      res
     rescue => e
       ClaimsApi::Logger.log('benefits_documents',
                             detail: "/upload failure for claimId #{claim&.id}, #{e.message}")

--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -27,10 +27,6 @@ module ClaimsApi
       raise ::Common::Exceptions::GatewayTimeout.new(detail: 'Upstream service error.') unless res.is_a?(Hash)
 
       res.deep_symbolize_keys
-    rescue ::Common::Exceptions::GatewayTimeout => e
-      ClaimsApi::Logger.log('benefits_documents',
-                            detail: "/search failure for claimId #{claim_id}, #{e.message}")
-      raise
     rescue => e
       ClaimsApi::Logger.log('benefits_documents',
                             detail: "/search failure for claimId #{claim_id}, #{e.message}")

--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -24,7 +24,7 @@ module ClaimsApi
                             detail: "calling benefits documents search for claimId #{claim_id}")
       res = client.post('documents/search', body)&.body
 
-      raise ::Common::Exceptions::GatewayTimeout.new(detail: "Gateway timeout. #{res}") unless res.is_a?(Hash)
+      raise ::Common::Exceptions::GatewayTimeout.new(detail: 'Upstream service error.') unless res.is_a?(Hash)
 
       res.deep_symbolize_keys
     rescue ::Common::Exceptions::GatewayTimeout => e

--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -51,7 +51,7 @@ module ClaimsApi
       raise ::Common::Exceptions::GatewayTimeout.new(detail: 'Upstream service error.') unless res.is_a?(Hash)
 
       res = res.deep_symbolize_keys
-      request_id = res&.dig(:data, :requestId)
+      request_id = res.dig(:data, :requestId)
       ClaimsApi::Logger.log('benefits_documents',
                             detail: "Successfully uploaded #{doc_type == 'L122' ? 'claim' : 'supporting'} doc to BD",
                             claim_id: claim.id, request_id:)

--- a/modules/claims_api/spec/lib/claims_api/bd_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bd_spec.rb
@@ -61,12 +61,16 @@ describe ClaimsApi::BD do
       let(:response) { instance_double(Faraday::Response, body: 'failed to request: timeout') }
 
       before do
+        allow(Rails).to receive(:logger).and_return(double('Logger', info: true))
         allow(Faraday).to receive(:new).and_return(client)
         allow(client).to receive(:post).and_return(response)
       end
 
-      it 'raises a GatewayTimeout exception' do
-        expect { subject.search(claim_id, file_number) }.to raise_error(Common::Exceptions::GatewayTimeout)
+      it 'logs the error and returns an empty hash' do
+        result = subject.search(claim_id, file_number)
+        expect(Rails.logger).to have_received(:info)
+          .with(%r{benefits_documents :: {"detail":"/search failure for claimId #{claim_id}, Gateway timeout"}})
+        expect(result).to eq({})
       end
     end
   end

--- a/modules/claims_api/spec/lib/claims_api/bd_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bd_spec.rb
@@ -41,5 +41,19 @@ describe ClaimsApi::BD do
       expect(result).to be_a Hash
       expect(result[:data][:documents]).to be_truthy
     end
+
+    context 'when the upstream service is down' do
+      let(:client) { instance_double(Faraday::Connection) }
+      let(:response) { instance_double(Faraday::Response, body: 'failed to request: timeout') }
+
+      before do
+        allow(Faraday).to receive(:new).and_return(client)
+        allow(client).to receive(:post).and_return(response)
+      end
+
+      it 'raises a GatewayTimeout exception' do
+        expect { subject.search(claim_id, file_number) }.to raise_error(Common::Exceptions::GatewayTimeout)
+      end
+    end
   end
 end

--- a/modules/claims_api/spec/lib/claims_api/bd_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bd_spec.rb
@@ -29,6 +29,20 @@ describe ClaimsApi::BD do
       js = JSON.parse(result[:parameters].read)
       expect(js['data']['docType']).to eq 'L023'
     end
+
+    context 'when the upstream service is down' do
+      let(:client) { instance_double(Faraday::Connection) }
+      let(:response) { instance_double(Faraday::Response, body: 'failed to request: timeout') }
+
+      before do
+        allow(Faraday).to receive(:new).and_return(client)
+        allow(client).to receive(:post).and_return(response)
+      end
+
+      it 'raises a GatewayTimeout exception' do
+        expect { subject.upload(claim:, pdf_path:) }.to raise_error(Common::Exceptions::GatewayTimeout)
+      end
+    end
   end
 
   describe '#search', vcr: 'claims_api/v2/claims_show' do


### PR DESCRIPTION
## Summary

In Benefits Documents, if the upstream service is down, raise a `GatewayTimeout` exception and log the error. This change handles the case in which the upstream service responds with a non-JSON (i.e., non-hash) object (and we assume the service is down). We do not change any client-facing functionality.

## Related issue(s)

[API-37793](https://jira.devops.va.gov/browse/API-37793)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
Benefits Documents API

## Acceptance criteria

- [x]  I  added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Do we want to log the error result from the upstream service?