### PR TITLE
chore: Remove unused puma_threads env var

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 workers Integer(ENV.fetch('WEB_CONCURRENCY', 0))
-puma_threads_count = Integer(ENV.fetch('PUMA_THREADS', 5))
-threads_count_min = Integer(ENV.fetch('RAILS_MIN_THREADS', puma_threads_count))
-threads_count_max = Integer(ENV.fetch('RAILS_MAX_THREADS', puma_threads_count))
+threads_count_min = Integer(ENV.fetch('RAILS_MIN_THREADS', 5))
+threads_count_max = Integer(ENV.fetch('RAILS_MAX_THREADS', 5))
 threads(threads_count_min, threads_count_max)
 
 # used for a healthcheck endpoint that will not consume one of the threads


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3015 removes the use of PUMA_THREADS.

This is no longer needed.