### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part 8

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -78,7 +78,7 @@ module V0
       job_status = Form526JobStatus.where(job_id: params[:job_id]).first
       raise Common::Exceptions::RecordNotFound, params[:job_id] unless job_status
 
-      render json: job_status, serializer: Form526JobStatusSerializer
+      render json: Form526JobStatusSerializer.new(job_status)
     end
 
     def rating_info

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -5,10 +5,8 @@ module V0
     def refresh
       resource = client.get_extract_status
 
-      render json: resource.data,
-             serializer: CollectionSerializer,
-             each_serializer: ExtractStatusSerializer,
-             meta: resource.metadata
+      options = { meta: resource.metadata }
+      render json: ExtractStatusSerializer.new(resource.data, options)
     end
 
     def eligible_data_classes

--- a/app/controllers/v0/profile/full_names_controller.rb
+++ b/app/controllers/v0/profile/full_names_controller.rb
@@ -23,10 +23,7 @@ module V0
       #   }
       #
       def show
-        render(
-          json: @current_user.full_name_normalized,
-          serializer: FullNameSerializer
-        )
+        render json: FullNameSerializer.new(@current_user.full_name_normalized)
       end
     end
   end

--- a/app/controllers/v0/profile/gender_identities_controller.rb
+++ b/app/controllers/v0/profile/gender_identities_controller.rb
@@ -17,7 +17,7 @@ module V0
 
           Rails.logger.info('GenderIdentitiesController#create request completed', sso_logging_info)
 
-          render json: response, serializer: GenderIdentitySerializer
+          render json: GenderIdentitySerializer.new(response)
         else
           raise Common::Exceptions::ValidationErrors, gender_identity
         end

--- a/app/serializers/evss_separation_location_serializer.rb
+++ b/app/serializers/evss_separation_location_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# NOT USING JSON:API Specification
+# app/controllers/v0/disability_compensation_forms_controller.rb
 class EVSSSeparationLocationSerializer < ActiveModel::Serializer
   attribute :separation_locations
 

--- a/app/serializers/extract_status_serializer.rb
+++ b/app/serializers/extract_status_serializer.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-class ExtractStatusSerializer < ActiveModel::Serializer
-  attribute :id
-  attribute :extract_type
-  attribute :last_updated
-  attribute :status
-  attribute :created_on
-  attribute :station_number
+class ExtractStatusSerializer
+  include JSONAPI::Serializer
+
+  set_type :extract_statuses
+
+  attributes :extract_type, :last_updated, :status, :created_on, :station_number
 end

--- a/app/serializers/form526_job_status_serializer.rb
+++ b/app/serializers/form526_job_status_serializer.rb
@@ -1,25 +1,21 @@
 # frozen_string_literal: true
 
-class Form526JobStatusSerializer < ActiveModel::Serializer
-  attribute :claim_id
-  attribute :job_id
-  attribute :submission_id
-  attribute :status
-  attribute :ancillary_item_statuses
+class Form526JobStatusSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
 
-  def claim_id
+  attributes :job_id, :status
+
+  attribute :claim_id do |object|
     object.submission.submitted_claim_id
   end
 
-  def submission_id
+  attribute :submission_id do |object|
     object.submission.id
   end
 
-  def ancillary_item_statuses
+  attribute :ancillary_item_statuses do |object|
     if object.job_class.include?('526')
       object.submission.form526_job_statuses.map do |status|
         status.attributes.except('form526_submission_id') unless status.id == object.id

--- a/app/serializers/form526_job_status_serializer.rb
+++ b/app/serializers/form526_job_status_serializer.rb
@@ -4,16 +4,19 @@ class Form526JobStatusSerializer
   include JSONAPI::Serializer
 
   set_id { '' }
-
-  attributes :job_id, :status
+  set_type :form526_job_statuses
 
   attribute :claim_id do |object|
     object.submission.submitted_claim_id
   end
 
+  attributes :job_id
+
   attribute :submission_id do |object|
     object.submission.id
   end
+
+  attributes :status
 
   attribute :ancillary_item_statuses do |object|
     if object.job_class.include?('526')

--- a/app/serializers/full_name_serializer.rb
+++ b/app/serializers/full_name_serializer.rb
@@ -1,28 +1,23 @@
 # frozen_string_literal: true
 
-class FullNameSerializer < ActiveModel::Serializer
-  attribute :first
-  attribute :middle
-  attribute :last
-  attribute :suffix
+class FullNameSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
 
-  def first
+  attribute :first do |object|
     object[:first]
   end
 
-  def middle
+  attribute :middle do |object|
     object[:middle]
   end
 
-  def last
+  attribute :last do |object|
     object[:last]
   end
 
-  def suffix
+  attribute :suffix do |object|
     object[:suffix]
   end
 end

--- a/app/serializers/gender_identity_serializer.rb
+++ b/app/serializers/gender_identity_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class GenderIdentitySerializer < ActiveModel::Serializer
-  attributes :gender_identity
+class GenderIdentitySerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+
+  attribute :gender_identity
 end

--- a/modules/my_health/spec/serializer/v1/extract_status_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/extract_status_serializer_spec.rb
@@ -14,6 +14,10 @@ describe MyHealth::V1::ExtractStatusSerializer, type: :serializer do
     expect(data['id']).to eq extract_status.id.to_s
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq 'extract_status'
+  end
+
   it 'includes :extract_type' do
     expect(attributes['extract_type']).to eq extract_status.extract_type
   end

--- a/spec/serializers/extract_status_serializer_spec.rb
+++ b/spec/serializers/extract_status_serializer_spec.rb
@@ -13,6 +13,10 @@ describe ExtractStatusSerializer, type: :serializer do
     expect(data['id']).to eq extract_status.id
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq 'extract_statuses'
+  end
+
   it 'includes :extract_type' do
     expect(attributes['extract_type']).to eq extract_status.extract_type
   end

--- a/spec/serializers/form526_job_status_serializer_spec.rb
+++ b/spec/serializers/form526_job_status_serializer_spec.rb
@@ -13,6 +13,10 @@ describe Form526JobStatusSerializer, type: :serializer do
     expect(data['id']).to be_blank
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq "form526_job_statuses"
+  end
+
   it 'includes :claim_id' do
     expect(attributes['claim_id']).to eq form526_job_status.submission.submitted_claim_id
   end


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- ExtractStatusSerializer
- Form526JobStatusSerializer
- GenderIdentitySerializer
- FullNameSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage