### PR TITLE
Allow optional content for 20-10207 to prevent error raising

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -81,7 +81,7 @@ module SimpleFormsApi
         combined_pdf = CombinePDF.new
         combined_pdf << CombinePDF.load(file_path)
         attachments.each do |attachment|
-          combined_pdf << CombinePDF.load(attachment)
+          combined_pdf << CombinePDF.load(attachment, allow_optional_content: true)
         end
 
         combined_pdf.save file_path


### PR DESCRIPTION
## Summary
This PR adds a flag to allow optional content in PDFs. Apparently PDFs can be encoded with optional content, which means that the content shows up conditionally (like a CSS media query). By default this causes an error to be thrown in the `combine_pdf` gem. With this `:allow_optional_content` flag, however, it will just display all content regardless when it attaches the documentation to our 20-10207 form (see screenshots).

More info here: https://github.com/boazsegev/combine_pdf/issues/28

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88181

## Screenshots
The left shows the original PDF with the optional content hidden and the right shows what we'd send to the BI API. It seems preferable to just include all content than to throw an error to the user that they cannot get around.
<img width="1717" alt="Screenshot 2024-07-12 at 8 47 40 AM" src="https://github.com/user-attachments/assets/a848b9b0-b0bb-4f53-8662-3e49c1b06940">
