### PR TITLE
Enrollment verification updates

### DIFF
--- a/modules/vye/app/models/concerns/vye/needs_enrollment_verification.rb
+++ b/modules/vye/app/models/concerns/vye/needs_enrollment_verification.rb
@@ -152,7 +152,7 @@ module Vye
       return if @award.award_end_date.blank?
       return if are_dates_the_same(@award.award_end_date, date_last_certified)
       return unless current_rec_ended?
-      return unless ldpm_before_aed?
+      return unless ldpm_before_aed? && are_dates_the_same(@award.award_begin_date, @award.award_end_date)
 
       @supress_future_award = true
 
@@ -175,7 +175,7 @@ module Vye
       return if @award.award_end_date.blank?
       return if are_dates_the_same(@award.award_end_date, date_last_certified)
       return unless current_rec_ended?
-      return if ldpm_before_aed?
+      return if ldpm_before_aed? && are_dates_the_same(@award.award_begin_date, @award.award_end_date)
 
       push_enrollment(
         award_id: @award.id,

--- a/modules/vye/app/models/concerns/vye/needs_enrollment_verification.rb
+++ b/modules/vye/app/models/concerns/vye/needs_enrollment_verification.rb
@@ -11,10 +11,18 @@ module Vye
         @award = award
 
         eval_case_eom
-        flag_open_cert || eval_case1a || eval_case1b || eval_case2 || eval_case3
-        eval_case4 || eval_case5
-        eval_case6 || eval_case7 || eval_case8
-        eval_case9
+
+        next if flag_open_cert
+        next if eval_case1a
+        next if eval_case1b
+        next if eval_case2
+        next if eval_case3
+        next if eval_case4
+        next if eval_case5
+        next if eval_case6
+        next if eval_case7
+        next if eval_case8
+        next if eval_case9
       end
 
       @enrollments
@@ -31,42 +39,44 @@ module Vye
       today.beginning_of_month - 1.day
     end
 
-    def current_rec_ended
-      @award.award_ind_current? && (@award.award_end_date < today)
+    def aed_minus1
+      return nil if @award.award_end_date.blank?
+
+      @award.award_end_date - 1.day
+    end
+
+    def current_rec_ended?
+      @award.award_ind_current? && aed_before_today?
     end
 
     def are_dates_the_same(date1, date2)
+      return false if date1.blank? && date2.blank?
+
       date1 == date2
     end
 
     # date_last_certified is before award_begin_date
-    def dlc_before_abd?
-      date_last_certified < @award.award_begin_date
-    end
+    def dlc_before_abd? = in_order?(first: date_last_certified, second: @award.award_begin_date)
 
     # date_last_certified is before last day of previous month
-    def dlc_before_ldpm?
-      date_last_certified < last_day_of_previous_month
-    end
+    def dlc_before_ldpm? = in_order?(first: date_last_certified, second: last_day_of_previous_month)
 
     # last day of previous month is before award_begin_date
-    def ldpm_before_abd?
-      last_day_of_previous_month < @award.award_begin_date
-    end
+    def ldpm_before_abd? = in_order?(first: last_day_of_previous_month, second: @award.award_begin_date)
 
     # last day of previous month is before award_end_date
-    def ldpm_before_aed?
-      last_day_of_previous_month < @award.award_end_date
-    end
+    def ldpm_before_aed? = in_order?(first: last_day_of_previous_month, second: @award.award_end_date)
 
     # award_begin_date is before today
-    def abd_before_today?
-      @award.award_begin_date < today
-    end
+    def abd_before_today? = in_order?(first: @award.award_begin_date, second: today)
 
     # award_end_date is before today
-    def aed_before_today?
-      @award.award_end_date < today
+    def aed_before_today? = in_order?(first: @award.award_end_date, second: today)
+
+    def in_order?(first:, second:)
+      return false if first.blank? || second.blank?
+
+      first < second
     end
 
     def last_day_of_month?
@@ -99,25 +109,31 @@ module Vye
     end
 
     def eval_case_eom
-      return unless dlc_before_ldpm?
       return unless last_day_of_month?
-      return unless abd_before_today?
-      return if aed_before_today?
-      return unless dlc_before_abd?
+      return unless abd_before_today? && !aed_before_today?
+
+      act_begin =
+        if dlc_before_abd? && dlc_before_ldpm?
+          @award.award_begin_date
+        else
+          date_last_certified
+        end
 
       push_enrollment(
         award_id: @award.id,
-        act_begin: @award.award_begin_date,
+        act_begin:,
         act_end: today,
         number_hours: @award.number_hours,
         monthly_rate: @award.monthly_rate,
         payment_date: @award.payment_date,
         trace: :case_eom
       )
+
+      true
     end
 
     def flag_open_cert
-      return unless dlc_before_ldpm?
+      return unless dlc_before_ldpm? || date_last_certified.blank?
       return unless @award.award_ind_current?
       return if @award.award_end_date.present?
 
@@ -126,16 +142,17 @@ module Vye
       @open_cert_credit_hours = @award.number_hours
       @open_cert_monthly_rate = @award.monthly_rate
       @open_cert_payment_date = @award.payment_date
+
+      true
     end
 
     def eval_case1a
-      return unless dlc_before_ldpm?
+      return unless dlc_before_ldpm? || date_last_certified.blank?
       return unless @award.award_ind_current?
       return if @award.award_end_date.blank?
       return if are_dates_the_same(@award.award_end_date, date_last_certified)
-      return unless current_rec_ended
+      return unless current_rec_ended?
       return unless ldpm_before_aed?
-      return unless are_dates_the_same(@award.award_begin_date, @award.award_end_date)
 
       @supress_future_award = true
 
@@ -148,33 +165,38 @@ module Vye
         payment_date: @award.payment_date,
         trace: :case1a
       )
+
+      true
     end
 
     def eval_case1b
-      return unless dlc_before_ldpm?
+      return unless dlc_before_ldpm? || date_last_certified.blank?
       return unless @award.award_ind_current?
       return if @award.award_end_date.blank?
       return if are_dates_the_same(@award.award_end_date, date_last_certified)
-      return unless current_rec_ended
+      return unless current_rec_ended?
+      return if ldpm_before_aed?
 
       push_enrollment(
         award_id: @award.id,
         act_begin: date_last_certified,
-        act_end: @award.award_end_date - 1.day,
+        act_end: aed_minus1,
         number_hours: @award.number_hours,
         monthly_rate: @award.monthly_rate,
         payment_date: @award.payment_date,
         trace: :case1b
       )
+
+      true
     end
 
     def eval_case2
-      return unless dlc_before_ldpm?
+      return unless dlc_before_ldpm? || date_last_certified.blank?
       return unless @award.award_ind_current?
       return if @award.award_end_date.blank?
       return if are_dates_the_same(@award.award_end_date, date_last_certified)
-      return unless ldpm_before_aed?
-      return if ldpm_before_abd?
+      return if current_rec_ended?
+      return unless ldpm_before_aed? && !ldpm_before_abd?
 
       push_enrollment(
         award_id: @award.id,
@@ -185,29 +207,34 @@ module Vye
         payment_date: @award.payment_date,
         trace: :case2
       )
+
+      true
     end
 
     def eval_case3
-      return unless dlc_before_ldpm?
+      return unless dlc_before_ldpm? || date_last_certified.blank?
       return unless @award.award_ind_current?
       return if @award.award_end_date.blank?
       return if are_dates_the_same(@award.award_end_date, date_last_certified)
+      return if current_rec_ended?
+      return if ldpm_before_aed? && !ldpm_before_abd?
 
       push_enrollment(
         award_id: @award.id,
         act_begin: date_last_certified,
-        act_end: @award.award_end_date - 1.day,
+        act_end: aed_minus1,
         number_hours: @award.number_hours,
         monthly_rate: @award.monthly_rate,
         payment_date: @award.payment_date,
         trace: :case3
       )
+
+      true
     end
 
     def eval_case4
-      return unless dlc_before_ldpm?
-      return unless @award.award_ind_future?
-      return if @supress_future_award
+      return unless dlc_before_ldpm? || date_last_certified.blank?
+      return unless @award.award_ind_future? && !@supress_future_award
       return unless @open_cert
       return unless ldpm_before_abd?
 
@@ -216,7 +243,7 @@ module Vye
         act_begin: date_last_certified,
         act_end: last_day_of_previous_month,
         number_hours: @open_cert_credit_hours,
-        monthly_rate: @award.monthly_rate,
+        monthly_rate: @open_cert_monthly_rate,
         payment_date: @open_cert_payment_date,
         trace: :case4
       )
@@ -226,19 +253,18 @@ module Vye
     end
 
     def eval_case5
-      return unless dlc_before_ldpm?
-      return unless @award.award_ind_future?
-      return if @supress_future_award
+      return unless dlc_before_ldpm? || date_last_certified.blank?
+      return unless @award.award_ind_future? && !@supress_future_award
       return unless @open_cert
-      return unless ldpm_before_aed?
       return if ldpm_before_abd?
+      return unless ldpm_before_aed?
 
       push_enrollment(
         award_id: @open_cert_award_id,
         act_begin: date_last_certified,
-        act_end: @award.award_end_date - 1.day,
+        act_end: aed_minus1,
         number_hours: @open_cert_credit_hours,
-        monthly_rate: @award.monthly_rate,
+        monthly_rate: @open_cert_monthly_rate,
         payment_date: @open_cert_payment_date,
         trace: :case5
       )
@@ -248,9 +274,9 @@ module Vye
     end
 
     def eval_case6
-      return unless dlc_before_ldpm?
-      return unless @award.award_ind_future?
-      return if @supress_future_award
+      return unless dlc_before_ldpm? || date_last_certified.blank?
+      return unless @award.award_ind_future? && !@supress_future_award
+      return if @open_cert
       return if ldpm_before_abd?
       return if date_last_certified.present?
 
@@ -263,13 +289,16 @@ module Vye
         payment_date: @award.payment_date,
         trace: :case6
       )
+
+      true
     end
 
     def eval_case7
-      return unless dlc_before_ldpm?
-      return unless @award.award_ind_future?
-      return if @supress_future_award
+      return unless dlc_before_ldpm? || date_last_certified.blank?
+      return unless @award.award_ind_future? && !@supress_future_award
+      return if @open_cert
       return if ldpm_before_abd?
+      return if date_last_certified.blank?
       return unless ldpm_before_aed?
 
       push_enrollment(
@@ -281,18 +310,22 @@ module Vye
         payment_date: @award.payment_date,
         trace: :case7
       )
+
+      true
     end
 
     def eval_case8
-      return unless dlc_before_ldpm?
-      return unless @award.award_ind_future?
-      return if @supress_future_award
+      return unless dlc_before_ldpm? || date_last_certified.blank?
+      return unless @award.award_ind_future? && !@supress_future_award
+      return if @open_cert
       return if ldpm_before_abd?
+      return if date_last_certified.blank?
+      return if ldpm_before_aed?
 
       push_enrollment(
         award_id: @award.id,
         act_begin: @award.award_begin_date,
-        act_end: @award.award_end_date - 1.day,
+        act_end: aed_minus1,
         number_hours: @award.number_hours,
         monthly_rate: @award.monthly_rate,
         payment_date: @award.payment_date,
@@ -303,14 +336,14 @@ module Vye
     end
 
     def eval_case9
-      return if dlc_before_ldpm?
+      return if dlc_before_ldpm? || date_last_certified.blank?
       return unless aed_before_today?
-      return unless are_dates_the_same(@award.award_begin_date, @award.award_end_date)
+      return if are_dates_the_same(@award.award_begin_date, @award.award_end_date)
 
       push_enrollment(
         award_id: @award.id,
         act_begin: date_last_certified,
-        act_end: @award.award_end_date - 1.day,
+        act_end: aed_minus1,
         number_hours: @award.number_hours,
         monthly_rate: @award.monthly_rate,
         payment_date: @award.payment_date,

--- a/modules/vye/app/models/vye/user_info.rb
+++ b/modules/vye/app/models/vye/user_info.rb
@@ -26,8 +26,7 @@ module Vye
     serialize :dob, coder: DateAttributeSerializer
 
     validates(
-      :date_last_certified, :fac_code, :indicator,
-      :mr_status, :rem_ent, :rpo_code, :stub_nm,
+      :fac_code, :indicator, :mr_status, :rem_ent, :rpo_code, :stub_nm,
       presence: true
     )
 

--- a/modules/vye/spec/models/vye/user_info_spec.rb
+++ b/modules/vye/spec/models/vye/user_info_spec.rb
@@ -43,5 +43,279 @@ RSpec.describe Vye::UserInfo, type: :model do
         expect(pending_verifications.first.trace).to eq('case_eom')
       end
     end
+
+    describe 'case 1a' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-05-15') }
+      let(:cur_award_ind) { Vye::Award.cur_award_inds[:current] }
+      let(:award_begin_date) { Date.parse('2024-07-01') }
+      let(:award_end_date) { Date.parse('2024-07-01') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) { FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:) }
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case1a')
+      end
+    end
+
+    describe 'case 1b' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-05-15') }
+      let(:cur_award_ind) { Vye::Award.cur_award_inds[:current] }
+      let(:award_begin_date) { Date.parse('2024-06-01') }
+      let(:award_end_date) { Date.parse('2024-06-29') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) { FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:) }
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case1b')
+      end
+    end
+
+    describe 'case 2' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-05-15') }
+      let(:cur_award_ind) { Vye::Award.cur_award_inds[:current] }
+      let(:award_begin_date) { Date.parse('2024-06-01') }
+      let(:award_end_date) { Date.parse('2024-07-20') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) { FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:) }
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case2')
+      end
+    end
+
+    describe 'case 3' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-05-15') }
+      let(:cur_award_ind) { Vye::Award.cur_award_inds[:current] }
+      let(:award_begin_date) { Date.parse('2024-07-01') }
+      let(:award_end_date) { Date.parse('2024-07-20') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) { FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:) }
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case3')
+      end
+    end
+
+    describe 'case 4' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-04-15') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award1) do
+        cur_award_ind = Vye::Award.cur_award_inds[:current]
+        award_begin_date = Date.parse('2024-05-01')
+        award_end_date = nil
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+      let!(:award2) do
+        cur_award_ind = Vye::Award.cur_award_inds[:future]
+        award_begin_date = Date.parse('2024-07-01')
+        award_end_date = Date.parse('2024-07-31')
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case4')
+      end
+    end
+
+    describe 'case 5' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-05-15') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award1) do
+        cur_award_ind = Vye::Award.cur_award_inds[:current]
+        award_begin_date = Date.parse('2024-05-01')
+        award_end_date = nil
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+      let!(:award2) do
+        cur_award_ind = Vye::Award.cur_award_inds[:future]
+        award_begin_date = Date.parse('2024-06-01')
+        award_end_date = Date.parse('2024-08-01')
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.find { |v| v.award_id = award2.id }.trace).to eq('case5')
+      end
+    end
+
+    describe 'case 6' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { nil }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) do
+        cur_award_ind = Vye::Award.cur_award_inds[:future]
+        award_begin_date = Date.parse('2024-06-01')
+        award_end_date = Date.parse('2024-07-15')
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case6')
+      end
+    end
+
+    describe 'case 7' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-05-15') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) do
+        cur_award_ind = Vye::Award.cur_award_inds[:future]
+        award_begin_date = Date.parse('2024-06-01')
+        award_end_date = Date.parse('2024-07-15')
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case7')
+      end
+    end
+
+    describe 'case 8' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-05-15') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) do
+        cur_award_ind = Vye::Award.cur_award_inds[:future]
+        award_begin_date = Date.parse('2024-05-01')
+        award_end_date = Date.parse('2024-06-30')
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case8')
+      end
+    end
+
+    describe 'case 9' do
+      let(:now) { Time.parse('2024-07-19T12:00:00-00:00') }
+      let(:date_last_certified) { Date.parse('2024-06-30') }
+      let!(:user_info) { FactoryBot.create(:vye_user_info, date_last_certified:) }
+      let!(:award) do
+        cur_award_ind = Vye::Award.cur_award_inds[:future]
+        award_begin_date = Date.parse('2024-07-01')
+        award_end_date = Date.parse('2024-07-18')
+        FactoryBot.create(:vye_award, user_info:, award_begin_date:, award_end_date:, cur_award_ind:)
+      end
+
+      before do
+        Timecop.travel(now)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'shows an enrollment' do
+        pending_verifications = user_info.pending_verifications
+
+        expect(pending_verifications.length).to eq(1)
+        expect(pending_verifications.first.trace).to eq('case9')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Updated enrollment verification logic to account for nils we are seeing in prod. The Enrollment Logic handles determining when an enrollment period is ready to be verified by the veteran. The data supplied is run through each of the 11 different cases until one is satisfied and is returned as a period that is ready for verification. If none of the cases are satisfied, then the enrollment period is not ready to be verified. 

## Testing
- Testing has been handled on local machine manually and with the creation of RSpec tests.
- Award end Date can be NIL and the previous code did not handle for NIL. 
- This code has been tested on local machine and now handles NIL values within the enrollment logic. 
- Peer review of this code was completed as well by walking through each case with another developer to ensure each case is correct based on legacy code written in Java. 

## Screenshots
### Test CASE EOM
![image](https://github.com/user-attachments/assets/16031f12-676f-4c9e-9ce4-1ffbbd425ad5)

### Test CASE  1A
![image](https://github.com/user-attachments/assets/7d8c6610-140d-4ae7-a698-db272d85b814)

### Test CASE 1B
![image](https://github.com/user-attachments/assets/ed34bffd-96b5-42a9-8829-c57412480ab5)

### Test CASE 2
![image](https://github.com/user-attachments/assets/9a8a600c-0e2a-4673-8058-bc975c9d5c1d)

### Test CASE 3
![image](https://github.com/user-attachments/assets/76871dce-fd67-4236-ac38-5bcb8b1609e0)

### Test CASE 4
![image](https://github.com/user-attachments/assets/f14cfa8b-e71c-483e-ab64-4d07f622eef3)

### Test CASE 5
![image](https://github.com/user-attachments/assets/92ed7cb1-0a1a-4547-8cbc-7ec2448cb1db)

### Test CASE 6
![image](https://github.com/user-attachments/assets/35dff213-cc24-4f05-8f64-6b32f838208a)

### Test CASE 7
![image](https://github.com/user-attachments/assets/5ed601f9-b345-49ed-8dbd-1b5cb2d58a59)

### Test CASE 8
![image](https://github.com/user-attachments/assets/2591ec0e-0560-4ea8-a168-4e5f2b06f338)

### Test CASE 9
![image](https://github.com/user-attachments/assets/2795ccf3-8ec3-45bc-b7a6-8a2fea25525f)

