### PR TITLE
properly use serializer to render JSON and not assume methods on the …

### DIFF
--- a/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
@@ -35,7 +35,7 @@ module MebApi
         response = claimant_response.status == 200 ? claim_status_response : claimant_response
         serializer = claimant_response.status == 200 ? ClaimStatusSerializer : ClaimantSerializer
 
-        render json: response, serializer:
+        render json: serializer.new(response)
       end
 
       def claimant_info


### PR DESCRIPTION
## Summary
It appears from this [PR where migrating](https://github.com/department-of-veterans-affairs/vets-api/pull/17235/c) from using Active Model Serializer to use FastJSONAPI that one of of our controller methods was still using the old formatting. 

## Related issue(s)
![Screenshot 2024-07-12 at 4 16 48 PM](https://github.com/user-attachments/assets/5d7b2ccd-8a9f-46d7-8c77-476a0394a924)

https://github.com/department-of-veterans-affairs/octo_watchofficer/issues/67

## Testing done
- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*


## Screenshots


## What areas of the site does it impact?
1990E TOE application

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

