### PR TITLE
chore: Use AUTOSCALING_TARGET_VALUE env var in is_ready

### DIFF
--- a/bin/is_ready
+++ b/bin/is_ready
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-# Uses the percentage of total pool_capacity to total max_threads to determine
-# readiness (e.g. "90" means 90% of pods are available/unused).
+# Uses the unavailable percentage (total pool_capacity to total max_threads) to
+# determine readiness (e.g. "90" means 90% of pods are unavailable/used).
 #
-# If the percentage is >= threshold, script will exit with a success (0) and
-# pod is considered ready for traffic. If the percentage is < threshold, script
-# will exit with a failure (1) and the probe will fail.
+# If the unavailable percentage is >= allowed threshold, script will exit with
+# a failure (1) as pod is not ready for traffic. If the unavailable percentage
+# is < allowed threshold, script will exit with a success as it's ready for
+# traffic.
 
-THRESHOLD=${AUTOSCALING_TARGET_VALUE:-25}
+ALLOWED_UNAVAILABLE_PERCENTAGE=${AUTOSCALING_TARGET_VALUE:-75}
 
 data=$(curl -s 127.0.0.1:9293/stats)
 
@@ -27,6 +28,6 @@ fi
 pool_capacity=$(echo "$data" | grep -oE '"pool_capacity":[0-9]+' | cut -f2 -d: | awk '{sum+=$1} END {print sum}')
 max_threads=$(echo "$data" | grep -oE '"max_threads":[0-9]+' | cut -f2 -d: | awk '{sum+=$1} END {print sum}')
 
-percentage=$(awk "BEGIN {printf \"%d\", ($pool_capacity * 100) / $max_threads}")
+unavailable_percentage=$(awk "BEGIN {printf \"%d\", 100 - (($pool_capacity * 100) / $max_threads)}")
 
-exit $((percentage >= THRESHOLD ? 0 : 1))
+exit $((unavailable_percentage >= ALLOWED_UNAVAILABLE_PERCENTAGE ? 1 : 0))

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -7,7 +7,7 @@
 # pod is considered ready for traffic. If the percentage is < threshold, script
 # will exit with a failure (1) and the probe will fail.
 
-THRESHOLD=25
+THRESHOLD=${AUTOSCALING_TARGET_VALUE:-25}
 
 data=$(curl -s 127.0.0.1:9293/stats)
 


### PR DESCRIPTION
This PR does two things:

- Makes is_ready easier to understand by inverting available to unavailable
- Looks for `$AUTOSCALING_TARGET_VALUE` for the allowed unavailable threshold which, once  https://github.com/department-of-veterans-affairs/vets-api/pull/17584 is merged, will combine the two scaling thresholds.

AUTOSCALING_TARGET_VALUE is not set anywhere yet. We should test and deploy this before we start setting it somewhere.

## Details

[In our Helm charts](https://github.com/department-of-veterans-affairs/vets-api/blob/parent-helm-charts/chart/templates/hpa-external-metric.yaml), we're calculating an "Unavailability" metric which we use for scaling. When we look at the HPA metric in Datadog, we see the percentage of Puma threads serving requests (which means these pods are unavailable). When we increase our [HPA targetValue](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/blob/c437c16d08e479aa569bae5d0390ce9cc7461dcd/apps/vets-api/prod/values.yaml#L502), we allow more of the pods to be **unavailable** which requires less pods.

Prior to this PR, the logic in `bin/is_ready` was using pool **availablity** which is the inverse of the HPA. This caused a bit of confusion about wether these thresholds could be consolidated.