### PR TITLE
Add lgy_sahsha defaults to Settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1619,6 +1619,12 @@ lgy:
   api_key: ~
   mock_coe: true
 
+lgy_sahsha:
+  base_url: http://www.example.com
+  app_id: ~
+  api_key: ~
+  mock_coe: false
+
 form526_backup:
   enabled: true
   # Can be single or multi, to send 1 payload or many, to central mail


### PR DESCRIPTION
## Summary
This PR adds `lgy_sahsha` to the `Settings` object on production. I already populated the three fields in AWS SSM.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88998
