### PR TITLE
Add logging whenever Simple Forms fails to perform multistamp on PDF

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -99,9 +99,10 @@ module SimpleFormsApi
       pdftk.multistamp(stamped_template_path, stamp_path, out_path)
       Common::FileHelpers.delete_file_if_exists(stamped_template_path)
       File.rename(out_path, stamped_template_path)
-    rescue
+    rescue => e
+      Rails.logger.error 'Simple forms api - Failed to perform multistamp', message: e.message
       Common::FileHelpers.delete_file_if_exists(out_path)
-      raise
+      raise e
     end
 
     def self.stamp_submission_date(stamped_template_path, desired_stamps)


### PR DESCRIPTION
## Summary
This adds some logging where I _think_ we're getting a number of exceptions. Unfortunately, it seems like our `verify` method is swallowing some of the stacktrace (maybe because we yield to a passed-in block) so hopefully this will clarify which of our errors come from this method.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88703
