### PR TITLE
Remove has_many :form_submissions from InProgressForm

### DIFF
--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -21,8 +21,6 @@ class InProgressForm < ApplicationRecord
   has_kms_key
   has_encrypted :form_data, key: :kms_key, **lockbox_options
 
-  has_many :form_submissions, dependent: :nullify
-
   enum :status, %w[pending processing], prefix: :submission, default: :pending
   scope :submission_pending, -> { where(status: [nil, 'pending']) } # override to include nil
 


### PR DESCRIPTION
## Summary
This PR is a prerequisite for https://github.com/department-of-veterans-affairs/vets-api/pull/17511. Tests on the other PR won't pass until this PR is in.

The purpose of this PR is to ultimately remove the association between `InProgressForm`s and `FormSubmission`s. We never used these, never saved any `FormSubmission`s with associations to `InProgressForm`s and are trying to tighten up the `FormSubmission` model so that it's less misleading about what associations/fields one can expect on it.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88145
