### PR TITLE
85391 update claim statuses

### DIFF
--- a/modules/check_in/app/sidekiq/check_in/travel_claim_status_check_worker.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_status_check_worker.rb
@@ -2,10 +2,10 @@
 
 module CheckIn
   class TravelClaimStatusCheckWorker < TravelClaimBaseWorker
-    SUCCESSFUL_CLAIM_STATUSES = ['approved for payment', 'claim paid', 'claim submitted', 'in manual review',
-                                 'in-process', 'submitted for payment', 'saved'].freeze
-    FAILED_CLAIM_STATUSES = ['appeal', 'closed with no payment', 'denied', 'fiscal rescinded', 'incomplete', 'on hold',
-                             'partial payment', 'payment canceled'].freeze
+    SUCCESSFUL_CLAIM_STATUSES = %w[ApprovedForPayment ClaimPaid ClaimSubmitted
+                                   InManualReview In-Process Saved SubmittedForPayment].freeze
+    FAILED_CLAIM_STATUSES = %w[Appeal ClosedWithNoPayment Denied FiscalRescinded Incomplete OnHold
+                               PartialPayment PaymentCanceled].freeze
 
     def perform(uuid, appointment_date)
       redis_client = TravelClaim::RedisClient.build
@@ -83,9 +83,9 @@ module CheckIn
 
         response_body = claim_status_resp.dig(:data, :body)
         claim_status = response_body.first.with_indifferent_access[:claimStatus]
-        if SUCCESSFUL_CLAIM_STATUSES.include?(claim_status.downcase)
+        if SUCCESSFUL_CLAIM_STATUSES.include?(claim_status)
           TravelClaim::Response::CODE_CLAIM_APPROVED
-        elsif FAILED_CLAIM_STATUSES.include?(claim_status.downcase)
+        elsif FAILED_CLAIM_STATUSES.include?(claim_status)
           TravelClaim::Response::CODE_CLAIM_NOT_APPROVED
         else
           logger.info({ message: 'Received non-matching claim status', claim_status:, uuid: })

--- a/modules/check_in/spec/sidekiq/travel_claim_status_check_worker_spec.rb
+++ b/modules/check_in/spec/sidekiq/travel_claim_status_check_worker_spec.rb
@@ -166,7 +166,7 @@ shared_examples 'travel claim status check worker #perform' do |facility_type|
       expect(StatsD).to have_received(:increment).with(CheckIn::Constants::STATSD_NOTIFY_SUCCESS).exactly(1).time
       expect(Sidekiq.logger).to have_received(:info).with({
                                                             message: 'Received non-matching claim status',
-                                                            claim_status: 'invalid',
+                                                            claim_status: 'Invalid',
                                                             uuid:
                                                           })
     end

--- a/spec/support/vcr_cassettes/check_in/btsss/claim_status/claim_status_200.yml
+++ b/spec/support/vcr_cassettes/check_in/btsss/claim_status/claim_status_200.yml
@@ -24,7 +24,7 @@ http_interactions:
               "aptSourceSystem": "test-apt-source",
               "aptSourceSystemId": "test-apt-system-id",
               "claimNum": "TC202207000011666",
-              "claimStatus": "approved for payment",
+              "claimStatus": "ApprovedForPayment",
               "claimLastModDateTime": "2024-05-30T18:44:22.733Z",
               "facilityStationNum": "test-facility-station-num"
             }

--- a/spec/support/vcr_cassettes/check_in/btsss/claim_status/failed_claim_status_200.yml
+++ b/spec/support/vcr_cassettes/check_in/btsss/claim_status/failed_claim_status_200.yml
@@ -24,7 +24,7 @@ http_interactions:
               "aptSourceSystem": "test-apt-source",
               "aptSourceSystemId": "test-apt-system-id",
               "claimNum": "TC202207000011666",
-              "claimStatus": "appeal",
+              "claimStatus": "Appeal",
               "claimLastModDateTime": "2024-05-30T18:44:22.733Z",
               "facilityStationNum": "test-facility-station-num"
             }

--- a/spec/support/vcr_cassettes/check_in/btsss/claim_status/multiple_claim_status_200.yml
+++ b/spec/support/vcr_cassettes/check_in/btsss/claim_status/multiple_claim_status_200.yml
@@ -24,7 +24,7 @@ http_interactions:
               "aptSourceSystem": "test-apt-source",
               "aptSourceSystemId": "test-apt-system-id-2",
               "claimNum": "TC202207000011666",
-              "claimStatus": "approved for payment",
+              "claimStatus": "ApprovedForPayment",
               "claimLastModDateTime": "2024-05-30T18:44:22.733Z",
               "facilityStationNum": "test-facility-station-num-2"
             },
@@ -34,7 +34,7 @@ http_interactions:
               "aptSourceSystem": "test-apt-source-2",
               "aptSourceSystemId": "test-apt-system-id-2",
               "claimNum": "TC202207000011633",
-              "claimStatus": "approved for payment",
+              "claimStatus": "ApprovedForPayment",
               "claimLastModDateTime": "2024-05-30T18:44:22.733Z",
               "facilityStationNum": "test-facility-station-num-2"
             }

--- a/spec/support/vcr_cassettes/check_in/btsss/claim_status/non_matching_claim_status_200.yml
+++ b/spec/support/vcr_cassettes/check_in/btsss/claim_status/non_matching_claim_status_200.yml
@@ -24,7 +24,7 @@ http_interactions:
               "aptSourceSystem": "test-apt-source",
               "aptSourceSystemId": "test-apt-system-id",
               "claimNum": "TC202207000011666",
-              "claimStatus": "invalid",
+              "claimStatus": "Invalid",
               "claimLastModDateTime": "2024-05-30T18:44:22.733Z",
               "facilityStationNum": "test-facility-station-num"
             }


### PR DESCRIPTION
## Summary
The claim statuses we are getting back from BTSSS claim_status endpoint are in `UpperCamelCase` (or is it `PascalCase`) style. This PR updates our code to handle the statuses.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/85391

## Testing done
- [x] rspecs

## What areas of the site does it impact?
*check-in travel claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
