### PR TITLE
Small refactor of Simple Forms Intent logic

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -12,6 +12,12 @@ module SimpleFormsApi
       @params = params
     end
 
+    def use_intent_api?
+      if params[:form_number] == '21-0966' && participant_id && icn && params[:preparer_identification] == 'VETERAN'
+        true
+      end
+    end
+
     def submit
       benefit_selections = []
       params['benefit_selection'].each { |benefit_type, is_selected| benefit_selections << benefit_type if is_selected }
@@ -36,14 +42,22 @@ module SimpleFormsApi
     end
 
     def existing_intents
-      @existing_intents ||= {
-        'compensation' => existing_compensation_intent,
-        'pension' => existing_pension_intent,
-        'survivor' => existing_survivor_intent
-      }
+      @existing_intents ||= if icn && participant_id
+                              {
+                                'compensation' => existing_compensation_intent,
+                                'pension' => existing_pension_intent,
+                                'survivor' => existing_survivor_intent
+                              }
+                            else
+                              {}
+                            end
     end
 
     private
+
+    def participant_id
+      user&.participant_id
+    end
 
     def benefits_claims_lighthouse_service
       @benefits_claims_lighthouse_service ||= BenefitsClaims::Service.new(icn)

--- a/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
+++ b/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
@@ -19,6 +19,7 @@ describe SimpleFormsApi::IntentToFile do
 
     it 'returns no confirmation number and no expiration date if no new ITF is filed' do
       user = build(:user)
+      allow(user).to receive_messages(icn: '123498767V234859', participant_id: 'fake-participant-id')
       intent_to_file_service = SimpleFormsApi::IntentToFile.new(user, params)
       expiration_date = 'fake-expiration-date'
       compensation_intent = {


### PR DESCRIPTION
## Summary
In preparation for more changes to how to fetch the `participant_id` when handling form 21-0966, I wanted to refactor our controller a little bit. The overriding idea here is to push more 0966-specific logic down to the `IntentToFile` service and out of the controller.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88757

## Testing done
Tests are still passing. One needed modification to pass.
