### PR TITLE
add ssn to 7959c

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -23,6 +23,7 @@ module IvcChampva
         'zipCode' => @data.dig('applicant_address', 'postal_code') || '00000',
         'country' => @data.dig('applicant_address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',
+        'ssn_or_tin' => @data['applicant_ssn'],
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
         'uuid' => @uuid,

--- a/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe IvcChampva::VHA107959c do
         'veteranLastName' => 'Doe',
         'fileNumber' => '123456789',
         'zipCode' => '12345',
+        'ssn_or_tin' => '123456789',
         'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '10-7959C',


### PR DESCRIPTION
## Summary

In order for PEGA to process 7959c, it needs x-amz-meta-ssn_or_tin embedded in the metadata.

## Screenshots
<img width="439" alt="Screenshot 2024-07-17 at 2 14 25 PM" src="https://github.com/user-attachments/assets/4220b0ab-bcd1-471b-9061-d6afcda9a241">

<img width="851" alt="Screenshot 2024-07-17 at 2 14 20 PM" src="https://github.com/user-attachments/assets/63887dfd-1b69-41bf-84d3-829ad0234ca4">

[Uploading 4d7f4aa4-b217-4603-ac01-26d87b194288_vha_10_7959c-tmp.pdf…]()

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
