### PR TITLE
[API-37989] POA v1 PUT /2122/{id} - Use Benefits Documents API

### DIFF
--- a/modules/claims_api/spec/sidekiq/poa_vbms_upload_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_vbms_upload_job_spec.rb
@@ -210,8 +210,12 @@ RSpec.describe ClaimsApi::PoaVBMSUploadJob, type: :job do
         allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_poa_use_bd).and_return true
       end
 
-      it 'calls the benefits document API' do
-        expect_any_instance_of(ClaimsApi::BD).to receive(:upload)
+      it 'calls the benefits document API with doc_type L075' do
+        expect_any_instance_of(ClaimsApi::BD).to receive(:upload).with(
+          claim: power_of_attorney,
+          pdf_path: anything,
+          doc_type: 'L075'
+        )
         subject.new.perform(power_of_attorney.id)
       end
     end


### PR DESCRIPTION
## Summary

Add feature flag to the Power of Attorney v1 `put` endpoint. 

* If the feature flag is enabled, upload via Benefits Documents with `doc_type` of L075.
* Otherwise, continue uploading via VBMS as before.
* Add tests.

## Related issue(s)

[API-37989](https://jira.devops.va.gov/browse/API-37989)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
POA v1 `PUT /2122/{id}` endpoint

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Could use help testing end-to-end.