### PR TITLE
[DR-73584] Add more logging (NOD + HLR)

### DIFF
--- a/app/controllers/v1/higher_level_reviews_controller.rb
+++ b/app/controllers/v1/higher_level_reviews_controller.rb
@@ -26,6 +26,21 @@ module V1
       end
       render json: hlr_response_body
     rescue => e
+      ::Rails.logger.error(
+        message: "Exception occurred while submitting Higher Level Review: #{e.message}",
+        backtrace: e.backtrace
+      )
+
+      handle_personal_info_error(e)
+    end
+
+    private
+
+    def error_class(method:, exception_class:)
+      "#{self.class.name}##{method} exception #{exception_class} (HLR_V1)"
+    end
+
+    def handle_personal_info_error(e)
       request = begin
         { body: request_body_hash }
       rescue
@@ -36,12 +51,6 @@ module V1
         e, error_class: error_class(method: 'create', exception_class: e.class), request:
       )
       raise
-    end
-
-    private
-
-    def error_class(method:, exception_class:)
-      "#{self.class.name}##{method} exception #{exception_class} (HLR_V1)"
     end
   end
 end

--- a/app/controllers/v1/notice_of_disagreements_controller.rb
+++ b/app/controllers/v1/notice_of_disagreements_controller.rb
@@ -22,16 +22,11 @@ module V1
       )
       render json: nod_response_body
     rescue => e
-      request = begin
-        { body: request_body_hash }
-      rescue
-        request_body_debug_data
-      end
-
-      log_exception_to_personal_information_log(
-        e, error_class: error_class(method: 'create', exception_class: e.class), request:
+      ::Rails.logger.error(
+        message: "Exception occurred while submitting Notice Of Disagreement: #{e.message}",
+        backtrace: e.backtrace
       )
-      raise
+      handle_personal_info_error(e)
     end
 
     private
@@ -42,6 +37,19 @@ module V1
 
     def version_number
       'v2'
+    end
+
+    def handle_personal_info_error(e)
+      request = begin
+        { body: request_body_hash }
+      rescue
+        request_body_debug_data
+      end
+
+      log_exception_to_personal_information_log(
+        e, error_class: error_class(method: 'create', exception_class: e.class), request:
+      )
+      raise
     end
   end
 end

--- a/spec/requests/v1/higher_level_reviews_controller_request_spec.rb
+++ b/spec/requests/v1/higher_level_reviews_controller_request_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe V1::HigherLevelReviewsController do
     }
   end
 
+  let(:extra_error_log_message) do
+    'BackendServiceException: {:source=>"Common::Client::Errors::ClientError raised in DecisionReviewV1::Service", ' \
+      ':code=>"DR_422"}'
+  end
+
   before { sign_in_as(user) }
 
   describe '#create' do
@@ -77,6 +82,11 @@ RSpec.describe V1::HigherLevelReviewsController do
 
         allow(Rails.logger).to receive(:error)
         expect(Rails.logger).to receive(:error).with(error_log_args)
+        expect(Rails.logger).to receive(:error).with(
+          message: "Exception occurred while submitting Higher Level Review: #{extra_error_log_message}",
+          backtrace: anything
+        )
+        expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
         allow(StatsD).to receive(:increment)
         expect(StatsD).to receive(:increment).with('decision_review.form_996.overall_claim_submission.failure')
 

--- a/spec/requests/v1/notice_of_disagreements_controller_request_spec.rb
+++ b/spec/requests/v1/notice_of_disagreements_controller_request_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe V1::NoticeOfDisagreementsController do
            headers:
     end
 
+    let(:extra_error_log_message) do
+      'BackendServiceException: {:source=>"Common::Client::Errors::ClientError raised in DecisionReviewV1::Service", ' \
+        ':code=>"DR_422"}'
+    end
+
     let(:test_request_body) do
       JSON.parse Rails.root.join('spec', 'fixtures', 'notice_of_disagreements',
                                  'valid_NOD_create_request.json').read
@@ -92,6 +97,11 @@ RSpec.describe V1::NoticeOfDisagreementsController do
                                                        },
                                                        version_number: 'v2'
                                                      })
+        expect(Rails.logger).to receive(:error).with(
+          message: "Exception occurred while submitting Notice Of Disagreement: #{extra_error_log_message}",
+          backtrace: anything
+        )
+        expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
         allow(StatsD).to receive(:increment)
         expect(StatsD).to receive(:increment).with('decision_review.form_10182.overall_claim_submission.failure')
         expect(personal_information_logs.count).to be 0


### PR DESCRIPTION
## Summary

Follow-up to #17497 — I only added the extra logging to Supplemental Claims but (of course) we got the `stack level too deep` errors for both NOD and HLR soon after. This adds the extra logs to those forms as well so we can see if the error we were able to pull from the SC log is the same one causing the stack level error in HLR and NOD.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/73584

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Decision Reviews backend

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

