### PR TITLE
Skip failing spec file, form526_document_upload_polling_job_spec.rb

### DIFF
--- a/spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb
+++ b/spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Lighthouse::Form526DocumentUploadPollingJob, type: :job do
-  before { skip("Skip temporarily: Failing on main 7/23/34") }
   before do
+    skip('Skip temporarily: Failing on main 7/23/34')
     Sidekiq::Job.clear_all
     # NOTE: to re-record the VCR cassettes for these tests:
     # 1. Comment out the line below stubbing the token

--- a/spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb
+++ b/spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Lighthouse::Form526DocumentUploadPollingJob, type: :job do
+  before { skip("Skip temporarily: Failing on main 7/23/34") }
   before do
     Sidekiq::Job.clear_all
     # NOTE: to re-record the VCR cassettes for these tests:


### PR DESCRIPTION
## Summary

- Tests in this file have suddenly started failing. Skipping them until they can be debugged. 

## Related issue(s)
Some failing specs [on master](https://github.com/department-of-veterans-affairs/vets-api/commits/master/):
- https://github.com/department-of-veterans-affairs/vets-api/actions/runs/10058710384/job/27802392805
- https://github.com/department-of-veterans-affairs/vets-api/actions/runs/10048055875/job/27776345076
- https://github.com/department-of-veterans-affairs/vets-api/actions/runs/10048596527/job/27772903049


## What areas of the site does it impact?
spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb

