### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - InProgressForms

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -6,9 +6,10 @@ module V0
     service_tag 'save-in-progress'
 
     def index
-      # :unaltered prevents the keys from being deeply transformed, which might corrupt some keys
+      # the keys of metadata shouldn't be deeply transformed, which might corrupt some keys
       # see https://github.com/department-of-veterans-affairs/va.gov-team/issues/17595 for more details
-      render json: InProgressForm.submission_pending.for_user(@current_user), key_transform: :unaltered
+      pending_submissions = InProgressForm.submission_pending.for_user(@current_user)
+      render json: InProgressFormSerializer.new(pending_submissions)
     end
 
     def show
@@ -30,14 +31,14 @@ module V0
         Lighthouse::CreateIntentToFileJob.perform_async(form.form_id, form.created_at, @current_user.icn)
       end
 
-      render json: form, key_transform: :unaltered
+      render json: InProgressFormSerializer.new(form)
     end
 
     def destroy
       raise Common::Exceptions::RecordNotFound, form_id if form_for_user.blank?
 
       form_for_user.destroy
-      render json: form_for_user, key_transform: :unaltered
+      render json: InProgressFormSerializer.new(form_for_user)
     end
 
     private

--- a/app/serializers/in_progress_form_serializer.rb
+++ b/app/serializers/in_progress_form_serializer.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
-class InProgressFormSerializer < ActiveModel::Serializer
+class InProgressFormSerializer
+  include JSONAPI::Serializer
+
+  set_id { '' }
+  set_type :in_progress_forms
+
   # ensures that the attribute keys are camelCase, whether or not the Inflection header is sent
-  attribute(:formId) { object.form_id }
-  attribute(:createdAt) { object.created_at }
-  attribute(:updatedAt) { object.updated_at }
-  attribute(:metadata) { object.metadata }
   # NOTE: camelCasing all keys (deep transform) is *not* the goal. (see the InProgressFormsController for more details)
+  attribute :formId, &:form_id
+
+  attribute :createdAt, &:created_at
+
+  attribute :updatedAt, &:updated_at
+
+  attribute :metadata, &:metadata
 end

--- a/spec/requests/in_progress_forms_request_spec.rb
+++ b/spec/requests/in_progress_forms_request_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe V0::InProgressFormsController do
     end
 
     describe '#index' do
-      subject do
-        get v0_in_progress_forms_url, params: nil
-      end
+      subject { get v0_in_progress_forms_url, params: nil }
 
       let(:user) { loa3_user }
       let!(:in_progress_form_edu) do
@@ -37,15 +35,12 @@ RSpec.describe V0::InProgressFormsController do
 
       context 'when the user is not loa3' do
         let(:user) { loa1_user }
+        let(:response_body) { JSON.parse(response.body) }
         let(:top_level_keys) { response_body.keys }
         let(:data) { response_body['data'] }
         let(:in_progress_form_with_nested_hash) { data.find { |ipf| ipf['attributes']['metadata']['howNow'] } }
         let(:metadata_returned_with_the_request) { in_progress_form_with_nested_hash['attributes']['metadata'] }
         let(:metadata_before_the_request) { in_progress_form_edu.metadata }
-
-        def response_body
-          JSON.parse response.body
-        end
 
         it 'returns a 200' do
           subject
@@ -110,6 +105,7 @@ RSpec.describe V0::InProgressFormsController do
             subject
             expect(metadata_before_the_request['howNow']['brown-cow']['-an eas-i-ly corRupted KEY.'])
               .to be_present
+            expect(metadata_returned_with_the_request['howNow']['brownCow']).to be_present
             expect(metadata_returned_with_the_request['howNow']['brownCow']['-an eas-i-ly corRupted KEY.'])
               .not_to be_present
           end

--- a/spec/serializers/in_progress_form_serializer_spec.rb
+++ b/spec/serializers/in_progress_form_serializer_spec.rb
@@ -3,35 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe InProgressFormSerializer do
-  subject { JSON.parse serialize(in_progress_form, serializer_class: described_class) }
+  subject { serialize(in_progress_form, serializer_class: described_class) }
 
-  let(:in_progress_form) { build :in_progress_form }
-  let(:top_level_keys) { subject.keys }
-  let(:data) { subject['data'] }
-  let(:type) { data['type'] }
+  let(:in_progress_form) { build(:in_progress_form) }
+  let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }
   let(:metadata) { attributes['metadata'] }
 
-  it 'has the correct shape (JSON:API)' do
-    expect(subject).to be_a Hash
-    expect(top_level_keys).to contain_exactly 'data'
-    expect(data.keys).to contain_exactly('id', 'type', 'attributes')
-    expect(type).to eq 'in_progress_forms'
-    expect(attributes.keys).to contain_exactly('form_id', 'created_at', 'updated_at', 'metadata')
+  it 'includes :id' do
+    expect(data['id']).to be_blank
+  end
+
+  it 'includes :type' do
+    expect(data['type']).to eq 'in_progress_forms'
+  end
+
+  it 'includes :createdAt' do
+    expect(attributes['createdAt']).to eq in_progress_form.created_at
+  end
+
+  it 'includes :metadata' do
+    expect(metadata).to eq in_progress_form.metadata
   end
 
   context 'with nested metadata' do
-    let(:in_progress_form) { build :in_progress_form, :with_nested_metadata }
-
-    it 'deeply transformed the keys to snake_case' do
-      expect(metadata['how_now']['brown_cow']).to be_present
-    end
-
-    it 'corrupts complicated keys' do
-      expect(in_progress_form.metadata['howNow']['brown-cow']['-an eas-i-ly corRupted KEY.'])
-        .to be_present
-      expect(metadata['how_now']['brown_cow']['-an eas-i-ly corRupted KEY.'])
-        .not_to be_present
+    it 'keep the original case of metadata' do
+      expect(metadata).to eq in_progress_form.metadata
+      expect(metadata.keys).to eq(in_progress_form.metadata.keys)
     end
   end
 end


### PR DESCRIPTION
## Summary

- My understanding is that metadata shouldn't change case, unless header `X-Key-Inflection` is specified
- The original serializer spec was passing because it was taking into account AMS deep key transformation (to snake case). Those examples were removed: `deeply transformed the keys to snake_case` & `corrupts complicated keys`
- A couple very minor refactorings for readability

Switched the following to JSONAPI::Serializer:

- InProgressFormSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/5582
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage