### PR TITLE
Api 38042 validation direct deposit

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -3789,9 +3789,9 @@
                                 },
                                 "accountNumber": {
                                   "description": "Account number for the direct deposit.",
-                                  "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                  "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                   "type": "string",
-                                  "maxLength": 14,
+                                  "maxLength": 1000,
                                   "nullable": true,
                                   "example": "123123123123"
                                 },
@@ -3807,7 +3807,7 @@
                                 },
                                 "financialInstitutionName": {
                                   "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                  "maxLength": 35,
+                                  "maxLength": 1000,
                                   "type": "string",
                                   "nullable": true,
                                   "example": "Some Bank"
@@ -3815,8 +3815,9 @@
                                 "routingNumber": {
                                   "description": "Routing number for the direct deposit.",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "nullable": true,
-                                  "pattern": "^(?:\\d{9})?$",
+                                  "pattern": "^$|^\\d{0,1000}$",
                                   "example": "123123123"
                                 }
                               }
@@ -5140,9 +5141,9 @@
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                 "type": "string",
-                                "maxLength": 14,
+                                "maxLength": 1000,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
@@ -5158,7 +5159,7 @@
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                "maxLength": 35,
+                                "maxLength": 1000,
                                 "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
@@ -5166,8 +5167,9 @@
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "nullable": true,
-                                "pattern": "^(?:\\d{9})?$",
+                                "pattern": "^$|^\\d{0,1000}$",
                                 "example": "123123123"
                               }
                             }
@@ -5702,7 +5704,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "79150c60-0eaa-4b13-95a1-4653f3396b43",
+                    "id": "e8d9092e-20fd-4c8e-9c3b-13964eac7379",
                     "type": "forms/526",
                     "attributes": {
                       "claimId": "600442191",
@@ -5885,7 +5887,7 @@
                         },
                         "federalActivation": {
                           "activationDate": "2023-10-01",
-                          "anticipatedSeparationDate": "2024-07-17"
+                          "anticipatedSeparationDate": "2024-07-24"
                         },
                         "confinements": [
                           {
@@ -7024,9 +7026,9 @@
                                 },
                                 "accountNumber": {
                                   "description": "Account number for the direct deposit.",
-                                  "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                  "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                   "type": "string",
-                                  "maxLength": 14,
+                                  "maxLength": 1000,
                                   "nullable": true,
                                   "example": "123123123123"
                                 },
@@ -7042,7 +7044,7 @@
                                 },
                                 "financialInstitutionName": {
                                   "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                  "maxLength": 35,
+                                  "maxLength": 1000,
                                   "type": "string",
                                   "nullable": true,
                                   "example": "Some Bank"
@@ -7050,8 +7052,9 @@
                                 "routingNumber": {
                                   "description": "Routing number for the direct deposit.",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "nullable": true,
-                                  "pattern": "^(?:\\d{9})?$",
+                                  "pattern": "^$|^\\d{0,1000}$",
                                   "example": "123123123"
                                 }
                               }
@@ -8375,9 +8378,9 @@
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                 "type": "string",
-                                "maxLength": 14,
+                                "maxLength": 1000,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
@@ -8393,7 +8396,7 @@
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                "maxLength": 35,
+                                "maxLength": 1000,
                                 "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
@@ -8401,8 +8404,9 @@
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "nullable": true,
-                                "pattern": "^(?:\\d{9})?$",
+                                "pattern": "^$|^\\d{0,1000}$",
                                 "example": "123123123"
                               }
                             }
@@ -10269,9 +10273,9 @@
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                 "type": "string",
-                                "maxLength": 14,
+                                "maxLength": 1000,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
@@ -10287,7 +10291,7 @@
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                "maxLength": 35,
+                                "maxLength": 1000,
                                 "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
@@ -10295,8 +10299,9 @@
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "nullable": true,
-                                "pattern": "^(?:\\d{9})?$",
+                                "pattern": "^$|^\\d{0,1000}$",
                                 "example": "123123123"
                               }
                             }
@@ -10580,7 +10585,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "3cb33906-2a37-4c22-a73a-8553fec74fe4",
+                    "id": "d3e22ffc-01ef-4519-b019-f3b86367202b",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -13455,8 +13460,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-07-15",
-                      "expirationDate": "2025-07-15",
+                      "creationDate": "2024-07-22",
+                      "expirationDate": "2025-07-22",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -14332,7 +14337,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "722216eb-4991-42ac-9059-cc5a8aa85a8b",
+                    "id": "b756ca5a-c99a-4111-9aee-e017e344c053",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -15025,7 +15030,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "42954b3c-7aad-4d1c-9a54-c793b03d6a29",
+                    "id": "90d2e000-f7a1-4c14-9849-009ad6b80584",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -16976,10 +16981,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "10044dd9-11b6-4c21-9ac4-b15f54393731",
+                    "id": "9cd947f4-6ab3-4f35-96da-b808036b7a90",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "dateRequestAccepted": "2024-07-15",
+                      "dateRequestAccepted": "2024-07-22",
                       "previousPoa": null,
                       "representative": {
                         "serviceOrganization": {

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -2402,9 +2402,9 @@
                                 },
                                 "accountNumber": {
                                   "description": "Account number for the direct deposit.",
-                                  "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                  "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                   "type": "string",
-                                  "maxLength": 14,
+                                  "maxLength": 1000,
                                   "nullable": true,
                                   "example": "123123123123"
                                 },
@@ -2420,7 +2420,7 @@
                                 },
                                 "financialInstitutionName": {
                                   "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                  "maxLength": 35,
+                                  "maxLength": 1000,
                                   "type": "string",
                                   "nullable": true,
                                   "example": "Some Bank"
@@ -2428,8 +2428,9 @@
                                 "routingNumber": {
                                   "description": "Routing number for the direct deposit.",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "nullable": true,
-                                  "pattern": "^(?:\\d{9})?$",
+                                  "pattern": "^$|^\\d{0,1000}$",
                                   "example": "123123123"
                                 }
                               }
@@ -3753,9 +3754,9 @@
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                 "type": "string",
-                                "maxLength": 14,
+                                "maxLength": 1000,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
@@ -3771,7 +3772,7 @@
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                "maxLength": 35,
+                                "maxLength": 1000,
                                 "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
@@ -3779,8 +3780,9 @@
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "nullable": true,
-                                "pattern": "^(?:\\d{9})?$",
+                                "pattern": "^$|^\\d{0,1000}$",
                                 "example": "123123123"
                               }
                             }
@@ -4315,7 +4317,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "be0b5388-a8c3-4db0-9b6d-d343a52fcb03",
+                    "id": "72ef0a7f-2659-474b-99fb-e948b5c461fe",
                     "type": "forms/526",
                     "attributes": {
                       "claimId": "600442191",
@@ -4498,7 +4500,7 @@
                         },
                         "federalActivation": {
                           "activationDate": "2023-10-01",
-                          "anticipatedSeparationDate": "2024-07-17"
+                          "anticipatedSeparationDate": "2024-07-24"
                         },
                         "confinements": [
                           {
@@ -5637,9 +5639,9 @@
                                 },
                                 "accountNumber": {
                                   "description": "Account number for the direct deposit.",
-                                  "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                  "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                   "type": "string",
-                                  "maxLength": 14,
+                                  "maxLength": 1000,
                                   "nullable": true,
                                   "example": "123123123123"
                                 },
@@ -5655,7 +5657,7 @@
                                 },
                                 "financialInstitutionName": {
                                   "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                  "maxLength": 35,
+                                  "maxLength": 1000,
                                   "type": "string",
                                   "nullable": true,
                                   "example": "Some Bank"
@@ -5663,8 +5665,9 @@
                                 "routingNumber": {
                                   "description": "Routing number for the direct deposit.",
                                   "type": "string",
+                                  "maxLength": 1000,
                                   "nullable": true,
-                                  "pattern": "^(?:\\d{9})?$",
+                                  "pattern": "^$|^\\d{0,1000}$",
                                   "example": "123123123"
                                 }
                               }
@@ -6988,9 +6991,9 @@
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                 "type": "string",
-                                "maxLength": 14,
+                                "maxLength": 1000,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
@@ -7006,7 +7009,7 @@
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                "maxLength": 35,
+                                "maxLength": 1000,
                                 "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
@@ -7014,8 +7017,9 @@
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "nullable": true,
-                                "pattern": "^(?:\\d{9})?$",
+                                "pattern": "^$|^\\d{0,1000}$",
                                 "example": "123123123"
                               }
                             }
@@ -8882,9 +8886,9 @@
                               },
                               "accountNumber": {
                                 "description": "Account number for the direct deposit.",
-                                "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+                                "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
                                 "type": "string",
-                                "maxLength": 14,
+                                "maxLength": 1000,
                                 "nullable": true,
                                 "example": "123123123123"
                               },
@@ -8900,7 +8904,7 @@
                               },
                               "financialInstitutionName": {
                                 "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-                                "maxLength": 35,
+                                "maxLength": 1000,
                                 "type": "string",
                                 "nullable": true,
                                 "example": "Some Bank"
@@ -8908,8 +8912,9 @@
                               "routingNumber": {
                                 "description": "Routing number for the direct deposit.",
                                 "type": "string",
+                                "maxLength": 1000,
                                 "nullable": true,
-                                "pattern": "^(?:\\d{9})?$",
+                                "pattern": "^$|^\\d{0,1000}$",
                                 "example": "123123123"
                               }
                             }
@@ -9193,7 +9198,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "325dd8b8-ae7a-469d-a0e9-66887dd5ec24",
+                    "id": "df6c72f7-2298-400d-9f81-87a1babbb38e",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -12068,8 +12073,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-07-15",
-                      "expirationDate": "2025-07-15",
+                      "creationDate": "2024-07-22",
+                      "expirationDate": "2025-07-22",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -12945,7 +12950,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "6ae7a4b3-2846-4a8d-ba20-13cfecf951cc",
+                    "id": "e37f6e2e-b23a-4b80-ab03-90ca959ba722",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -13638,7 +13643,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "ac0a296b-c1ee-4f20-8fa1-f02305aa0bff",
+                    "id": "c5b10341-5b5d-4b8d-8c3c-5ac5f7213d53",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -15589,10 +15594,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "2481cfc2-318d-4f1a-9b84-6768f6037604",
+                    "id": "91e1b40f-a365-4a21-8747-0654ceaafd3c",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "dateRequestAccepted": "2024-07-15",
+                      "dateRequestAccepted": "2024-07-22",
                       "previousPoa": null,
                       "representative": {
                         "serviceOrganization": {

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -1036,7 +1036,7 @@
           "type": ["string", "null"],
           "maxLength": 1000,
           "nullable": true,
-          "pattern": "^[0-9]+$",
+          "pattern": "^$|^\\d{0,1000}$",
           "example": "123123123"
         }
       }

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -1011,9 +1011,9 @@
         },
         "accountNumber": {
           "description": "Account number for the direct deposit.",
-          "pattern": "^(?:[a-zA-Z0-9]{4,17})?$",
+          "pattern": "^(?:[a-zA-Z0-9-]{4,1000})?$",
           "type": ["string", "null"],
-          "maxLength": 14,
+          "maxLength": 1000,
           "nullable": true,
           "example": "123123123123"
         },
@@ -1026,7 +1026,7 @@
         },
         "financialInstitutionName": {
           "description": "Provide the name of the financial institution where the Veteran wants the direct deposit.",
-          "maxLength": 35,
+          "maxLength": 1000,
           "type": ["string", "null"],
           "nullable": true,
           "example": "Some Bank"
@@ -1034,8 +1034,9 @@
         "routingNumber": {
           "description": "Routing number for the direct deposit.",
           "type": ["string", "null"],
+          "maxLength": 1000,
           "nullable": true,
-          "pattern": "^(?:\\d{9})?$",
+          "pattern": "^[0-9]+$",
           "example": "123123123"
         }
       }

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -4130,7 +4130,7 @@ RSpec.describe 'Disability Claims', type: :request do
             {
               accountType: 'CHECKING',
               accountNumber: '123123123123',
-              routingNumber: '1234567891011121314',
+              routingNumber: '12345678-1011121314',
               financialInstitutionName: 'Global Bank',
               noAccount: false
             }
@@ -4143,6 +4143,28 @@ RSpec.describe 'Disability Claims', type: :request do
               data = json.to_json
               post submit_path, params: data, headers: auth_header
               expect(response).to have_http_status(:unprocessable_entity)
+            end
+          end
+        end
+
+        context 'when direct deposit information includes a long account number and financial institution name' do
+          let(:direct_deposit) do
+            {
+              accountType: 'CHECKING',
+              accountNumber: '123123123123888888-888888',
+              routingNumber: '123123123',
+              financialInstitutionName: 'Long financial institution name example test longer than 35 characters',
+              noAccount: false
+            }
+          end
+
+          it 'returns a 422' do
+            mock_ccg(scopes) do |auth_header|
+              json = JSON.parse data
+              json['data']['attributes']['directDeposit'] = direct_deposit
+              data = json.to_json
+              post submit_path, params: data, headers: auth_header
+              expect(response).to have_http_status(:accepted)
             end
           end
         end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Implements changes to the 526 schema related to direct deposit information.
- accoutNumber field updated to allow 1000 characters max, allowing digits and dashes.
- routingNumber field updated to allow 1000 characters max, allowing only digits.
- financialInstitutionName field updated to allow 1000 characters max. 



## Related issue(s)

[API-38042](https://jira.devops.va.gov/browse/API-38042)

## Testing done

- [x] *New code is covered by unit tests*
- Previous validation errored on dashes in accountNumber field, length greater than 14
- Previous validation errored on routingNumber greater than 9 characters.
- Previous validation errored on financialInstitutionName greater than 35 characters.


## What areas of the site does it impact?
526 validation for the following endpoints:
POST /veterans/{veteranId}/526/validate
POST /veterans/{veteranId}/526
POST /veterans/{veteranId}/526/synchronous
POST /veterans/{veteranId}/526/generatePDF/minimum-validations

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

