### PR TITLE
feat: is_ready exits 0 when replicaSet unhealthy

### DIFF
--- a/bin/is_ready
+++ b/bin/is_ready
@@ -27,10 +27,12 @@ unavailable_percentage=$(awk "BEGIN {printf \"%d\", 100 - (($pool_capacity * 100
 if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
   CURRENT_TIME=$(date +%s)
 
+  dd_env=$(echo $DD_ENV | cut -f2 -d-)
+  cluster_env=${DD_ENV#eks-}
   dd_data=$(
     curl -sG \
       'https://vagov.ddog-gov.com/api/v1/query' \
-      --data-urlencode "query=avg:kubernetes_state.deployment.replicas_available{kube_cluster_name:dsva-vagov-prod-cluster,kube_namespace:vets-api} by {kube_deployment}" \
+      --data-urlencode "query=avg:kubernetes_state.deployment.replicas_available{kube_cluster_name:dsva-vagov-${cluster_env:-prod}-cluster,kube_namespace:vets-api} by {kube_deployment}" \
       -d "from=$((CURRENT_TIME - 60))" \
       -d "to=${CURRENT_TIME}" \
       -H "DD-API-KEY: $DD_API_KEY" \

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -48,6 +48,11 @@ if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
   KUBE_DEPLOYMENT=$(echo $POD_NAME | rev | cut -d'-' -f3- | rev)
   LATEST_VALUE=$(echo "$dd_data" | tr -d '\n' | sed 's/},/\n/g' | grep "\"kube_deployment:$KUBE_DEPLOYMENT\"" | sed 's/.*pointlist":\[\[\([0-9\.]*,[0-9\.]*\)\].*/\1/' | awk -F, '{print $2}')
 
+  if [ -z "$LATEST_VALUE" ]; then
+    echo "No results found for deployment $KUBE_DEPLOYMENT. From: ${FROM_TIME}, To: ${CURRENT_TIME}, Cluster Env: ${cluster_env:-prod}"
+    exit 0 # Accumulate a backlog if data not found in DD
+  fi
+
   # Convert LATEST_VALUE to an integer
   LATEST_VALUE=${LATEST_VALUE%.*}
 

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -51,7 +51,7 @@ if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
   # Convert LATEST_VALUE to an integer
   LATEST_VALUE=${LATEST_VALUE%.*}
 
-  # Check if the latest value is 2 or below
+  # Determine if we have enough ready pods in replicaSet
   if [ $LATEST_VALUE -le $MIN_NOT_READY_PODS ]; then
     echo "Pod is unhealthy but only $LATEST_VALUE (need $MIN_NOT_READY_PODS) pods are ready for traffic. Accumulating a backlog."
     exit 0 # Ready pods is too low, accumulate a backlog

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -56,7 +56,7 @@ if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
     echo "Pod is unhealthy but only $LATEST_VALUE (need $MIN_NOT_READY_PODS) pods are ready for traffic. Accumulating a backlog."
     exit 0 # Ready pods is too low, accumulate a backlog
   else
-    echo "Pod nod ready (too much traffic) and we have $LATEST_VALUE pods ready. We only need $MIN_NOT_READY_PODS."
+    echo "Pod not ready (too much traffic) and we have $LATEST_VALUE pods ready. We only need $MIN_NOT_READY_PODS."
     exit 1 # Enough pods are available but this one has too much traffic.
   fi
 else

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -44,6 +44,13 @@ if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
     exit 0 # Accumulate a backlog if DD is inaccessible
   fi
 
+  # Check for errors in the dd_data response
+  if echo "$dd_data" | grep -q '"errors"'; then
+    echo "Datadog response contains errors:"
+    echo "$dd_data" | grep '"errors"' | sed 's/.*"errors":\[\([^]]*\)\].*/\1/'
+    exit 0 # Accumulate a backlog if there are errors in the response
+  fi
+
   # Extract the latest value for the given kube_deployment
   KUBE_DEPLOYMENT=$(echo $POD_NAME | rev | cut -d'-' -f3- | rev)
   LATEST_VALUE=$(echo "$dd_data" | tr -d '\n' | sed 's/},/\n/g' | grep "\"kube_deployment:$KUBE_DEPLOYMENT\"" | sed 's/.*pointlist":\[\[\([0-9\.]*,[0-9\.]*\)\].*/\1/' | awk -F, '{print $2}')

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -9,25 +9,54 @@
 # traffic.
 
 ALLOWED_UNAVAILABLE_PERCENTAGE=${AUTOSCALING_TARGET_VALUE:-75}
+MIN_NOT_READY_PODS=${MIN_NOT_READY_PODS:-3}
+POD_NAME=${POD_NAME:-"vets-api-web-5bf4f8d6c7-pn475"} # Example POD_NAME for testing
 
-data=$(curl -s 127.0.0.1:9293/stats)
+puma_data=$(curl -s 127.0.0.1:9293/stats)
 
-if [ $? -ne 0 ] || [ -z "$data" ]; then
+if [ $? -ne 0 ] || [ -z "$puma_data" ]; then
 	echo "Failed to get a valid response from the server. Is Puma Stats app running?"
 	exit 1
 fi
 
-# Check if BACKLOG_POD is set to true and exit 0 if it is. A BACKLOG_POD will
-# accumulate a backlog intentinally so that it's not possible for all pods to
-# be unavailable in a traffic surge.
-if [ "$BACKLOG_POD" = "true" ]; then
-	echo "BACKLOG_POD is set to true. Exiting with success."
-	exit 0
-fi
-
-pool_capacity=$(echo "$data" | grep -oE '"pool_capacity":[0-9]+' | cut -f2 -d: | awk '{sum+=$1} END {print sum}')
-max_threads=$(echo "$data" | grep -oE '"max_threads":[0-9]+' | cut -f2 -d: | awk '{sum+=$1} END {print sum}')
+pool_capacity=$(echo "$puma_data" | grep -oE '"pool_capacity":[0-9]+' | cut -f2 -d: | awk '{sum+=$1} END {print sum}')
+max_threads=$(echo "$puma_data" | grep -oE '"max_threads":[0-9]+' | cut -f2 -d: | awk '{sum+=$1} END {print sum}')
 
 unavailable_percentage=$(awk "BEGIN {printf \"%d\", 100 - (($pool_capacity * 100) / $max_threads)}")
 
-exit $((unavailable_percentage >= ALLOWED_UNAVAILABLE_PERCENTAGE ? 1 : 0))
+if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
+  CURRENT_TIME=$(date +%s)
+
+  dd_data=$(
+    curl -sG \
+      'https://vagov.ddog-gov.com/api/v1/query' \
+      --data-urlencode "query=avg:kubernetes_state.deployment.replicas_available{kube_cluster_name:dsva-vagov-prod-cluster,kube_namespace:vets-api} by {kube_deployment}" \
+      -d "from=$((CURRENT_TIME - 60))" \
+      -d "to=${CURRENT_TIME}" \
+      -H "DD-API-KEY: $DD_API_KEY" \
+      -H "DD-APPLICATION-KEY: $DD_APPLICATION_KEY"
+  )
+
+  if [ $? -ne 0 ] || [ -z "$dd_data" ]; then
+    echo "Failed to get a valid response from Datadog."
+    exit 0 # Accumulate a backlog if DD is inaccessible
+  fi
+
+  # Extract the latest value for the given kube_deployment
+  KUBE_DEPLOYMENT=$(echo $POD_NAME | rev | cut -d'-' -f3- | rev)
+  LATEST_VALUE=$(echo "$dd_data" | tr -d '\n' | sed 's/},/\n/g' | grep "\"kube_deployment:$KUBE_DEPLOYMENT\"" | sed 's/.*pointlist":\[\[\([0-9\.]*,[0-9\.]*\)\].*/\1/' | awk -F, '{print $2}')
+
+  # Convert LATEST_VALUE to an integer
+  LATEST_VALUE=${LATEST_VALUE%.*}
+
+  # Check if the latest value is 2 or below
+  if [ $LATEST_VALUE -le $MIN_NOT_READY_PODS ]; then
+    echo "Pod is unhealthy but only $LATEST_VALUE (need $MIN_NOT_READY_PODS) pods are ready for traffic. Accumulating a backlog."
+    exit 0 # Ready pods is too low, accumulate a backlog
+  else
+    echo "Pod nod ready (too much traffic) and we have $LATEST_VALUE pods ready. We only need $MIN_NOT_READY_PODS."
+    exit 1 # Enough pods are available but this one has too much traffic.
+  fi
+else
+  exit 0 # Not checking others pods, this one is healthy
+fi

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -49,7 +49,7 @@ if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
   LATEST_VALUE=$(echo "$dd_data" | tr -d '\n' | sed 's/},/\n/g' | grep "\"kube_deployment:$KUBE_DEPLOYMENT\"" | sed 's/.*pointlist":\[\[\([0-9\.]*,[0-9\.]*\)\].*/\1/' | awk -F, '{print $2}')
 
   if [ -z "$LATEST_VALUE" ]; then
-    echo "No results found for deployment $KUBE_DEPLOYMENT. From: ${FROM_TIME}, To: ${CURRENT_TIME}, Cluster Env: ${cluster_env:-prod}"
+    echo "No results found for deployment $KUBE_DEPLOYMENT. From: $((CURRENT_TIME - 60)), To: ${CURRENT_TIME}, Cluster Env: ${cluster_env:-prod}"
     exit 0 # Accumulate a backlog if data not found in DD
   fi
 

--- a/bin/is_ready
+++ b/bin/is_ready
@@ -36,7 +36,7 @@ if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
       -d "from=$((CURRENT_TIME - 60))" \
       -d "to=${CURRENT_TIME}" \
       -H "DD-API-KEY: $DD_API_KEY" \
-      -H "DD-APPLICATION-KEY: $DD_APPLICATION_KEY"
+      -H "DD-APPLICATION-KEY: $DD_APP_KEY"
   )
 
   if [ $? -ne 0 ] || [ -z "$dd_data" ]; then


### PR DESCRIPTION
This queries the `replicas_available` for the appropriate cluster and deployment by using `$DD_ENV` and `$POD_NAME`. If the pod is unhealthy but there are too few of healthy pods in the replica set, the pod will exit 0 forcing it to accumulate a backlog. If all pods are marked as unhealthy, Traefik will drop traffic (503ing). We prefer a line to form (backlog) while new pods spin up rather than just dropping traffic.

## Testing

To test, start `bin/rails s` and run:

```
AUTOSCALING_TARGET_VALUE=0 bin/is_ready # Force an unhealthy state
echo $? # Run this each time to see exit code
AUTOSCALING_TARGET_VALUE=0 MIN_NOT_READY_PODS=10 bin/is_ready # Force a backlog to accumulate
echo $?
AUTOSCALING_TARGET_VALUE=0 MIN_NOT_READY_PODS=5 bin/is_ready # Play with min not ready to see exit code
echo $?
```
