### PR TITLE
Tempfile workaround for Simple Forms PDF filling

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -25,9 +25,9 @@ module SimpleFormsApi
 
       # Tempfile workaround inspired by this:
       #   https://github.com/actions/runner-images/issues/4443#issuecomment-965391736
-      tempfile = Tempfile.new(["tmp", ".pdf"]).tap do |tempfile|
-        IO.copy_stream(template_form_path, tempfile)
-        tempfile.close
+      tempfile = Tempfile.new(['tmp', '.pdf']).tap do |tmpfile|
+        IO.copy_stream(template_form_path, tmpfile)
+        tmpfile.close
       end
       FileUtils.touch(tempfile)
       FileUtils.copy_file(tempfile.path, stamped_template_path)

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -22,7 +22,16 @@ module SimpleFormsApi
       generated_form_path = "tmp/#{name}-tmp.pdf"
       stamped_template_path = "tmp/#{name}-stamped.pdf"
       pdftk = PdfForms.new(Settings.binaries.pdftk)
-      FileUtils.copy(template_form_path, stamped_template_path)
+
+      # Tempfile workaround inspired by this:
+      #   https://github.com/actions/runner-images/issues/4443#issuecomment-965391736
+      tempfile = Tempfile.new(["tmp", ".pdf"]).tap do |tempfile|
+        IO.copy_stream(template_form_path, tempfile)
+        tempfile.close
+      end
+      FileUtils.touch(tempfile)
+      FileUtils.copy_file(tempfile.path, stamped_template_path)
+
       if File.exist? stamped_template_path
         PdfStamper.stamp_pdf(stamped_template_path, form, current_loa)
         pdftk.fill_form(stamped_template_path, generated_form_path, mapped_data, flatten: true)

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -37,6 +37,7 @@ describe SimpleFormsApi::PdfFiller do
       context "when mapping the pdf data given JSON file: #{file_name}" do
         let(:form_number) { file_name.gsub('-min', '') }
         let(:expected_pdf_path) { "tmp/#{name}-tmp.pdf" }
+        let(:expected_stamped_path) { "tmp/#{name}-stamped.pdf" }
         let(:data) { JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{file_name}.json")) }
         let(:form) { "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
         let(:name) { SecureRandom.hex }
@@ -48,6 +49,14 @@ describe SimpleFormsApi::PdfFiller do
             expect do
               described_class.new(form_number:, form:, name:).generate
             end.to change { File.exist?(expected_pdf_path) }.from(false).to(true)
+          end
+
+          it 'uses a temporary file to initialize a stampable template file' do
+            allow(FileUtils).to receive(:copy_file).and_call_original
+
+            described_class.new(form_number:, form:, name:).generate
+
+            expect(FileUtils).to have_received(:copy_file).with(anything, expected_stamped_path)
           end
         end
       end


### PR DESCRIPTION
## Summary
We've been seeing errors like this one: https://vagov.ddog-gov.com/dashboard/a9w-jhk-den/simple-forms-api?fromUser=false&graphType=flamegraph&refresh_mode=sliding&shouldShowLegend=true&sort=time&spanID=551294370726133741&spanViewType=errors&traceID=594988394759685708&view=spans&from_ts=1721227852516&to_ts=1721400652516&live=true -- `stamped template file does not exist`

After a bit of research, I came across this workaround with `Tempfile`: https://github.com/actions/runner-images/issues/4443#issuecomment-965391736

And I thought it was worth a try!

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88703
