### PR TITLE
fix: redis pool needs size

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
     connect_timeout: 2,
     url: Settings.redis.rails_cache.url,
     expires_in: 30.minutes,
-    pool: ENV.fetch('RAILS_MAX_THREADS', 5).to_i
+    pool: { size: ENV.fetch('RAILS_MAX_THREADS', 5).to_i }
   }
 
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
From Rails' docs:
```
config.cache_store = :mem_cache_store, "cache.example.com", { pool: { size: 32, timeout: 1 } }
```
https://edgeguides.rubyonrails.org/caching_with_rails.html#connection-pool-options
