### PR TITLE
[DBX-86443] remove backup status check 526 success scope

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -73,7 +73,6 @@ class Form526Submission < ApplicationRecord
   scope :success_type, lambda {
     left_joins(:form526_submission_remediations)
       .where.not(submitted_claim_id: nil)
-      .where(backup_submitted_claim_status: nil)
       .or(where.not(backup_submitted_claim_id: nil)
         .where(backup_submitted_claim_status: backup_submitted_claim_statuses[:accepted]))
       .or(where(form526_submission_remediations: { success: true }))


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):NO*
- This change removes a problematic constraint on the new Form526Submission `success_type` scope. When a submission has a `submitted_claim_id`, it is automatically 'success type', and we should not complicated it filtering out submissions that may have also gone to the backup path
- [This document outlines what it means to be success type and why it matters](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#key-terms-and-concepts)
- DBeX team 2 / Team Carbs

## Related issue(s)

- [Associated Ticket for backfilling state requires this fix](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/86443)

## Testing done

- [x] *New code is covered by unit tests*
- Would incorrectly exclude successfully primary path submissions from the 'success type' scope
- Manually patched this in via a production terminal and tested it there

## What areas of the site does it impact?
Form 526 Submission Remediation / Auditing / Code Yellow 3

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
