### PR TITLE
87959: Minor tweaks to file names

### DIFF
--- a/modules/ivc_champva/spec/requests/v1/pega_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/pega_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'Pega callback', type: :request do
     let(:valid_payload) do
       {
         form_uuid: '12345678-1234-5678-1234-567812345678',
-        file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d-tmp.pdf',
-                     '12345678-1234-5678-1234-567812345678_vha_10_10d-tmp-1.pdf'],
+        file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
+                     '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
         case_id: 'ABC-1234',
         status: 'Processed'
       }
@@ -27,7 +27,7 @@ RSpec.describe 'Pega callback', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d-tmp.pdf',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil
@@ -39,7 +39,7 @@ RSpec.describe 'Pega callback', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d-tmp-1.pdf',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf',
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil
@@ -51,7 +51,7 @@ RSpec.describe 'Pega callback', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d-tmp-2.pdf',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf',
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil
@@ -77,7 +77,7 @@ RSpec.describe 'Pega callback', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: 'd8f2902b-0b6e-4b8e-88d4-5f7a4a5b7f6d_vha_10_10d-tmp.pdf',
+          file_name: 'd8f2902b-0b6e-4b8e-88d4-5f7a4a5b7f6d_vha_10_10d.pdf',
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil
@@ -89,7 +89,7 @@ RSpec.describe 'Pega callback', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d-tmp.pdf',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil

--- a/modules/ivc_champva/spec/services/attachments_spec.rb
+++ b/modules/ivc_champva/spec/services/attachments_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe IvcChampva::Attachments do
     context 'when there are supporting documents' do
       it 'renames and processes attachments' do
         expect(File).to receive(:rename).with(file_path, "tmp/#{uuid}_#{form_id}-tmp.pdf")
-        expect(test_instance).to receive(:get_attachments).and_return(['attachment1.pdf', 'attachment2.pdf'])
+        expect(test_instance).to receive(:get_attachments).and_return(['attachment1.pdf', 'attachment2.png'])
         expect(File).to receive(:rename).with('attachment1.pdf', "./#{uuid}_#{form_id}-tmp1.pdf")
-        expect(File).to receive(:rename).with('attachment2.pdf', "./#{uuid}_#{form_id}-tmp2.pdf")
+        expect(File).to receive(:rename).with('attachment2.png', "./#{uuid}_#{form_id}-tmp2.png")
 
         result = test_instance.handle_attachments(file_path)
         expect(result).to contain_exactly("tmp/#{uuid}_#{form_id}-tmp.pdf", "./#{uuid}_#{form_id}-tmp1.pdf",
-                                          "./#{uuid}_#{form_id}-tmp2.pdf")
+                                          "./#{uuid}_#{form_id}-tmp2.png")
       end
     end
 

--- a/modules/ivc_champva/spec/services/file_uploader_spec.rb
+++ b/modules/ivc_champva/spec/services/file_uploader_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 
 describe IvcChampva::FileUploader do
   let(:form_id) { '123' }
-  let(:metadata) { { key: 'value' } }
-  let(:file_paths) { ['tmp/file1.pdf', 'tmp/file2.pdf'] }
+  let(:metadata) { { 'uuid' => '4171e61a-03b5-49f3-8717-dbf340310473' } }
+  let(:file_paths) { ['tmp/file1.pdf', 'tmp/file2.png'] }
   let(:attachment_ids) { ['Social Security card', 'Birth certificate'] }
-  let(:uploader) { IvcChampva::FileUploader.new(form_id, metadata, file_paths, attachment_ids) }
+  let(:insert_db_row) { false }
+  let(:uploader) { IvcChampva::FileUploader.new(form_id, metadata, file_paths, attachment_ids, insert_db_row) }
 
   describe '#handle_uploads' do
     context 'when all PDF uploads succeed' do
@@ -33,7 +34,7 @@ describe IvcChampva::FileUploader do
   end
 
   describe '#generate_and_upload_meta_json' do
-    let(:meta_file_path) { "tmp/#{form_id}_metadata.json" }
+    let(:meta_file_path) { "tmp/#{metadata['uuid']}_#{form_id}_metadata.json" }
 
     before do
       allow(File).to receive(:write)
@@ -44,7 +45,7 @@ describe IvcChampva::FileUploader do
     it 'writes metadata to a JSON file and uploads it' do
       expect(File).to receive(:write).with(meta_file_path, metadata.to_json)
       expect(uploader).to receive(:upload).with(
-        "#{form_id}_metadata.json",
+        "#{metadata['uuid']}_#{form_id}_metadata.json",
         meta_file_path,
         attachment_ids:
       ).and_return([200, nil])

--- a/modules/ivc_champva/spec/services/pdf_filler_spec.rb
+++ b/modules/ivc_champva/spec/services/pdf_filler_spec.rb
@@ -44,9 +44,7 @@ describe IvcChampva::PdfFiller do
             filled_pdf_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'pdfs',
                                               "#{file_name}-filled.pdf")
 
-            expect do
-              described_class.new(form_number:, form:).generate
-            end.to change { File.exist?(expected_pdf_path) }.from(false).to(true)
+            described_class.new(form_number:, form:).generate
 
             expect(expected_pdf_path).to match_pdf_content_of(filled_pdf_path)
           end


### PR DESCRIPTION
1. When an attachment is uploaded that is not a PDF it's missing when saved in the DB.
2. The file name we send to the S3 bucket is 4171e61a-03b5-49f3-8717-dbf340310473_vha_10_10d1.pdf but saved in the DB like 4171e61a-03b5-49f3-8717-dbf340310473_vha_10_10d-tmp1.pdf. This will certainly cause issues for them when sending the payload.
3. The metadata JSON file is being sent to S3 like vha_10_10d_metadata.json and it needs to include the form_uuid like 4171e61a-03b5-49f3-8717-dbf340310473_vha_10_10d_metadata.json to ensure it's not overwritten.


## Summary

- Updated meta JSON file to include UUID
- Updated logic to remove tmp to match whats going into S3
- Updates specs

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87959

## Testing done

- [x] *Rspec*
