### PR TITLE
[65692] removes inherited_proof_verified_user_accounts

### DIFF
--- a/db/migrate/20240722144512_remove_inherited_proof_verified_user_accounts.rb
+++ b/db/migrate/20240722144512_remove_inherited_proof_verified_user_accounts.rb
@@ -1,0 +1,19 @@
+class RemoveInheritedProofVerifiedUserAccounts < ActiveRecord::Migration[7.1]
+  def up
+    if index_exists?(:inherited_proof_verified_user_accounts, :user_account_id)
+      remove_index :inherited_proof_verified_user_accounts, :user_account_id, name: 'index_inherited_proof_verified_user_accounts_on_user_account_id'
+    end
+    drop_table :inherited_proof_verified_user_accounts
+  end
+
+  def down
+    create_table :inherited_proof_verified_user_accounts do |t|
+      t.uuid :user_account_id, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+    end
+
+    add_index :inherited_proof_verified_user_accounts, :user_account_id, name: 'index_inherited_proof_verified_user_accounts_on_user_account_id', unique: true
+    add_foreign_key :inherited_proof_verified_user_accounts, :user_accounts, column: :user_account_id
+  end
+end

--- a/db/migrate/20240722144512_remove_inherited_proof_verified_user_accounts.rb
+++ b/db/migrate/20240722144512_remove_inherited_proof_verified_user_accounts.rb
@@ -1,8 +1,6 @@
 class RemoveInheritedProofVerifiedUserAccounts < ActiveRecord::Migration[7.1]
   def up
-    if index_exists?(:inherited_proof_verified_user_accounts, :user_account_id)
-      remove_index :inherited_proof_verified_user_accounts, :user_account_id, name: 'index_inherited_proof_verified_user_accounts_on_user_account_id'
-    end
+    remove_index :inherited_proof_verified_user_accounts, :user_account_id if index_exists?(:inherited_proof_verified_user_accounts, :user_account_id)
     drop_table :inherited_proof_verified_user_accounts
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -838,13 +838,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_183559) do
     t.index ["user_uuid"], name: "index_in_progress_forms_on_user_uuid"
   end
 
-  create_table "inherited_proof_verified_user_accounts", force: :cascade do |t|
-    t.uuid "user_account_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_account_id"], name: "index_inherited_proof_verified_user_accounts_on_user_account_id", unique: true
-  end
-
   create_table "intent_to_file_queue_exhaustions", force: :cascade do |t|
     t.string "veteran_icn", null: false
     t.string "form_type"
@@ -1601,7 +1594,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_183559) do
   add_foreign_key "form_submissions", "user_accounts"
   add_foreign_key "health_quest_questionnaire_responses", "user_accounts"
   add_foreign_key "in_progress_forms", "user_accounts"
-  add_foreign_key "inherited_proof_verified_user_accounts", "user_accounts"
   add_foreign_key "lighthouse526_document_uploads", "form526_submissions"
   add_foreign_key "lighthouse526_document_uploads", "form_attachments"
   add_foreign_key "mhv_opt_in_flags", "user_accounts"


### PR DESCRIPTION
## Summary

- removes `inherited_proof_verified_user_accounts` table & associations
- Inherited Proofing functionality removed in https://github.com/department-of-veterans-affairs/vets-api/pull/17417

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/65692

## Testing done

- no changes, table is no longer used
- authentication performed