### PR TITLE
Render empty string if search query is null when calling SearchTypeahead Service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -956,6 +956,7 @@ lib/rx @department-of-veterans-affairs/mobile-api-team @department-of-veterans-a
 lib/saml @department-of-veterans-affairs/octo-identity
 lib/salesforce @department-of-veterans-affairs/govcio-vfep-codereviewers
 lib/search @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/search_typeahead @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/sentry @department-of-veterans-affairs/backend-review-group
 lib/sentry_logging.rb @department-of-veterans-affairs/backend-review-group
 lib/sftp_writer @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers

--- a/lib/search_typeahead/service.rb
+++ b/lib/search_typeahead/service.rb
@@ -20,7 +20,7 @@ module SearchTypeahead
     attr_reader :query
 
     def initialize(query)
-      @query = query
+      @query = query || ''
     end
 
     # GETs suggestion data from search.gov

--- a/spec/requests/search_typeahead_request_spec.rb
+++ b/spec/requests/search_typeahead_request_spec.rb
@@ -21,11 +21,19 @@ describe 'search_typeahead' do
       end
     end
 
-    context 'with an empty query' do
+    context 'with an empty string query' do
       it 'has an empty response body', :aggregate_failures do
         VCR.use_cassette('search_typeahead/missing_query') do
           get '/v0/search_typeahead', params: { query: '' }
 
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq ''
+        end
+      end
+
+      it 'has an null response body', :aggregate_failures do
+        VCR.use_cassette('search_typeahead/missing_query') do
+          get '/v0/search_typeahead', params: { query: nil }
           expect(response).to have_http_status(:ok)
           expect(response.body).to eq ''
         end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
We are experiencing issues with feature toggles affecting Puma backlog and resulting in 499 errors reported by Traefik. This issue needs a thorough investigation to identify the root cause and implement a solution.

The response errors out and the response body is null when the query is null. When the query is null, the search typeahead should not return an error but an empty string.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#[87454](https://github.com/department-of-veterans-affairs/va.gov-team/issues/87454)
- [Search Typeahead Error](https://vagov.ddog-gov.com/logs?query=env%3Aeks-prod%20pod_name%3Avets-api-feature-%2A%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZB0EYjE0H2qbgAAAAAAAAAYAAAAAEFaQjBFWTJ4QUFBT0R1ZHpxQkhNTndBbgAAACQAAAAAMDE5MDc0MTItM2Y1NC00MDkxLWEzMjUtYWVmMGUwNTYzYjJi&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort=time&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1719933406500&to_ts=1719934306500&live=true)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*



## What areas of the site does it impact?
* Search Typeahead

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

