### PR TITLE
Generate additionalAppointmentDetails from appointment request reasoncode.text

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -25,8 +25,8 @@ module VAOS
         # Extract contact fields from hash
         if reason_code_hash.key?('phone number') || reason_code_hash.key?('email')
           contact_info = []
-          contact_info.push({ system: 'phone', value: reason_code_hash['phone number'] })
-          contact_info.push({ system: 'email', value: reason_code_hash['email'] })
+          contact_info.push({ type: 'phone', value: reason_code_hash['phone number'] })
+          contact_info.push({ type: 'email', value: reason_code_hash['email'] })
           appointment[:contact] = { telecom: contact_info }
         end
 

--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -29,6 +29,9 @@ module VAOS
           contact_info.push({ system: 'email', value: reason_code_hash['email'] })
           appointment[:contact] = { telecom: contact_info }
         end
+
+        # Extract additionalAppointmentDetails from hash
+        appointment[:additional_appointment_details] = reason_code_hash['comments'] if reason_code_hash.key?('comments')
       end
     end
   end

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -35,8 +35,8 @@ describe VAOS::V2::AppointmentsReasonCodeService do
     it 'extract valid reason text for va request' do
       appt = FactoryBot.build(:appointment_form_v2, :va_proposed_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
-      expect(appt[:contact][:telecom][0]).to eq({ system: 'phone', value: '6195551234' })
-      expect(appt[:contact][:telecom][1]).to eq({ system: 'email', value: 'myemail72585885@unattended.com' })
+      expect(appt[:contact][:telecom][0]).to eq({ type: 'phone', value: '6195551234' })
+      expect(appt[:contact][:telecom][1]).to eq({ type: 'email', value: 'myemail72585885@unattended.com' })
       expect(appt[:additional_appointment_details]).to eq('test')
     end
   end

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -8,24 +8,28 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :va_proposed_base).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
+      expect(appt[:additional_appointment_details]).to be_nil
     end
 
     it 'returns without modification if no valid reason code text fields exists' do
       appt = FactoryBot.build(:appointment_form_v2, :va_proposed_invalid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
+      expect(appt[:additional_appointment_details]).to be_nil
     end
 
     it 'returns without modification for cc request' do
       appt = FactoryBot.build(:appointment_form_v2, :community_cares_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
+      expect(appt[:additional_appointment_details]).to be_nil
     end
 
     it 'returns without modification for va booked' do
       appt = FactoryBot.build(:appointment_form_v2, :va_booked_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
+      expect(appt[:additional_appointment_details]).to be_nil
     end
 
     it 'extract valid reason text for va request' do
@@ -33,6 +37,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact][:telecom][0]).to eq({ system: 'phone', value: '6195551234' })
       expect(appt[:contact][:telecom][1]).to eq({ system: 'email', value: 'myemail72585885@unattended.com' })
+      expect(appt[:additional_appointment_details]).to eq('test')
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is part of the api consolidation effort and moves the logic for extracting additional appointment details (AKA comments) information from the reason code text from the FE to BE. The source logic is [here](https://github.com/department-of-veterans-affairs/vets-website/blob/0bdd33547c4e4eea0c989976a23ce93b42b0c1c6/src/applications/vaos/services/appointment/transformers.js#L240-L245)
- This is work by the Appointments team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86917

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior returns the information as part of the reason code text and additionalAppointmentDetails field is non existent.
- Tested API response to ensure it matches with ACs

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
