### PR TITLE
Add array defaults to sign_in_service configs

### DIFF
--- a/db/migrate/20240722150708_add_service_account_configs_array_defaults.rb
+++ b/db/migrate/20240722150708_add_service_account_configs_array_defaults.rb
@@ -1,0 +1,6 @@
+class AddServiceAccountConfigsArrayDefaults < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :service_account_configs, :scopes, from: nil, to: []
+    change_column_default :service_account_configs, :certificates, from: nil, to: []
+  end
+end

--- a/db/migrate/20240722150751_add_client_configs_array_defaults.rb
+++ b/db/migrate/20240722150751_add_client_configs_array_defaults.rb
@@ -1,0 +1,5 @@
+class AddClientConfigsArrayDefaults < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :client_configs, :certificates, from: nil, to: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_195104) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_150751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -425,7 +425,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_195104) do
     t.datetime "updated_at", null: false
     t.text "logout_redirect_uri"
     t.boolean "pkce"
-    t.string "certificates", array: true
+    t.string "certificates", default: [], array: true
     t.text "description"
     t.string "access_token_attributes", default: [], array: true
     t.text "terms_of_use_url"
@@ -1057,10 +1057,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_195104) do
   create_table "service_account_configs", force: :cascade do |t|
     t.string "service_account_id", null: false
     t.text "description", null: false
-    t.text "scopes", null: false, array: true
+    t.text "scopes", default: [], null: false, array: true
     t.string "access_token_audience", null: false
     t.interval "access_token_duration", null: false
-    t.string "certificates", array: true
+    t.string "certificates", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "access_token_user_attributes", default: [], array: true

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -160,3 +160,8 @@ btsss.update!(
   access_token_duration: SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
   certificates: [File.read('spec/fixtures/sign_in/sts_client.crt')]
 )
+
+# Update any exisitng ServiceAccountConfigs and ClientConfigs with default empty arrays
+SignIn::ServiceAccountConfig.where(certificates: nil).update(certificates: [])
+SignIn::ServiceAccountConfig.where(scopes: nil).update(scopes: [])
+SignIn::ClientConfig.where(certificates: nil).update(certificates: [])


### PR DESCRIPTION
## Summary
Add empty array defaults to `SignIn::ServiceAccountConfig.scopes`, `SignIn::ServiceAccountConfig.certificates`, and `SignIn::ClientConfig.certificates`. It is expected to receive an empty array when calling the API and is consistent with other array columns in these tables.

These will be run in all envs 
```ruby
SignIn::ServiceAccountConfig.where(certificates: nil).update(certificates: [])
SignIn::ServiceAccountConfig.where(scopes: nil).update(scopes: [])
SignIn::ClientConfig.where(certificates: nil).update(certificates: [])
```

## Testing 
- Migrate database
  ```bash
   rails db:migrate
  ```
- Seed database
  ```bash
  rails db:seed
  ```
  

## What areas of the site does it impact?
Sign-in Service

