### PR TITLE
Generate preferred dates from request reasoncode.text

### DIFF
--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -10,6 +10,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
+      expect(appt[:preferred_dates]).to be_nil
     end
 
     it 'returns without modification if no valid reason code text fields exists' do
@@ -18,6 +19,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
+      expect(appt[:preferred_dates]).to be_nil
     end
 
     it 'returns without modification for cc request' do
@@ -26,6 +28,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
+      expect(appt[:preferred_dates]).to be_nil
     end
 
     it 'returns without modification for va booked' do
@@ -34,6 +37,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:contact]).to eq({})
       expect(appt[:additional_appointment_details]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
+      expect(appt[:preferred_dates]).to be_nil
     end
 
     it 'extract valid reason text for va request' do
@@ -43,6 +47,41 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:contact][:telecom][1]).to eq({ type: 'email', value: 'myemail72585885@unattended.com' })
       expect(appt[:additional_appointment_details]).to eq('test')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
+      expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
+                                            'Wed, June 26, 2024 in the afternoon'])
+    end
+  end
+
+  describe '#extract_reason_for_appointment' do
+    [
+      ['', nil],
+      ['NON_EXISTENT', nil],
+      ['ROUTINEVISIT', 'Routine/Follow-up'],
+      ['MEDICALISSUE', 'New medical issue'],
+      ['QUESTIONMEDS', 'Medication concern'],
+      ['OTHER_REASON', 'My reason isn’t listed']
+    ].each do |input, output|
+      it "#{input} returns #{output}" do
+        input_hash = {}
+        input_hash['reason code'] = input
+        expect(subject.send(:extract_reason_for_appointment, input_hash)).to eq(output)
+      end
+    end
+  end
+
+  describe '#extract_preferred_dates' do
+    [
+      ['', nil],
+      ['06/26/2024 AM', ['Wed, June 26, 2024 in the morning']],
+      ['06/26/2024 PM', ['Wed, June 26, 2024 in the afternoon']],
+      ['06/26/2024 AM,06/26/2024 PM', ['Wed, June 26, 2024 in the morning', 'Wed, June 26, 2024 in the afternoon']],
+      ['09/06/2024 PM', ['Fri, September 6, 2024 in the afternoon']]
+    ].each do |input, output|
+      it "#{input} returns #{output}" do
+        input_hash = {}
+        input_hash['preferred dates'] = input
+        expect(subject.send(:extract_preferred_dates, input_hash)).to eq(output)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is part of the api consolidation effort and moves the logic for extracting preferred date information from the reason code text from the FE to BE. The source logic is [here](https://github.com/department-of-veterans-affairs/vets-website/blob/c33b8f64b8d06f67aa0d4af5b9cc4e9b6f9f5f9c/src/applications/vaos/services/appointment/transformers.js#L62-L94)
- This is work by the Appointments team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86897

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior returns the information as part of the reason code text and reasonForAppointment field is non existent.
- Tested API response to ensure it matches with ACs

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
