### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part 4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -368,6 +368,7 @@ app/serializers/async_transaction/base_serializer.rb @department-of-veterans-aff
 app/serializers/attachment_serializer.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/serializers/backend_statuses_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/backend_status_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/serializers/category_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/cemetery_serializer.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/central_mail_submission_serializer.rb @department-of-veterans-affairs/backend-review-group
 app/serializers/ch33_bank_account_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/claims_base_controller.rb
+++ b/app/controllers/claims_base_controller.rb
@@ -40,7 +40,8 @@ class ClaimsBaseController < ApplicationController
   end
 
   def show
-    render(json: CentralMailSubmission.joins(:central_mail_claim).find_by(saved_claims: { guid: params[:id] }))
+    submission = CentralMailSubmission.joins(:central_mail_claim).find_by(saved_claims: { guid: params[:id] })
+    render json: CentralMailSubmissionSerializer.new(submission)
   end
 
   private

--- a/app/controllers/v0/appointments_controller.rb
+++ b/app/controllers/v0/appointments_controller.rb
@@ -8,7 +8,7 @@ module V0
     def index
       response = service.appointments
 
-      render json: response, serializer: AppointmentSerializer
+      render json: AppointmentSerializer.new(response)
     end
 
     private

--- a/app/controllers/v0/burial_claims_controller.rb
+++ b/app/controllers/v0/burial_claims_controller.rb
@@ -12,7 +12,7 @@ module V0
         state = submission_attempt.aasm_state == 'failure' ? 'failure' : 'success'
         render(json: { data: { attributes: { state: } } })
       elsif central_mail_submission
-        render(json: central_mail_submission)
+        render json: CentralMailSubmissionSerializer.new(central_mail_submission)
       else
         Rails.logger.error("ActiveRecord::RecordNotFound: Claim submission not found for claim_id: #{params[:id]}")
         render(json: { data: { attributes: { state: 'not found' } } }, status: :not_found)

--- a/app/controllers/v0/messages_controller.rb
+++ b/app/controllers/v0/messages_controller.rb
@@ -85,10 +85,7 @@ module V0
     end
 
     def categories
-      resource = client.get_categories
-
-      render json: resource,
-             serializer: CategorySerializer
+      render json: CategorySerializer.new(client.get_categories)
     end
 
     def move

--- a/app/controllers/v0/preneeds/cemeteries_controller.rb
+++ b/app/controllers/v0/preneeds/cemeteries_controller.rb
@@ -5,9 +5,7 @@ module V0
     class CemeteriesController < PreneedsController
       def index
         resource = client.get_cemeteries
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: CemeterySerializer
+        render json: CemeterySerializer.new(resource.data)
       end
     end
   end

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-class AppointmentSerializer < ActiveModel::Serializer
-  attributes :appointments
+class AppointmentSerializer
+  include JSONAPI::Serializer
 
-  delegate :appointments, to: :object
+  set_id { '' }
 
-  def id
-    nil
-  end
+  attribute :appointments
 end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class CategorySerializer < ActiveModel::Serializer
-  def id
-    object.category_id
-  end
+class CategorySerializer
+  include JSONAPI::Serializer
 
-  attribute(:message_category_type)
+  set_id :category_id
+  set_type :categories
+
+  attribute :message_category_type
 end

--- a/app/serializers/cemetery_serializer.rb
+++ b/app/serializers/cemetery_serializer.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
-class CemeterySerializer < ActiveModel::Serializer
-  attribute :id
+class CemeterySerializer
+  include JSONAPI::Serializer
 
-  attribute(:cemetery_id) { object.id }
+  set_type :preneeds_cemeteries
+
   attribute :name
   attribute :cemetery_type
   attribute :num
+
+  attributes :cemetery_id do |object|
+    object.id
+  end
 end

--- a/app/serializers/cemetery_serializer.rb
+++ b/app/serializers/cemetery_serializer.rb
@@ -8,8 +8,5 @@ class CemeterySerializer
   attribute :name
   attribute :cemetery_type
   attribute :num
-
-  attributes :cemetery_id do |object|
-    object.id
-  end
+  attribute :cemetery_id, &:id
 end

--- a/app/serializers/central_mail_submission_serializer.rb
+++ b/app/serializers/central_mail_submission_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-class CentralMailSubmissionSerializer < ActiveModel::Serializer
-  attribute(:state)
+class CentralMailSubmissionSerializer
+  include JSONAPI::Serializer
+
+  attribute :state
 end

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CategorySerializer do
   end
 
   it 'includes :type' do
-    expect(data['type']).to eq("categories")
+    expect(data['type']).to eq('categories')
   end
 
   it 'includes :message_category_type' do

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe CategorySerializer do
     expect(data['id'].to_i).to eq(category.category_id)
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq("categories")
+  end
+
   it 'includes :message_category_type' do
     expect(attributes['message_category_type']).to eq(category.message_category_type)
   end

--- a/spec/serializers/cemetery_serializer_spec.rb
+++ b/spec/serializers/cemetery_serializer_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe CemeterySerializer do
     expect(data['id']).to eq(cemetery.id)
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq('preneeds_cemeteries')
+  end
+
   it 'includes :cemetery_id' do
     expect(attributes['cemetery_id']).to eq(cemetery.id)
   end


### PR DESCRIPTION
## Summary

- AppointmentSerializer
- CategorySerializer
- CemeterySerializer
- CentralMailSubmissionSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [ ]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage