### PR TITLE
Add logging for sending 26-4555 to LGY from Simple Forms

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -114,6 +114,10 @@ module SimpleFormsApi
         lgy_response = LGY::Service.new.post_grant_application(payload: form.as_payload)
         reference_number = lgy_response.body['reference_number']
         status = lgy_response.body['status']
+        Rails.logger.info(
+          'Simple forms api - sent to lgy',
+          { form_number: params[:form_number], status:, reference_number: }
+        )
         { json: { reference_number:, status: }, status: lgy_response.status }
       end
 


### PR DESCRIPTION
## Summary
This PR adds logging whenever we submit a 26-4555 form to the LGY (Loan Guaranty) API endpoint.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1206
