### PR TITLE
10-10EZ - Increment statsd value when submission failure email is sent

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -301,6 +301,7 @@ class HealthCareApplication < ApplicationRecord
           { 'salutation' => salutation },
           api_key
         )
+        StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.submission_failure_email_sent")
       rescue => e
         log_exception_to_sentry(e)
       end

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -529,6 +529,10 @@ RSpec.describe HealthCareApplication, type: :model do
               expect { subject }.not_to raise_error
             end
 
+            it 'increments statsd' do
+              expect { subject }.to trigger_statsd_increment('api.1010ez.submission_failure_email_sent')
+            end
+
             context 'without first name' do
               subject do
                 health_care_application.parsed_form['veteranFullName'] = nil


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Add new statsd value and increment it when a 1010EZ submission failure email is sent

## Related issue(s)

- [*Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/86500)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*10-10EZ

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

