### PR TITLE
Update SiS assertion validators to validate localhost hostname

### DIFF
--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -89,8 +89,9 @@ module SignIn
     end
 
     def hostname
-      scheme = Settings.vsp_environment == 'localhost' ? 'http://' : 'https://'
-      "#{scheme}#{Settings.hostname}"
+      return localhost_hostname if Settings.vsp_environment == 'localhost'
+
+      "https://#{Settings.hostname}"
     end
 
     def decoded_assertion
@@ -156,6 +157,12 @@ module SignIn
       raise Errors::AssertionExpiredError.new message: 'Assertion has expired'
     rescue JWT::DecodeError
       raise Errors::AssertionMalformedJWTError.new message: 'Assertion is malformed'
+    end
+
+    def localhost_hostname
+      port = URI.parse("http://#{Settings.hostname}").port
+
+      "http://localhost:#{port}"
     end
   end
 end

--- a/app/services/sign_in/client_assertion_validator.rb
+++ b/app/services/sign_in/client_assertion_validator.rb
@@ -48,8 +48,9 @@ module SignIn
     end
 
     def hostname
-      scheme = Settings.vsp_environment == 'localhost' ? 'http://' : 'https://'
-      "#{scheme}#{Settings.hostname}"
+      return localhost_hostname if Settings.vsp_environment == 'localhost'
+
+      "https://#{Settings.hostname}"
     end
 
     def decoded_client_assertion
@@ -73,6 +74,12 @@ module SignIn
       raise Errors::ClientAssertionExpiredError.new message: 'Client assertion has expired'
     rescue JWT::DecodeError
       raise Errors::ClientAssertionMalformedJWTError.new message: 'Client assertion is malformed'
+    end
+
+    def localhost_hostname
+      port = URI.parse("http://#{Settings.hostname}").port
+
+      "http://localhost:#{port}"
     end
   end
 end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -74,6 +74,17 @@ sample_client_api.update!(authentication: SignIn::Constants::Auth::API,
                           logout_redirect_uri: 'http://localhost:4567',
                           refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
+# Create Config for example sts service account
+sample_sts_config = SignIn::ServiceAccountConfig.find_or_initialize_by(service_account_id: 'sample_sts_service_account')
+sample_sts_config.update!(
+  description: 'Sample STS Service Account',
+  scopes: [],
+  access_token_audience: 'http://localhost:3000',
+  access_token_user_attributes: [],
+  access_token_duration: SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
+  certificates: [File.read('spec/fixtures/sign_in/sts_client.crt')]
+)
+
 # Create Config for VA Identity Dashboard using cookie auth
 vaid_dash = SignIn::ClientConfig.find_or_initialize_by(client_id: 'identity_dashboard')
 vaid_dash.update!(authentication: SignIn::Constants::Auth::COOKIE,


### PR DESCRIPTION
## Summary

- Currently the assertion validators check for `Settings.hostname`, which is set to `127.0.0.1`, host when validating the JWT payload. All of our examples use `localhost` and I believe this is more commonly used than `127.0.0.1`

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87954

## Testing 
- Migrate and seed database:
```bash
rails db:migrate
rails db:seed
```
- Start `vets-api` - `rails s`
- Create JWT assertion and make a request in rails console - `rails c`
```ruby
payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: [],
  service_account_id: 'sample_sts_service_account'
}

key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(payload, key, 'RS256')

query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion:
}

uri = URI.parse('http://localhost:3000/v0/sign_in/token')
uri.query = URI.encode_www_form(query_params)

http = Net::HTTP.new(uri.host, uri.port)
request = Net::HTTP::Post.new(uri.request_uri)
response = http.request(request)

JSON.parse(response.body)
```
- You should get back an access_token in the response body:
```ruby
{"data"=>
  {"access_token"=>
    "eyJhbGciOiJSUzI1NiJ9...."}} 
```

