### PR TITLE
Revert "[DBX-88811] treat LH BI success state as true success"

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -61,9 +61,7 @@ class Form526Submission < ApplicationRecord
   belongs_to :user_account, dependent: nil, optional: true
 
   validates(:auth_headers_json, presence: true)
-  # Documentation describing the purpose of 'paranoid success'
-  # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/paranoid_success_submissions.md
-  enum backup_submitted_claim_status: { accepted: 0, rejected: 1, paranoid_success: 2 }
+  enum backup_submitted_claim_status: { accepted: 0, rejected: 1 }
   enum submit_endpoint: { evss: 0, claims_api: 1, benefits_intake_api: 2 }
 
   # Documentation describing the purpose of these scopes:
@@ -97,22 +95,10 @@ class Form526Submission < ApplicationRecord
     where(id: accepted_to_primary_path.select(:id))
       .or(where(id: accepted_to_backup_path.select(:id)))
       .or(where(id: remediated.select(:id)))
-      .or(where(id: paranoid_success_type.select(:id)))
-      .or(where(id: success_by_age_type.select(:id)))
   }
   scope :failure_type, lambda {
     where.not(id: in_process.select(:id))
          .where.not(id: success_type.select(:id))
-  }
-  # after 1 year as paranoid success, we consider it fully successful
-  scope :success_by_age_type, lambda {
-    where(backup_submitted_claim_status: backup_submitted_claim_statuses[:paranoid_success])
-      .where(arel_table[:created_at].lt(1.year.ago))
-  }
-  # addresses a Benefits Intake API edge case where 'success' can revert to failure
-  scope :paranoid_success_type, lambda {
-    where(backup_submitted_claim_status: backup_submitted_claim_statuses[:paranoid_success])
-      .where(arel_table[:created_at].gt(1.year.ago))
   }
 
   FORM_526 = 'form526'
@@ -481,10 +467,6 @@ class Form526Submission < ApplicationRecord
     self.class.in_process.exists?(id:)
   end
 
-  def last_remediation
-    form526_submission_remediations&.order(:created_at)&.last
-  end
-
   private
 
   attr_accessor :lighthouse_validation_response
@@ -592,5 +574,9 @@ class Form526Submission < ApplicationRecord
 
   def cleanup
     EVSS::DisabilityCompensationForm::SubmitForm526Cleanup.perform_async(id)
+  end
+
+  def last_remediation
+    form526_submission_remediations&.order(:created_at)&.last
   end
 end

--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -8,26 +8,23 @@ class Form526StatusPollingJob
 
   STATS_KEY = 'api.benefits_intake.submission_status'
   MAX_BATCH_SIZE = 1000
-  attr_reader :max_batch_size, :paranoid
+  attr_reader :max_batch_size
 
-  def initialize(max_batch_size: MAX_BATCH_SIZE, paranoid: false)
+  def initialize(max_batch_size: MAX_BATCH_SIZE)
     @max_batch_size = max_batch_size
     @total_handled = 0
-    @paranoid = paranoid
   end
 
   def perform
-    Rails.logger.info('Beginning Form 526 Intake Status polling', paranoid:)
+    Rails.logger.info('Beginning Form 526 Intake Status polling')
     submissions.in_batches(of: max_batch_size) do |batch|
       batch_ids = batch.pluck(:backup_submitted_claim_id).flatten
       response = api_to_poll.get_bulk_status_of_uploads(batch_ids)
       handle_response(response)
     end
-    Rails.logger.info('Form 526 Intake Status polling complete',
-                      total_handled: @total_handled, paranoid:)
+    Rails.logger.info('Form 526 Intake Status polling complete', total_handled: @total_handled)
   rescue => e
-    Rails.logger.error('Error processing 526 Intake Status batch',
-                       class: self.class.name, message: e.message, paranoid:)
+    Rails.logger.error('Error processing 526 Intake Status batch', class: self.class.name, message: e.message)
   end
 
   private
@@ -37,11 +34,7 @@ class Form526StatusPollingJob
   end
 
   def submissions
-    @submissions ||= if paranoid
-                       Form526Submission.paranoid_success_type
-                     else
-                       Form526Submission.pending_backup_submissions
-                     end
+    @submissions ||= Form526Submission.pending_backup_submissions
   end
 
   def handle_response(response)
@@ -49,36 +42,22 @@ class Form526StatusPollingJob
       status = submission.dig('attributes', 'status')
       form_submission = Form526Submission.find_by(backup_submitted_claim_id: submission['id'])
 
-      handle_submission(status, form_submission)
+      if %w[error expired].include? status
+        log_result('failure')
+        form_submission.rejected!
+      elsif status == 'success'
+        Rails.logger.info('Form526StatusPollingJob', status: 'pending', submission_id: form_submission.id)
+      elsif status == 'vbms'
+        log_result('success')
+        form_submission.accepted!
+      else
+        Rails.logger.warn(
+          'Unknown status returned from Benefits Intake API for 526 submission',
+          status:,
+          submission_id: form_submission.id
+        )
+      end
       @total_handled += 1
-    end
-  end
-
-  def handle_submission(status, form_submission)
-    if %w[error expired].include? status
-      log_result('failure')
-      form_submission.rejected!
-    elsif status == 'vbms'
-      log_result('true success')
-      form_submission.accepted!
-    elsif status == 'success' && !paranoid
-      # This is a weird, condition, here's how it works:
-      # if paranoid: true, then this job is only checking submissions already paranoid_success
-      # if paranoid: false, then this job is only checking submissions that are pending
-      # THEREFORE
-      # if paranoid: true, setting paranoid_success would be redundant
-      # if paranoid: false, this submission is pending but needs to become paranoid success
-      log_result('paranoid success')
-      form_submission.paranoid_success!
-    elsif status == 'processing' && paranoid
-      log_result('reverted to processing')
-      form_submission.update!(backup_submitted_claim_status: nil)
-    else
-      Rails.logger.info(
-        'Unknown or incomplete status returned from Benefits Intake API for 526 submission',
-        status:,
-        submission_id: form_submission.id
-      )
     end
   end
 

--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -43,8 +43,6 @@ PERIODIC_JOBS = lambda { |mgr|
   # Update Lighthouse526DocumentUpload statuses according to Lighthouse Benefits Documents service tracking
   mgr.register('0 3 * * *', 'Form526StatusPollingJob')
   # Updates status of FormSubmissions per call to Lighthouse Benefits Intake API
-  mgr.register('0 2 * * 0', 'Form526StatusPollingJob', args => [{ paranoid: true }])
-  # Checks all 'success' type submissions in LH to ensure they haven't changed
 
   # mgr.register('0 0 * * *', 'VRE::CreateCh31SubmissionsReportJob')
 

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -34,10 +34,6 @@ FactoryBot.define do
     backup_submitted_claim_status { 'rejected' }
   end
 
-  trait :paranoid_success do
-    backup_submitted_claim_status { 'paranoid_success' }
-  end
-
   trait :with_everything do
     form_json do
       File.read("#{submissions_path}/with_everything.json")

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -88,14 +88,6 @@ RSpec.describe Form526Submission do
       end
     end
 
-    context 'when backup_submitted_claim_status is paranoid_success' do
-      let(:backup_submitted_claim_status) { 'paranoid_success' }
-
-      it 'is valid' do
-        expect(subject).to be_valid
-      end
-    end
-
     context 'when backup_submitted_claim_status is neither accepted, rejected nor nil' do
       it 'is invalid' do
         expect do
@@ -116,28 +108,6 @@ RSpec.describe Form526Submission do
     let!(:remediated_and_expired) { create(:form526_submission, :remediated, :created_more_than_3_days_ago) }
     let!(:remediated_and_rejected) { create(:form526_submission, :remediated, :backup_path, :backup_rejected) }
     let!(:no_longer_remediated) { create(:form526_submission, :no_longer_remediated) }
-    let!(:paranoid_success) { create(:form526_submission, :backup_path, :paranoid_success) }
-    let!(:success_by_age) do
-      Timecop.freeze((1.year + 1.day).ago) do
-        create(:form526_submission, :backup_path, :paranoid_success)
-      end
-    end
-
-    describe 'paranoid_success_type' do
-      it 'returns records less than a year old with paranoid_success backup status' do
-        expect(Form526Submission.paranoid_success_type).to contain_exactly(
-          paranoid_success
-        )
-      end
-    end
-
-    describe 'success_by_age_type' do
-      it 'returns records more than a year old with paranoid_success backup status' do
-        expect(Form526Submission.success_by_age_type).to contain_exactly(
-          success_by_age
-        )
-      end
-    end
 
     describe 'pending_backup_submissions' do
       it 'returns records submitted to the backup path but lacking a decisive state' do
@@ -198,9 +168,7 @@ RSpec.describe Form526Submission do
           remediated_and_expired,
           remediated_and_rejected,
           happy_path_success,
-          accepted_backup,
-          paranoid_success,
-          success_by_age
+          accepted_backup
         )
       end
     end

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -9,217 +9,117 @@ RSpec.describe Form526StatusPollingJob, type: :job do
     let!(:backup_submission_b) { create(:form526_submission, :backup_path) }
     let!(:backup_submission_c) { create(:form526_submission, :backup_path) }
     let!(:backup_submission_d) { create(:form526_submission, :backup_path) }
-    let!(:paranoid_submission_a) { create(:form526_submission, :backup_path, :paranoid_success) }
-    let!(:paranoid_submission_b) { create(:form526_submission, :backup_path, :paranoid_success) }
-    let!(:paranoid_submission_c) { create(:form526_submission, :backup_path, :paranoid_success) }
-    let!(:old_paranoid_submission) do
-      Timecop.freeze((1.year + 1.day).ago) do
-        create(:form526_submission, :backup_path, :paranoid_success)
-      end
-    end
     let!(:accepted_backup_submission) do
-      create(:form526_submission, :backup_path, :backup_accepted)
+      create(:form526_submission, :backup_path, backup_submitted_claim_status: 'accepted')
     end
     let!(:rejected_backup_submission) do
-      create(:form526_submission, :backup_path, :backup_rejected)
+      create(:form526_submission, :backup_path, backup_submitted_claim_status: 'rejected')
     end
 
-    context 'polling on parnoid success type submissions' do
+    describe 'submission to the bulk status report endpoint' do
+      it 'submits only pending form submissions' do
+        pending_claim_ids = Form526Submission.pending_backup_submissions.pluck(:backup_submitted_claim_id)
+        response = double
+        allow(response).to receive(:body).and_return({ 'data' => [] })
+
+        expect(pending_claim_ids).to contain_exactly(
+          backup_submission_a.backup_submitted_claim_id,
+          backup_submission_b.backup_submitted_claim_id,
+          backup_submission_c.backup_submitted_claim_id,
+          backup_submission_d.backup_submitted_claim_id
+        )
+
+        expect_any_instance_of(BenefitsIntakeService::Service)
+          .to receive(:get_bulk_status_of_uploads)
+          .with(pending_claim_ids)
+          .and_return(response)
+
+        Form526StatusPollingJob.new.perform
+      end
+    end
+
+    describe 'when batch size is greater than max batch size' do
+      it 'successfully submits batch intake via batch' do
+        response = double
+        service = double(get_bulk_status_of_uploads: response)
+        allow(response).to receive(:body).and_return({ 'data' => [] })
+        allow(BenefitsIntakeService::Service).to receive(:new).and_return(service)
+
+        Form526StatusPollingJob.new(max_batch_size: 3).perform
+
+        expect(service).to have_received(:get_bulk_status_of_uploads).twice
+      end
+    end
+
+    describe 'when bulk status update fails' do
+      it 'logs the error' do
+        service = double
+        message = 'error'
+        allow(BenefitsIntakeService::Service).to receive(:new).and_return(service)
+        allow(service).to receive(:get_bulk_status_of_uploads).and_raise(message)
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:error)
+
+        Form526StatusPollingJob.new.perform
+
+        expect(Rails.logger).to have_received(:error).with('Error processing 526 Intake Status batch',
+                                                           class: 'Form526StatusPollingJob', message:)
+        expect(Rails.logger).not_to have_received(:info).with('Form 526 Intake Status polling complete')
+      end
+    end
+
+    describe 'updating the form 526s local submission state' do
       let(:api_response) do
         {
           'data' => [
             {
-              'id' => paranoid_submission_a.backup_submitted_claim_id,
+              'id' => backup_submission_a.backup_submitted_claim_id,
               'attributes' => {
-                'guid' => paranoid_submission_a.backup_submitted_claim_id,
+                'guid' => backup_submission_a.backup_submitted_claim_id,
+                'status' => 'vbms'
+              }
+            },
+            {
+              'id' => backup_submission_b.backup_submitted_claim_id,
+              'attributes' => {
+                'guid' => backup_submission_b.backup_submitted_claim_id,
                 'status' => 'success'
               }
             },
             {
-              'id' => paranoid_submission_b.backup_submitted_claim_id,
+              'id' => backup_submission_c.backup_submitted_claim_id,
               'attributes' => {
-                'guid' => paranoid_submission_b.backup_submitted_claim_id,
-                'status' => 'processing'
+                'guid' => backup_submission_c.backup_submitted_claim_id,
+                'status' => 'error'
               }
             },
             {
-              'id' => paranoid_submission_c.backup_submitted_claim_id,
+              'id' => backup_submission_d.backup_submitted_claim_id,
               'attributes' => {
-                'guid' => paranoid_submission_c.backup_submitted_claim_id,
-                'status' => 'error'
+                'guid' => backup_submission_d.backup_submitted_claim_id,
+                'status' => 'expired'
               }
             }
           ]
         }
       end
 
-      describe 'submission to the bulk status report endpoint' do
-        it 'submits only paranoid_success form submissions' do
-          paranoid_claim_ids = Form526Submission.paranoid_success_type.pluck(:backup_submitted_claim_id)
-          response = double
-          allow(response).to receive(:body).and_return(api_response)
-          allow_any_instance_of(BenefitsIntakeService::Service)
-            .to receive(:get_bulk_status_of_uploads)
-            .with(paranoid_claim_ids)
-            .and_return(response)
+      it 'updates local state to reflect the returned statuses' do
+        pending_claim_ids = Form526Submission.pending_backup_submissions.pluck(:backup_submitted_claim_id)
+        response = double
 
-          expect(paranoid_claim_ids).to contain_exactly(
-            paranoid_submission_a.backup_submitted_claim_id,
-            paranoid_submission_b.backup_submitted_claim_id,
-            paranoid_submission_c.backup_submitted_claim_id
-          )
+        allow(response).to receive(:body).and_return(api_response)
+        allow_any_instance_of(BenefitsIntakeService::Service)
+          .to receive(:get_bulk_status_of_uploads)
+          .with(pending_claim_ids)
+          .and_return(response)
 
-          expect_any_instance_of(BenefitsIntakeService::Service)
-            .to receive(:get_bulk_status_of_uploads)
-            .with(paranoid_claim_ids)
-            .and_return(response)
+        Form526StatusPollingJob.new.perform
 
-          Form526StatusPollingJob.new(paranoid: true).perform
-        end
-      end
-
-      describe 'updating changed states' do
-        it 'updates paranoid submissions to their correct state' do
-          paranoid_claim_ids = Form526Submission.paranoid_success_type.pluck(:backup_submitted_claim_id)
-          response = double
-          allow(response).to receive(:body).and_return(api_response)
-          allow_any_instance_of(BenefitsIntakeService::Service)
-            .to receive(:get_bulk_status_of_uploads)
-            .with(paranoid_claim_ids)
-            .and_return(response)
-
-          expect(paranoid_claim_ids).to contain_exactly(
-            paranoid_submission_a.backup_submitted_claim_id,
-            paranoid_submission_b.backup_submitted_claim_id,
-            paranoid_submission_c.backup_submitted_claim_id
-          )
-
-          Form526StatusPollingJob.new(paranoid: true).perform
-          paranoid_submission_a.reload
-          paranoid_submission_b.reload
-          paranoid_submission_c.reload
-
-          expect(paranoid_submission_a.backup_submitted_claim_status).to eq 'paranoid_success'
-          expect(paranoid_submission_b.backup_submitted_claim_status).to eq nil
-          expect(paranoid_submission_c.backup_submitted_claim_status).to eq 'rejected'
-        end
-      end
-    end
-
-    context 'polling on pending submissions' do
-      describe 'submission to the bulk status report endpoint' do
-        it 'submits only pending form submissions' do
-          pending_claim_ids = Form526Submission.pending_backup_submissions.pluck(:backup_submitted_claim_id)
-          response = double
-          allow(response).to receive(:body).and_return({ 'data' => [] })
-
-          expect(pending_claim_ids).to contain_exactly(
-            backup_submission_a.backup_submitted_claim_id,
-            backup_submission_b.backup_submitted_claim_id,
-            backup_submission_c.backup_submitted_claim_id,
-            backup_submission_d.backup_submitted_claim_id
-          )
-
-          expect_any_instance_of(BenefitsIntakeService::Service)
-            .to receive(:get_bulk_status_of_uploads)
-            .with(pending_claim_ids)
-            .and_return(response)
-
-          Form526StatusPollingJob.new.perform
-        end
-      end
-
-      describe 'when batch size is greater than max batch size' do
-        it 'successfully submits batch intake via batch' do
-          response = double
-          service = double(get_bulk_status_of_uploads: response)
-          allow(response).to receive(:body).and_return({ 'data' => [] })
-          allow(BenefitsIntakeService::Service).to receive(:new).and_return(service)
-
-          Form526StatusPollingJob.new(max_batch_size: 3).perform
-
-          expect(service).to have_received(:get_bulk_status_of_uploads).twice
-        end
-      end
-
-      describe 'when bulk status update fails' do
-        it 'logs the error' do
-          service = double
-          message = 'error'
-          allow(BenefitsIntakeService::Service).to receive(:new).and_return(service)
-          allow(service).to receive(:get_bulk_status_of_uploads).and_raise(message)
-          allow(Rails.logger).to receive(:info)
-          allow(Rails.logger).to receive(:error)
-
-          Form526StatusPollingJob.new.perform
-
-          expect(Rails.logger)
-            .to have_received(:error)
-            .with(
-              'Error processing 526 Intake Status batch',
-              class: 'Form526StatusPollingJob',
-              message:,
-              paranoid: false
-            )
-          expect(Rails.logger)
-            .not_to have_received(:info).with('Form 526 Intake Status polling complete')
-        end
-      end
-
-      describe 'updating the form 526s local submission state' do
-        let(:api_response) do
-          {
-            'data' => [
-              {
-                'id' => backup_submission_a.backup_submitted_claim_id,
-                'attributes' => {
-                  'guid' => backup_submission_a.backup_submitted_claim_id,
-                  'status' => 'vbms'
-                }
-              },
-              {
-                'id' => backup_submission_b.backup_submitted_claim_id,
-                'attributes' => {
-                  'guid' => backup_submission_b.backup_submitted_claim_id,
-                  'status' => 'success'
-                }
-              },
-              {
-                'id' => backup_submission_c.backup_submitted_claim_id,
-                'attributes' => {
-                  'guid' => backup_submission_c.backup_submitted_claim_id,
-                  'status' => 'error'
-                }
-              },
-              {
-                'id' => backup_submission_d.backup_submitted_claim_id,
-                'attributes' => {
-                  'guid' => backup_submission_d.backup_submitted_claim_id,
-                  'status' => 'expired'
-                }
-              }
-            ]
-          }
-        end
-
-        it 'updates local state to reflect the returned statuses' do
-          pending_claim_ids = Form526Submission.pending_backup_submissions
-                                               .pluck(:backup_submitted_claim_id)
-          response = double
-
-          allow(response).to receive(:body).and_return(api_response)
-          allow_any_instance_of(BenefitsIntakeService::Service)
-            .to receive(:get_bulk_status_of_uploads)
-            .with(pending_claim_ids)
-            .and_return(response)
-
-          Form526StatusPollingJob.new.perform
-
-          expect(backup_submission_a.reload.backup_submitted_claim_status).to eq 'accepted'
-          expect(backup_submission_b.reload.backup_submitted_claim_status).to eq 'paranoid_success'
-          expect(backup_submission_c.reload.backup_submitted_claim_status).to eq 'rejected'
-          expect(backup_submission_d.reload.backup_submitted_claim_status).to eq 'rejected'
-        end
+        expect(backup_submission_a.reload.backup_submitted_claim_status).to eq 'accepted'
+        expect(backup_submission_b.reload.backup_submitted_claim_status).to eq nil
+        expect(backup_submission_c.reload.backup_submitted_claim_status).to eq 'rejected'
+        expect(backup_submission_d.reload.backup_submitted_claim_status).to eq 'rejected'
       end
     end
   end


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#17621

Error seen in ArgoCD dev and staging sidekiq pod logs:
```
undefined local variable or method `args' for main
/app/lib/periodic_jobs.rb:46:in `block in <top (required)>'
```