### PR TITLE
Removed secondary navigation toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -748,10 +748,6 @@ features:
     actor_type: user
     description: Enables personalized content on the My HealtheVet landing page.
     enable_in_development: true
-  mhv_secondary_navigation_enabled:
-    actor_type: user
-    description: Enables the My HealtheVet secondary navigation
-    enable_in_development: true
   mhv_transitional_medical_records_landing_page:
     actor_type: user
     description: Enables the transitional Medical Records page at /my-health/records


### PR DESCRIPTION
## Summary
Removed the MHV secondary navigation toggle. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87134

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
MHV secondary navigation

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [X]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

