### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part 7

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -50,7 +50,7 @@ module V0
 
     def suggested_conditions
       results = DisabilityContention.suggested(params[:name_part])
-      render json: results, each_serializer: DisabilityContentionSerializer
+      render json: DisabilityContentionSerializer.new(results)
     end
 
     def submit_all_claim

--- a/app/controllers/v0/education_benefits_claims_controller.rb
+++ b/app/controllers/v0/education_benefits_claims_controller.rb
@@ -18,14 +18,14 @@ module V0
       Rails.logger.info "ClaimID=#{claim.id} RPO=#{claim.education_benefits_claim.region} Form=#{form_type}"
       claim.after_submit(@current_user)
       clear_saved_form(claim.in_progress_form_id)
-      render(json: claim.education_benefits_claim)
+      render json: EducationBenefitsClaimSerializer.new(claim.education_benefits_claim)
     end
 
     def stem_claim_status
       current_applications = []
       current_applications = user_stem_automated_decision_claims unless @current_user.nil?
 
-      render json: current_applications, each_serializer: EducationStemClaimStatusSerializer
+      render json: EducationStemClaimStatusSerializer.new(current_applications)
     end
 
     private

--- a/app/controllers/v0/profile/direct_deposits/disability_compensations_controller.rb
+++ b/app/controllers/v0/profile/direct_deposits/disability_compensations_controller.rb
@@ -25,18 +25,13 @@ module V0
         def show
           response = client.get_payment_info
 
-          render status: response.status,
-                 json: response.body,
-                 serializer: DisabilityCompensationsSerializer
+          render json: DisabilityCompensationsSerializer.new(response.body), status: response.status
         end
 
         def update
           response = client.update_payment_info(payment_account)
           send_confirmation_email
-
-          render status: response.status,
-                 json: response.body,
-                 serializer: DisabilityCompensationsSerializer
+          render json: DisabilityCompensationsSerializer.new(response.body), status: response.status
         end
 
         private

--- a/app/controllers/v0/profile/direct_deposits_controller.rb
+++ b/app/controllers/v0/profile/direct_deposits_controller.rb
@@ -27,9 +27,7 @@ module V0
       def show
         response = client.get_payment_info
 
-        render status: response.status,
-               json: response.body,
-               serializer: DisabilityCompensationsSerializer
+        render json: DisabilityCompensationsSerializer.new(response.body), status: response.status
       end
 
       def update
@@ -38,9 +36,7 @@ module V0
         response = client.update_payment_info(@payment_account)
         send_confirmation_email
 
-        render status: response.status,
-               json: response.body,
-               serializer: DisabilityCompensationsSerializer
+        render json: DisabilityCompensationsSerializer.new(response.body), status: response.status
       end
 
       private

--- a/app/serializers/disability_compensations_serializer.rb
+++ b/app/serializers/disability_compensations_serializer.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
-class DisabilityCompensationsSerializer < ActiveModel::Serializer
-  type 'direct_deposit/disability_compensations'
+class DisabilityCompensationsSerializer
+  include JSONAPI::Serializer
+
+  set_id { '' }
+  set_type 'direct_deposit/disability_compensations'
 
   attributes :control_information, :payment_account
 
-  def control_information
+  attribute :control_information do |object|
     object[:control_information]
   end
 
-  def payment_account
-    return unless object.key?(:payment_account)
+  attribute :payment_account do |object|
+    next nil unless object.key?(:payment_account)
 
     payment_account = object[:payment_account]
 
@@ -21,9 +24,5 @@ class DisabilityCompensationsSerializer < ActiveModel::Serializer
     payment_account[:routing_number] = StringHelpers.mask_sensitive(routing_number) if routing_number
 
     payment_account
-  end
-
-  def id
-    nil
   end
 end

--- a/app/serializers/disability_contention_serializer.rb
+++ b/app/serializers/disability_contention_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class DisabilityContentionSerializer < ActiveModel::Serializer
+class DisabilityContentionSerializer
+  include JSONAPI::Serializer
+
   attribute :code
   attribute :medical_term
   attribute :lay_term

--- a/app/serializers/education_benefits_claim_serializer.rb
+++ b/app/serializers/education_benefits_claim_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-class EducationBenefitsClaimSerializer < ActiveModel::Serializer
-  attributes :id, :form, :regional_office, :confirmation_number
+class EducationBenefitsClaimSerializer
+  include JSONAPI::Serializer
+
+  attributes :form, :regional_office, :confirmation_number
 end

--- a/app/serializers/education_stem_claim_status_serializer.rb
+++ b/app/serializers/education_stem_claim_status_serializer.rb
@@ -5,7 +5,6 @@ class EducationStemClaimStatusSerializer
 
   attribute :confirmation_number
 
-  # rubocop:disable Naming/PredicateName
   attribute :is_enrolled_stem do |object|
     object.saved_claim.parsed_form['isEnrolledStem']
   end
@@ -13,7 +12,6 @@ class EducationStemClaimStatusSerializer
   attribute :is_pursuing_teaching_cert do |object|
     object.saved_claim.parsed_form['isPursuingTeachingCert']
   end
-  # rubocop:enable Naming/PredicateName
 
   attribute :benefit_left do |object|
     object.saved_claim.parsed_form['benefitLeft']

--- a/app/serializers/education_stem_claim_status_serializer.rb
+++ b/app/serializers/education_stem_claim_status_serializer.rb
@@ -1,44 +1,37 @@
 # frozen_string_literal: true
 
-class EducationStemClaimStatusSerializer < ActiveModel::Serializer
-  attributes :confirmation_number,
-             :is_enrolled_stem,
-             :is_pursuing_teaching_cert,
-             :benefit_left,
-             :remaining_entitlement,
-             :automated_denial,
-             :denied_at,
-             :submitted_at
+class EducationStemClaimStatusSerializer
+  include JSONAPI::Serializer
+
+  attribute :confirmation_number
 
   # rubocop:disable Naming/PredicateName
-  def is_enrolled_stem
+  attribute :is_enrolled_stem do |object|
     object.saved_claim.parsed_form['isEnrolledStem']
   end
 
-  def is_pursuing_teaching_cert
+  attribute :is_pursuing_teaching_cert do |object|
     object.saved_claim.parsed_form['isPursuingTeachingCert']
   end
   # rubocop:enable Naming/PredicateName
 
-  def benefit_left
+  attribute :benefit_left do |object|
     object.saved_claim.parsed_form['benefitLeft']
   end
 
-  def remaining_entitlement
+  attribute :remaining_entitlement do |object|
     object.education_stem_automated_decision.remaining_entitlement
   end
 
-  def automated_denial
+  attribute :automated_denial do |object|
     object.education_stem_automated_decision.automated_decision_state == 'denied'
   end
 
-  def denied_at
-    return nil if object.education_stem_automated_decision.automated_decision_state != 'denied'
+  attribute :denied_at do |object|
+    next nil if object.education_stem_automated_decision.automated_decision_state != 'denied'
 
     object.education_stem_automated_decision.updated_at
   end
 
-  def submitted_at
-    object.created_at
-  end
+  attribute :submitted_at, &:created_at
 end

--- a/spec/factories/disability_compensations.rb
+++ b/spec/factories/disability_compensations.rb
@@ -3,9 +3,12 @@
 FactoryBot.define do
   factory :disability_compensation, class: Hash do
     control_information
-    payment_account
 
-    initialize_with { { control_information:, payment_account: } }
+    trait :with_payment_account do
+      payment_account
+    end
+
+    initialize_with { attributes }
   end
 
   factory :control_information, class: Hash do

--- a/spec/serializers/disability_compensations_serializer_spec.rb
+++ b/spec/serializers/disability_compensations_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe DisabilityCompensationsSerializer, type: :serializer do
   subject { serialize(compensation, serializer_class: described_class) }
 
-  let(:compensation) { build(:disability_compensation) }
+  let(:compensation) { build(:disability_compensation, :with_payment_account) }
   let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }
 
@@ -33,5 +33,13 @@ describe DisabilityCompensationsSerializer, type: :serializer do
   it 'masks routing number' do
     masked_routing_number = StringHelpers.mask_sensitive(compensation[:payment_account][:routing_number])
     expect(attributes['payment_account']['routing_number']).to eq masked_routing_number
+  end
+
+  context 'when payment_account does not exist' do
+    let(:compensation) { build(:disability_compensation) }
+
+    it 'includes :payment_account as nil' do
+      expect(attributes['payment_account']).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- DisabilityCompensationsSerializer
- DisabilityContentionSerializer
- EducationBenefitsClaimSerializer
- EducationStemClaimStatusSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage