### PR TITLE
Add pension_medical_evidence_clarification flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -877,6 +877,10 @@ features:
     description: When enabled, will allow display of PDF cert warnings in find-a-form
     actor_type: user
     enable_in_development: true
+  pension_medical_evidence_clarification:
+   actor_type: user
+   description: >
+     [Front-end only] When enabled, 21P-527EZ will display additional explanations for the medical evidence requirement.
   pre_entry_covid19_screener:
     actor_type: user
     description: >


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Adds a feature toggle for a new front-end feature, additional clarifying text for the medical evidence requirement in Pensions.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88388

## Testing done

- Confirmed that the flipper appears at http://localhost:3000/flipper/features/pension_medical_evidence_clarification locally

## What areas of the site does it impact?
Pensions

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

