### PR TITLE
Add safe nav to user.id calls

### DIFF
--- a/app/sidekiq/lighthouse/create_intent_to_file_job.rb
+++ b/app/sidekiq/lighthouse/create_intent_to_file_job.rb
@@ -19,7 +19,8 @@ module Lighthouse
 
     # retry for one day
     # exhausted attempts will be logged in intent_to_file_queue_exhaustions table
-    sidekiq_options retry: 14, queue: 'low'
+    # TODO: set this back to 14 after testing is complete
+    sidekiq_options retry: 0, queue: 'low'
     sidekiq_retries_exhausted do |msg, error|
       form_type, form_start_date, veteran_icn = msg['args']
       itf_log_monitor = BenefitsClaims::IntentToFile::Monitor.new
@@ -54,11 +55,11 @@ module Lighthouse
     def perform(form_type, form_start_date, veteran_icn)
       init(form_type, veteran_icn)
 
-      @itf_log_monitor.track_create_itf_begun(@itf_type, form_start_date, @user_account.id)
+      @itf_log_monitor.track_create_itf_begun(@itf_type, form_start_date, @user_account&.id)
       @service.create_intent_to_file(@itf_type, '')
-      @itf_log_monitor.track_create_itf_success(@itf_type, form_start_date, @user_account.id)
+      @itf_log_monitor.track_create_itf_success(@itf_type, form_start_date, @user_account&.id)
     rescue => e
-      @itf_log_monitor.track_create_itf_failure(@itf_type, form_start_date, @user_account.id, e)
+      @itf_log_monitor.track_create_itf_failure(@itf_type, form_start_date, @user_account&.id, e)
       raise e
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Added safe nav to all references to the benefits_claims/intent_to_file/monitor.rb class. Also temporarily setting the Lighthouse::CreateIntentToFileJob retries to 0 for testing purposes. We'll be changing that back to the standard 14 once our testing in staging is complete.
- if User info is not present, it will cause the logging and monitoring logic to fail, which would fail to be captured in datadog.
- Adding safe nav will ensure failures are logged and tracked properly in datadog.
- Pension benefits team to own this work.

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/88144)
- [*Link to epic if not included in ticket*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76690)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
