### PR TITLE
[DR-73584] Add rescue and logging to personal information log create in Supplemental Claims

### DIFF
--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -55,12 +55,10 @@ module FailedRequestLoggable
     begin
       PersonalInformationLog.create!(error_class:, data:)
     rescue => e
-      Rails.logger.error(
-        "Error occurred while creating PersonalInformationLog. Original Exception: #{exception.message}"
-      )
       # Not sure if the error message could include PII
       # so just logging the backtrace as it would still tell us if there's a validation error or something
       Rails.logger.error('PersonalInformationLog error backtrace', e.backtrace)
+      raise
     end
   end
 end

--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -52,6 +52,13 @@ module FailedRequestLoggable
     }
     data[:additional_data] = additional_data if additional_data.present?
 
-    PersonalInformationLog.create! error_class:, data:
+    begin
+      PersonalInformationLog.create!(error_class:, data:)
+    rescue => e
+      Rails.logger.error("Error occurred while creating PersonalInformationLog. Original Exception: #{exception.message}")
+      # Not sure if the error message could include PII
+      # so just logging the backtrace as it would still tell us if there's a validation error or something
+      Rails.logger.error('PersonalInformationLog error backtrace', e.backtrace)
+    end
   end
 end

--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -55,7 +55,9 @@ module FailedRequestLoggable
     begin
       PersonalInformationLog.create!(error_class:, data:)
     rescue => e
-      Rails.logger.error("Error occurred while creating PersonalInformationLog. Original Exception: #{exception.message}")
+      Rails.logger.error(
+        "Error occurred while creating PersonalInformationLog. Original Exception: #{exception.message}"
+      )
       # Not sure if the error message could include PII
       # so just logging the backtrace as it would still tell us if there's a validation error or something
       Rails.logger.error('PersonalInformationLog error backtrace', e.backtrace)

--- a/app/controllers/v1/supplemental_claims_controller.rb
+++ b/app/controllers/v1/supplemental_claims_controller.rb
@@ -17,32 +17,8 @@ module V1
       raise
     end
 
-    # rubocop:disable Metrics/MethodLength
     def create
-      req_body_obj = request_body_hash.is_a?(String) ? JSON.parse(request_body_hash) : request_body_hash
-      form4142 = req_body_obj.delete('form4142')
-      sc_evidence = req_body_obj.delete('additionalDocuments')
-      zip_from_frontend = req_body_obj.dig('data', 'attributes', 'veteran', 'address', 'zipCode5')
-      sc_response = decision_review_service.create_supplemental_claim(request_body: req_body_obj, user: @current_user)
-      submitted_appeal_uuid = sc_response.body.dig('data', 'id')
-      unless submitted_appeal_uuid.nil?
-        ActiveRecord::Base.transaction do
-          appeal_submission = create_appeal_submission(submitted_appeal_uuid, zip_from_frontend)
-
-          appeal_submission_id = appeal_submission.id
-          ::Rails.logger.info(post_create_log_msg(appeal_submission_id:, submitted_appeal_uuid:))
-          if form4142.present?
-            handle_4142(request_body: req_body_obj,
-                        form4142:,
-                        appeal_submission_id:, submitted_appeal_uuid:)
-          end
-          submit_evidence(sc_evidence, appeal_submission_id, submitted_appeal_uuid) if sc_evidence.present?
-          # Only destroy InProgressForm after evidence upload step
-          # so that we still have references if a fatal error occurs before this step
-          clear_in_progress_form
-        end
-        render json: sc_response.body, status: sc_response.status
-      end
+      process_submission
     rescue => e
       ::Rails.logger.error(
         message: "Exception occurred while submitting Supplemental Claim: #{e.message}",
@@ -50,7 +26,6 @@ module V1
       )
       handle_personal_info_error(e)
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 
@@ -110,14 +85,45 @@ module V1
       raise
     end
 
+    def process_submission
+      req_body_obj = request_body_hash.is_a?(String) ? JSON.parse(request_body_hash) : request_body_hash
+      form4142 = req_body_obj.delete('form4142')
+      sc_evidence = req_body_obj.delete('additionalDocuments')
+      zip_from_frontend = req_body_obj.dig('data', 'attributes', 'veteran', 'address', 'zipCode5')
+      sc_response = decision_review_service.create_supplemental_claim(request_body: req_body_obj, user: @current_user)
+      submitted_appeal_uuid = sc_response.body.dig('data', 'id')
+      unless submitted_appeal_uuid.nil?
+        ActiveRecord::Base.transaction do
+          appeal_submission_id = create_appeal_submission(submitted_appeal_uuid, zip_from_frontend)
+
+          ::Rails.logger.info(post_create_log_msg(appeal_submission_id:, submitted_appeal_uuid:))
+          if form4142.present?
+            handle_4142(request_body: req_body_obj,
+                        form4142:,
+                        appeal_submission_id:, submitted_appeal_uuid:)
+          end
+          submit_evidence(sc_evidence, appeal_submission_id, submitted_appeal_uuid) if sc_evidence.present?
+          # Only destroy InProgressForm after evidence upload step
+          # so that we still have references if a fatal error occurs before this step
+          clear_in_progress_form
+        end
+        render json: sc_response.body, status: sc_response.status
+      end
+    end
+
     def create_appeal_submission(submitted_appeal_uuid, backup_zip)
-      AppealSubmission.create! user_uuid: @current_user.uuid,
-                               user_account: @current_user.user_account,
-                               type_of_appeal: 'SC',
-                               submitted_appeal_uuid:,
-                               upload_metadata: DecisionReviewV1::Service.file_upload_metadata(
-                                 @current_user, backup_zip
-                               )
+      upload_metadata = DecisionReviewV1::Service.file_upload_metadata(
+        @current_user, backup_zip
+      )
+      create_params = {
+        user_uuid: @current_user.uuid,
+        user_account: @current_user.user_account,
+        type_of_appeal: 'SC',
+        submitted_appeal_uuid:,
+        upload_metadata:
+      }
+      appeal_submission = AppealSubmission.create!(create_params)
+      appeal_submission.id
     end
 
     def clear_in_progress_form

--- a/app/controllers/v1/supplemental_claims_controller.rb
+++ b/app/controllers/v1/supplemental_claims_controller.rb
@@ -44,8 +44,9 @@ module V1
         render json: sc_response.body, status: sc_response.status
       end
     rescue => e
-      Rails.logger.error(
-        "Exception occurred while submitting Supplemental Claim: #{e.message}", backtrace: e.backtrace
+      ::Rails.logger.error(
+        message: "Exception occurred while submitting Supplemental Claim: #{e.message}",
+        backtrace: e.backtrace
       )
       handle_personal_info_error(e)
     end

--- a/app/controllers/v1/supplemental_claims_controller.rb
+++ b/app/controllers/v1/supplemental_claims_controller.rb
@@ -45,7 +45,7 @@ module V1
       end
     rescue => e
       Rails.logger.error(
-        "Exception occurred while submitting Supplemental Claim: #{e.message}"
+        "Exception occurred while submitting Supplemental Claim: #{e.message}", backtrace: e.backtrace
       )
       handle_personal_info_error(e)
     end

--- a/app/controllers/v1/supplemental_claims_controller.rb
+++ b/app/controllers/v1/supplemental_claims_controller.rb
@@ -17,6 +17,7 @@ module V1
       raise
     end
 
+    # rubocop:disable Metrics/MethodLength
     def create
       req_body_obj = request_body_hash.is_a?(String) ? JSON.parse(request_body_hash) : request_body_hash
       form4142 = req_body_obj.delete('form4142')
@@ -45,6 +46,7 @@ module V1
     rescue => e
       handle_personal_info_error(e)
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/controllers/v1/supplemental_claims_controller.rb
+++ b/app/controllers/v1/supplemental_claims_controller.rb
@@ -25,15 +25,21 @@ module V1
       sc_response = decision_review_service.create_supplemental_claim(request_body: req_body_obj, user: @current_user)
       submitted_appeal_uuid = sc_response.body.dig('data', 'id')
       unless submitted_appeal_uuid.nil?
-        appeal_submission, _ipf_id = clear_in_progress_form(submitted_appeal_uuid, zip_from_frontend)
-        appeal_submission_id = appeal_submission.id
-        ::Rails.logger.info(post_create_log_msg(appeal_submission_id:, submitted_appeal_uuid:))
-        if form4142.present?
-          handle_4142(request_body: req_body_obj,
-                      form4142:,
-                      appeal_submission_id:, submitted_appeal_uuid:)
+        ActiveRecord::Base.transaction do
+          appeal_submission = create_appeal_submission(submitted_appeal_uuid, zip_from_frontend)
+
+          appeal_submission_id = appeal_submission.id
+          ::Rails.logger.info(post_create_log_msg(appeal_submission_id:, submitted_appeal_uuid:))
+          if form4142.present?
+            handle_4142(request_body: req_body_obj,
+                        form4142:,
+                        appeal_submission_id:, submitted_appeal_uuid:)
+          end
+          submit_evidence(sc_evidence, appeal_submission_id, submitted_appeal_uuid) if sc_evidence.present?
+          # Only destroy InProgressForm after evidence upload step
+          # so that we still have references if a fatal error occurs before this step
+          clear_in_progress_form
         end
-        submit_evidence(sc_evidence, appeal_submission_id, submitted_appeal_uuid) if sc_evidence.present?
         render json: sc_response.body, status: sc_response.status
       end
     rescue => e
@@ -98,20 +104,18 @@ module V1
       raise
     end
 
-    def clear_in_progress_form(submitted_appeal_uuid, backup_zip)
-      ret = [nil, nil]
-      ActiveRecord::Base.transaction do
-        ret[0] = AppealSubmission.create! user_uuid: @current_user.uuid,
-                                          user_account: @current_user.user_account,
-                                          type_of_appeal: 'SC',
-                                          submitted_appeal_uuid:,
-                                          upload_metadata: DecisionReviewV1::Service.file_upload_metadata(
-                                            @current_user, backup_zip
-                                          )
-        # Clear in-progress form since submit was successful
-        ret[1] = InProgressForm.form_for_user('20-0995', @current_user)&.destroy!
-      end
-      ret
+    def create_appeal_submission(submitted_appeal_uuid, backup_zip)
+      AppealSubmission.create! user_uuid: @current_user.uuid,
+                               user_account: @current_user.user_account,
+                               type_of_appeal: 'SC',
+                               submitted_appeal_uuid:,
+                               upload_metadata: DecisionReviewV1::Service.file_upload_metadata(
+                                 @current_user, backup_zip
+                               )
+    end
+
+    def clear_in_progress_form
+      InProgressForm.form_for_user('20-0995', @current_user)&.destroy!
     end
 
     def error_class(method:, exception_class:)

--- a/app/controllers/v1/supplemental_claims_controller.rb
+++ b/app/controllers/v1/supplemental_claims_controller.rb
@@ -44,6 +44,9 @@ module V1
         render json: sc_response.body, status: sc_response.status
       end
     rescue => e
+      Rails.logger.error(
+        "Exception occurred while submitting Supplemental Claim: #{e.message}"
+      )
       handle_personal_info_error(e)
     end
     # rubocop:enable Metrics/MethodLength

--- a/spec/requests/v1/supplemental_claims_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims_controller_request_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe V1::SupplementalClaimsController do
       }
     }
   end
+  let(:extra_error_log_message) do
+    "BackendServiceException: "\
+    "{:source=>\"Common::Client::Errors::ClientError raised in DecisionReviewV1::Service\", :code=>\"DR_422\"}"
+  end
 
   before { sign_in_as(user) }
 
@@ -81,6 +85,11 @@ RSpec.describe V1::SupplementalClaimsController do
         expect(personal_information_logs.count).to be 0
         allow(Rails.logger).to receive(:error)
         expect(Rails.logger).to receive(:error).with(error_log_args)
+        expect(Rails.logger).to receive(:error).with(
+          message: "Exception occurred while submitting Supplemental Claim: #{extra_error_log_message}", 
+          backtrace: anything
+        )
+        expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
         allow(StatsD).to receive(:increment)
         expect(StatsD).to receive(:increment).with('decision_review.form_995.overall_claim_submission.failure')
 

--- a/spec/requests/v1/supplemental_claims_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims_controller_request_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe V1::SupplementalClaimsController do
     }
   end
   let(:extra_error_log_message) do
-    "BackendServiceException: "\
-    "{:source=>\"Common::Client::Errors::ClientError raised in DecisionReviewV1::Service\", :code=>\"DR_422\"}"
+    'BackendServiceException: ' \
+      '{:source=>"Common::Client::Errors::ClientError raised in DecisionReviewV1::Service", :code=>"DR_422"}'
   end
 
   before { sign_in_as(user) }
@@ -86,7 +86,7 @@ RSpec.describe V1::SupplementalClaimsController do
         allow(Rails.logger).to receive(:error)
         expect(Rails.logger).to receive(:error).with(error_log_args)
         expect(Rails.logger).to receive(:error).with(
-          message: "Exception occurred while submitting Supplemental Claim: #{extra_error_log_message}", 
+          message: "Exception occurred while submitting Supplemental Claim: #{extra_error_log_message}",
           backtrace: anything
         )
         expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)


### PR DESCRIPTION

## Summary
We have been seeing a few `stack level too deep` errors that are causing inconsistent issues with form submissions for Supplemental Claims (with a seemingly one-off case for HLR) — this adds some rescuing and logging to see if we can get better visibility into what kind of request/response could be causing the recursive loop. If needed we can add to our other forms, but the majority of errors are from SC

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/73584

## Testing done
- [x] Added log specs

## What areas of the site does it impact?
Decision Reviews backend

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

