### PR TITLE
Replace Simple Forms' authentication override with :load_user

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -9,7 +9,7 @@ module SimpleFormsApi
   module V1
     class UploadsController < ApplicationController
       skip_before_action :authenticate
-      before_action :authenticate, if: :should_authenticate
+      before_action :load_user
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {
@@ -26,8 +26,6 @@ module SimpleFormsApi
         '40-10007' => 'vba_40_10007',
         '20-10207' => 'vba_20_10207'
       }.freeze
-
-      UNAUTHENTICATED_FORMS = %w[40-0247 21-10210 21P-0847 40-10007].freeze
 
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
@@ -73,15 +71,6 @@ module SimpleFormsApi
           pension_intent: existing_intents['pension'],
           survivor_intent: existing_intents['survivor']
         }
-      end
-
-      def authenticate
-        super
-      rescue Common::Exceptions::Unauthorized
-        Rails.logger.info(
-          'Simple forms api - unauthenticated user submitting form',
-          { form_number: params[:form_number] }
-        )
       end
 
       private
@@ -202,10 +191,6 @@ module SimpleFormsApi
       def form_is264555_and_should_use_lgy_api
         # TODO: Remove comment octothorpe and ALWAYS require icn
         params[:form_number] == '26-4555' # && icn
-      end
-
-      def should_authenticate
-        true unless UNAUTHENTICATED_FORMS.include? params[:form_number]
       end
 
       def participant_id


### PR DESCRIPTION
## Summary
This PR uses an alternative to `:authenticate` in the `UploadsController` so that it will allow unauthenticated users to proceed even though there will be no `@current_user` object populated. But it will populate that instance variable in other cases.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88938

## Testing
I tested this locally with both unauthed and authenticated users and got expected results from `@current_user`.
