### PR TITLE
84329: Add DR form submissions to SavedClaims

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -315,6 +315,9 @@ app/models/saved_claim/income_and_assets.rb @department-of-veterans-affairs/pens
 app/models/saved_claim/pension.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/education_career_counseling_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/saved_claim/higher_level_review.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
+app/models/saved_claim/notice_of_disagreement.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
+app/models/saved_claim/supplemental_claim.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/sign_in @department-of-veterans-affairs/octo-identity
 app/models/single_logout_request.rb @department-of-veterans-affairs/octo-identity
 app/models/spool_file_event.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v1/higher_level_reviews_controller.rb
+++ b/app/controllers/v1/higher_level_reviews_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require 'decision_review/utilities/saved_claim/service'
+
 module V1
   class HigherLevelReviewsController < AppealsBaseControllerV1
+    include DecisionReview::SavedClaim::Service
     service_tag 'higher-level-review'
 
     def show
@@ -22,7 +25,8 @@ module V1
         AppealSubmission.create!(user_uuid: @current_user.uuid, user_account: @current_user.user_account,
                                  type_of_appeal: 'HLR', submitted_appeal_uuid:)
 
-        store_request_in_saved_claim(form: request_body_hash.to_json, guid: submitted_appeal_uuid)
+        store_saved_claim(claim_class: SavedClaim::HigherLevelReview, form: request_body_hash.to_json,
+                          guid: submitted_appeal_uuid)
 
         # Clear in-progress form since submit was successful
         InProgressForm.form_for_user('20-0996', current_user)&.destroy!
@@ -54,14 +58,6 @@ module V1
         e, error_class: error_class(method: 'create', exception_class: e.class), request:
       )
       raise
-    end
-
-    def store_request_in_saved_claim(form:, guid:)
-      claim = SavedClaim::HigherLevelReview.new(form:, guid:)
-      claim.save!
-    rescue => e
-      Rails.logger.warn('HigherLevelReviewsController: Error saving SavedClaim::HigherLevelReview',
-                        { guid:, error: e.message })
     end
   end
 end

--- a/app/controllers/v1/notice_of_disagreements_controller.rb
+++ b/app/controllers/v1/notice_of_disagreements_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require 'decision_review/utilities/saved_claim/service'
+
 module V1
   class NoticeOfDisagreementsController < AppealsBaseControllerV1
+    include DecisionReview::SavedClaim::Service
     service_tag 'board-appeal'
 
     def show
@@ -14,12 +17,16 @@ module V1
     end
 
     def create
+      saved_claim_request_body = request_body_hash.to_json # serialize before modifications are made to request body
       nod_response_body = AppealSubmission.submit_nod(
         current_user: @current_user,
         request_body_hash:,
         decision_review_service:,
         version_number:
       )
+      store_saved_claim(claim_class: SavedClaim::NoticeOfDisagreement, form: saved_claim_request_body,
+                        guid: nod_response_body.dig('data', 'id'))
+
       render json: nod_response_body
     rescue => e
       ::Rails.logger.error(

--- a/app/models/appeal_submission.rb
+++ b/app/models/appeal_submission.rb
@@ -25,10 +25,8 @@ class AppealSubmission < ApplicationRecord
       nod_response_body = decision_review_service.create_notice_of_disagreement(request_body: request_body_hash,
                                                                                 user: current_user)
                                                  .body
-      appeal_submission.submitted_appeal_uuid = guid = nod_response_body.dig('data', 'id')
+      appeal_submission.submitted_appeal_uuid = nod_response_body.dig('data', 'id')
       appeal_submission.save!
-
-      store_request_in_saved_claims(form: request_body_hash.to_json, guid:, uploaded_forms: uploads_arr)
 
       # Clear in-progress form if submit was successful
       InProgressForm.form_for_user('10182',
@@ -47,13 +45,4 @@ class AppealSubmission < ApplicationRecord
       DecisionReview::SubmitUpload.perform_async(asu.id)
     end
   end
-
-  def self.store_request_in_saved_claims(form:, guid:, uploaded_forms:)
-    claim = SavedClaim::NoticeOfDisagreement.new(form:, guid:, uploaded_forms:)
-    claim.save!
-  rescue => e
-    Rails.logger.warn('AppealSubmission: Error saving SavedClaim::NoticeOfDisagreement', { guid:, error: e.message })
-  end
-
-  private_class_method :store_request_in_saved_claims
 end

--- a/app/models/saved_claim/higher_level_review.rb
+++ b/app/models/saved_claim/higher_level_review.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SavedClaim::HigherLevelReview < SavedClaim
+  FORM = '20-0996'
+
+  def form_matches_schema
+    return unless form_is_string
+
+    schema = VetsJsonSchema::SCHEMAS['HLR-CREATE-REQUEST-BODY_V1']
+    schema.delete '$schema' # workaround for JSON::Schema::SchemaError (Schema not found)
+
+    validation_errors = JSON::Validator.fully_validate(schema, parsed_form)
+
+    unless validation_errors.empty?
+      Rails.logger.warn("SavedClaim: form schema errors detected for form #{FORM}", validation_errors)
+    end
+
+    true # allow storage of invalid requests for debugging
+  end
+
+  def process_attachments!
+    # Inherited from SavedClaim. Disabling since this claim handles attachments separately.
+    raise NotImplementedError, 'Not Implemented for Form 20-0996'
+  end
+end

--- a/app/models/saved_claim/notice_of_disagreement.rb
+++ b/app/models/saved_claim/notice_of_disagreement.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SavedClaim::NoticeOfDisagreement < SavedClaim
+  FORM = '10182'
+
+  def form_matches_schema
+    return unless form_is_string
+
+    schema = VetsJsonSchema::SCHEMAS['NOD-CREATE-REQUEST-BODY_V1']
+    schema.delete '$schema' # workaround for JSON::Schema::SchemaError (Schema not found)
+
+    validation_errors = JSON::Validator.fully_validate(schema, parsed_form)
+
+    unless validation_errors.empty?
+      Rails.logger.warn("SavedClaim: form schema errors detected for form #{FORM}", validation_errors)
+    end
+
+    true # allow storage of invalid requests for debugging
+  end
+
+  def process_attachments!
+    # Inherited from SavedClaim. Disabling since this claim handles attachments separately.
+    raise NotImplementedError, 'Not Implemented for Form 10182'
+  end
+end

--- a/app/models/saved_claim/supplemental_claim.rb
+++ b/app/models/saved_claim/supplemental_claim.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SavedClaim::SupplementalClaim < SavedClaim
+  FORM = '20-0995'
+
+  def form_matches_schema
+    return unless form_is_string
+
+    schema = VetsJsonSchema::SCHEMAS['SC-CREATE-REQUEST-BODY_V1']
+    schema.delete '$schema' # workaround for JSON::Schema::SchemaError (Schema not found)
+
+    validation_errors = JSON::Validator.fully_validate(schema, parsed_form)
+
+    unless validation_errors.empty?
+      Rails.logger.warn("SavedClaim: form schema errors detected for form #{FORM}", validation_errors)
+    end
+
+    true # allow storage of invalid requests for debugging
+  end
+
+  def process_attachments!
+    # Inherited from SavedClaim. Disabling since this claim handles attachments separately.
+    raise NotImplementedError, 'Not Implemented for Form 20-0995'
+  end
+end

--- a/lib/decision_review/utilities/saved_claim/service.rb
+++ b/lib/decision_review/utilities/saved_claim/service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DecisionReview
+  ##
+  # Service for persisting Decision Review SavedClaim
+  #
+  module SavedClaim
+    module Service
+      VALID_CLASS = [
+        ::SavedClaim::HigherLevelReview,
+        ::SavedClaim::NoticeOfDisagreement,
+        ::SavedClaim::SupplementalClaim
+      ].freeze
+
+      def store_saved_claim(claim_class:, form:, guid:, uploaded_forms: [])
+        raise Exception("Invalid class type '#{claim_class}'") unless VALID_CLASS.include? claim_class
+
+        claim = claim_class.new(form:, guid:, uploaded_forms:)
+        claim.save!
+      rescue => e
+        Rails.logger.warn("DecisionReview:Error saving #{claim_class}", { guid:, error: e.message })
+      end
+    end
+  end
+end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -48,6 +48,8 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
       AppealsApi::AddIcnUpdater.perform_async(@higher_level_review.id, 'AppealsApi::HigherLevelReview')
     end
 
+    store_request_in_saved_claim(form: @json_body.to_json, guid: @higher_level_review.id)
+
     render_higher_level_review
   end
 
@@ -137,6 +139,14 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
     )
 
     render_model_errors unless @higher_level_review.validate
+  end
+
+  def store_request_in_saved_claim(form:, guid:)
+    claim = SavedClaim::HigherLevelReview.new(form:, guid:)
+    claim.save!
+  rescue => e
+    Rails.logger.warn('HigherLevelReviewsController: Error saving SavedClaim::HigherLevelReview',
+                      { guid:, error: e.message })
   end
 
   def render_model_errors

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -50,7 +50,8 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
       AppealsApi::AddIcnUpdater.perform_async(@higher_level_review.id, 'AppealsApi::HigherLevelReview')
     end
 
-    store_saved_claim(claim_class: SavedClaim::HigherLevelReview, form: @json_body.to_json, guid: @higher_level_review.id)
+    store_saved_claim(claim_class: SavedClaim::HigherLevelReview, form: @json_body.to_json,
+                      guid: @higher_level_review.id)
 
     render_higher_level_review
   end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
@@ -39,6 +39,8 @@ class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < Appeals
       'AppealsApi::NoticeOfDisagreement',
       'v3'
     )
+    store_request_in_saved_claim(form: @json_body.to_json, guid: @notice_of_disagreement.id)
+
     render_notice_of_disagreement
   end
 
@@ -122,6 +124,14 @@ class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < Appeals
       veteran_icn: request_headers['X-VA-ICN']
     )
     render_model_errors unless @notice_of_disagreement.validate
+  end
+
+  def store_request_in_saved_claim(form:, guid:)
+    claim = SavedClaim::NoticeOfDisagreement.new(form:, guid:)
+    claim.save!
+  rescue => e
+    Rails.logger.warn('NoticeOfDisagreementController: Error saving SavedClaim::NoticeOfDisagreement',
+                      { guid:, error: e.message })
   end
 
   # Follows JSON API v1.0 error object standard (https://jsonapi.org/format/1.0/#error-objects)

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
@@ -46,7 +46,7 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
 
     sc.save
 
-    store_saved_claim(form: @json_body.to_json, guid: sc.id)
+    store_saved_claim(claim_class: SavedClaim::SupplementalClaim, form: @json_body.to_json, guid: sc.id)
 
     AppealsApi::PdfSubmitJob.perform_async(sc.id, 'AppealsApi::SupplementalClaim', 'v3')
     AppealsApi::AddIcnUpdater.perform_async(sc.id, 'AppealsApi::SupplementalClaim') if sc.veteran_icn.blank?

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'appeals_api/form_schemas'
+require 'decision_review/utilities/saved_claim/service'
 
 class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi::ApplicationController
   include AppealsApi::JsonFormatValidation
@@ -9,6 +10,7 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
   include AppealsApi::MPIVeteran
   include AppealsApi::Schemas
   include AppealsApi::PdfDownloads
+  include DecisionReview::SavedClaim::Service
 
   skip_before_action :authenticate
   before_action :validate_icn_header, only: %i[index download]
@@ -44,7 +46,7 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
 
     sc.save
 
-    store_request_in_saved_claim(form: @json_body.to_json, guid: sc.id)
+    store_saved_claim(form: @json_body.to_json, guid: sc.id)
 
     AppealsApi::PdfSubmitJob.perform_async(sc.id, 'AppealsApi::SupplementalClaim', 'v3')
     AppealsApi::AddIcnUpdater.perform_async(sc.id, 'AppealsApi::SupplementalClaim') if sc.veteran_icn.blank?
@@ -154,13 +156,5 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
 
   def evidence_submission_indicated?
     @json_body.dig('data', 'attributes', 'evidenceSubmission', 'evidenceType').include?('upload')
-  end
-
-  def store_request_in_saved_claim(form:, guid:)
-    claim = SavedClaim::SupplementalClaim.new(form:, guid:)
-    claim.save!
-  rescue => e
-    Rails.logger.warn('SupplementalClaimsController: Error saving SavedClaim::SupplementalClaim',
-                      { guid:, error: e.message })
   end
 end

--- a/modules/appeals_api/spec/requests/higher_level_reviews/v0/higher_level_reviews_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/higher_level_reviews/v0/higher_level_reviews_controller_spec.rb
@@ -103,6 +103,11 @@ describe AppealsApi::HigherLevelReviews::V0::HigherLevelReviewsController, type:
         expect(created_hlr.api_version).to eq('V0')
       end
 
+      it 'creates a SavedClaim::HigherLevelReview record with the request data' do
+        saved_claim = SavedClaim::HigherLevelReview.find_by(guid: created_hlr)
+        expect(JSON.parse(saved_claim.form)).to eq data
+      end
+
       it 'includes the form_data with PII in the serialized response' do
         expect(parsed_response['data']['attributes']['formData']).to be_present
       end

--- a/modules/appeals_api/spec/requests/notice_of_disagreements/v0/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/notice_of_disagreements/v0/notice_of_disagreements_controller_spec.rb
@@ -70,6 +70,11 @@ describe AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController,
         expect(created_notice_of_disagreement.api_version).to eq('V0')
       end
 
+      it 'creates a SavedClaim::NoticeOfDisagreement record with the request data' do
+        saved_claim = SavedClaim::NoticeOfDisagreement.find_by(guid: created_notice_of_disagreement)
+        expect(JSON.parse(saved_claim.form)).to eq data
+      end
+
       it 'includes the form_data with PII in the serialized response' do
         expect(parsed_response.dig('data', 'attributes', 'formData')).to be_present
       end

--- a/modules/appeals_api/spec/requests/supplemental_claims/v0/supplemental_claims_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/supplemental_claims/v0/supplemental_claims_controller_spec.rb
@@ -104,6 +104,11 @@ describe AppealsApi::SupplementalClaims::V0::SupplementalClaimsController, type:
         expect(created_supplemental_claim.api_version).to eq('V0')
       end
 
+      it 'creates a SavedClaim::SupplementalClaim record with the request data' do
+        saved_claim = SavedClaim::SupplementalClaim.find_by(guid: created_supplemental_claim)
+        expect(JSON.parse(saved_claim.form)).to eq data
+      end
+
       it 'includes the form_data with PII in the serialized response' do
         expect(json_body.dig('data', 'attributes', 'formData')).to be_present
       end

--- a/modules/appeals_api/spec/requests/v2/higher_level_reviews_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v2/higher_level_reviews_controller_spec.rb
@@ -86,6 +86,10 @@ describe AppealsApi::V2::DecisionReviews::HigherLevelReviewsController, type: :r
         expect(parsed['data']['type']).to eq('higherLevelReview')
         expect(parsed['data']['attributes']['status']).to eq('pending')
         expect(parsed.dig('data', 'attributes', 'formData')).to be_a Hash
+
+        saved_claim = SavedClaim::HigherLevelReview.find_by(guid: hlr_guid)
+        expect(saved_claim.guid).to eq(hlr_guid)
+        expect(JSON.parse(saved_claim.form)).to eq(JSON.parse(data_default))
       end
     end
 

--- a/modules/appeals_api/spec/requests/v2/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v2/notice_of_disagreements_controller_spec.rb
@@ -81,6 +81,11 @@ describe AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController, type:
         expect(nod.veteran_icn).to eq('1013062086V794840')
         expect(parsed['data']['type']).to eq('noticeOfDisagreement')
         expect(parsed['data']['attributes']['status']).to eq('pending')
+
+        guid = parsed['data']['id']
+        saved_claim = SavedClaim::NoticeOfDisagreement.find_by(guid:)
+        expect(saved_claim.guid).to eq(guid)
+        expect(JSON.parse(saved_claim.form)).to eq(JSON.parse(max_data))
       end
     end
 

--- a/modules/appeals_api/spec/requests/v2/supplemental_claims_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v2/supplemental_claims_controller_spec.rb
@@ -95,6 +95,16 @@ describe AppealsApi::V2::DecisionReviews::SupplementalClaimsController, type: :r
 
         expect(sc.metadata.dig('form_data', 'evidence_type')).to eq(data_evidence_type)
       end
+
+      it 'stores the request as a SavedClaim' do
+        post(path, params: data, headers:)
+
+        guid = parsed['data']['id']
+
+        saved_claim = SavedClaim::SupplementalClaim.find_by(guid:)
+        expect(saved_claim.guid).to eq(guid)
+        expect(JSON.parse(saved_claim.form)).to eq(JSON.parse(data))
+      end
     end
 
     context 'when icn header is present' do

--- a/spec/requests/v1/higher_level_reviews_controller_request_spec.rb
+++ b/spec/requests/v1/higher_level_reviews_controller_request_spec.rb
@@ -73,6 +73,9 @@ RSpec.describe V1::HigherLevelReviewsController do
         # InProgressForm should be destroyed after successful submission
         in_progress_form = InProgressForm.find_by(user_uuid: user.uuid, form_id: '20-0996')
         expect(in_progress_form).to be_nil
+        # SavedClaim should be created with request data
+        saved_claim = SavedClaim::HigherLevelReview.find_by(guid: appeal_uuid)
+        expect(saved_claim.form).to eq(VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY_V1').to_json)
       end
     end
 

--- a/spec/requests/v1/notice_of_disagreements_controller_request_spec.rb
+++ b/spec/requests/v1/notice_of_disagreements_controller_request_spec.rb
@@ -77,6 +77,9 @@ RSpec.describe V1::NoticeOfDisagreementsController do
         # InProgressForm should be destroyed after successful submission
         in_progress_form = InProgressForm.find_by(user_uuid: user.uuid, form_id: '10182')
         expect(in_progress_form).to be_nil
+        # SavedClaim should be created with request data
+        saved_claim = SavedClaim::NoticeOfDisagreement.find_by(guid: id)
+        expect(saved_claim.form).to eq(test_request_body)
       end
     end
 

--- a/spec/requests/v1/notice_of_disagreements_controller_request_spec.rb
+++ b/spec/requests/v1/notice_of_disagreements_controller_request_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe V1::NoticeOfDisagreementsController do
         expect(in_progress_form).to be_nil
         # SavedClaim should be created with request data
         saved_claim = SavedClaim::NoticeOfDisagreement.find_by(guid: id)
-        expect(saved_claim.form).to eq(test_request_body)
+        expect(JSON.parse(saved_claim.form)).to eq(test_request_body)
       end
     end
 

--- a/spec/requests/v1/supplemental_claims_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims_controller_request_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe V1::SupplementalClaimsController do
         expect(in_progress_form).to be_nil
         # SavedClaim should be created with request data
         saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
-        expect(saved_claim.form).to eq(test_request_body)
+        expect(saved_claim.form).to eq(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY_V1').to_json)
       end
     end
 

--- a/spec/requests/v1/supplemental_claims_controller_request_spec.rb
+++ b/spec/requests/v1/supplemental_claims_controller_request_spec.rb
@@ -77,6 +77,9 @@ RSpec.describe V1::SupplementalClaimsController do
         # InProgressForm should be destroyed after successful submission
         in_progress_form = InProgressForm.find_by(user_uuid: user.uuid, form_id: '20-0995')
         expect(in_progress_form).to be_nil
+        # SavedClaim should be created with request data
+        saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
+        expect(saved_claim.form).to eq(test_request_body)
       end
     end
 


### PR DESCRIPTION

## Summary

* Adds SavedClaim child models to store submitted requests for several Decision Review forms (Higher Level Review, Supplemental Claim, and Notice of Disagreement)
* Updates V0, V1, and V2 controllers to securely store form submission requests

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84329

## Testing done

- [x] *New code is covered by unit tests*
- No old behavior prior to this change


## What areas of the site does it impact?
* Additional records stored during submission of SC, NOD, and HLR forms

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
