### PR TITLE
Extract reason code text fields from DS appointments

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -25,10 +25,6 @@ module VAOS
       #
       # @param appointment [Hash] the appointment to modify
       def extract_reason_code_fields(appointment)
-        # Return if the appointment is a CC request or not a request.
-        # We consider appointments with requested_periods as requests.
-        return if appointment[:kind] == 'cc' || appointment[:requested_periods].blank?
-
         # Retrieve the reason code text, or return if it is not present
         reason_code_text = appointment&.dig(:reason_code, :text)
         return if reason_code_text.nil?
@@ -39,10 +35,18 @@ module VAOS
                                            .to_h { |pair| pair.split(':').map!(&:strip) }
         return if reason_code_hash.empty?
 
-        contact = extract_contact_fields(reason_code_hash)
-        comments = reason_code_hash['comments'] if reason_code_hash.key?('comments')
-        reason = extract_reason_for_appointment(reason_code_hash)
-        preferred_dates = extract_preferred_dates(reason_code_hash)
+        # Direct Scheduling appointments
+        if appointment[:kind] == 'clinic' && appointment[:status] == 'booked'
+          comments = reason_code_hash['comments'] if reason_code_hash.key?('comments')
+          reason = extract_reason_for_appointment(reason_code_hash)
+
+        # Appointment requests
+        elsif appointment[:requested_periods].present? && appointment[:kind] != 'cc'
+          contact = extract_contact_fields(reason_code_hash)
+          comments = reason_code_hash['comments'] if reason_code_hash.key?('comments')
+          reason = extract_reason_for_appointment(reason_code_hash)
+          preferred_dates = extract_preferred_dates(reason_code_hash)
+        end
 
         appointment[:contact] = contact unless contact.nil?
         appointment[:patient_comments] = comments unless comments.nil?

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -211,6 +211,7 @@ FactoryBot.define do
 
     trait :va_proposed_valid_reason_code_text do
       va_proposed_base
+      kind { 'clinic' }
       reason_code do
         { 'text': 'station id: 983|preferred modality: FACE TO FACE|phone number: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:test' } # rubocop:disable Layout/LineLength
       end
@@ -263,13 +264,26 @@ FactoryBot.define do
       kind { 'phone' }
     end
 
-    trait :with_direct_scheduling do
+    trait :with_direct_scheduling_base do
       kind { 'cc' }
       status { 'booked' }
       location_id { '983' }
       practitioner_ids { [{ system: 'HSRM', value: '1234567890' }] }
       preferred_language { 'English' }
       reason { 'Testing' }
+      service_type { 'CCPOD' }
+    end
+
+    trait :ds_cc_booked_valid_reason_code_text do
+      with_direct_scheduling_base
+
+      reason_code do
+        { 'text': 'station id: 983|preferred modality: FACE TO FACE|phone number: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:test' } # rubocop:disable Layout/LineLength
+      end
+    end
+
+    trait :with_direct_scheduling do
+      with_direct_scheduling_base
 
       contact do
         {
@@ -286,7 +300,6 @@ FactoryBot.define do
         }
       end
 
-      service_type { 'CCPOD' }
       requested_periods do
         [
           {

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -44,7 +44,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :va_booked_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
-      expect(appt[:additional_appointment_details]).to eq('test')
+      expect(appt[:patient_comments]).to eq('test')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
       expect(appt[:preferred_dates]).to be_nil
     end

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -31,8 +31,8 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:preferred_dates]).to be_nil
     end
 
-    it 'returns without modification for va booked' do
-      appt = FactoryBot.build(:appointment_form_v2, :va_booked_valid_reason_code_text).attributes
+    it 'returns without modification for cc booked' do
+      appt = FactoryBot.build(:appointment_form_v2, :ds_cc_booked_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
       expect(appt[:patient_comments]).to be_nil
@@ -40,7 +40,16 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:preferred_dates]).to be_nil
     end
 
-    it 'extract valid reason text for va request' do
+    it 'extract valid reason code fields for va direct scheduling appointments' do
+      appt = FactoryBot.build(:appointment_form_v2, :va_booked_valid_reason_code_text).attributes
+      subject.extract_reason_code_fields(appt)
+      expect(appt[:contact]).to eq({})
+      expect(appt[:additional_appointment_details]).to eq('test')
+      expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
+      expect(appt[:preferred_dates]).to be_nil
+    end
+
+    it 'extract valid reason code fields for va request' do
       appt = FactoryBot.build(:appointment_form_v2, :va_proposed_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact][:telecom][0]).to eq({ type: 'phone', value: '6195551234' })


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is part of the api consolidation effort and moves the logic for extracting additional appointment details and reason for appointment from the reason code text from the FE to BE for Direct Scheduled (DS) appointments. The source logic is [here](https://github.com/department-of-veterans-affairs/vets-website/blob/6e8dc3ca9de43eb9ee11c347d1250043fef9436e/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js#L49-L52)
- This is work by the Appointments team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88692
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88693

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior returns the information as part of the reason code text and reasonForAppointment field is non existent.
- Tested API response to ensure it matches with ACs

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
