### PR TITLE
Removed helpdesk info toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -751,9 +751,6 @@ features:
   mhv_transitional_medical_records_landing_page:
     actor_type: user
     description: Enables the transitional Medical Records page at /my-health/records
-  mhv_helpdesk_information_enabled:
-    actor_type: user
-    description: Enables the MHV helpdesk information
   mhv_secure_messaging_to_va_gov_release:
     actor_type: user
     description: Enables/disables Secure Messaging Patient on VA.gov (intial transition from MHV to VA.gov)


### PR DESCRIPTION
## Summary
Removed the helpdesk info toggle for the MHV Landing Page. See [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/30911) for removing the toggle on the front end.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87130

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
MHV Landing Page

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [X]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

