### PR TITLE
Add benefits_claims_id to form_submissions table

### DIFF
--- a/db/migrate/20240711193208_add_benefits_claims_id_to_form_submissions.rb
+++ b/db/migrate/20240711193208_add_benefits_claims_id_to_form_submissions.rb
@@ -1,0 +1,8 @@
+class AddBenefitsClaimsIdToFormSubmissions < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+  
+  def change
+    add_column :form_submissions, :benefits_claims_id, :string
+    add_index :form_submissions, :benefits_claims_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_09_171552) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_11_193208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -763,6 +763,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_09_171552) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "form_data_ciphertext"
+    t.string "benefits_claims_id"
+    t.index ["benefits_claims_id"], name: "index_form_submissions_on_benefits_claims_id"
     t.index ["benefits_intake_uuid"], name: "index_form_submissions_on_benefits_intake_uuid"
     t.index ["in_progress_form_id"], name: "index_form_submissions_on_in_progress_form_id"
     t.index ["saved_claim_id"], name: "index_form_submissions_on_saved_claim_id"


### PR DESCRIPTION
## Summary
We want to start tracking submissions to the Benefits Claims API (specifically, the Intent to File endpoints) so we'll need another field on `FormSubmission` to accommodate the id we get back upon submission.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88145
