### PR TITLE
bump docker/build-push-action@v6 and set DOCKER_BUILD_SUMMARY to false

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -46,7 +46,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           build-args: |
             BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ env.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -34,7 +34,9 @@ jobs:
         with:
           mask-password: true
       - name: Build Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           build-args: |
             BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ env.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           build-args: |
             BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ env.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -64,7 +64,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           build-args: |
             BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ env.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}


### PR DESCRIPTION
## Summary

- bump docker/build-push-action to v6
- set DOCKER_BUILD_SUMMARY to false
    - Seemed to be interfering with a job

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/17137

## Testing done

- [ ] No new tests

## Acceptance criteria

- [x]  Publish Test Results and Coverage => actions/download-artifact@v4 succeeds 