### PR TITLE
[10-10 EZ] 85948 Remove HCA Failure Submission Email Flipper Toggle

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -287,27 +287,21 @@ class HealthCareApplication < ApplicationRecord
   end
 
   def send_failure_email
-    if Flipper.enabled?(:hca_submission_failure_email_va_notify)
-      begin
-        first_name = parsed_form.dig('veteranFullName', 'first')
-        template_id = Settings.vanotify.services.health_apps_1010.template_id.form1010_ez_failure_email
-        api_key = Settings.vanotify.services.health_apps_1010.api_key
+    first_name = parsed_form.dig('veteranFullName', 'first')
+    template_id = Settings.vanotify.services.health_apps_1010.template_id.form1010_ez_failure_email
+    api_key = Settings.vanotify.services.health_apps_1010.api_key
 
-        salutation = first_name ? "Dear #{first_name}," : ''
+    salutation = first_name ? "Dear #{first_name}," : ''
 
-        VANotify::EmailJob.perform_async(
-          email,
-          template_id,
-          { 'salutation' => salutation },
-          api_key
-        )
-        StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.submission_failure_email_sent")
-      rescue => e
-        log_exception_to_sentry(e)
-      end
-    else
-      HCASubmissionFailureMailer.build(email, google_analytics_client_id).deliver_now
-    end
+    VANotify::EmailJob.perform_async(
+      email,
+      template_id,
+      { 'salutation' => salutation },
+      api_key
+    )
+    StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.submission_failure_email_sent")
+  rescue => e
+    log_exception_to_sentry(e)
   end
 
   # If the hca_use_facilities_API flag is on then vaMedicalFacility will only

--- a/config/features.yml
+++ b/config/features.yml
@@ -69,9 +69,6 @@ features:
   hca_use_facilities_API:
     actor_type: user
     description: Allow list of medical care facilites to be fetched by way of the Facilities API.
-  hca_submission_failure_email_va_notify:
-    actor_type: user
-    description: Send HCA Submission Failure email using VANotify.
   ezr_prod_enabled:
     actor_type: user
     description: Enables access to the 10-10EZR application in prod for the purposes of conducting user reasearch

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -491,26 +491,47 @@ RSpec.describe HealthCareApplication, type: :model do
     end
 
     describe '#send_failure_email' do
-      context 'VANotify flipper enabled' do
-        before do
-          Flipper.enable(:hca_submission_failure_email_va_notify)
-        end
+      context 'has form' do
+        context 'with email address' do
+          let(:email_address) { health_care_application.parsed_form['email'] }
+          let(:api_key) { Settings.vanotify.services.health_apps_1010.api_key }
+          let(:template_id) { Settings.vanotify.services.health_apps_1010.template_id.form1010_ez_failure_email }
+          let(:template_params) do
+            [
+              email_address,
+              template_id,
+              {
+                'salutation' => "Dear #{health_care_application.parsed_form['veteranFullName']['first']},"
+              },
+              api_key
+            ]
+          end
 
-        after do
-          Flipper.disable(:hca_submission_failure_email_va_notify)
-        end
+          let(:standard_error) { StandardError.new('Test error') }
 
-        context 'has form' do
-          context 'with email address' do
-            let(:email_address) { health_care_application.parsed_form['email'] }
-            let(:api_key) { Settings.vanotify.services.health_apps_1010.api_key }
-            let(:template_id) { Settings.vanotify.services.health_apps_1010.template_id.form1010_ez_failure_email }
-            let(:template_params) do
+          it 'sends a failure email to the email address provided on the form' do
+            subject
+            expect(VANotify::EmailJob).to have_received(:perform_async).with(*template_params)
+          end
+
+          it 'logs error to sentry if email job throws error' do
+            allow(VANotify::EmailJob).to receive(:perform_async).and_raise(standard_error)
+            expect_any_instance_of(SentryLogging).to receive(:log_exception_to_sentry).with(standard_error)
+            expect { subject }.not_to raise_error
+          end
+
+          context 'without first name' do
+            subject do
+              health_care_application.parsed_form['veteranFullName'] = nil
+              super()
+            end
+
+            let(:template_params_no_name) do
               [
                 email_address,
                 template_id,
                 {
-                  'salutation' => "Dear #{health_care_application.parsed_form['veteranFullName']['first']},"
+                  'salutation' => ''
                 },
                 api_key
               ]
@@ -520,7 +541,7 @@ RSpec.describe HealthCareApplication, type: :model do
 
             it 'sends a failure email to the email address provided on the form' do
               subject
-              expect(VANotify::EmailJob).to have_received(:perform_async).with(*template_params)
+              expect(VANotify::EmailJob).to have_received(:perform_async).with(*template_params_no_name)
             end
 
             it 'logs error to sentry if email job throws error' do
@@ -556,99 +577,43 @@ RSpec.describe HealthCareApplication, type: :model do
               end
             end
           end
-
-          context 'without email address' do
-            subject do
-              health_care_application.parsed_form['email'] = nil
-              super()
-            end
-
-            it 'does not send email' do
-              expect(health_care_application).not_to receive(:send_failure_email)
-              subject
-            end
-          end
         end
 
-        context 'does not have form' do
+        context 'without email address' do
           subject do
-            health_care_application.form = nil
+            health_care_application.parsed_form['email'] = nil
             super()
           end
 
-          context 'with email address' do
-            it 'does not send email' do
-              expect(health_care_application).not_to receive(:send_failure_email)
-              subject
-            end
-          end
-
-          context 'without email address' do
-            subject do
-              health_care_application.parsed_form['email'] = nil
-              super()
-            end
-
-            it 'does not send email' do
-              expect(health_care_application).not_to receive(:send_failure_email)
-              subject
-            end
+          it 'does not send email' do
+            expect(health_care_application).not_to receive(:send_failure_email)
+            subject
           end
         end
       end
 
-      context 'VANotify flipper disabled' do
-        before do
-          Flipper.disable(:hca_submission_failure_email_va_notify)
+      context 'does not have form' do
+        subject do
+          health_care_application.form = nil
+          super()
         end
 
-        context 'has form' do
-          context 'with email address' do
-            let(:email_address) { health_care_application.parsed_form['email'] }
-
-            it 'sends a failure email to the email address provided on the form' do
-              expect(health_care_application).to receive(:send_failure_email).and_call_original
-              expect(HCASubmissionFailureMailer).to receive(:build).and_call_original
-              subject
-            end
-          end
-
-          context 'without email address' do
-            subject do
-              health_care_application.parsed_form['email'] = nil
-              super()
-            end
-
-            it 'does not send email' do
-              expect(health_care_application).not_to receive(:send_failure_email)
-              subject
-            end
+        context 'with email address' do
+          it 'does not send email' do
+            expect(health_care_application).not_to receive(:send_failure_email)
+            subject
           end
         end
 
-        context 'does not have form' do
+        context 'without email address' do
           subject do
-            health_care_application.form = nil
+            health_care_application.parsed_form['email'] = nil
             super()
           end
 
-          context 'with email address' do
-            it 'does not send email' do
-              expect(health_care_application).not_to receive(:send_failure_email)
-              subject
-            end
-          end
-
-          context 'without email address' do
-            subject do
-              health_care_application.parsed_form['email'] = nil
-              super()
-            end
-
-            it 'does not send email' do
-              expect(health_care_application).not_to receive(:send_failure_email)
-              subject
-            end
+          it 'does not send email' do
+            expect(health_care_application).not_to receive(:send_failure_email)
+            subject
           end
         end
       end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Removing Flipper toggle since we no longer need to toggle this feature. We will merge this after we turn the feature on in production. 
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85948
## Testing done

- [x] *New code is covered by unit tests*
- Previously it would use the old ApplicationMailer if the toggle was off. Now it will _always_ use VANotify to send an email.

## What areas of the site does it impact?
1010-EZ 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback