### PR TITLE
Add nil check for backend transform GMT threshold

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/streamlined_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/streamlined_calculator.rb
@@ -82,15 +82,21 @@ module DebtsApi
         end
 
         def are_liquid_assets_below_gmt_threshold?
+          return false if @gmt_data['gmt_threshold'].blank?
+
           liquid_assets = @asset_data['cashOnHand'].to_f + @asset_data['cashInBank'].to_f
           liquid_assets < @gmt_data['gmt_threshold']
         end
 
         def income_below_gmt_threshold?
+          return false if @gmt_data['gmt_threshold'].blank?
+
           total_annual_income < @gmt_data['gmt_threshold']
         end
 
         def cash_below_gmt_threshold?
+          return false if @gmt_data['gmt_threshold'].blank?
+
           @asset_data['cashOnHand'].to_f < @gmt_data['gmt_threshold']
         end
 


### PR DESCRIPTION
## Summary

This is a bug fix for the backend transform work. `gmt_threshold` can be `nil`, but this isn't considered in several functions. These functions check if it is higher or lower than other financial metrics. When `gmt_threshold` is `nil`, this makes these functions default to `false` instead of throwing an error.

- *This work is behind a feature toggle (flipper): YES*

## Testing done

- [ ] Existing unit tests still pass

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
