### PR TITLE
[86453] always puts message to stdout

### DIFF
--- a/rakelib/prod/user_credential.rake
+++ b/rakelib/prod/user_credential.rake
@@ -61,11 +61,8 @@ namespace :user_credential do
   end
 
   def log_message(level:, message:)
-    if Rails.env.production?
-      `echo "#{datadog_log(level:, message:).to_json.dump}" >> /proc/1/fd/1`
-    else
-      puts message
-    end
+    `echo "#{datadog_log(level:, message:).to_json.dump}" >> /proc/1/fd/1` if Rails.env.production?
+    puts message
   end
 
   def datadog_log(level:, message:)


### PR DESCRIPTION
## Summary

- Updates logging method to also print to console in production; this makes manual updating of the user_credential lock sheet easier

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86453

## Testing done

- no functional changes