### PR TITLE
Removes toggle:  mhv_landing_page_enable_va_gov_health_tools_links

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -817,9 +817,6 @@ features:
     actor_type: user
     description: Enables/disables documentation-related content for Medications on VA.gov
     enable_in_development: true
-  mhv_landing_page_enable_va_gov_health_tools_links:
-    actor_type: user
-    description: Enables VA.gov Health Tools links (Appts, SM, Rx, Records) on MHV-on-VA.gov Landing Page
   mhv_to_logingov_account_transition:
     actor_type: cookie_id
     description: Enables/disables MHV to Login.gov account transfer experience (Identity)


### PR DESCRIPTION
## Summary

- Removes toggle:  mhv_landing_page_enable_va_gov_health_tools_links

## Related issue(s)

department-of-veterans-affairs/va.gov-team#87133

