### PR TITLE
Enable ToU authentication check in production

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -59,8 +59,6 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
   end
 
   def load_user(skip_terms_check: false)
-    skip_terms_check = true if Settings.vsp_environment == 'production'
-
     if cookies[SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME]
       super()
     else


### PR DESCRIPTION
## Summary

This PR removes the environment check that prevents ToU authentication checks in production.

## Related issue(s)

https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/zh/448

## Testing done

The underlying functionality works in lower environments.

## Screenshots

Not relevant.

## What areas of the site does it impact?

Authentication and ToU.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None.