### PR TITLE
Check pid before getting ITFs (Simple Forms)

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -61,8 +61,12 @@ module SimpleFormsApi
       end
 
       def get_intents_to_file
-        intent_service = SimpleFormsApi::IntentToFile.new(icn)
-        existing_intents = intent_service.existing_intents
+        existing_intents = {}
+
+        if icn && participant_id
+          intent_service = SimpleFormsApi::IntentToFile.new(icn)
+          existing_intents = intent_service.existing_intents
+        end
 
         render json: {
           compensation_intent: existing_intents['compensation'],

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -511,7 +511,6 @@ RSpec.describe 'Forms uploader', type: :request do
       VCR.insert_cassette('lighthouse/benefits_claims/intent_to_file/404_response_pension')
       VCR.insert_cassette('lighthouse/benefits_claims/intent_to_file/404_response_survivor')
       sign_in
-      allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
       allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
     end
 
@@ -590,6 +589,22 @@ RSpec.describe 'Forms uploader', type: :request do
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['compensation_intent']['type']).to eq 'compensation'
         expect(parsed_response['pension_intent']['type']).to eq 'pension'
+        expect(parsed_response['survivor_intent']).to eq nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'no participant_id' do
+      before do
+        allow_any_instance_of(User).to receive(:participant_id).and_return(nil)
+      end
+
+      it 'returns no intents' do
+        get '/simple_forms_api/v1/simple_forms/get_intents_to_file'
+
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['compensation_intent']).to eq nil
+        expect(parsed_response['pension_intent']).to eq nil
         expect(parsed_response['survivor_intent']).to eq nil
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
## Summary
This PR does two things:
1. Check the `participant_id` before getting ITFs from the Benefits Claims API. This should reduce errors.
2. Remove unnecessary line in testing where we supply an `icn`. By logging in in the spec, it's already provided.
