### PR TITLE
Add ssn to metadata 7959a  7959f1 7959f2

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -23,6 +23,7 @@ module IvcChampva
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
         'ssn_or_tin' => @data['applicant_member_number'],
+        'member_number' => @data['applicant_member_number'],
         'country' => @data.dig('applicant_address', 'country') || 'USA',
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info']

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -16,9 +16,9 @@ module IvcChampva
 
     def metadata
       {
-        'veteranFirstName' => @data.dig('veteran', 'full_name', 'first'),
-        'veteranLastName' => @data.dig('veteran', 'full_name', 'last'),
-        'zipCode' => @data.dig('veteran', 'address', 'postal_code'),
+        'veteranFirstName' => @data.dig('applicant_name', 'first'),
+        'veteranLastName' => @data.dig('applicant_name', 'last'),
+        'zipCode' => @data.dig('applicant_address', 'postal_code'),
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -22,6 +22,7 @@ module IvcChampva
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
+        'ssn_or_tin' => @data.dig('veteran', 'ssn_or_tin'),
         'country' => @data.dig('applicant_address', 'country') || 'USA',
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info']

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -22,7 +22,7 @@ module IvcChampva
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
-        'ssn_or_tin' => @data.dig('veteran', 'ssn_or_tin'),
+        'ssn_or_tin' => @data['applicant_member_number'],
         'country' => @data.dig('applicant_address', 'country') || 'USA',
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info']

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -23,6 +23,7 @@ module IvcChampva
         'zipCode' => @data.dig('veteran', 'mailing_address', 'postal_code') || '00000',
         'country' => @data.dig('veteran', 'mailing_address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',
+        'ssn_or_tin' => @data.dig('veteran', 'ssn'),
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
         'uuid' => @uuid,

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
@@ -20,6 +20,7 @@ module IvcChampva
         'veteranMiddleName' => @data.dig('veteran', 'full_name', 'middle'),
         'veteranLastName' => @data.dig('veteran', 'full_name', 'last'),
         'fileNumber' => @data.dig('veteran', 'va_claim_number').presence || @data.dig('veteran', 'ssn'),
+        'ssn_or_tin' => @data.dig('veteran', 'ssn'),
         'zipCode' => @data.dig('veteran', 'mailing_address', 'postal_code') || '00000',
         'country' => @data.dig('veteran', 'mailing_address', 'country') || 'USA',
         'source' => 'VA Platform Digital Forms',

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IvcChampva::VHA107959a do
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'va_claim_number' => '123456789',
+        'ssn_or_tin' => '123456789',
         'address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => '10-7959A',
@@ -37,6 +38,7 @@ RSpec.describe IvcChampva::VHA107959a do
         'country' => 'USA',
         'source' => 'VA Platform Digital Forms',
         'docType' => '10-7959A',
+        'ssn_or_tin' => '123456789',
         'businessLine' => 'CMP',
         'primaryContactInfo' => {
           'name' => {

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe IvcChampva::VHA107959a do
         'source' => 'VA Platform Digital Forms',
         'docType' => '10-7959A',
         'ssn_or_tin' => '123456789',
+        'member_number' => '123456789',
         'businessLine' => 'CMP',
         'primaryContactInfo' => {
           'name' => {

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -13,11 +13,8 @@ RSpec.describe IvcChampva::VHA107959a do
         'email' => false
       },
       'applicant_member_number' => '123456789',
-      'veteran' => {
-        'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
-        'va_claim_number' => '123456789',
-        'address' => { 'country' => 'USA', 'postal_code' => '12345' }
-      },
+      'applicant_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
+      'applicant_address' => { 'country' => 'USA', 'postal_code' => '12345' },
       'form_number' => '10-7959A',
       'veteran_supporting_documents' => [
         { 'confirmation_code' => 'abc123' },

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe IvcChampva::VHA107959a do
         },
         'email' => false
       },
+      'applicant_member_number' => '123456789',
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'va_claim_number' => '123456789',
-        'ssn_or_tin' => '123456789',
         'address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => '10-7959A',

--- a/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IvcChampva::VHA107959f1 do
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'va_claim_number' => '123456789',
+        'ssn' => '123456789',
         'mailing_address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => '10-7959F-1',
@@ -42,6 +43,7 @@ RSpec.describe IvcChampva::VHA107959f1 do
         'veteranMiddleName' => 'P',
         'veteranLastName' => 'Doe',
         'fileNumber' => '123456789',
+        'ssn_or_tin' => '123456789',
         'zipCode' => '12345',
         'country' => 'USA',
         'source' => 'VA Platform Digital Forms',

--- a/modules/ivc_champva/spec/models/vha_10_7959f_2_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_2_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IvcChampva::VHA107959f2 do
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
         'va_claim_number' => '123456789',
+        'ssn' => '123456789',
         'mailing_address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => '10-7959F-2',
@@ -35,6 +36,7 @@ RSpec.describe IvcChampva::VHA107959f2 do
         'veteranMiddleName' => 'P',
         'veteranLastName' => 'Doe',
         'fileNumber' => '123456789',
+        'ssn_or_tin' => '123456789',
         'zipCode' => '12345',
         'country' => 'USA',
         'source' => 'VA Platform Digital Forms',


### PR DESCRIPTION
## Summary
As a PEGA user, I need SSN or x-amz-meta-ssn_or_tin for all forms to process in the PEGA workflow.
AC: x-amz-meta-ssn_or_tin is in the metadata for all IVC CHAMPVA forms.

## Related issue(s)
Similar work  for 7959C
(https://github.com/department-of-veterans-affairs/vets-api/pull/17578/files)

## Testing done
Successfully ran unit test for 7959a, 7959f1 and 7959f2.
No pdfs were generated 
