### PR TITLE
Fix the form_id and add a test for 21-0966 prefill

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -144,7 +144,7 @@ module SimpleFormsApi
       def get_file_paths_and_metadata(parsed_form_data)
         form_id = get_form_id
         form = "SimpleFormsApi::#{form_id.titleize.gsub(' ', '')}".constantize.new(parsed_form_data)
-        form = form.populate_veteran_data(@current_user) if form_id == '21-0966' && first_party?
+        form = form.populate_veteran_data(@current_user) if form_id == 'vba_21_0966' && first_party?
         filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, form:)
 
         file_path = if @current_user

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -22,6 +22,7 @@ module SimpleFormsApi
       }
       @data['veteran_date_of_birth'] ||= user.birth_date
       @data['veteran_phone'] ||= user.home_phone
+      @data['veteran_email'] ||= user.email
 
       self
     end

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21_0966-prefill.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21_0966-prefill.json
@@ -1,0 +1,21 @@
+{
+  "form_number": "21-0966",
+  "preparer_identification": "VETERAN",
+  "full_name": {
+    "first": "Veteran",
+    "last": "Eteranvay"
+  },
+  "address": {
+    "country": "CAN",
+    "street": "867 Five St",
+    "city": "Threeoh",
+    "postal_code": "99999"
+  },
+  "date_of_birth": "1990-03-12",
+  "ssn": "246813579",
+  "benefit_selection": {
+    "compensation": true
+  },
+  "statement_of_truth_signature": "Veteran Eteranvay",
+  "statement_of_truth_certified": true
+}

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -136,6 +136,19 @@ RSpec.describe 'Forms uploader', type: :request do
             allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
           end
 
+          context 'veteran' do
+            it 'calls #populate_veteran_data' do
+              expect_any_instance_of(SimpleFormsApi::VBA210966).to receive(:populate_veteran_data).and_call_original
+
+              fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
+                                             'vba_21_0966-prefill.json')
+              data = JSON.parse(fixture_path.read)
+              data['preparer_identification'] = 'VETERAN'
+
+              post '/simple_forms_api/v1/simple_forms', params: data
+            end
+          end
+
           context 'third party' do
             let(:expiration_date) { Time.zone.now }
 

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe 'Forms uploader', type: :request do
           before do
             sign_in
             allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
+            allow_any_instance_of(User).to receive(:participant_id).and_return(nil)
             allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
           end
 


### PR DESCRIPTION
## Summary
This PR fixes the `id` for 21-0966 so that prefill data can correctly be added to the Intent to File PDF. It also adds a test which, had I written it before, this problem would have been caught yesterday.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/87615
