### PR TITLE
Remove duplicate indexes

### DIFF
--- a/db/migrate/20240709171552_remove_redundant_indexes.rb
+++ b/db/migrate/20240709171552_remove_redundant_indexes.rb
@@ -1,0 +1,9 @@
+class RemoveRedundantIndexes < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :accreditations, name: 'index_accreditations_on_accredited_individual_id', if_exists: true
+
+    remove_index :async_transactions, name: 'index_async_transactions_on_transaction_id', if_exists: true
+
+    remove_index :va_notify_in_progress_reminders_sent, name: 'index_va_notify_in_progress_reminders_sent_on_user_account_id', if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_08_210311) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_09_171552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -60,7 +60,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_210311) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["accredited_individual_id", "accredited_organization_id"], name: "index_accreditations_on_indi_and_org_ids", unique: true
-    t.index ["accredited_individual_id"], name: "index_accreditations_on_accredited_individual_id"
     t.index ["accredited_organization_id"], name: "index_accreditations_on_accredited_organization_id"
   end
 
@@ -287,7 +286,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_210311) do
     t.index ["id", "type"], name: "index_async_transactions_on_id_and_type"
     t.index ["source_id"], name: "index_async_transactions_on_source_id"
     t.index ["transaction_id", "source"], name: "index_async_transactions_on_transaction_id_and_source", unique: true
-    t.index ["transaction_id"], name: "index_async_transactions_on_transaction_id"
     t.index ["user_account_id"], name: "index_async_transactions_on_user_account_id"
     t.index ["user_uuid"], name: "index_async_transactions_on_user_uuid"
   end
@@ -1285,7 +1283,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_210311) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_account_id", "form_id"], name: "index_in_progress_reminders_sent_user_account_form_id", unique: true
-    t.index ["user_account_id"], name: "index_va_notify_in_progress_reminders_sent_on_user_account_id"
   end
 
   create_table "vba_documents_monthly_stats", force: :cascade do |t|


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- These are duplicate indexes listed in PgHero. 

This was the message from PgHero:
> **Duplicate Indexes**
      These indexes exist, but aren’t needed. Remove themfor faster writes.    
Details
--
On accreditations               
`index_accreditations_on_accredited_individual_id (accredited_individual_id)` is covered by               `index_accreditations_on_indi_and_org_ids (accredited_individual_id, accredited_organization_id)`
On async_transactions
`index_async_transactions_on_transaction_id (transaction_id)` is covered by               `index_async_transactions_on_transaction_id_and_source (transaction_id, source)`
On va_notify_in_progress_reminders_sent            
`index_va_notify_in_progress_reminders_sent_on_user_account_id (user_account_id)` is covered by               `index_in_progress_reminders_sent_user_account_form_id (user_account_id, form_id)`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87373

## Testing done

- Migration ran locally.
- [ ] Keep an eye on dev and staging to make sure the migrations run after merge, during sync.
- [ ] Watch sandbox and prod at daily deploy


## What areas of the site does it impact?
- Three tables. See details above. 
