### PR TITLE
88384: Fix missing uuid in front of 10-7959F-1 submissions

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -3,6 +3,7 @@
 module IvcChampva
   class VHA107959f1
     include Virtus.model(nullify_blank: true)
+    include Attachments
 
     attribute :data
     attr_reader :form_id

--- a/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe IvcChampva::VHA107959f1 do
     }
   end
   let(:vha107959f1) { described_class.new(data) }
+  let(:file_path) { 'vha_10_7959f_1-tmp.pdf' }
+  let(:uuid) { SecureRandom.uuid }
+  let(:instance) { IvcChampva::VHA107959f1.new(data) }
+
+  before do
+    allow(instance).to receive_messages(uuid:, get_attachments: [])
+  end
 
   describe '#metadata' do
     it 'returns metadata for the form' do
@@ -51,12 +58,11 @@ RSpec.describe IvcChampva::VHA107959f1 do
     end
   end
 
-  describe '#method_missing' do
-    context 'when method is missing' do
-      it 'returns the arguments passed to it' do
-        args = %w[arg1 arg2]
-        expect(IvcChampva::VHA107959f1.new('data').handle_attachments(args)).to eq(args)
-      end
+  describe '#handle_attachments' do
+    it 'renames the file and returns the new file path' do
+      allow(File).to receive(:rename)
+      result = instance.handle_attachments(file_path)
+      expect(result).to eq(["#{uuid}_vha_10_7959f_1-tmp.pdf"])
     end
   end
 end


### PR DESCRIPTION
Prefix UUID to 10-7959F-1 submissions to avoid overwriting in S3


## Summary

- The UUId prefix was missing from this form. That means it would be overwritten when any other forms were submitted.
- Updated test

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88384

## Screenshots
<img width="660" alt="Screenshot 2024-07-16 at 11 57 28 AM" src="https://github.com/user-attachments/assets/2fa9df76-1a37-480b-86d6-8e7a6c3d8be0">