### PR TITLE
[DBEX] create UpdateDocumentsStatus and Polling services

### DIFF
--- a/lib/lighthouse/benefits_documents/form526/documents_status_polling_service.rb
+++ b/lib/lighthouse/benefits_documents/form526/documents_status_polling_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'common/client/base'
+require 'lighthouse/benefits_documents/configuration'
+
+module BenefitsDocuments
+  module Form526
+    class DocumentsStatusPollingService < Common::Client::Base
+      configuration BenefitsDocuments::Configuration
+
+      def self.call(args)
+        new(args).check_documents_status
+      end
+
+      def initialize(document_request_ids)
+        @document_request_ids = document_request_ids
+        super()
+      end
+
+      def check_documents_status
+        fetch_documents_status
+      end
+
+      private
+
+      def fetch_documents_status
+        config.get_documents_status(@document_request_ids)
+      end
+    end
+  end
+end

--- a/lib/lighthouse/benefits_documents/form526/update_documents_status_service.rb
+++ b/lib/lighthouse/benefits_documents/form526/update_documents_status_service.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'lighthouse/benefits_documents/form526/documents_status_polling_service'
+require 'lighthouse/benefits_documents/form526/upload_status_updater'
+
+module BenefitsDocuments
+  module Form526
+    class UpdateDocumentsStatusService
+      # Queries the Lighthouse Benefits Documents API's '/uploads/status' endpoint
+      # to check the progression of Lighthouse526DocumentUpload records submitted to Lighthouse.
+      #
+      # Once submitted to Lighthouse, they are forwarded to VBMS and, if successful, to BGS as well.
+      # All steps must complete before a document is considered to have been successfully processed.
+      # Whenever a document is submitted to Lighthouse, a 'request_id' corresponding to that document is returned,
+      # which is saved as lighthouse_document_request_id on a Lighthouse526DocumentUpload record.
+      #
+      # Lighthouse provides an endpoint, '/uploads/status', which takes an array of request ids and ressponds with
+      # a detailed JSON representiation of each document's upload progress to VBMS and BGS, including failures.
+      # This service class uses those data to update the status of each Lighthouse526DocumentUpload record,
+      # and log success, failure and timeout metrics to StatsD, where the data are used to drive dashboards.
+      #
+      # Documentation for Lighthouse's Benefits Documents API and '/uploads/status' endpoint is available here:
+      # https://dev-developer.va.gov/explore/api/benefits-documents/docs?version=current
+
+      STATSD_BASE_KEY = 'api.form526.lighthouse_document_upload_processing_status'
+      STATSD_DOCUMENT_COMPLETE_KEY = 'complete'
+      STATSD_DOCUMENT_FAILED_KEY = 'failed'
+      STATSD_PROCESSING_TIMEOUT_KEY = 'processing_timeout'
+      STATSD_DOCUMENT_TYPE_KEY_MAP = {
+        Lighthouse526DocumentUpload::VETERAN_UPLOAD_DOCUMENT_TYPE => 'veteran_upload',
+        Lighthouse526DocumentUpload::BDD_INSTRUCTIONS_DOCUMENT_TYPE => 'bdd_instructions',
+        Lighthouse526DocumentUpload::FORM_0781_DOCUMENT_TYPE => 'form_0781',
+        Lighthouse526DocumentUpload::FORM_0781A_DOCUMENT_TYPE => 'form_0781a'
+      }.freeze
+
+      def self.call(*)
+        new(*).call
+      end
+
+      # @param lighthouse526_document_uploads [Lighthouse526DocumentUpload] a collection of
+      # Lighthouse526DocumentUpload records polled for status updates on Lighthouse's '/uploads/status' endpoint
+      def initialize(lighthouse526_document_uploads, lighthouse_status_response)
+        @lighthouse526_document_uploads = lighthouse526_document_uploads
+        @lighthouse_status_response = lighthouse_status_response
+      end
+
+      def call
+        update_documents_status
+      end
+
+      private
+
+      def update_documents_status
+        @lighthouse_status_response.dig('data', 'statuses').each do |status|
+          update_document_status(status)
+        end
+      end
+
+      def update_document_status(status)
+        document_upload = @lighthouse526_document_uploads.find_by!(lighthouse_document_request_id: status['requestId'])
+
+        # UploadStatusUpdater encapsulates all parsing of a status response from Lighthouse
+        status_updater = BenefitsDocuments::Form526::UploadStatusUpdater.new(status, document_upload)
+        status_updater.update_status
+
+        statsd_document_type_key = STATSD_DOCUMENT_TYPE_KEY_MAP[document_upload.document_type]
+        statsd_document_base_key = "#{STATSD_BASE_KEY}.#{statsd_document_type_key}"
+
+        if document_upload.completed?
+          # ex. 'api.form526.lighthouse_document_upload_processing_status.bdd_instructions.complete'
+          StatsD.increment("#{statsd_document_base_key}.#{STATSD_DOCUMENT_COMPLETE_KEY}")
+        elsif document_upload.failed?
+          # Because Lighthouse's processing steps are subject to change, these metrics must be dyanmic.
+          # Currently, this should return either claims_evidence or benefits_gateway_service
+          failure_step_key = status_updater.get_failure_step.downcase
+
+          # ex. 'api.form526.lighthouse_document_upload_processing_status.bdd_instructions.failed.claims_evidence'
+          StatsD.increment("#{statsd_document_base_key}.#{STATSD_DOCUMENT_FAILED_KEY}.#{failure_step_key}")
+        elsif status_updater.processing_timeout?
+          # Triggered when a document is still pending more than 24 hours after processing began
+          # ex. 'api.form526.lighthouse_document_upload_processing_status.bdd_instructions.processing_timeout'
+          StatsD.increment("#{statsd_document_base_key}.#{STATSD_PROCESSING_TIMEOUT_KEY}")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/lighthouse/benefits_documents/form526/update_documents_status_service_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/form526/update_documents_status_service_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'lighthouse/benefits_documents/form526/update_documents_status_service'
+require 'lighthouse/benefits_documents/form526/documents_status_polling_service'
+
+RSpec.describe BenefitsDocuments::Form526::UpdateDocumentsStatusService do
+  describe '#call' do
+    let(:pending_document_upload) { create(:lighthouse526_document_upload, document_type: 'Veteran Upload') }
+    let(:uploads) { Lighthouse526DocumentUpload.where(id: pending_document_upload.id) }
+    let(:status_response) do
+      {
+        'data' => {
+          'statuses' => [
+            {
+              'requestId' => pending_document_upload.lighthouse_document_request_id,
+              'status' => status,
+              'time' => { 'startTime' => 499_152_030, 'endTime' => end_time },
+              'steps' => steps,
+              'error' => error
+            }
+          ]
+        }
+      }
+    end
+
+    shared_examples 'document status updater' do |expected_state, metrics_key|
+      it "transitions the document to #{expected_state}" do
+        described_class.call(uploads, status_response)
+        expect(pending_document_upload.reload.aasm_state).to eq(expected_state)
+      end
+
+      it "logs the #{expected_state} document to DataDog" do
+        expect { described_class.call(uploads, status_response) }.to trigger_statsd_increment(metrics_key)
+      end
+    end
+
+    context 'when a Lighthouse526DocumentUpload has completed all steps in Lighthouse' do
+      let(:status) { 'SUCCESS' }
+      let(:steps) do
+        [
+          { 'name' => 'CLAIMS_EVIDENCE', 'status' => 'SUCCESS' },
+          { 'name' => 'BENEFITS_GATEWAY_SERVICE', 'status' => 'SUCCESS' }
+        ]
+      end
+      let(:error) { nil }
+      let(:end_time) { 499_152_060 }
+
+      it_behaves_like 'document status updater', 'completed',
+                      'api.form526.lighthouse_document_upload_processing_status.veteran_upload.complete'
+    end
+
+    context 'when a Lighthouse526DocumentUpload fails in Lighthouse processing' do
+      let(:status) { 'FAILED' }
+      let(:steps) do
+        [
+          { 'name' => 'CLAIMS_EVIDENCE', 'status' => 'FAILED' },
+          { 'name' => 'BENEFITS_GATEWAY_SERVICE', 'status' => 'NOT_STARTED' }
+        ]
+      end
+      let(:error) { { 'detail' => 'VBMS System Outage', 'step' => 'CLAIMS_EVIDENCE' } }
+      let(:end_time) { 499_152_060 }
+
+      it_behaves_like 'document status updater', 'failed',
+                      'api.form526.lighthouse_document_upload_processing_status.veteran_upload.failed.claims_evidence'
+    end
+
+    context 'when a Lighthouse526DocumentUpload is still in progress at Lighthouse' do
+      let(:status) { 'IN_PROGRESS' }
+      let(:steps) do
+        [
+          { 'name' => 'CLAIMS_EVIDENCE', 'status' => 'IN_PROGRESS' },
+          { 'name' => 'BENEFITS_GATEWAY_SERVICE', 'status' => 'NOT_STARTED' }
+        ]
+      end
+      let(:error) { nil }
+      let(:lighthouse_processing_start_time) { DateTime.new(1985, 10, 26) }
+      let(:end_time) { nil }
+
+      before do
+        allow(pending_document_upload).to receive(:lighthouse_processing_started_at)
+          .and_return(lighthouse_processing_start_time)
+      end
+
+      context 'when it has been more than 24 hours since Lighthouse started processing a Lighthouse526DocumentUpload' do
+        it 'logs a processing timeout metric to statsd' do
+          Timecop.freeze(lighthouse_processing_start_time + 2.days) do
+            expect { described_class.call(uploads, status_response) }.to trigger_statsd_increment(
+              'api.form526.lighthouse_document_upload_processing_status.veteran_upload.processing_timeout'
+            )
+          end
+        end
+      end
+
+      context 'when it has been less than 24 hours since Lighthouse started processing a Lighthouse526DocumentUpload' do
+        it 'does not log a processing timeout metric to statsd' do
+          Timecop.freeze(lighthouse_processing_start_time + 2.hours) do
+            expect { described_class.call(uploads, status_response) }.not_to trigger_statsd_increment(
+              'api.form526.lighthouse_document_upload_processing_status.veteran_upload.processing_timeout'
+            )
+          end
+        end
+      end
+    end
+
+    describe 'document type in statsd metrics' do
+      # Helper method to generate identical responses that vary only in document request id
+      def mock_success_response(request_id)
+        {
+          'data' => {
+            'statuses' => [
+              {
+                'requestId' => request_id,
+                'status' => 'SUCCESS',
+                'time' => { 'startTime' => 499_152_030, 'endTime' => 499_152_060 }
+              }
+            ]
+          }
+        }
+      end
+
+      before do
+        # Stub update behavior; tests metrics keys include the correct document type
+        allow_any_instance_of(BenefitsDocuments::Form526::UploadStatusUpdater).to receive(:update_status)
+        allow_any_instance_of(Lighthouse526DocumentUpload).to receive(:completed?).and_return(true)
+      end
+
+      shared_examples 'correct statsd metric' do |document_type, metrics_key|
+        let(:document_upload) { create(:lighthouse526_document_upload, document_type:) }
+        let(:uploads) { Lighthouse526DocumentUpload.where(id: document_upload.id) }
+        let(:status_response) { mock_success_response(document_upload.lighthouse_document_request_id) }
+
+        it "increments the correct statsd metric for #{document_type}" do
+          expect { described_class.call(uploads, status_response) }.to trigger_statsd_increment(metrics_key)
+        end
+      end
+
+      it_behaves_like 'correct statsd metric', 'BDD Instructions',
+                      'api.form526.lighthouse_document_upload_processing_status.bdd_instructions.complete'
+      it_behaves_like 'correct statsd metric', 'Form 0781',
+                      'api.form526.lighthouse_document_upload_processing_status.form_0781.complete'
+      it_behaves_like 'correct statsd metric', 'Form 0781a',
+                      'api.form526.lighthouse_document_upload_processing_status.form_0781a.complete'
+      it_behaves_like 'correct statsd metric', 'Veteran Upload',
+                      'api.form526.lighthouse_document_upload_processing_status.veteran_upload.complete'
+    end
+  end
+end

--- a/spec/lib/lighthouse/benefits_documents/form526/upload_status_updater_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/form526/upload_status_updater_spec.rb
@@ -162,4 +162,52 @@ RSpec.describe BenefitsDocuments::Form526::UploadStatusUpdater do
       end
     end
   end
+
+  describe '#get_failure_step' do
+    let(:failed_document_status) do
+      {
+        'status' => 'FAILED',
+        'time' => { 'startTime' => 499_152_060, 'endTime' => 499_153_000 },
+        'steps' => [
+          { 'name' => 'CLAIMS_EVIDENCE', 'status' => 'SUCCESS' },
+          { 'name' => 'BENEFITS_GATEWAY_SERVICE', 'status' => 'FAILED' }
+        ],
+        'error' => { 'detail' => 'BGS outage', 'step' => 'BENEFITS_GATEWAY_SERVICE' }
+      }
+    end
+
+    it 'returns the name of the step Lighthouse reported failed' do
+      status_updater = described_class.new(failed_document_status, lighthouse526_document_upload)
+      expect(status_updater.get_failure_step).to eq('BENEFITS_GATEWAY_SERVICE')
+    end
+  end
+
+  describe '#processing_timeout?' do
+    shared_examples 'processing timeout' do |status, start_time, expected|
+      it "returns #{expected}" do
+        Timecop.freeze(past_date_time.utc) do
+          status_updater = described_class.new(
+            {
+              'status' => status,
+              'time' => { 'startTime' => start_time, 'endTime' => nil },
+              'steps' => [
+                { 'name' => 'CLAIMS_EVIDENCE', 'status' => 'IN_PROGRESS' },
+                { 'name' => 'BENEFITS_GATEWAY_SERVICE', 'status' => 'NOT_STARTED' }
+              ]
+            },
+            lighthouse526_document_upload
+          )
+          expect(status_updater.processing_timeout?).to eq(expected)
+        end
+      end
+    end
+
+    context 'when the document has been in progress for more than 24 hours' do
+      it_behaves_like('processing timeout', 'IN_PROGRESS', DateTime.new(1985, 10, 23).to_time.to_i, true)
+    end
+
+    context 'when the document has been in progress for less than 24 hours' do
+      it_behaves_like('processing timeout', 'IN_PROGRESS', DateTime.new(1985, 10, 25, 20).utc.to_time.to_i, false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

**Objective:** Implements a system for periodically polling the Lighthouse [uploads/status](https://dev-developer.va.gov/explore/api/benefits-documents/docs?version=current) endpoint to confirm the status of supplemental documents submitted to Lighthouse as part of a Form 526 Submission. The purpose of this system is to surface successes and failures that happen in the Form 526 process after being forwarded to Lighthouse for processing.

- Create `DocumentsStatusPolling` and `UpdateDocumentsStatus` service classes
  - Configure connection and data transmission to Benefits Documents '/uploads/status' endpoint
  - Add processing timeout window and failure step logic to `UploadStatusUpdater`
- Subsequent PRs will further implement the interaction with the Lighthouse Benefits Document API client
- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/17439
- https://github.com/department-of-veterans-affairs/vets-api/pull/17405
- https://github.com/department-of-veterans-affairs/vets-api/pull/17407
- https://github.com/department-of-veterans-affairs/vets-api/pull/15964
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87619
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75804

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?

- non-user facing, asynchronous job tracking the status of uploaded documents submitted in conjunction with Form 526EZ 

## Acceptance criteria

- [x]  I fixed|updated|**added** unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature