### PR TITLE
[Dbx-87964] refine 526 scopes

### DIFF
--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -26,6 +26,14 @@ FactoryBot.define do
     }
   end
 
+  trait :backup_accepted do
+    backup_submitted_claim_status { 'accepted' }
+  end
+
+  trait :backup_rejected do
+    backup_submitted_claim_status { 'rejected' }
+  end
+
   trait :with_everything do
     form_json do
       File.read("#{submissions_path}/with_everything.json")
@@ -263,11 +271,22 @@ FactoryBot.define do
     submitted_claim_id { SecureRandom.rand(900_000_000) }
   end
 
-  trait :with_accepted_backup_status do
-    backup_submitted_claim_status { :accepted }
-  end
-
   trait :created_more_than_3_days_ago do
     created_at { 4.days.ago }
+  end
+
+  trait :remediated do
+    after(:create) do |submission|
+      create(:form526_submission_remediation, form526_submission: submission, lifecycle: ['i have been remediated'])
+    end
+  end
+
+  trait :no_longer_remediated do
+    after(:create) do |submission|
+      create(:form526_submission_remediation,
+             form526_submission: submission,
+             lifecycle: ['i am no longer remediated'],
+             success: false)
+    end
   end
 end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -98,72 +98,87 @@ RSpec.describe Form526Submission do
   end
 
   describe 'scopes' do
-    describe 'pending_backup_submissions' do
-      let!(:new_submission) { create(:form526_submission) }
-      let!(:rejected_backup_submission) do
-        create(:form526_submission, :backup_path, backup_submitted_claim_status: 'rejected')
-      end
-      let!(:accepted_backup_submission) do
-        create(:form526_submission, :backup_path, backup_submitted_claim_status: 'accepted')
-      end
-      let!(:backup_submission_a) { create(:form526_submission, :backup_path) }
-      let!(:backup_submission_b) { create(:form526_submission, :backup_path) }
+    let!(:in_process) { create(:form526_submission) }
+    let!(:expired) { create(:form526_submission, :created_more_than_3_days_ago) }
+    let!(:happy_path_success) { create(:form526_submission, :with_submitted_claim_id) }
+    let!(:pending_backup) { create(:form526_submission, :backup_path) }
+    let!(:accepted_backup) { create(:form526_submission, :backup_path, :backup_accepted) }
+    let!(:rejected_backup) { create(:form526_submission, :backup_path, :backup_rejected) }
+    let!(:remediated) { create(:form526_submission, :remediated) }
+    let!(:remediated_and_expired) { create(:form526_submission, :remediated) }
+    let!(:remediated_and_rejected) { create(:form526_submission, :remediated, :backup_path) }
+    let!(:no_longer_remediated) { create(:form526_submission, :no_longer_remediated) }
 
+    describe 'pending_backup_submissions' do
       it 'returns records submitted to the backup path but lacking a decisive state' do
         expect(Form526Submission.pending_backup_submissions).to contain_exactly(
-          backup_submission_a,
-          backup_submission_b
+          pending_backup
         )
       end
     end
 
     describe 'in_process' do
-      let!(:in_process_submission1) { create(:form526_submission) }
-      let!(:in_process_submission2) { create(:form526_submission, :backup_path) }
-      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_3_days_ago) }
-      let!(:backup_accepted_submission) { create(:form526_submission, :backup_path, :with_accepted_backup_status) }
-      let!(:successful_submission) { create(:form526_submission, :with_submitted_claim_id) }
+      it 'only returns submissions that are still in process' do
+        expect(Form526Submission.in_process).to contain_exactly(
+          in_process,
+          pending_backup
+        )
+      end
+    end
 
-      it 'only returns submissions that are in process' do
-        result = Form526Submission.in_process
+    describe 'accepted_to_primary_path' do
+      it 'returns submissions with a submitted_claim_id' do
+        expect(Form526Submission.accepted_to_primary_path).to contain_exactly(
+          happy_path_success
+        )
+      end
+    end
 
-        expect(result).to include(in_process_submission1, in_process_submission2)
-        expect(result).not_to include(expired_submission, backup_accepted_submission, successful_submission)
+    describe 'accepted_to_backup_path' do
+      it 'returns submissions with a backup_submitted_claim_id that have been explicitly rejected' do
+        expect(Form526Submission.accepted_to_backup_path).to contain_exactly(
+          accepted_backup
+        )
+      end
+    end
+
+    describe 'rejected_from_backup_path' do
+      it 'returns submissions with a backup_submitted_claim_id that have been explicitly rejected' do
+        expect(Form526Submission.rejected_from_backup_path).to contain_exactly(
+          rejected_backup
+        )
+      end
+    end
+
+    describe 'remediated' do
+      it 'returns everything with a successful remediation' do
+        expect(Form526Submission.remediated).to contain_exactly(
+          remediated,
+          remediated_and_expired,
+          remediated_and_rejected
+        )
       end
     end
 
     describe 'success_type' do
-      let!(:successful_submission) { create(:form526_submission, :with_submitted_claim_id) }
-      let!(:backup_accepted_submission) { create(:form526_submission, :backup_path, :with_accepted_backup_status) }
-      let!(:in_process_submission) { create(:form526_submission) }
-      let!(:remediated_submission) do
-        create(:form526_submission_remediation, form526_submission: subject)
-        subject
-      end
-
-      it 'only returns submissions that are successful types' do
-        result = Form526Submission.success_type
-
-        expect(result).to include(successful_submission, backup_accepted_submission, remediated_submission)
-        expect(result).not_to include(in_process_submission)
+      it 'returns all submissions on which no further action is required' do
+        expect(Form526Submission.success_type).to contain_exactly(
+          remediated,
+          remediated_and_expired,
+          remediated_and_rejected,
+          happy_path_success,
+          accepted_backup
+        )
       end
     end
 
     describe 'failure_type' do
-      let!(:in_process_submission) { create(:form526_submission) }
-      let!(:successful_submission) { create(:form526_submission, :with_submitted_claim_id) }
-      let!(:rejected_submission) { create(:form526_submission, :backup_path, backup_submitted_claim_status: :rejected) }
-      let!(:expired_submission) { create(:form526_submission, :backup_path, :created_more_than_3_days_ago) }
-      let!(:remediated_submission) do
-        create(:form526_submission_remediation, form526_submission: subject)
-        subject
-      end
-
-      it 'only returns submissions that are failure types' do
-        result = Form526Submission.failure_type
-
-        expect(result).to include(rejected_submission, expired_submission)
-        expect(result).not_to include(successful_submission, in_process_submission, remediated_submission)
+      it 'returns anything not explicitly successful or still in process' do
+        expect(Form526Submission.failure_type).to contain_exactly(
+          rejected_backup,
+          no_longer_remediated,
+          expired
+        )
       end
     end
   end
@@ -1371,7 +1386,7 @@ RSpec.describe Form526Submission do
     end
 
     context 'when backup_submitted_claim_id is present and backup_submitted_claim_status is accepted' do
-      subject { create(:form526_submission, :backup_path, :with_accepted_backup_status) }
+      subject { create(:form526_submission, :backup_path, :backup_accepted) }
 
       it 'returns true' do
         expect(subject).to be_success_type
@@ -1419,7 +1434,7 @@ RSpec.describe Form526Submission do
     end
 
     context 'when backup_submitted_claim_status is not nil' do
-      subject { create(:form526_submission, :backup_path, :with_accepted_backup_status) }
+      subject { create(:form526_submission, :backup_path, :backup_accepted) }
 
       it 'returns false' do
         expect(subject).not_to be_in_process

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Form526Submission do
     let!(:accepted_backup) { create(:form526_submission, :backup_path, :backup_accepted) }
     let!(:rejected_backup) { create(:form526_submission, :backup_path, :backup_rejected) }
     let!(:remediated) { create(:form526_submission, :remediated) }
-    let!(:remediated_and_expired) { create(:form526_submission, :remediated) }
+    let!(:remediated_and_expired) { create(:form526_submission, :remediated, :created_more_than_3_days_ago) }
     let!(:remediated_and_rejected) { create(:form526_submission, :remediated, :backup_path) }
     let!(:no_longer_remediated) { create(:form526_submission, :no_longer_remediated) }
 
@@ -135,7 +135,7 @@ RSpec.describe Form526Submission do
     end
 
     describe 'accepted_to_backup_path' do
-      it 'returns submissions with a backup_submitted_claim_id that have been explicitly rejected' do
+      it 'returns submissions with a backup_submitted_claim_id that have been explicitly accepted' do
         expect(Form526Submission.accepted_to_backup_path).to contain_exactly(
           accepted_backup
         )

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Form526Submission do
     let!(:rejected_backup) { create(:form526_submission, :backup_path, :backup_rejected) }
     let!(:remediated) { create(:form526_submission, :remediated) }
     let!(:remediated_and_expired) { create(:form526_submission, :remediated, :created_more_than_3_days_ago) }
-    let!(:remediated_and_rejected) { create(:form526_submission, :remediated, :backup_path) }
+    let!(:remediated_and_rejected) { create(:form526_submission, :remediated, :backup_path, :backup_rejected) }
     let!(:no_longer_remediated) { create(:form526_submission, :no_longer_remediated) }
 
     describe 'pending_backup_submissions' do
@@ -145,7 +145,8 @@ RSpec.describe Form526Submission do
     describe 'rejected_from_backup_path' do
       it 'returns submissions with a backup_submitted_claim_id that have been explicitly rejected' do
         expect(Form526Submission.rejected_from_backup_path).to contain_exactly(
-          rejected_backup
+          rejected_backup,
+          remediated_and_rejected
         )
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Refine existing 526 scopes for correctness
- Refine existing 526 scopes for readability

These scopes are part of our greater push to close out Code Yellow 3 by ensuring we have accurate, easily accessible ways to view Form 526 submissions that may require remediation.

Team: DBeX team carbs

## Related issue(s)

- [TDD outlining the purpose of these scopes](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md)
- [Ticket capturing this work](https://github.com/department-of-veterans-affairs/va.gov-team/issues/87964)

## Testing done

- [x] *New code is covered by unit tests*
- Previously these scopes incorrectly excluded submissions from success states
- All of these scopes have been manually tested in a rails console
- No flipper; there will be no apparent impact to Vets or application processes at this time.

## What areas of the site does it impact?
Form 526 submissions 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected 
- [x]  I added a screenshot of the developed feature (n/a)
