### PR TITLE
8861: cc appointment request friendly location name

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -165,7 +165,7 @@ module Mobile
         # this does not match the way friendly name is set for web.
         # our mocks do not match the web mocks 1:1 so different data is needed
         def friendly_location_name
-          return appointment[:location][:name] if va_appointment? || appointment_request?
+          return appointment.dig(:location, :name) if va_appointment? || appointment_request?
 
           appointment.dig(:extension, :cc_location, :practice_name)
         end

--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -162,8 +162,10 @@ module Mobile
           identifier[:value]&.split(':', 2)&.second
         end
 
+        # this does not match the way friendly name is set for web.
+        # our mocks do not match the web mocks 1:1 so different data is needed
         def friendly_location_name
-          return location[:name] if va_appointment?
+          return appointment[:location][:name] if va_appointment? || appointment_request?
 
           appointment.dig(:extension, :cc_location, :practice_name)
         end

--- a/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
+++ b/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
@@ -1102,7 +1102,7 @@ preferred dates:12/13/2022 PM|pager number:8675309"
       end
 
       it 'is set to nil when location name is absent' do
-        appointment[:location].delete(:name)
+        appointment.delete(:location)
         expect(parsed_appointment.friendly_location_name).to eq(nil)
       end
     end
@@ -1115,7 +1115,7 @@ preferred dates:12/13/2022 PM|pager number:8675309"
       end
 
       it 'is set to nil when location name is absent' do
-        appointment[:location].delete(:name)
+        appointment.delete(:location)
         expect(parsed_appointment.friendly_location_name).to eq(nil)
       end
     end
@@ -1128,7 +1128,7 @@ preferred dates:12/13/2022 PM|pager number:8675309"
       end
 
       it 'is set to nil when cc locatino practice name is absent' do
-        appointment[:extension][:cc_location].delete(:practice_name)
+        appointment.delete(:extension)
         expect(parsed_appointment.friendly_location_name).to eq(nil)
       end
     end


### PR DESCRIPTION
## Summary

Corrects handling of friendly name for cc appointment requests to better match web. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-mobile-app/issues/8861

## Testing done

Will test on staging.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

