### PR TITLE
[API-38039] Relax treatment begin date validation

### DIFF
--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -1499,7 +1499,7 @@ RSpec.describe 'Disability Claims', type: :request do
             context "when 'monthlyAmount' is below the minimum" do
               let(:military_retired_payment_amount) { 0 }
 
-              it 'responds with an unprocessible entity' do
+              it 'responds with an unprocessable entity' do
                 mock_ccg(scopes) do |auth_header|
                   json_data = JSON.parse data
                   params = json_data
@@ -1513,7 +1513,7 @@ RSpec.describe 'Disability Claims', type: :request do
             context "when 'monthlyAmount' is above the maximum" do
               let(:military_retired_payment_amount) { 1_000_000 }
 
-              it 'responds with an unprocessible entity' do
+              it 'responds with an unprocessable entity' do
                 mock_ccg(scopes) do |auth_header|
                   json_data = JSON.parse data
                   params = json_data
@@ -1554,7 +1554,7 @@ RSpec.describe 'Disability Claims', type: :request do
                   }
                 end
 
-                it 'responds with an unprocessible entity' do
+                it 'responds with an unprocessable entity' do
                   mock_ccg(scopes) do |auth_header|
                     json_data = JSON.parse data
                     params = json_data
@@ -1607,7 +1607,7 @@ RSpec.describe 'Disability Claims', type: :request do
             context "when 'preTaxAmountReceived' is below the minimum" do
               let(:separation_payment_amount) { 0 }
 
-              it 'responds with an unprocessible entity' do
+              it 'responds with an unprocessable entity' do
                 mock_ccg(scopes) do |auth_header|
                   json_data = JSON.parse data
                   params = json_data
@@ -1621,7 +1621,7 @@ RSpec.describe 'Disability Claims', type: :request do
             context "when 'preTaxAmountReceived' is above the maximum" do
               let(:separation_payment_amount) { 1_000_000 }
 
-              it 'responds with an unprocessible entity' do
+              it 'responds with an unprocessable entity' do
                 mock_ccg(scopes) do |auth_header|
                   json_data = JSON.parse data
                   params = json_data
@@ -1746,7 +1746,106 @@ RSpec.describe 'Disability Claims', type: :request do
         end
       end
 
-      describe 'Validation of treament elements' do
+      describe 'Validating treatment beginDate and first service period beginDate' do
+        def update_json_and_submit(updated_json_lambda)
+          mock_ccg(scopes) do |auth_header|
+            json = JSON.parse(data)
+            updated_json = updated_json_lambda.call(json)
+            post submit_path, params: updated_json.to_json, headers: auth_header
+            response
+          end
+        end
+
+        context 'when treatment beginDate has a YYYY-MM pattern' do
+          it 'returns a 202 when the treatment beginDate is after the first service period beginDate' do
+            response = update_json_and_submit(
+              lambda do |json|
+                json['data']['attributes']['treatments'][0]['beginDate'] = '2009-03'
+                json['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] =
+                  '2008-01-01'
+                json
+              end
+            )
+            expect(response).to have_http_status(:accepted)
+          end
+
+          it 'returns a 202 when the treatment beginDate is the same as the first service period beginDate' do
+            response = update_json_and_submit(
+              lambda do |json|
+                json['data']['attributes']['treatments'][0]['beginDate'] = '2008-01'
+                json['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] =
+                  '2008-01-31'
+                json
+              end
+            )
+            expect(response).to have_http_status(:accepted)
+          end
+
+          it 'returns a 422 when the treatment beginDate is before the first service period beginDate' do
+            response = update_json_and_submit(
+              lambda do |json|
+                json['data']['attributes']['treatments'][0]['beginDate'] = '2007-12'
+                json['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] =
+                  '2008-01-01'
+                json
+              end
+            )
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it 'returns a 422 when the treatment beginDate is a month before the first service period beginDate' do
+            response = update_json_and_submit(
+              lambda do |json|
+                json['data']['attributes']['treatments'][0]['beginDate'] = '2008-07'
+                json['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] =
+                  '2008-08-01'
+                json
+              end
+            )
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
+        context 'when treatment beginDate has a YYYY pattern' do
+          it 'returns a 202 when the treatment beginDate is after the first service period beginDate' do
+            response = update_json_and_submit(
+              lambda do |json|
+                json['data']['attributes']['treatments'][0]['beginDate'] = '2009'
+                json['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] =
+                  '2008-01-01'
+                json
+              end
+            )
+            expect(response).to have_http_status(:accepted)
+          end
+
+          it 'returns a 202 when the treatment beginDate is the same year as the first service period beginDateDate' do
+            response = update_json_and_submit(
+              lambda do |json|
+                json['data']['attributes']['treatments'][0]['beginDate'] = '2008'
+                json['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] =
+                  '2008-12-31'
+                json
+              end
+            )
+            expect(response).to have_http_status(:accepted)
+          end
+
+          it 'returns a 422 when the treatment beginDate is before the first service period beginDate' do
+            response = update_json_and_submit(
+              lambda do |json|
+                json['data']['attributes']['treatments'][0]['beginDate'] = '2007'
+                json['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] =
+                  '2008-01-01'
+                json
+              end
+            )
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+      end
+
+      describe 'Validation of treatment elements' do
         context 'when treatments values are not submitted' do
           it 'returns a 202' do
             mock_ccg(scopes) do |auth_header|
@@ -2103,8 +2202,8 @@ RSpec.describe 'Disability Claims', type: :request do
             end
           end
 
-          context 'when federalActivation is present anticipatedSeperationDate is required' do
-            context 'when anticipatedSeperationDate is missing' do
+          context 'when federalActivation is present anticipatedSeparationDate is required' do
+            context 'when anticipatedSeparationDate is missing' do
               it 'returns a 422' do
                 mock_ccg(scopes) do |auth_header|
                   json = JSON.parse(data)
@@ -2350,7 +2449,7 @@ RSpec.describe 'Disability Claims', type: :request do
         context 'when the activeDutyEndDate is in the future' do
           let(:active_duty_end_date) { 2.months.from_now.strftime('%Y-%m-%d') }
 
-          context 'and the seperationLocationCode is present' do
+          context 'and the separationLocationCode is present' do
             it 'responds with a 202' do
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
@@ -2362,7 +2461,7 @@ RSpec.describe 'Disability Claims', type: :request do
               end
             end
 
-            context 'and the seperationLocationCode is blank' do
+            context 'and the separationLocationCode is blank' do
               let(:separation_location_code) { nil }
 
               it 'responds with a 422' do
@@ -2378,7 +2477,7 @@ RSpec.describe 'Disability Claims', type: :request do
               end
             end
 
-            context 'and the seperationLocationCode is an empty string' do
+            context 'and the separationLocationCode is an empty string' do
               let(:separation_location_code) { '' }
 
               it 'responds with a 422' do
@@ -2396,7 +2495,7 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        context 'when there are mutiple confinements' do
+        context 'when there are multiple confinements' do
           let(:confinements) do
             [
               {
@@ -2421,7 +2520,7 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        context 'when there are mutiple confinements that overlap' do
+        context 'when there are multiple confinements that overlap' do
           let(:confinements) do
             [
               {
@@ -2771,8 +2870,8 @@ RSpec.describe 'Disability Claims', type: :request do
         end
       end
 
-      describe "'disabilites' validations" do
-        context 'when disabilties.name is not present' do
+      describe "'disabilities' validations" do
+        context 'when disabilities.name is not present' do
           it 'responds with 422 bad request' do
             mock_ccg(scopes) do |auth_header|
               json = JSON.parse(data)
@@ -2785,7 +2884,7 @@ RSpec.describe 'Disability Claims', type: :request do
         end
 
         describe "'disabilities.classificationCode' validations" do
-          context "when 'disabilites.classificationCode' is valid" do
+          context "when 'disabilities.classificationCode' is valid" do
             it 'returns a successful response' do
               mock_ccg(scopes) do |auth_header|
                 json_data = JSON.parse data
@@ -2796,7 +2895,7 @@ RSpec.describe 'Disability Claims', type: :request do
             end
           end
 
-          context "when 'disabilites.classificationCode' is invalid" do
+          context "when 'disabilities.classificationCode' is invalid" do
             it 'responds with a bad request' do
               mock_ccg(scopes) do |auth_header|
                 json_data = JSON.parse data
@@ -2808,7 +2907,7 @@ RSpec.describe 'Disability Claims', type: :request do
             end
           end
 
-          context "when 'disabilites.classificationCode' is null" do
+          context "when 'disabilities.classificationCode' is null" do
             it 'responds with a 202' do
               mock_ccg(scopes) do |auth_header|
                 json_data = JSON.parse data
@@ -2822,7 +2921,7 @@ RSpec.describe 'Disability Claims', type: :request do
         end
 
         describe "'disabilities.ratedDisabilityId' validations" do
-          context "when 'disabilites.disabilityActionType' equals 'INCREASE'" do
+          context "when 'disabilities.disabilityActionType' equals 'INCREASE'" do
             context "and 'disabilities.ratedDisabilityId' is not provided" do
               it 'responds with a 202' do
                 mock_ccg(scopes) do |auth_header|
@@ -2928,9 +3027,9 @@ RSpec.describe 'Disability Claims', type: :request do
             end
           end
 
-          context "when 'disabilites.disabilityActionType' equals 'NONE'" do
-            context "and 'disabilites.secondaryDisabilities' is defined" do
-              context "and 'disabilites.diagnosticCode is not provided" do
+          context "when 'disabilities.disabilityActionType' equals 'NONE'" do
+            context "and 'disabilities.secondaryDisabilities' is defined" do
+              context "and 'disabilities.diagnosticCode is not provided" do
                 it 'responds with a 202' do
                   mock_ccg(scopes) do |auth_header|
                     json_data = JSON.parse data
@@ -2970,7 +3069,7 @@ RSpec.describe 'Disability Claims', type: :request do
             end
           end
 
-          context "when 'disabilites.disabilityActionType' equals value other than 'INCREASE'" do
+          context "when 'disabilities.disabilityActionType' equals value other than 'INCREASE'" do
             context "and 'disabilities.ratedDisabilityId' is not provided" do
               it 'responds with a 202' do
                 mock_ccg(scopes) do |auth_header|
@@ -2986,7 +3085,7 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        describe "'disabilites.approximateDate' validations" do
+        describe "'disabilities.approximateDate' validations" do
           context "when 'approximateDate' is in the future" do
             let(:approximate_date) { (Time.zone.today + 1.year).strftime('%Y-%m-%d') }
 
@@ -3116,7 +3215,7 @@ RSpec.describe 'Disability Claims', type: :request do
         end
 
         describe "'disabilities.serviceRelevance' validations" do
-          context "when 'disabilites.disabilityActionType' equals 'NEW'" do
+          context "when 'disabilities.disabilityActionType' equals 'NEW'" do
             context "and 'disabilities.serviceRelevance' is not provided" do
               it 'responds with a 422' do
                 mock_ccg(scopes) do |auth_header|
@@ -3302,7 +3401,7 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        context "when 'disabilites.secondaryDisabilities.classificationCode' is invalid" do
+        context "when 'disabilities.secondaryDisabilities.classificationCode' is invalid" do
           it 'raises an exception' do
             mock_ccg(scopes) do |auth_header|
               json_data = JSON.parse data
@@ -3330,7 +3429,7 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        context "when 'disabilites.secondaryDisabilities.classificationCode' does not match name" do
+        context "when 'disabilities.secondaryDisabilities.classificationCode' does not match name" do
           it 'raises an exception' do
             mock_ccg(scopes) do |auth_header|
               json_data = JSON.parse data
@@ -3358,7 +3457,7 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        context "when 'disabilites.secondaryDisabilities.approximateDate' is present" do
+        context "when 'disabilities.secondaryDisabilities.approximateDate' is present" do
           it 'raises an exception if date is invalid' do
             mock_ccg(scopes) do |auth_header|
               json_data = JSON.parse data
@@ -3516,7 +3615,7 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        context "when 'disabilites.secondaryDisabilities.classificationCode' is not present" do
+        context "when 'disabilities.secondaryDisabilities.classificationCode' is not present" do
           it 'raises an exception if name is not valid structure' do
             mock_ccg(scopes) do |auth_header|
               json_data = JSON.parse data


### PR DESCRIPTION
## Summary

Assume the best if there is any ambiguity when comparing treatment begin date with the first service period begin date. i.e., if the first service begin date is `YYYY-MM-DD`, allow any treatments that begin in `YYYY` or `YYYY-MM`.

Continue to disallow treatment begin dates where there is no ambiguity, i.e., service begin date is `YYYY-MM-DD` and treatment begin date is `YYYY-MM` minus one month.

## Related issue(s)

[API-38039](https://jira.devops.va.gov/browse/API-38039)

## Testing done

- [x] *New code is covered by unit tests*
- [x] *Tested submission locally with @rockwellwindsor-va and verified PDF in S3*

## Screenshots
N/A

## What areas of the site does it impact?
Claims API > Disability Compensation

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
Could use help testing against live environments while [awaiting AWS access](https://github.com/department-of-veterans-affairs/va.gov-team/issues/87113).