### PR TITLE
Stop removing sidekiq gems from gemfile.lock file when running bundle install locally

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_WITHOUT: "sidekiq_enterprise"

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 #   git config --global core.excludesfile '~/.gitignore_global'
 
 # Ignore bundler config.
-/.bundle
 .envrc
 
 # Ignore all logfiles and tempfiles.

--- a/Gemfile
+++ b/Gemfile
@@ -232,6 +232,13 @@ if (Bundler::Settings.new(Bundler.app_config_path)['enterprise.contribsys.com'].
     Bundler::Settings.new(Bundler.app_config_path)['enterprise.contribsys.com']&.empty?) &&
    ENV.fetch('BUNDLE_ENTERPRISE__CONTRIBSYS__COM', '').empty? && ENV.keys.grep(/DEPENDABOT/).empty?
   Bundler.ui.warn 'No credentials found to install Sidekiq Enterprise. This is fine for local development but you may not check in this Gemfile.lock with any Sidekiq gems removed. The README file in this directory contains more information.'
+  
+  group :sidekiq_enterprise do
+    source 'https://enterprise.contribsys.com/' do
+      gem 'sidekiq-ent'
+      gem 'sidekiq-pro'
+    end
+  end
 else
   source 'https://enterprise.contribsys.com/' do
     gem 'sidekiq-ent'

--- a/Gemfile
+++ b/Gemfile
@@ -232,7 +232,7 @@ if (Bundler::Settings.new(Bundler.app_config_path)['enterprise.contribsys.com'].
     Bundler::Settings.new(Bundler.app_config_path)['enterprise.contribsys.com']&.empty?) &&
    ENV.fetch('BUNDLE_ENTERPRISE__CONTRIBSYS__COM', '').empty? && ENV.keys.grep(/DEPENDABOT/).empty?
   Bundler.ui.warn 'No credentials found to install Sidekiq Enterprise. This is fine for local development but you may not check in this Gemfile.lock with any Sidekiq gems removed. The README file in this directory contains more information.'
-  
+
   group :sidekiq_enterprise do
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'
@@ -241,7 +241,9 @@ if (Bundler::Settings.new(Bundler.app_config_path)['enterprise.contribsys.com'].
   end
 else
   source 'https://enterprise.contribsys.com/' do
+    # rubocop:disable Bundler/DuplicatedGem
     gem 'sidekiq-ent'
     gem 'sidekiq-pro'
+    # rubocop:enable Bundler/DuplicatedGem
   end
 end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
-  I was looking for a way to not have to continually undo the deletion of the enterprise sidekiq gems locally after running `bundle install` for devs that do not need the enterprise acccess. This change introduces a group that is used with `BUNDLE_WITHOUT` by default in the `.bundle/config` file. If the conditions for not installing the gems locally are true, this then includes them in a new `sidekiq_enterprise` group that allows for not updating the `gemfile.lock`. 
-  `.bundle/config` was previously being ignored by git, and I am not fully sure adding it causes other issues? 
- This help solve a development headache of accidentally removing the sidekiq enterprise gems locally, but it should behave the same for users who do have sidekiq enterprise access. 

## Testing done
-  I ran this locally and it does not remove the gems from `gemfile.lock`, and when running it where the condition is false for this it attempts to install the gems as would be correct for devs who locally have access to sidekiq enterprise. 

## What areas of the site does it impact?
Installing gems. I'd like insight from any platform devs on if they think this is valid solution or if there are issues that I am not aware of for building gems in non local environments. 

## Requested Feedback
Is this a valid solution to this problem? Are there concerns around removing `.bundle/config` from the .gitignore?
