### PR TITLE
Populate veteran data for 21-0966 from prefill

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -137,6 +137,7 @@ module SimpleFormsApi
       def get_file_paths_and_metadata(parsed_form_data)
         form_id = get_form_id
         form = "SimpleFormsApi::#{form_id.titleize.gsub(' ', '')}".constantize.new(parsed_form_data)
+        form = form.populate_veteran_data(@current_user) if form_id == "21-0966"
         filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, form:)
 
         file_path = if @current_user

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -11,6 +11,21 @@ module SimpleFormsApi
       @data = data
     end
 
+    def populate_veteran_data(user)
+      @data['veteran_full_name'] ||= {
+        'first' => user.first_name,
+        'last' => user.last_name
+      }
+      @data['veteran_mailing_address'] ||= {
+        'postal_code' => user.address['postal_code']
+      }
+      @data['veteran_id'] ||= {
+        'ssn' => user.ssn
+      }
+
+      self
+    end
+
     def words_to_remove
       veteran_ssn + veteran_date_of_birth + veteran_address + veteran_home_phone + veteran_email +
         surviving_dependent_ssn + surviving_dependent_address + surviving_dependent_phone +

--- a/modules/simple_forms_api/spec/models/vba_21_0966_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_0966_spec.rb
@@ -3,6 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe SimpleFormsApi::VBA210966 do
+  describe 'populate_veteran_data' do
+    context 'data does not already have what it needs' do
+      let(:expected_first_name) { 'Rory' }
+      let(:expected_last_name) { 'Stewart' }
+      let(:expected_address) { {
+        'postal_code' => '12345'
+      } }
+      let(:expected_ssn) { 'fake-ssn' }
+      let(:user) { create(:user, first_name: expected_first_name, last_name: expected_last_name, ssn: expected_ssn) }
+      let(:data) { {} }
+
+      it 'pulls the name from the user' do
+        allow(user).to receive(:address).and_return(expected_address)
+
+        form = SimpleFormsApi::VBA210966.new(data).populate_veteran_data(user)
+
+        expect(form.data['veteran_full_name']).to eq ({ 'first' => expected_first_name, 'last' => expected_last_name})
+        expect(form.data['veteran_mailing_address']).to eq expected_address
+        expect(form.data['veteran_id']).to eq ({ 'ssn' => expected_ssn })
+      end
+    end
+
+    context 'data already has what it needs' do
+      let(:expected_address) { {
+        'postal_code' => '12345'
+      } }
+      let(:expected_full_name) { { 'first' => 'John', 'last' => 'Darwin'} }
+      let(:expected_ssn) { 'fake-ssn' }
+      let(:user) { create(:user) }
+      let(:data) { { 'veteran_full_name' => expected_full_name, 'veteran_mailing_address' => expected_address, 'veteran_id' => { 'ssn' => expected_ssn}} }
+
+      it 'pulls the name from the user' do
+        form = SimpleFormsApi::VBA210966.new(data).populate_veteran_data(user)
+
+        expect(form.data['veteran_full_name']).to eq (expected_full_name)
+        expect(form.data['veteran_mailing_address']).to eq expected_address
+        expect(form.data['veteran_id']).to eq ({ 'ssn' => expected_ssn })
+      end
+    end
+  end
+
   describe 'zip_code_is_us_based' do
     subject(:zip_code_is_us_based) { described_class.new(data).zip_code_is_us_based }
 


### PR DESCRIPTION
## Summary
This PR populates veteran data from prefill for 21-0966. Currently, the metadata validator is failing because the FE does not (and is not intended to) send this data back when the user is logged in and has prefill working.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/87615
