### PR TITLE
Create ServiceAccountConfigsController

### DIFF
--- a/app/controllers/sign_in/service_account_configs_controller.rb
+++ b/app/controllers/sign_in/service_account_configs_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module SignIn
+  class ServiceAccountConfigsController < ServiceAccountApplicationController
+    service_tag 'identity'
+    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+    before_action :set_service_account_config, only: %i[show update destroy]
+
+    def index
+      service_account_configs = ServiceAccountConfig.where(service_account_id: params[:service_account_ids])
+
+      render json: service_account_configs, status: :ok
+    end
+
+    def show
+      render json: @service_account_config, status: :ok
+    end
+
+    def create
+      service_account_config = ServiceAccountConfig.new(service_account_config_params)
+
+      if service_account_config.save
+        render json: service_account_config, status: :created
+      else
+        render json: service_account_config.errors, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      if @service_account_config.update(service_account_config_params)
+        render json: @service_account_config, status: :ok
+      else
+        render json: @service_account_config.errors, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      if @service_account_config.destroy
+        head :no_content
+      else
+        render json: @service_account_config.errors, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def service_account_config_params
+      params.require(:service_account_config).permit(:service_account_id,
+                                                     :description,
+                                                     :access_token_audience,
+                                                     :access_token_duration,
+                                                     scopes: [],
+                                                     certificates: [],
+                                                     access_token_user_attributes: [])
+    end
+
+    def set_service_account_config
+      @service_account_config = ServiceAccountConfig.find(params[:id])
+    end
+
+    def not_found
+      render json: { error: 'Service account config not found' }, status: :not_found
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   unless Settings.vsp_environment == 'production'
     namespace :sign_in do
       resources :client_configs
+      resources :service_account_configs
     end
   end
 

--- a/spec/controllers/sign_in/service_account_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/service_account_configs_controller_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
+  let(:service_account_config) { create(:service_account_config, scopes:) }
+  let(:service_account_id) { service_account_config.service_account_id }
+  let(:scopes) { ['http://www.example.com/sign_in/service_account_configs'] }
+  let(:service_account_access_token) { create(:service_account_access_token, service_account_id:, scopes:) }
+  let(:sts_token) { SignIn::ServiceAccountAccessTokenJwtEncoder.new(service_account_access_token:).perform }
+  let(:valid_attributes) { attributes_for(:service_account_config) }
+  let(:invalid_attributes) { attributes_for(:service_account_config, service_account_id: nil) }
+  let(:response_body) { JSON.parse(response.body) }
+
+  before do
+    controller.request.headers['Authorization'] = "Bearer #{sts_token}"
+  end
+
+  describe 'GET #index' do
+    context 'when authenticated' do
+      it 'returns a success response' do
+        service_account_config
+        get :index, params: { service_account_ids: [service_account_id] }
+        expect(response).to be_successful
+        expect(response_body.pluck('service_account_id')).to include(service_account_id)
+      end
+    end
+
+    context 'when not authenticated' do
+      let(:sts_token) { 'invalid_token' }
+
+      it 'returns an unauthorized response' do
+        get :index, params: { service_account_ids: [service_account_id] }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    context 'when authenticated' do
+      context 'when the client config exists' do
+        it 'returns a success response' do
+          get :show, params: { id: service_account_config.to_param }
+          expect(response).to be_successful
+          expect(response_body['service_account_id']).to eq(service_account_id)
+        end
+      end
+
+      context 'when the client config does not exist' do
+        it 'returns a not found response' do
+          get :show, params: { id: 'non_existent_service_account_id' }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'when not authenticated' do
+      let(:sts_token) { 'invalid_token' }
+
+      it 'returns an unauthorized response' do
+        get :show, params: { id: service_account_config.to_param }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context 'when authenticated' do
+      context 'with valid params' do
+        it 'creates a new SignIn::ServiceAccountConfig' do
+          expect do
+            post :create, params: { service_account_config: valid_attributes }, as: :json
+          end.to change(SignIn::ServiceAccountConfig, :count).by(1)
+        end
+
+        it 'returns a created response' do
+          post :create, params: { service_account_config: valid_attributes }, as: :json
+          expect(response).to have_http_status(:created)
+          expect(response_body['service_account_id']).to eq(valid_attributes[:service_account_id])
+        end
+      end
+
+      context 'with invalid params' do
+        it 'does not create a new SignIn::ServiceAccountConfig' do
+          expect do
+            post :create, params: { service_account_config: invalid_attributes }, as: :json
+          end.not_to change(SignIn::ServiceAccountConfig, :count)
+        end
+
+        it 'renders an error' do
+          post :create, params: { service_account_config: invalid_attributes }, as: :json
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_body['service_account_id']).to include("can't be blank")
+        end
+      end
+    end
+
+    context 'when not authenticated' do
+      let(:sts_token) { 'invalid_token' }
+
+      it 'returns an unauthorized response' do
+        post :create, params: { service_account_config: valid_attributes }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'when authenticated' do
+      context 'with valid params' do
+        let(:new_attributes) { attributes_for(:service_account_config, service_account_id:) }
+
+        it 'updates the requested service_account_config' do
+          put :update, params: { id: service_account_config.to_param, service_account_config: new_attributes },
+                       as: :json
+          service_account_config.reload
+          expect(service_account_config.service_account_id).to eq(service_account_id)
+        end
+      end
+
+      context 'with invalid params' do
+        it 'renders an error' do
+          put :update, params: { id: service_account_config.to_param, service_account_config: invalid_attributes },
+                       as: :json
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_body['service_account_id']).to include("can't be blank")
+        end
+      end
+    end
+
+    context 'when not authenticated' do
+      let(:sts_token) { 'invalid_token' }
+
+      it 'returns an unauthorized response' do
+        put :update, params: { id: service_account_config.to_param, service_account_config: valid_attributes },
+                     as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'when authenticated' do
+      context 'when the service_account_config exists' do
+        it 'destroys the requested service_account_config' do
+          service_account_config
+          expect do
+            delete :destroy, params: { id: service_account_config.to_param }
+          end.to change(SignIn::ServiceAccountConfig, :count).by(-1)
+        end
+
+        it 'returns a no content response' do
+          delete :destroy, params: { id: service_account_config.to_param }
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+
+      context 'when the service_account_config does not exist' do
+        it 'returns a not found response' do
+          delete :destroy, params: { id: 'non_existent_service_account_id' }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'when not authenticated' do
+      let(:sts_token) { 'invalid_token' }
+
+      it 'returns an unauthorized response' do
+        delete :destroy, params: { id: service_account_config.to_param }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create ServiceAccountConfigs controller and routes. Endpoint is protected by sts auth

## Related issue(s)
-https://github.com/department-of-veterans-affairs/va.gov-team/issues/88542

## Testing 
### Setup
migrate and seed the database
- `rails db:migrate`
- `rails db:seed`

Start the server
- `rails s`

Update the service account config
- `rails c`
```ruby
SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').update!(scopes: ['http://localhost:3000/sign_in/service_account_configs'])
```

### Test in rails console
copy 🍝  and run of these into the console
**Note** if your token expires just request a new one

#### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/service_account_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```

#### GET - Index
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
service_account_ids = %w[sample_sts_service_account 01b8ebaac5215f84640ade756b645f28]

params = { service_account_ids: service_account_ids }
uri.query = params.to_query
request = Net::HTTP::Get.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
JSON.parse(response.body)
```

#### GET - Show
```ruby
id = SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').id
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{id}")
request = Net::HTTP::Get.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
JSON.parse(response.body)
```

#### POST - Create
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: []
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

#### PUT - Update
```ruby
id = SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account_new').id
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    description: 'Sample STS service account updated'
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

#### DELETE - Destroy
```ruby
id = SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account_new').id
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{id}")
request = Net::HTTP::Delete.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
JSON.parse(response.body)
```

## What areas of the site does it impact?
service account configs

