### PR TITLE
feat: Feature Toggles: Cache cpu-intense iterations

### DIFF
--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -38,18 +38,20 @@ module V0
     end
 
     def fetch_features_with_gate_keys
-      FLIPPER_FEATURE_CONFIG['features']
-        .map { |name, config| { name:, enabled: false, actor_type: config['actor_type'] } }
-        .tap do |features|
-          # Update enabled to true if globally enabled
-          feature_gates.each do |row|
-            feature = features.find { |f| f[:name] == row['feature_name'] }
-            next unless feature # Ignore features not in config/features.yml
+      Rails.cache.fetch('features_with_gate_keys', expires_in: 1.minute) do
+        FLIPPER_FEATURE_CONFIG['features']
+          .map { |name, config| { name:, enabled: false, actor_type: config['actor_type'] } }
+          .tap do |features|
+            # Update enabled to true if globally enabled
+            feature_gates.each do |row|
+              feature = features.find { |f| f[:name] == row['feature_name'] }
+              next unless feature # Ignore features not in config/features.yml
 
-            feature[:gate_key] = row['gate_key'] # Add gate_key for use in add_feature_gate_values
-            feature[:enabled] = true if row['gate_key'] == 'boolean' && row['value'] == 'true'
+              feature[:gate_key] = row['gate_key'] # Add gate_key for use in add_feature_gate_values
+              feature[:enabled] = true if row['gate_key'] == 'boolean' && row['value'] == 'true'
+            end
           end
-        end
+      end
     end
 
     def add_feature_gate_values(features)
@@ -87,13 +89,11 @@ module V0
     end
 
     def feature_gates
-      Rails.cache.fetch('global_feature_gates', expires_in: 1.minute) do
-        ActiveRecord::Base.connection.select_all(<<-SQL.squish)
-          SELECT flipper_features.key AS feature_name, flipper_gates.key AS gate_key, flipper_gates.value
-          FROM flipper_features
-          LEFT JOIN flipper_gates ON flipper_features.key = flipper_gates.feature_key
-        SQL
-      end
+      ActiveRecord::Base.connection.select_all(<<-SQL.squish)
+        SELECT flipper_features.key AS feature_name, flipper_gates.key AS gate_key, flipper_gates.value
+        FROM flipper_features
+        LEFT JOIN flipper_gates ON flipper_features.key = flipper_gates.feature_key
+      SQL
     end
 
     def flipper_id


### PR DESCRIPTION
`fetch_features_with_gate_keys` collects all the features together and appends information for `add_feature_gate_values`. I removed the cachiing of the sql call as `fetch_features_with_gate_keys` is the only place it is called AND it could cause features to be cached for up to 2 minutes.

Moving the caching here improves response times considerably [compared to the optimizations](https://github.com/department-of-veterans-affairs/vets-api/pull/17679).

Future caching could add russian doll caches based on `MAX updated_at`.
