### PR TITLE
fix(security): Remove VYE module from routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -477,7 +477,6 @@ Rails.application.routes.draw do
   mount MyHealth::Engine, at: '/my_health', as: 'my_health'
   mount TravelPay::Engine, at: '/travel_pay'
   mount VAOS::Engine, at: '/vaos'
-  mount Vye::Engine, at: '/vye'
   mount Pensions::Engine, at: '/pensions'
   # End Modules
 


### PR DESCRIPTION
Master is not deployable as VYE routes are circumventing authentication and logging SSN and other details to Datadog. Removing until a fix can be implemented.