### PR TITLE
Check for file extension in lighthouse document model

### DIFF
--- a/app/models/lighthouse_document.rb
+++ b/app/models/lighthouse_document.rb
@@ -11,6 +11,7 @@ class LighthouseDocument < Common::Base
   attribute :claim_id, Integer
   attribute :document_type, String
   attribute :file_name, String
+  attribute :file_extension, String
   attribute :file_obj, ActionDispatch::Http::UploadedFile
   attribute :participant_id, String
   attribute :password, String
@@ -21,7 +22,9 @@ class LighthouseDocument < Common::Base
   validates(:participant_id, presence: true)
   validate :known_document_type?
   validate :unencrypted_pdf?
-  before_validation :normalize_text, :convert_to_unlocked_pdf, :normalize_file_name
+  # Taken from LighthouseDocumentUploaderBase
+  validates(:file_extension, inclusion: { in: %w[pdf gif png tiff tif jpeg jpg bmp txt] })
+  before_validation :set_file_extension, :normalize_text, :convert_to_unlocked_pdf, :normalize_file_name
 
   # rubocop:disable Layout/LineLength
   DOCUMENT_TYPES = {
@@ -124,6 +127,10 @@ class LighthouseDocument < Common::Base
     else
       errors.add(:base, I18n.t('errors.messages.uploads.malformed_pdf'))
     end
+  end
+
+  def set_file_extension
+    self.file_extension = file_name.split('.').last
   end
 
   def normalize_text

--- a/modules/mobile/spec/request/claims_document_upload_spec.rb
+++ b/modules/mobile/spec/request/claims_document_upload_spec.rb
@@ -146,9 +146,8 @@ RSpec.describe 'claims document upload', :skip_json_api_validation, type: :reque
     it 'rejects files with invalid document_types' do
       params = { file:, claim_id:, tracked_item_id:, document_type: }
       post '/mobile/v0/claim/600117255/documents', params:, headers: sis_headers
-      expect(response.status).to eq(500)
-      expect(response.parsed_body['errors'].first['title']).to eq('Internal server error')
-      expect(response.parsed_body['errors'].first['meta']['exception']).to match(/can.t upload/)
+      expect(response.status).to eq(422)
+      expect(response.parsed_body['errors'].first['title']).to eq('File extension is not included in the list')
     end
   end
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
We can check ahead of time whether a lighthouse document upload will fail due to the wrong file extension type. This adds validation at the model level

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9023

## Testing done
Existing tests cover the changes

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
