### PR TITLE
Remove in_progress_form association from form_submission

### DIFF
--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -5,7 +5,6 @@ class FormSubmission < ApplicationRecord
   has_encrypted :form_data, key: :kms_key, **lockbox_options
 
   has_many :form_submission_attempts, dependent: :destroy
-  belongs_to :in_progress_form, optional: true
   belongs_to :saved_claim, optional: true
   belongs_to :user_account, optional: true
 

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe FormSubmission, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:in_progress_form).optional }
     it { is_expected.to belong_to(:saved_claim).optional }
     it { is_expected.to belong_to(:user_account).optional }
   end


### PR DESCRIPTION
## Summary
This PR removes the last unused field from `FormSubmission` : in_progress_form. It really ought to have been part of this: https://github.com/department-of-veterans-affairs/vets-api/pull/17523

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88145
