### PR TITLE
Check that `respond` method exists in ServiceException

### DIFF
--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -70,6 +70,7 @@ module BenefitsDocuments
       Lighthouse::DocumentUpload.perform_async(@user.icn, document_data.to_serializable_hash)
     rescue CarrierWave::IntegrityError => e
       handle_error(e, lighthouse_client_id, uploader.store_dir)
+      raise e
     end
 
     def build_lh_doc(file, file_params)

--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -27,9 +27,9 @@ module Lighthouse
     # formats the Lighthouse exception for the controller ExceptionHandling to report out to the consumer
     def self.send_error(error, service_name, lighthouse_client_id, url)
       send_error_logs(error, service_name, lighthouse_client_id, url)
+      return error unless error.respond_to?(:response)
 
       response = error.response
-
       status_code = get_status_code(response)
       return error unless status_code
 
@@ -90,9 +90,8 @@ module Lighthouse
     # log errors
     def self.send_error_logs(error, service_name, lighthouse_client_id, url)
       logging_options = { url:, lighthouse_client_id: }
-      if error.response.present?
-        # Faraday error may contain request data
-        error.response.delete(:request)
+
+      if error.respond_to?(:response) && error.response.present?
         logging_options[:status] = error.response[:status]
         logging_options[:body] = error.response[:body]
       else


### PR DESCRIPTION
## Summary

- Fixes broken specs that will be become apparent when bumping to ruby 3.3.3
- checks that `#response` method exists on class before calling it. Not doing so was causing errors, but the way that the specs were capturing errors, the true error was getting ignored
- We'll just re-raise the `CarrierWave::IntegrityError (after logging to Sentry), so that the original error handling/specs work as intended. Mobile Team will address this pattern/how their service is handling various errors in the near future.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87948

## Testing done

- [ ] Specs passing

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
