### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part 13

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -92,7 +92,7 @@ module V0
         rating_info_service = EVSS::CommonService.new(auth_headers)
         response = rating_info_service.get_rating_info
 
-        render json: response, serializer: RatingInfoSerializer
+        render json: RatingInfoSerializer.new(response)
       end
     end
 

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -26,8 +26,7 @@ module V0
 
       response = api_provider.get_rated_disabilities
 
-      render json: response,
-             serializer: RatedDisabilitiesSerializer
+      render json: RatedDisabilitiesSerializer.new(response)
     end
 
     def separation_locations

--- a/app/controllers/v0/preneeds/burial_forms_controller.rb
+++ b/app/controllers/v0/preneeds/burial_forms_controller.rb
@@ -22,7 +22,7 @@ module V0
         send_confirmation_email
 
         clear_saved_form(FORM)
-        render json: @resource, serializer: ReceiveApplicationSerializer
+        render json: ReceiveApplicationSerializer.new(@resource)
       end
 
       def send_confirmation_email

--- a/app/controllers/v0/profile/service_histories_controller.rb
+++ b/app/controllers/v0/profile/service_histories_controller.rb
@@ -43,11 +43,10 @@ module V0
         handle_errors!(response.episodes)
         report_results(response.episodes)
 
-        json = JSON.parse(response.episodes.to_json, symbolize_names: true)
+        service_history_json = JSON.parse(response.episodes.to_json, symbolize_names: true)
+        options = { is_collection: false }
 
-        render status: response.status,
-               json:,
-               serializer: ServiceHistorySerializer
+        render json: ServiceHistorySerializer.new(service_history_json, options), status: response.status
       end
 
       def check_authorization

--- a/app/controllers/v0/search_controller.rb
+++ b/app/controllers/v0/search_controller.rb
@@ -16,8 +16,9 @@ module V0
     #
     def index
       response = Search::Service.new(query, page).results
+      options = { meta: { pagination: response.pagination } }
 
-      render json: response, serializer: SearchSerializer, meta: { pagination: response.pagination }
+      render json: SearchSerializer.new(response, options)
     end
 
     private

--- a/app/serializers/rated_disabilities_serializer.rb
+++ b/app/serializers/rated_disabilities_serializer.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-class RatedDisabilitiesSerializer < ActiveModel::Serializer
-  attribute :rated_disabilities
+class RatedDisabilitiesSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+  attribute :rated_disabilities
 end

--- a/app/serializers/rating_info_serializer.rb
+++ b/app/serializers/rating_info_serializer.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-class RatingInfoSerializer < ActiveModel::Serializer
-  attributes :user_percent_of_disability, :source_system
+class RatingInfoSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
+  set_id { '' }
+
+  attribute :user_percent_of_disability do |object|
+    object[:user_percent_of_disability]
   end
 
-  def source_system
+  attribute :source_system do |_|
     'EVSS'
   end
 end

--- a/app/serializers/receive_application_serializer.rb
+++ b/app/serializers/receive_application_serializer.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class ReceiveApplicationSerializer < ActiveModel::Serializer
-  def id
-    object.receive_application_id
-  end
+class ReceiveApplicationSerializer
+  include JSONAPI::Serializer
+
+  set_id :receive_application_id
+  set_type :preneeds_receive_applications
 
   attribute :receive_application_id
   attribute :tracking_number

--- a/app/serializers/search_serializer.rb
+++ b/app/serializers/search_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class SearchSerializer < ActiveModel::Serializer
-  attributes :body
+class SearchSerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
+
+  attribute :body
 end

--- a/app/serializers/service_history_serializer.rb
+++ b/app/serializers/service_history_serializer.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-class ServiceHistorySerializer < ActiveModel::Serializer
-  attributes :service_history
+class ServiceHistorySerializer
+  include JSONAPI::Serializer
 
-  def id
-    nil
-  end
+  set_id { '' }
 
-  def service_history
+  attributes :service_history do |object|
     object
   end
 end

--- a/spec/serializers/receive_application_serializer_spec.rb
+++ b/spec/serializers/receive_application_serializer_spec.rb
@@ -9,27 +9,31 @@ RSpec.describe ReceiveApplicationSerializer do
   let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }
 
-  it 'includes id' do
+  it 'includes :id' do
     expect(data['id']).to eq(receive_application.receive_application_id)
   end
 
-  it 'includes tracking_number as attribute' do
+  it 'includes :type' do
+    expect(data['type']).to eq('preneeds_receive_applications')
+  end
+
+  it 'includes :tracking_number as attribute' do
     expect(attributes['tracking_number']).to eq(receive_application.tracking_number)
   end
 
-  it 'includes submitted_at as attribute' do
+  it 'includes Lsubmitted_at as attribute' do
     expect(attributes['submitted_at']).to eq(receive_application.submitted_at.iso8601(3))
   end
 
-  it 'includes return_code as attribute' do
+  it 'includes :return_code as attribute' do
     expect(attributes['return_code']).to eq(receive_application.return_code)
   end
 
-  it 'includes application_uuid as attribute' do
+  it 'includes :application_uuid as attribute' do
     expect(attributes['application_uuid']).to eq(receive_application.application_uuid)
   end
 
-  it 'includes return_description as attribute' do
+  it 'includes :return_description as attribute' do
     expect(attributes['return_description']).to eq(receive_application.return_description)
   end
 end

--- a/spec/serializers/receive_application_serializer_spec.rb
+++ b/spec/serializers/receive_application_serializer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ReceiveApplicationSerializer do
     expect(attributes['tracking_number']).to eq(receive_application.tracking_number)
   end
 
-  it 'includes Lsubmitted_at as attribute' do
+  it 'includes :submitted_at as attribute' do
     expect(attributes['submitted_at']).to eq(receive_application.submitted_at.iso8601(3))
   end
 

--- a/spec/serializers/service_history_serializer_spec.rb
+++ b/spec/serializers/service_history_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe ServiceHistorySerializer, type: :serializer do
-  subject { serialize(service_history, serializer_class: described_class) }
+  subject { serialize(service_history, {serializer_class: described_class, is_collection: false}) }
 
   let(:service_history) do
     histories = [build(:service_history, :with_deployments)]

--- a/spec/serializers/service_history_serializer_spec.rb
+++ b/spec/serializers/service_history_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe ServiceHistorySerializer, type: :serializer do
-  subject { serialize(service_history, {serializer_class: described_class, is_collection: false}) }
+  subject { serialize(service_history, { serializer_class: described_class, is_collection: false }) }
 
   let(:service_history) do
     histories = [build(:service_history, :with_deployments)]


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- RatedDisabilitiesSerializer
- ReceiveApplicationSerializer
- SearchSerializer
- ServiceHistorySerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage