### PR TITLE
Generate appointment reason from request reasoncode.text

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -4,6 +4,14 @@ module VAOS
   module V2
     # This class contains the logic for extracting extra fields from reason codes and updating the appointment.
     class AppointmentsReasonCodeService
+      # Reason code purpose text
+      PURPOSE_TEXT = {
+        'ROUTINEVISIT' => 'Routine/Follow-up',
+        'MEDICALISSUE' => 'New medical issue',
+        'QUESTIONMEDS' => 'Medication concern',
+        'OTHER_REASON' => 'My reason isn’t listed'
+      }.freeze
+
       # Modifies the appointment, extracting individual fields from the reason code text whenever possible.
       #
       # @param appointment [Hash] the appointment to modify
@@ -32,6 +40,11 @@ module VAOS
 
         # Extract additionalAppointmentDetails from hash
         appointment[:additional_appointment_details] = reason_code_hash['comments'] if reason_code_hash.key?('comments')
+
+        # Extract reason for appointment from hash
+        if reason_code_hash.key?('reason code') && PURPOSE_TEXT.key?(reason_code_hash['reason code'])
+          appointment[:reason_for_appointment] = PURPOSE_TEXT[reason_code_hash['reason code']]
+        end
       end
     end
   end

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -9,6 +9,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
+      expect(appt[:reason_for_appointment]).to be_nil
     end
 
     it 'returns without modification if no valid reason code text fields exists' do
@@ -16,6 +17,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
+      expect(appt[:reason_for_appointment]).to be_nil
     end
 
     it 'returns without modification for cc request' do
@@ -23,6 +25,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
+      expect(appt[:reason_for_appointment]).to be_nil
     end
 
     it 'returns without modification for va booked' do
@@ -30,6 +33,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
+      expect(appt[:reason_for_appointment]).to be_nil
     end
 
     it 'extract valid reason text for va request' do
@@ -38,6 +42,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:contact][:telecom][0]).to eq({ type: 'phone', value: '6195551234' })
       expect(appt[:contact][:telecom][1]).to eq({ type: 'email', value: 'myemail72585885@unattended.com' })
       expect(appt[:additional_appointment_details]).to eq('test')
+      expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is part of the api consolidation effort and moves the logic for extracting reason for appointment information from the reason code text from the FE to BE. The source logic is [here](https://github.com/department-of-veterans-affairs/vets-website/blob/5fc5b4a339e34be9db43e680a4c35798b963ff9b/src/applications/vaos/services/appointment/transformers.js#L233-L239) and [here](https://github.com/department-of-veterans-affairs/vets-website/blob/5fc5b4a339e34be9db43e680a4c35798b963ff9b/src/applications/vaos/services/appointment/transformers.js#L362-L366)
- This is work by the Appointments team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86905

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior returns the information as part of the reason code text and reasonForAppointment field is non existent.
- Tested API response to ensure it matches with ACs

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
