### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part 9

### DIFF
--- a/app/controllers/v0/gi_bill_feedbacks_controller.rb
+++ b/app/controllers/v0/gi_bill_feedbacks_controller.rb
@@ -21,11 +21,12 @@ module V0
 
       clear_saved_form(GIBillFeedback::FORM_ID)
 
-      render(json: gi_bill_feedback)
+      render json: GIBillFeedbackSerializer.new(gi_bill_feedback)
     end
 
     def show
-      render(json: GIBillFeedback.find(params[:id]))
+      gi_bill_feedback =  GIBillFeedback.find(params[:id])
+      render json: GIBillFeedbackSerializer.new(gi_bill_feedback)
     end
   end
 end

--- a/app/controllers/v0/gi_bill_feedbacks_controller.rb
+++ b/app/controllers/v0/gi_bill_feedbacks_controller.rb
@@ -25,7 +25,7 @@ module V0
     end
 
     def show
-      gi_bill_feedback =  GIBillFeedback.find(params[:id])
+      gi_bill_feedback = GIBillFeedback.find(params[:id])
       render json: GIBillFeedbackSerializer.new(gi_bill_feedback)
     end
   end

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -38,11 +38,16 @@ module V0
 
       clear_saved_form(FORM_ID)
 
-      render(json: result)
+      if result[:id]
+        render json: HealthCareApplicationSerializer.new(result)
+      else
+        render json: result
+      end
     end
 
     def show
-      render(json: HealthCareApplication.find(params[:id]))
+      application = HealthCareApplication.find(params[:id])
+      render json: HealthCareApplicationSerializer.new(application)
     end
 
     def enrollment_status

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -22,7 +22,8 @@ module V0
       service = BGS::Service.new(current_user)
       disability_rating = service.find_rating_data[:disability_rating_record][:service_connected_combined_degree]
 
-      render json: HCARatingInfoSerializer.new({ user_percent_of_disability: disability_rating })
+      hca_rating_info = { user_percent_of_disability: disability_rating }
+      render json: HCARatingInfoSerializer.new(hca_rating_info)
     end
 
     def create

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -21,12 +21,8 @@ module V0
     def rating_info
       service = BGS::Service.new(current_user)
       disability_rating = service.find_rating_data[:disability_rating_record][:service_connected_combined_degree]
-      render(
-        json: {
-          user_percent_of_disability: disability_rating
-        },
-        serializer: HCARatingInfoSerializer
-      )
+
+      render json: HCARatingInfoSerializer.new({user_percent_of_disability: disability_rating})
     end
 
     def create

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -22,7 +22,7 @@ module V0
       service = BGS::Service.new(current_user)
       disability_rating = service.find_rating_data[:disability_rating_record][:service_connected_combined_degree]
 
-      render json: HCARatingInfoSerializer.new({user_percent_of_disability: disability_rating})
+      render json: HCARatingInfoSerializer.new({ user_percent_of_disability: disability_rating })
     end
 
     def create

--- a/app/controllers/v0/intent_to_files_controller.rb
+++ b/app/controllers/v0/intent_to_files_controller.rb
@@ -38,14 +38,12 @@ module V0
       )
       type = params['itf_type'] || 'compensation'
       response = intent_to_file_provider.get_intent_to_file(type, nil, nil)
-      render json: response,
-             serializer: IntentToFileSerializer
+      render json: IntentToFileSerializer.new(response)
     end
 
     def active
       response = strategy.cache_or_service(@current_user.uuid, params[:type]) { service.get_active(params[:type]) }
-      render json: response,
-             serializer: IntentToFileSerializer
+      render json: IntentToFileSerializer.new(response)
     end
 
     def submit
@@ -58,8 +56,7 @@ module V0
       )
       type = params['itf_type'] || 'compensation'
       response = intent_to_file_provider.create_intent_to_file(type, nil, nil)
-      render json: response,
-             serializer: IntentToFileSerializer
+      render json: IntentToFileSerializer.new(response)
     end
 
     private

--- a/app/controllers/v0/letters_controller.rb
+++ b/app/controllers/v0/letters_controller.rb
@@ -30,8 +30,7 @@ module V0
 
     def beneficiary
       response = service.get_letter_beneficiary
-      render json: response,
-             serializer: LetterBeneficiarySerializer
+      render json: LetterBeneficiarySerializer.new(response)
     end
 
     private

--- a/app/controllers/v0/letters_controller.rb
+++ b/app/controllers/v0/letters_controller.rb
@@ -11,8 +11,7 @@ module V0
 
     def index
       response = service.get_letters
-      render json: response,
-             serializer: LettersSerializer
+      render json: LettersSerializer.new(response)
     end
 
     def download

--- a/app/serializers/gi_bill_feedback_serializer.rb
+++ b/app/serializers/gi_bill_feedback_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class GIBillFeedbackSerializer < ActiveModel::Serializer
-  attribute(:guid)
-  attribute(:state)
-  attribute(:parsed_response)
+class GIBillFeedbackSerializer
+  include JSONAPI::Serializer
+
+  attributes :guid, :state, :parsed_response
 end

--- a/app/serializers/hca_rating_info_serializer.rb
+++ b/app/serializers/hca_rating_info_serializer.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-class HCARatingInfoSerializer < ActiveModel::Serializer
-  attribute :user_percent_of_disability
+class HCARatingInfoSerializer
+  include JSONAPI::Serializer
 
-  def user_percent_of_disability
+  set_id { '' }
+
+  attribute :user_percent_of_disability do |object|
     object[:user_percent_of_disability].to_i
-  end
-
-  def id
-    nil
   end
 end

--- a/app/serializers/health_care_application_serializer.rb
+++ b/app/serializers/health_care_application_serializer.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
-class HealthCareApplicationSerializer < ActiveModel::Serializer
-  attributes :id, :state, :form_submission_id, :timestamp
+class HealthCareApplicationSerializer
+  include JSONAPI::Serializer
+
+  set_type :health_care_applications
+
+  attributes :state, :form_submission_id, :timestamp
 end

--- a/app/serializers/intent_to_file_serializer.rb
+++ b/app/serializers/intent_to_file_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class IntentToFileSerializer < ActiveModel::Serializer
-  attribute :intent_to_file
+class IntentToFileSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+
+  attribute :intent_to_file
 end

--- a/app/serializers/letter_beneficiary_serializer.rb
+++ b/app/serializers/letter_beneficiary_serializer.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-class LetterBeneficiarySerializer < ActiveModel::Serializer
+class LetterBeneficiarySerializer
+  include JSONAPI::Serializer
+
+  set_id { '' }
   attribute :benefit_information
   attribute :military_service
-
-  def id
-    nil
-  end
 end

--- a/app/serializers/letters_serializer.rb
+++ b/app/serializers/letters_serializer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-class LettersSerializer < ActiveModel::Serializer
+class LettersSerializer
+  include JSONAPI::Serializer
+
+  set_id { '' }
+
   attribute :letters
   attribute :full_name
-
-  def id
-    nil
-  end
 end

--- a/spec/serializers/health_care_application_serializer_spec.rb
+++ b/spec/serializers/health_care_application_serializer_spec.rb
@@ -13,6 +13,10 @@ describe HealthCareApplicationSerializer, type: :serializer do
     expect(data['id']).to eq application.id.to_s
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq 'health_care_applications'
+  end
+
   it 'includes :state' do
     expect(attributes['state']).to eq application.state
   end


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- GIBillFeedbackSerializer
- HCARatingInfoSerializer
- HealthCareApplicationSerializer
- IntentToFileSerializer
- LetterBeneficiarySerializer
- LetterSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage