### PR TITLE
Ask VA/ Prefill Metadata

### DIFF
--- a/app/models/form_profiles/va_0873.rb
+++ b/app/models/form_profiles/va_0873.rb
@@ -75,7 +75,7 @@ class FormProfiles::VA0873 < FormProfile
     {
       version: 0,
       prefill: true,
-      returnUrl: '/topic'
+      returnUrl: '/category-topic-1'
     }
   end
 end


### PR DESCRIPTION
## Summary

- This PR is updating the route for the prefill. FE doesn't hit `/topics` anymore.

## Related issue(s)

- Ticket [here](https://app.zenhub.com/workspaces/ask-va-647a476551689d06655cc815/issues/gh/department-of-veterans-affairs/ask-va/755)
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- Url was updated to test in dev and staging env.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This only impacts the Ask VA form

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
