### PR TITLE
Remove va_online_scheduling_clinic_location feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1196,10 +1196,6 @@ features:
     actor_type: user
     description: Toggle for new mobile facility service v2 endpoints
     enable_in_development: true
-  va_online_scheduling_clinic_location:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for display of clinic location on appointment detail page
   va_online_scheduling_status_improvement_canceled:
     actor_type: user
     enable_in_development: true
@@ -1576,4 +1572,4 @@ features:
     description: Enable VYE
   military_benefit_estimates:
     actor_type: user
-    description: swap order of the military details in GI search filters 
+    description: swap order of the military details in GI search filters


### PR DESCRIPTION
## Summary

- Removing va_online_scheduling_clinic_location feature flag

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88615

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?

Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
