### PR TITLE
Expand EP400 Merge eligibility to multi-contention claims

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -121,9 +121,11 @@ module Form526ClaimFastTrackingConcern
   end
 
   def eligible_for_ep_merge?
+    user = User.find(user_uuid)
+    return true if Flipper.enabled?(:disability_526_ep_merge_multi_contention, user)
     return false unless disabilities.count == 1
 
-    Flipper.enabled?(:disability_526_ep_merge_new_claims, User.find(user_uuid)) ? increase_or_new? : increase_only?
+    Flipper.enabled?(:disability_526_ep_merge_new_claims, user) ? increase_or_new? : increase_only?
   end
 
   def prepare_for_evss!

--- a/config/features.yml
+++ b/config/features.yml
@@ -388,6 +388,9 @@ features:
   disability_526_ep_merge_new_claims:
     actor_type: user
     description: enables EP Merge for single-contention 526 claims for a new condition
+  disability_526_ep_merge_multi_contention:
+    actor_type: user
+    description: enables EP Merge for multi-contention 526 claims
   disability_526_toxic_exposure:
     actor_type: user
     description: enables new pages, processing, and submission of toxic exposure claims

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1274,10 +1274,19 @@ RSpec.describe Form526Submission do
   describe '#eligible_for_ep_merge?' do
     subject { Form526Submission.create(form_json: File.read(path)).eligible_for_ep_merge? }
 
+    before { Flipper.disable(:disability_526_ep_merge_multi_contention) }
+
     context 'when there are multiple contentions' do
       let(:path) { 'spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities.json' }
 
-      it { is_expected.to be_falsey }
+      context 'when multi-contention claims are not eligible' do
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when multi-contention claims are eligible' do
+        before { Flipper.enable(:disability_526_ep_merge_multi_contention) }
+        it { is_expected.to be_truthy }
+      end
     end
 
     context 'when there is a single new contention' do

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1285,6 +1285,7 @@ RSpec.describe Form526Submission do
 
       context 'when multi-contention claims are eligible' do
         before { Flipper.enable(:disability_526_ep_merge_multi_contention) }
+
         it { is_expected.to be_truthy }
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This PR adds the feature toggle `disability_526_ep_merge_multi_contention` which enables multi-contention 526 claims to be eligible for EP400 Merge
- I'm on the Employee Experience team; we work with the Disability Benefits team which maintains 526.
- The new feature toggle `disability_526_ep_merge_multi_contention` will be enabled in late July, and removed 30 days after launch assuming no unrecoverable errors are seen in the EP400 Merge dashboard.

## Related issue(s)
- department-of-veterans-affairs/abd-vro#3156

## Testing done
- [x] *New code is covered by unit tests*
- Old behavior: only single-contention 526 claims are eligible
- New RSpec added to cover eligibility test for feature toggle on and off
- Testing plan for rollout: Verify eligibility in Staging + VBMS UAT

## What areas of the site does it impact?
* No user-facing changes

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
