### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part 5

### DIFF
--- a/app/controllers/v0/profile/ch33_bank_accounts_controller.rb
+++ b/app/controllers/v0/profile/ch33_bank_accounts_controller.rb
@@ -40,11 +40,8 @@ module V0
       end
 
       def render_find_ch33_dd_eft
-        get_ch33_dd_eft_info = service.get_ch33_dd_eft_info
-        render(
-          json: get_ch33_dd_eft_info,
-          serializer: Ch33BankAccountSerializer
-        )
+        ch33_dd_eft_info = service.get_ch33_dd_eft_info
+        render json: Ch33BankAccountSerializer.new(ch33_dd_eft_info)
       end
 
       def service

--- a/app/serializers/ch33_bank_account_serializer.rb
+++ b/app/serializers/ch33_bank_account_serializer.rb
@@ -1,29 +1,26 @@
 # frozen_string_literal: true
 
-class Ch33BankAccountSerializer < ActiveModel::Serializer
-  attributes :account_type, :account_number, :financial_institution_routing_number, :financial_institution_name
+class Ch33BankAccountSerializer
+  include JSONAPI::Serializer
 
-  def account_type
-    dposit_acnt_type_nm = object[:dposit_acnt_type_nm]
+  set_id { '' }
+  set_type :hashes
 
-    if dposit_acnt_type_nm.present?
-      dposit_acnt_type_nm == 'C' ? 'Checking' : 'Savings'
-    end
+  attribute :account_type do |object|
+    next nil unless  object[:dposit_acnt_type_nm].present?
+
+    object[:dposit_acnt_type_nm] == 'C' ? 'Checking' : 'Savings'
   end
 
-  def account_number
+  attribute :account_number do |object|
     StringHelpers.mask_sensitive(object[:dposit_acnt_nbr])
   end
 
-  def financial_institution_routing_number
+  attribute :financial_institution_routing_number do |object|
     StringHelpers.mask_sensitive(object[:routng_trnsit_nbr])
   end
 
-  def financial_institution_name
+  attribute :financial_institution_name do |object|
     object[:financial_institution_name]
-  end
-
-  def id
-    nil
   end
 end

--- a/app/serializers/ch33_bank_account_serializer.rb
+++ b/app/serializers/ch33_bank_account_serializer.rb
@@ -7,7 +7,7 @@ class Ch33BankAccountSerializer
   set_type :hashes
 
   attribute :account_type do |object|
-    next nil unless  object[:dposit_acnt_type_nm].present?
+    next nil if object[:dposit_acnt_type_nm].blank?
 
     object[:dposit_acnt_type_nm] == 'C' ? 'Checking' : 'Savings'
   end

--- a/app/serializers/communication_groups_serializer.rb
+++ b/app/serializers/communication_groups_serializer.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-class CommunicationGroupsSerializer < ActiveModel::Serializer
-  attributes :communication_groups
+class CommunicationGroupsSerializer
+  include JSONAPI::Serializer
 
-  def communication_groups
+  set_id { '' }
+  set_type :hashes
+
+  attribute :communication_groups do |object|
     object[:communication_groups]
-  end
-
-  def id
-    nil
   end
 end

--- a/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
+++ b/spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe V0::Profile::Ch33BankAccountsController, type: :controller do
     expect(JSON.parse(response.body)).to eq(
       {
         'data' => {
-          'id' => '', 'type' => 'hashes',
+          'id' => '',
+          'type' => 'hashes',
           'attributes' => {
             'account_type' => 'Checking',
             'account_number' => '123',

--- a/spec/serializers/ch33_bank_account_serializer_spec.rb
+++ b/spec/serializers/ch33_bank_account_serializer_spec.rb
@@ -20,6 +20,10 @@ describe Ch33BankAccountSerializer, type: :serializer do
     expect(data['id']).to be_blank
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq('hashes')
+  end
+
   context 'when :dposit_acnt_type_nm is C' do
     it 'includes :account_type is Checking' do
       expect(attributes['account_type']).to eq 'Checking'

--- a/spec/serializers/communication_groups_serializer_spec.rb
+++ b/spec/serializers/communication_groups_serializer_spec.rb
@@ -14,6 +14,10 @@ describe CommunicationGroupsSerializer, type: :serializer do
     expect(data['id']).to be_blank
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq('hashes')
+  end
+
   it 'includes :communication_groups' do
     expect(attributes['communication_groups'].size).to eq communication_groups[:communication_groups].size
     expect(attributes['communication_groups'].first['id']).to eq communication_groups[:communication_groups].first.id


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:
- Ch33BankAccountSerializer
- CommunicationGroupsSerializer

Also:
- Refactored CommunicationPreferencesController for readability

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [ ]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage