### PR TITLE
feat: is_ready: Timeout if puma/dd slow

### DIFF
--- a/bin/is_ready
+++ b/bin/is_ready
@@ -12,7 +12,7 @@ ALLOWED_UNAVAILABLE_PERCENTAGE=${AUTOSCALING_TARGET_VALUE:-75}
 MIN_NOT_READY_PODS=${MIN_NOT_READY_PODS:-3}
 POD_NAME=${POD_NAME:-"vets-api-web-5bf4f8d6c7-pn475"} # Example POD_NAME for testing
 
-puma_data=$(curl -s 127.0.0.1:9293/stats)
+puma_data=$(curl -s --max-time 2 127.0.0.1:9293/stats)
 
 if [ $? -ne 0 ] || [ -z "$puma_data" ]; then
 	echo "Failed to get a valid response from the server. Is Puma Stats app running?"
@@ -30,7 +30,7 @@ if [ $unavailable_percentage -ge $ALLOWED_UNAVAILABLE_PERCENTAGE ]; then
   dd_env=$(echo $DD_ENV | cut -f2 -d-)
   cluster_env=${DD_ENV#eks-}
   dd_data=$(
-    curl -sG \
+    curl -s --max-time 2 -G \
       'https://vagov.ddog-gov.com/api/v1/query' \
       --data-urlencode "query=avg:kubernetes_state.deployment.replicas_available{kube_cluster_name:dsva-vagov-${cluster_env:-prod}-cluster,kube_namespace:vets-api} by {kube_deployment}" \
       -d "from=$((CURRENT_TIME - 60))" \


### PR DESCRIPTION
We were getting timeout errors in Argo and the pod was being marked unhealthy.

This adds a two second timeout for DD and puma.