### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part SavedClaim

### DIFF
--- a/app/controllers/claims_base_controller.rb
+++ b/app/controllers/claims_base_controller.rb
@@ -36,7 +36,7 @@ class ClaimsBaseController < ApplicationController
     Rails.logger.info "Submitted job ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM} UserID=#{user_uuid}"
 
     clear_saved_form(claim.form_id)
-    render(json: claim)
+    render json: SavedClaimSerializer.new(claim)
   end
 
   def show

--- a/app/controllers/v0/burial_claims_controller.rb
+++ b/app/controllers/v0/burial_claims_controller.rb
@@ -43,7 +43,7 @@ module V0
 
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.form_id}"
       clear_saved_form(claim.form_id)
-      render(json: claim)
+      render json: SavedClaimSerializer.new(claim)
     end
 
     def short_name

--- a/app/controllers/v0/dependents_applications_controller.rb
+++ b/app/controllers/v0/dependents_applications_controller.rb
@@ -19,7 +19,7 @@ module V0
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
       # clear_saved_form(claim.form_id) # We do not want to destroy the InProgressForm for this submission
 
-      render(json: claim)
+      render json: SavedClaimSerializer.new(claim)
     end
 
     def show

--- a/app/controllers/v0/dependents_verifications_controller.rb
+++ b/app/controllers/v0/dependents_verifications_controller.rb
@@ -27,8 +27,7 @@ module V0
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
       clear_saved_form(claim.form_id)
 
-      # SavedClaimSerializer - this comment will be remove later
-      render(json: claim)
+      render json: SavedClaimSerializer.new(claim)
     end
 
     private

--- a/app/controllers/v0/education_career_counseling_claims_controller.rb
+++ b/app/controllers/v0/education_career_counseling_claims_controller.rb
@@ -17,7 +17,7 @@ module V0
 
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
       clear_saved_form(claim.form_id)
-      render(json: claim)
+      render json: SavedClaimSerializer.new(claim)
     end
 
     private

--- a/app/controllers/v0/pension_claims_controller.rb
+++ b/app/controllers/v0/pension_claims_controller.rb
@@ -55,7 +55,7 @@ module V0
       pension_monitor.track_create_success(in_progress_form, claim, current_user)
 
       clear_saved_form(claim.form_id)
-      render(json: claim)
+      render json: SavedClaimSerializer.new(claim)
     rescue => e
       pension_monitor.track_create_error(in_progress_form, claim, current_user, e)
       raise e

--- a/app/controllers/v0/veteran_readiness_employment_claims_controller.rb
+++ b/app/controllers/v0/veteran_readiness_employment_claims_controller.rb
@@ -13,7 +13,7 @@ module V0
         VRE::Submit1900Job.perform_async(claim.id, current_user.uuid)
         Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
         clear_saved_form(claim.form_id)
-        render json: claim
+        render json: SavedClaimSerializer.new(claim)
       else
         StatsD.increment("#{stats_key}.failure")
         Sentry.set_tags(team: 'vfs-ebenefits') # tag sentry logs with team name

--- a/app/serializers/saved_claim_serializer.rb
+++ b/app/serializers/saved_claim_serializer.rb
@@ -5,7 +5,5 @@ class SavedClaimSerializer
 
   attributes :submitted_at, :regional_office, :confirmation_number, :guid
 
-  attribute :form do |object|
-    object.form_id
-  end
+  attribute :form, &:form_id
 end

--- a/app/serializers/saved_claim_serializer.rb
+++ b/app/serializers/saved_claim_serializer.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
-class SavedClaimSerializer < ActiveModel::Serializer
-  attributes :id, :submitted_at, :regional_office, :confirmation_number, :guid
-  attribute :form_id, key: :form
+class SavedClaimSerializer
+  include JSONAPI::Serializer
+
+  attributes :submitted_at, :regional_office, :confirmation_number, :guid
+
+  attribute :form do |object|
+    object.form_id
+  end
 end

--- a/modules/pensions/app/controllers/pensions/v0/pension_claims_controller.rb
+++ b/modules/pensions/app/controllers/pensions/v0/pension_claims_controller.rb
@@ -56,7 +56,7 @@ module Pensions
         pension_monitor.track_create_success(in_progress_form, claim, current_user)
 
         clear_saved_form(claim.form_id)
-        render(json: claim)
+        render json: SavedClaimSerializer.new(claim)
       rescue => e
         pension_monitor.track_create_error(in_progress_form, claim, current_user, e)
         raise e


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- SavedClaimSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage