### PR TITLE
vfep-1628 - remove 1990 Spool file reqlinquish feature flag

### DIFF
--- a/app/sidekiq/education_form/templates/1990-disclosure/_CH33.erb
+++ b/app/sidekiq/education_form/templates/1990-disclosure/_CH33.erb
@@ -1,9 +1,1 @@
-EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 <% if Settings.vsp_environment.eql?('production') -%>- Not Eligible for Other Listed Benefits
-
-By electing Chapter 33, I acknowledge that I understand the following:
-* I may not receive more than a total of 48 months of benefits under two or more programs.
-* If electing chapter 33 in lieu of chapter 30, my months of entitlement under chapter 33 will be limited to the number of months of entitlement remaining under chapter 30 on the effective date of my election.
-* I will not receive a Montgomery GI Bill (Active Duty-Chapter 30 or Selected reserve-Chapter 1606) 'Kicker' under the Post-9/11 GI Bill, unless I was eligible for the kicker at the time I applied and I relinquished that benefit for the Post-9/11 GI Bill-Chapter 33.
-* When choosing the effective date, I understand that benefits for training under Chapter 33 are not payable prior to that date.
-* My election is irrevocable and may not be changed.
-<% end -%>
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 

--- a/app/sidekiq/education_form/templates/1990-disclosure/_CH33_1606.erb
+++ b/app/sidekiq/education_form/templates/1990-disclosure/_CH33_1606.erb
@@ -1,9 +1,1 @@
-EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 <% if Settings.vsp_environment.eql?('production') -%>in Lieu of Chapter 1606 - Effective: <%= @applicant.benefitsRelinquishedDate %>
-
-By electing Chapter 33, I acknowledge that I understand the following:
-* I may not receive more than a total of 48 months of benefits under two or more programs.
-* If electing chapter 33 in lieu of chapter 30, my months of entitlement under chapter 33 will be limited to the number of months of entitlement remaining under chapter 30 on the effective date of my election.
-* I will not receive a Montgomery GI Bill (Active Duty-Chapter 30 or Selected reserve-Chapter 1606) 'Kicker' under the Post-9/11 GI Bill, unless I was eligible for the kicker at the time I applied and I relinquished that benefit for the Post-9/11 GI Bill-Chapter 33.
-* When choosing the effective date, I understand that benefits for training under Chapter 33 are not payable prior to that date.
-* My election is irrevocable and may not be changed.
-<% end -%>
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 

--- a/app/sidekiq/education_form/templates/1990-disclosure/_CH33_1607.erb
+++ b/app/sidekiq/education_form/templates/1990-disclosure/_CH33_1607.erb
@@ -1,9 +1,1 @@
-EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 <% if Settings.vsp_environment.eql?('production') -%>in Lieu of Chapter 1607 - Effective: <%= @applicant.benefitsRelinquishedDate %>
-
-By electing Chapter 33, I acknowledge that I understand the following:
-* I may not receive more than a total of 48 months of benefits under two or more programs.
-* If electing chapter 33 in lieu of chapter 30, my months of entitlement under chapter 33 will be limited to the number of months of entitlement remaining under chapter 30 on the effective date of my election.
-* I will not receive a Montgomery GI Bill (Active Duty-Chapter 30 or Selected reserve-Chapter 1606) 'Kicker' under the Post-9/11 GI Bill, unless I was eligible for the kicker at the time I applied and I relinquished that benefit for the Post-9/11 GI Bill-Chapter 33.
-* When choosing the effective date, I understand that benefits for training under Chapter 33 are not payable prior to that date.
-* My election is irrevocable and may not be changed.
-<% end -%>
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 

--- a/app/sidekiq/education_form/templates/1990-disclosure/_CH33_30.erb
+++ b/app/sidekiq/education_form/templates/1990-disclosure/_CH33_30.erb
@@ -1,9 +1,1 @@
-EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 <% if Settings.vsp_environment.eql?('production') -%>in Lieu of Chapter 30 - Effective: <%= @applicant.benefitsRelinquishedDate %>
-
-By electing Chapter 33, I acknowledge that I understand the following:
-* I may not receive more than a total of 48 months of benefits under two or more programs.
-* If electing chapter 33 in lieu of chapter 30, my months of entitlement under chapter 33 will be limited to the number of months of entitlement remaining under chapter 30 on the effective date of my election.
-* I will not receive a Montgomery GI Bill (Active Duty-Chapter 30 or Selected reserve-Chapter 1606) 'Kicker' under the Post-9/11 GI Bill, unless I was eligible for the kicker at the time I applied and I relinquished that benefit for the Post-9/11 GI Bill-Chapter 33.
-* When choosing the effective date, I understand that benefits for training under Chapter 33 are not payable prior to that date.
-* My election is irrevocable and may not be changed.
-<% end -%>
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 


### PR DESCRIPTION
vfep-1628 - remove 1990 Spool file reqlinquish feature flag

## Summary

- *This work is behind a feature toggle (flipper): NO (removing feature flag)*
- remove feature flag from 1990 spool file for removing Reliquish language
- *(If bug, how to reproduce)* N/A
- remove environment wrapper around the removal of references to Relinquish
- VFEP
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- [vfep-1628](https://jira.devops.va.gov/browse/VFEP-1628)
- [vfep-1514](https://jira.devops.va.gov/browse/VFEP-1514)
- [github 17428](https://github.com/department-of-veterans-affairs/vets-api/issues/17428)

## Testing done

- [x] *New code is covered by unit tests*
- showed relinquish language in 1990 spool file on production
- submit a 1990 form and check the resulting spool file

## What areas of the site does it impact?
1990 spool file

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

