### PR TITLE
Bump rexml to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -863,7 +863,7 @@ GEM
       hashie (>= 1.2.0, < 6.0)
       jwt (>= 1.5.6)
     retriable (3.1.2)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rgeo (3.0.1)
     rgeo-activerecord (7.0.1)


### PR DESCRIPTION
## Summary

- Bump `rexml` to `3.3.2`
- Fixes [CVE-2024-39908 : DoS in REXML](https://www.ruby-lang.org/en/news/2024/07/16/dos-rexml-cve-2024-39908/)

## Testing done

- n/a

## Acceptance criteria

- [ ]  `rexml` is 3.3.2
- [ ]  Tests pass