### PR TITLE
88016: Drop DecisionReviewEvidenceAttachmentValidation table

### DIFF
--- a/db/migrate/20240713000047_drop_decision_review_evidence_attachment_validation.rb
+++ b/db/migrate/20240713000047_drop_decision_review_evidence_attachment_validation.rb
@@ -1,0 +1,6 @@
+class DropDecisionReviewEvidenceAttachmentValidation < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :decision_review_evidence_attachment_validations, column: :decision_review_evidence_attachment_guid, name: "index_dr_evidence_attachment_validation_on_guid"
+    drop_table :decision_review_evidence_attachment_validations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -481,15 +481,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_143105) do
     t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true
   end
 
-  create_table "decision_review_evidence_attachment_validations", force: :cascade do |t|
-    t.uuid "decision_review_evidence_attachment_guid", null: false
-    t.text "password_ciphertext"
-    t.text "encrypted_kms_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["decision_review_evidence_attachment_guid"], name: "index_dr_evidence_attachment_validation_on_guid"
-  end
-
   create_table "deprecated_user_accounts", force: :cascade do |t|
     t.uuid "user_account_id"
     t.bigint "user_verification_id"


### PR DESCRIPTION
## Summary
This PR is to clean up sensitive data by removing a table that is no longer used. This table is owned by the Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/88016
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87405

## Testing done
Ran `rails db:migrate` with no errors

```
== 20240713000047 DropDecisionReviewEvidenceAttachmentValidation: migrating ===
-- remove_index(:decision_review_evidence_attachment_validations, {:column=>:decision_review_evidence_attachment_guid, :name=>"index_dr_evidence_attachment_validation_on_guid"})
   -> 0.0031s
-- drop_table(:decision_review_evidence_attachment_validations)
   -> 0.0009s
== 20240713000047 DropDecisionReviewEvidenceAttachmentValidation: migrated (0.0060s)
```

## What areas of the site does it impact?
This will be a minor impact to the Postgres DB as it will drop a table containing < 100 rows.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
