### PR TITLE
Add error handler implementation to Form4142DocumentUploadFailureEmail job

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
@@ -73,9 +73,19 @@ module EVSS
 
           StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
         end
+      rescue => e
+        retryable_error_handler(e)
       end
 
       private
+
+      def retryable_error_handler(error)
+        # Needed to log the error properly in the Sidekiq::Form526JobStatusTracker::JobTracker,
+        # which is included near the top of this job's inheritance tree in EVSS::DisabilityCompensationForm::JobStatus
+
+        super(error)
+        raise error
+      end
 
       def mailer_template_id
         Settings.vanotify.services

--- a/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
@@ -82,7 +82,6 @@ module EVSS
       def retryable_error_handler(error)
         # Needed to log the error properly in the Sidekiq::Form526JobStatusTracker::JobTracker,
         # which is included near the top of this job's inheritance tree in EVSS::DisabilityCompensationForm::JobStatus
-
         super(error)
         raise error
       end


### PR DESCRIPTION
## Summary
Implements the `retryable_error_handler` pattern for jobs including the `Sidekiq::Form526JobStatusTracker::JobTracker` concern in the `EVSS::DisabilityCompensationForm::Form4142DocumentUploadFailureEmail` job. This method is meant to catch any errors thrown in the perform block so we can log them in a Form526JobStatus record before we lose the trace and the job falls into the Sidekiq dead queue (that's my understanding based on the documentation in the tracker concern)

- *This work is behind a feature toggle (flipper): NO (the job is already behind a flipper I discovered this issue in testing)
- *(Which team do you work for, does your team own the maintenance of this component?)* Benefits Disability Team, I will be testing, releasing and monitoring the release of this mailer.


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88719

## Testing done

- [X] *New code is covered by unit tests*



## What areas of the site does it impact?
N/A
## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A, testing rescue blocks well is always tricky but I think my strategy is the best Rspec offers us. Open to other suggestions.
