### PR TITLE
[CST] [Backend] Added a feature flag for making evidence uploads a synchronous task

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -215,6 +215,10 @@ features:
     actor_type: user
     description: When enabled, claims status tool uses DataDog's Real User Monitoring logging
     enable_in_development: false
+  cst_synchronous_evidence_uploads:
+    actor_type: user
+    description: When enabled, claims status tool uses synchronous evidence uploads
+    enable_in_development: true
   coe_access:
     actor_type: user
     description: Feature gates the certificate of eligibility application


### PR DESCRIPTION
## Summary

- Added `cst_synchronous_evidence_uploads` feature flag to `vets-api`

## Related issue(s)

- [[CST] Make evidence submission a synchronous task](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76660)
- [[PR] [CST] [Frontend] Added a feature flag for making evidence uploads a synchronous task](https://github.com/department-of-veterans-affairs/vets-website/pull/30975)


