### PR TITLE
feat: Feature Toggles: Add russian doll caching

### DIFF
--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -39,9 +39,11 @@ module V0
 
     def fetch_features_with_gate_keys
       Rails.cache.fetch('features_with_gate_keys', expires_in: 1.minute) do
-        last_updated_at = Flipper::Adapters::ActiveRecord::Gate.maximum(:updated_at)
+        last_feature_updated_at = Flipper::Adapters::ActiveRecord::Feature.maximum(:updated_at)
+        last_gate_updated_at = Flipper::Adapters::ActiveRecord::Gate.where(key: 'boolean').maximum(:updated_at)
+        cache_key = "features_with_gate_keys/#{last_feature_updated_at}/#{last_gate_updated_at}"
 
-        Rails.cache.fetch("features_with_gate_keys/#{last_updated_at}", expires_in: 24.hours) do
+        Rails.cache.fetch(cache_key, expires_in: 24.hours) do
           FLIPPER_FEATURE_CONFIG['features']
             .map { |name, config| { name:, enabled: false, actor_type: config['actor_type'] } }
             .tap do |features|

--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -39,18 +39,22 @@ module V0
 
     def fetch_features_with_gate_keys
       Rails.cache.fetch('features_with_gate_keys', expires_in: 1.minute) do
-        FLIPPER_FEATURE_CONFIG['features']
-          .map { |name, config| { name:, enabled: false, actor_type: config['actor_type'] } }
-          .tap do |features|
-            # Update enabled to true if globally enabled
-            feature_gates.each do |row|
-              feature = features.find { |f| f[:name] == row['feature_name'] }
-              next unless feature # Ignore features not in config/features.yml
+        last_updated_at = Flipper::Adapters::ActiveRecord::Gate.maximum(:updated_at)
 
-              feature[:gate_key] = row['gate_key'] # Add gate_key for use in add_feature_gate_values
-              feature[:enabled] = true if row['gate_key'] == 'boolean' && row['value'] == 'true'
+        Rails.cache.fetch("features_with_gate_keys/#{last_updated_at}", expires_in: 24.hours) do
+          FLIPPER_FEATURE_CONFIG['features']
+            .map { |name, config| { name:, enabled: false, actor_type: config['actor_type'] } }
+            .tap do |features|
+              # Update enabled to true if globally enabled
+              feature_gates.each do |row|
+                feature = features.find { |f| f[:name] == row['feature_name'] }
+                next unless feature # Ignore features not in config/features.yml
+
+                feature[:gate_key] = row['gate_key'] # Add gate_key for use in add_feature_gate_values
+                feature[:enabled] = true if row['gate_key'] == 'boolean' && row['value'] == 'true'
+              end
             end
-          end
+        end
       end
     end
 


### PR DESCRIPTION
Adds russian-doll-style caching on top of the [CPU-intense caching](https://github.com/department-of-veterans-affairs/vets-api/pull/17693). This makes it so it only checks in once per 24 hours if none of the feature toggles have changed—at the cost of querying the max updated_at once per minute (which is still just one sql query).
