### PR TITLE
87405: Clean up storage of evidence attachments + records used for validation

### DIFF
--- a/app/controllers/v0/decision_review_evidences_controller.rb
+++ b/app/controllers/v0/decision_review_evidences_controller.rb
@@ -20,7 +20,7 @@ module V0
       form_attachment_guid = form_attachment&.guid
       password = filtered_params[:password]
 
-      params = {
+      log_params = {
         form_attachment_guid:,
         encrypted: password.present?
       }
@@ -33,9 +33,9 @@ module V0
         super
       end
 
-      log_formatted(**common_log_params.merge(params:, is_success: true))
+      log_formatted(**common_log_params.merge(params: log_params, is_success: true))
     rescue => e
-      log_formatted(**common_log_params.merge(params:, is_success: false, response_error: e))
+      log_formatted(**common_log_params.merge(params: log_params, is_success: false, response_error: e))
       raise e
     end
 

--- a/app/controllers/v0/decision_review_evidences_controller.rb
+++ b/app/controllers/v0/decision_review_evidences_controller.rb
@@ -20,6 +20,11 @@ module V0
       form_attachment_guid = form_attachment&.guid
       password = filtered_params[:password]
 
+      params = {
+        form_attachment_guid:,
+        encrypted: password.present?
+      }
+
       # Unlock pdf with hexapdf instead of using pdftk
       if password.present?
         unlocked_pdf = unlock_pdf(filtered_params[:file_data], password)
@@ -27,11 +32,6 @@ module V0
       else
         super
       end
-
-      params = {
-        form_attachment_guid:,
-        encrypted: password.present?
-      }
 
       log_formatted(**common_log_params.merge(params:, is_success: true))
     rescue => e

--- a/config/features.yml
+++ b/config/features.yml
@@ -334,14 +334,6 @@ features:
   decision_review_delay_evidence:
     actor_type: user
     description: Ensures that NOD and SC evidence is not received in Central Mail before the appeal itself
-  decision_review_save_encrypted_attachments:
-    actor_type: user
-    description: Enables saving a copy of encrypted decision review evidence attachment files for manual validation
-    enable_in_development: true
-  decision_review_use_hexapdf_for_encrypted_attachments:
-    actor_type: user
-    description: Enables using Hexapdf instead of PDFTK for decrypting password protected decision review evidence attachment files
-    enable_in_development: true
   dependency_verification:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.

--- a/spec/controllers/v0/decision_review_evidences_controller_spec.rb
+++ b/spec/controllers/v0/decision_review_evidences_controller_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe V0::DecisionReviewEvidencesController, type: :controller do
 
           form_attachment
         end
-        expect(subject).to receive(:render).with(json: form_attachment).and_call_original # rubocop:disable RSpec/SubjectStub
 
         post(:create, params:)
 

--- a/spec/controllers/v0/decision_review_evidences_controller_spec.rb
+++ b/spec/controllers/v0/decision_review_evidences_controller_spec.rb
@@ -91,139 +91,32 @@ RSpec.describe V0::DecisionReviewEvidencesController, type: :controller do
         }
       end
 
-      context 'and the save encrypted feature switch is disabled' do
-        before { Flipper.disable :decision_review_save_encrypted_attachments }
+      it 'creates a FormAttachment, logs formatted success message, and increments statsd' do
+        request.headers['Source-App-Name'] = '10182-board-appeal'
+        params = { param_namespace => { file_data: pdf_file, password: 'test_password' } }
 
-        it 'creates a FormAttachment, logs formatted error, and increments statsd' do
-          request.headers['Source-App-Name'] = '10182-board-appeal'
-          params = { param_namespace => { file_data: pdf_file, password: 'test_password' } }
+        expect(Common::PdfHelpers).to receive(:unlock_pdf)
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(encrypted_log_params_success)
+        expect(StatsD).to receive(:increment).with('decision_review.form_10182.evidence_upload_to_s3.success')
+        form_attachment = build(attachment_factory_id, guid: form_attachment_guid)
 
-          expect_any_instance_of(form_attachment_model::ATTACHMENT_UPLOADER_CLASS).not_to receive(:store!)
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).not_to receive(:info).with(
-            'DR-81205: Evidence Attachment Validation upload success', form_attachment_guid:
-          )
-          expect(Rails.logger).to receive(:info).with(encrypted_log_params_success)
-          expect(StatsD).to receive(:increment).with('decision_review.form_10182.evidence_upload_to_s3.success')
-          form_attachment = build(attachment_factory_id, guid: form_attachment_guid)
+        expect(form_attachment_model).to receive(:new) do
+          expect(form_attachment).to receive(:set_file_data!)
 
-          expect(form_attachment_model).to receive(:new) do
-            expect(form_attachment).to receive(:set_file_data!)
-
-            expect(form_attachment).to receive(:save!) do
-              form_attachment.id = 99
-              form_attachment
-            end
-
+          expect(form_attachment).to receive(:save!) do
+            form_attachment.id = 99
             form_attachment
           end
-          expect(subject).to receive(:render).with(json: form_attachment).and_call_original # rubocop:disable RSpec/SubjectStub
 
-          post(:create, params:)
-
-          expect(response).to have_http_status(:ok)
-          expect(JSON.parse(response.body)).to eq(expected_response_body)
+          form_attachment
         end
-      end
+        expect(subject).to receive(:render).with(json: form_attachment).and_call_original # rubocop:disable RSpec/SubjectStub
 
-      context 'and the save encrypted feature switch is enabled' do
-        before { Flipper.enable :decision_review_save_encrypted_attachments }
+        post(:create, params:)
 
-        it 'creates a FormAttachment, logs formatted status, and stores the encrypted file' do
-          request.headers['Source-App-Name'] = '10182-board-appeal'
-          params = { param_namespace => { file_data: pdf_file, password: 'test_password' } }
-
-          expect_any_instance_of(form_attachment_model::ATTACHMENT_UPLOADER_CLASS).to receive(:store!)
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(
-            'DR-81205: Evidence Attachment Validation upload success', form_attachment_guid:
-          )
-          expect(Rails.logger).to receive(:info).with(encrypted_log_params_success)
-          expect(StatsD).to receive(:increment).with('decision_review.form_10182.evidence_upload_to_s3.success')
-
-          form_attachment = build(attachment_factory_id, guid: form_attachment_guid)
-
-          expect(form_attachment_model).to receive(:new) do
-            expect(form_attachment).to receive(:set_file_data!)
-
-            expect(form_attachment).to receive(:save!) do
-              form_attachment.id = 99
-              form_attachment
-            end
-
-            form_attachment
-          end
-          expect(subject).to receive(:render).with(json: form_attachment).and_call_original # rubocop:disable RSpec/SubjectStub
-
-          post(:create, params:)
-
-          expect(response).to have_http_status(:ok)
-          expect(JSON.parse(response.body)).to eq(expected_response_body)
-        end
-      end
-
-      context 'and the use hexapdf feature switch is disabled' do
-        before { Flipper.disable :decision_review_use_hexapdf_for_encrypted_attachments }
-
-        it 'creates a FormAttachment, logs formatted success message, and increments statsd' do
-          request.headers['Source-App-Name'] = '10182-board-appeal'
-          params = { param_namespace => { file_data: pdf_file, password: 'test_password' } }
-
-          expect(Common::PdfHelpers).not_to receive(:unlock_pdf)
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(encrypted_log_params_success)
-          expect(StatsD).to receive(:increment).with('decision_review.form_10182.evidence_upload_to_s3.success')
-          form_attachment = build(attachment_factory_id, guid: form_attachment_guid)
-
-          expect(form_attachment_model).to receive(:new) do
-            expect(form_attachment).to receive(:set_file_data!)
-
-            expect(form_attachment).to receive(:save!) do
-              form_attachment.id = 99
-              form_attachment
-            end
-
-            form_attachment
-          end
-          expect(subject).to receive(:render).with(json: form_attachment).and_call_original # rubocop:disable RSpec/SubjectStub
-
-          post(:create, params:)
-
-          expect(response).to have_http_status(:ok)
-          expect(JSON.parse(response.body)).to eq(expected_response_body)
-        end
-      end
-
-      context 'and the use hexapdf feature switch is enabled' do
-        before { Flipper.enable :decision_review_use_hexapdf_for_encrypted_attachments }
-
-        it 'creates a FormAttachment, logs formatted success message, and increments statsd' do
-          request.headers['Source-App-Name'] = '10182-board-appeal'
-          params = { param_namespace => { file_data: pdf_file, password: 'test_password' } }
-
-          expect(Common::PdfHelpers).to receive(:unlock_pdf)
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(encrypted_log_params_success)
-          expect(StatsD).to receive(:increment).with('decision_review.form_10182.evidence_upload_to_s3.success')
-          form_attachment = build(attachment_factory_id, guid: form_attachment_guid)
-
-          expect(form_attachment_model).to receive(:new) do
-            expect(form_attachment).to receive(:set_file_data!)
-
-            expect(form_attachment).to receive(:save!) do
-              form_attachment.id = 99
-              form_attachment
-            end
-
-            form_attachment
-          end
-          expect(subject).to receive(:render).with(json: form_attachment).and_call_original # rubocop:disable RSpec/SubjectStub
-
-          post(:create, params:)
-
-          expect(response).to have_http_status(:ok)
-          expect(JSON.parse(response.body)).to eq(expected_response_body)
-        end
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq(expected_response_body)
       end
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO* No
This PR is to remove storage of evidence attachment data due to the completion of validating the attachment decryption process.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87405

## Testing done

- [x] *New code is covered by unit tests*
Unprocessed (encrypted) versions of the evidence attachments will no longer be stored. Hexapdf will always be used for decrypting PDFs in the DR evidence flow.

## What areas of the site does it impact?
This impacts the Decision Review evidence attachment processing

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
