### PR TITLE
fix indexing on 3 or more pdfs

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -37,8 +37,8 @@ module IvcChampva
          @data[self.class::ADDITIONAL_PDF_KEY].is_a?(Array) &&
          @data[self.class::ADDITIONAL_PDF_KEY].count > self.class::ADDITIONAL_PDF_COUNT
         additional_data = @data[self.class::ADDITIONAL_PDF_KEY].drop(self.class::ADDITIONAL_PDF_COUNT)
-        additional_data.each_slice(self.class::ADDITIONAL_PDF_COUNT) do |data|
-          file_path = generate_additional_pdf(data)
+        additional_data.each_slice(self.class::ADDITIONAL_PDF_COUNT).with_index(1) do |data, index|
+          file_path = generate_additional_pdf(data, index)
           attachments << file_path
         end
       end
@@ -53,15 +53,14 @@ module IvcChampva
       attachments
     end
 
-    def generate_additional_pdf(additional_data)
+    def generate_additional_pdf(additional_data, index)
       additional_form_data = @data
       additional_form_data[self.class::ADDITIONAL_PDF_KEY] = additional_data
       filler = IvcChampva::PdfFiller.new(
         form_number: form_id,
         form: self.class.name.constantize.new(additional_form_data),
-        name: "#{form_id}_additional_#{self.class::ADDITIONAL_PDF_KEY}"
+        name: "#{form_id}_additional_#{self.class::ADDITIONAL_PDF_KEY}-#{index}"
       )
-
       filler.generate
     end
   end


### PR DESCRIPTION
## Summary
This PR fixes the use case where there are more than 7 applicants in one session. This adds robust indexing to the loop.

## Related issue(s)

## Testing done

I've added 7 applicants with 3 attachments in the child support section.

## Screenshots
[1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d-tmp5.pdf](https://github.com/user-attachments/files/16268206/1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d-tmp5.pdf)
[1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d-tmp4.pdf](https://github.com/user-attachments/files/16268207/1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d-tmp4.pdf)
[1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d-tmp3.pdf](https://github.com/user-attachments/files/16268208/1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d-tmp3.pdf)
[1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d_additional_applicants-2-tmp2.pdf](https://github.com/user-attachments/files/16268209/1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d_additional_applicants-2-tmp2.pdf)
[1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d_additional_applicants-1-tmp1.pdf](https://github.com/user-attachments/files/16268211/1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d_additional_applicants-1-tmp1.pdf)
[Uploading 1f949f9e-ea87-4b5c-8423-14baf41f503b_vha_10_10d-tmp.pdf…]()


## What areas of the site does it impact?
Only Champva Ivc forms






## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
