### PR TITLE
#88075 [10-10EZ] [10-10EZR]: Add logger for individual attachment sizes

### DIFF
--- a/lib/va1010_forms/utils.rb
+++ b/lib/va1010_forms/utils.rb
@@ -57,7 +57,8 @@ module VA1010Forms
       # Log the attachment sizes in descending order
       if attachment_count.positive?
         # Convert the attachments into xml format so they resemble what will be sent to VES
-        attachment_sizes = attachments.map { |a| a.to_xml.size }.sort.reverse!.map { |size| number_to_human_size(size) }.join(', ')
+        attachment_sizes =
+          attachments.map { |a| a.to_xml.size }.sort.reverse!.map { |size| number_to_human_size(size) }.join(', ')
 
         Rails.logger.info("Attachment sizes in descending order: #{attachment_sizes}")
       end

--- a/lib/va1010_forms/utils.rb
+++ b/lib/va1010_forms/utils.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'benchmark'
 require 'hca/configuration'
 require 'hca/overrides_parser'
 
@@ -55,14 +56,10 @@ module VA1010Forms
       attachment_count = attachments&.length || 0
       # Log the attachment sizes in descending order
       if attachment_count.positive?
-        attachment_sizes = 'Attachment sizes in descending order: '
         # Convert the attachments into xml format so they resemble what will be sent to VES
-        attachments.sort_by { |a| a.to_xml.size }.reverse.each_with_index do |attachment, index|
-          attachment_sizes +=
-            "#{number_to_human_size(attachment.to_xml.size)}#{', ' unless index + 1 == attachment_count}"
-        end
+        attachment_sizes = attachments.map { |a| a.to_xml.size }.sort.reverse!.map { |size| number_to_human_size(size) }.join(', ')
 
-        Rails.logger.info(attachment_sizes)
+        Rails.logger.info("Attachment sizes in descending order: #{attachment_sizes}")
       end
 
       Rails.logger.info("Payload for submitted #{form_name}: " \

--- a/lib/va1010_forms/utils.rb
+++ b/lib/va1010_forms/utils.rb
@@ -54,11 +54,12 @@ module VA1010Forms
       attachments = formatted_form.dig('va:form', 'va:attachments')
       attachment_count = attachments&.length || 0
       # Log the attachment sizes in descending order
-      if attachment_count > 0
-        attachment_sizes = "Attachment sizes in descending order - "
+      if attachment_count.positive?
+        attachment_sizes = 'Attachment sizes in descending order: '
         # Convert the attachments into xml format so they resemble what will be sent to VES
         attachments.sort_by { |a| a.to_xml.size }.reverse.each_with_index do |attachment, index|
-          attachment_sizes += "#{index + 1}: #{number_to_human_size(attachment.to_xml.size)}#{', ' unless index + 1 == attachment_count}"
+          attachment_sizes +=
+            "#{number_to_human_size(attachment.to_xml.size)}#{', ' unless index + 1 == attachment_count}"
         end
 
         Rails.logger.info(attachment_sizes)

--- a/lib/va1010_forms/utils.rb
+++ b/lib/va1010_forms/utils.rb
@@ -51,7 +51,18 @@ module VA1010Forms
 
     def log_payload_info(formatted_form, submission_body)
       form_name = formatted_form.dig('va:form', 'va:formIdentifier', 'va:value')
-      attachment_count = formatted_form.dig('va:form', 'va:attachments')&.length || 0
+      attachments = formatted_form.dig('va:form', 'va:attachments')
+      attachment_count = attachments&.length || 0
+      # Log the attachment sizes in descending order
+      if attachment_count > 0
+        attachment_sizes = "Attachment sizes in descending order - "
+        # Convert the attachments into xml format so they resemble what will be sent to VES
+        attachments.sort_by { |a| a.to_xml.size }.reverse.each_with_index do |attachment, index|
+          attachment_sizes += "#{index + 1}: #{number_to_human_size(attachment.to_xml.size)}#{', ' unless index + 1 == attachment_count}"
+        end
+
+        Rails.logger.info(attachment_sizes)
+      end
 
       Rails.logger.info("Payload for submitted #{form_name}: " \
                         "Body size of #{number_to_human_size(submission_body.bytesize)} " \

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Form1010Ezr::Service do
           expect(Rails.logger).to have_received(:info).with('Payload for submitted 1010EZR: ' \
                                                             'Body size of 15.6 KB with 2 attachment(s)')
           expect(Rails.logger).to have_received(:info).with(
-            "Attachment sizes in descending order - 1: 1.8 KB, 2: 1.8 KB"
+            'Attachment sizes in descending order: 1.8 KB, 1.8 KB'
           )
         end
       end

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe Form1010Ezr::Service do
     described_class.new(current_user).submit_form(form)
   end
 
+  def ezr_form_with_attachments
+    form.merge(
+      'attachments' => [
+        {
+          'confirmationCode' => create(:form1010_ezr_attachment).guid
+        },
+        {
+          'confirmationCode' => create(:form1010_ezr_attachment).guid
+        }
+      ]
+    )
+  end
+
   describe '#add_financial_flag' do
     context 'when the form has veteran gross income' do
       let(:parsed_form) do
@@ -177,16 +190,20 @@ RSpec.describe Form1010Ezr::Service do
         end
       end
 
-      it 'logs the submission id and payload size', run_at: 'Tue, 21 Nov 2023 20:42:44 GMT' do
+      it 'logs the submission id, payload size, and individual attachment sizes in descending order (if applicable)',
+         run_at: 'Tue, 18 Jun 2024 18:17:40 GMT' do
         VCR.use_cassette(
-          'form1010_ezr/authorized_submit',
+          'form1010_ezr/authorized_submit_with_attachments',
           { match_requests_on: %i[method uri body], erb: true }
         ) do
-          submission_response = submit_form(form)
+          submission_response = submit_form(ezr_form_with_attachments)
 
           expect(Rails.logger).to have_received(:info).with("SubmissionID=#{submission_response[:formSubmissionId]}")
           expect(Rails.logger).to have_received(:info).with('Payload for submitted 1010EZR: ' \
-                                                            'Body size of 12.1 KB with 0 attachment(s)')
+                                                            'Body size of 15.6 KB with 2 attachment(s)')
+          expect(Rails.logger).to have_received(:info).with(
+            "Attachment sizes in descending order - 1: 1.8 KB, 2: 1.8 KB"
+          )
         end
       end
 
@@ -251,27 +268,16 @@ RSpec.describe Form1010Ezr::Service do
         end
       end
 
-      context 'submitting with attachment' do
+      context 'submitting with attachments' do
         let(:form) { get_fixture('form1010_ezr/valid_form') }
 
-        context 'with a pdf attachment' do
+        context 'with pdf attachments' do
           it 'returns a success object', run_at: 'Tue, 18 Jun 2024 18:17:40 GMT' do
             VCR.use_cassette(
               'form1010_ezr/authorized_submit_with_attachments',
               { match_requests_on: %i[method uri body], erb: true }
             ) do
-              form_with_attachments = form.merge(
-                'attachments' => [
-                  {
-                    'confirmationCode' => create(:form1010_ezr_attachment).guid
-                  },
-                  {
-                    'confirmationCode' => create(:form1010_ezr_attachment).guid
-                  }
-                ]
-              )
-
-              expect(submit_form(form_with_attachments)).to eq(
+              expect(submit_form(ezr_form_with_attachments)).to eq(
                 {
                   success: true,
                   formSubmissionId: 435_240_209,

--- a/spec/lib/hca/service_spec.rb
+++ b/spec/lib/hca/service_spec.rb
@@ -191,6 +191,9 @@ describe HCA::Service do
           expect(result[:success]).to eq(true)
           expect(Rails.logger).to have_received(:info).with('Payload for submitted 1010EZ: ' \
                                                             'Body size of 16 KB with 2 attachment(s)')
+          expect(Rails.logger).to have_received(:info).with(
+            "Attachment sizes in descending order - 1: 1.8 KB, 2: 1.8 KB"
+          )
         end
       end
 

--- a/spec/lib/hca/service_spec.rb
+++ b/spec/lib/hca/service_spec.rb
@@ -192,7 +192,7 @@ describe HCA::Service do
           expect(Rails.logger).to have_received(:info).with('Payload for submitted 1010EZ: ' \
                                                             'Body size of 16 KB with 2 attachment(s)')
           expect(Rails.logger).to have_received(:info).with(
-            "Attachment sizes in descending order - 1: 1.8 KB, 2: 1.8 KB"
+            'Attachment sizes in descending order: 1.8 KB, 1.8 KB'
           )
         end
       end


### PR DESCRIPTION
## Summary

- Adds a logger that returns the size of each attachment in the request payload

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88075

## Testing done

- [X] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10EZ and 10-10EZR forms

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
