### PR TITLE
Use complete file path when stamping Simple Forms PDF

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -19,8 +19,8 @@ module SimpleFormsApi
 
     def generate(current_loa = nil)
       template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
-      generated_form_path = "tmp/#{name}-tmp.pdf"
-      stamped_template_path = "tmp/#{name}-stamped.pdf"
+      generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf")
+      stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf")
       pdftk = PdfForms.new(Settings.binaries.pdftk)
 
       # Tempfile workaround inspired by this:

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -19,7 +19,7 @@ module SimpleFormsApi
 
     def generate(current_loa = nil)
       template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
-      generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf")
+      generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf").to_s
       stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf")
       pdftk = PdfForms.new(Settings.binaries.pdftk)
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -55,7 +55,7 @@ module SimpleFormsApi
     end
 
     def self.multistamp(stamped_template_path, signature_text, page_configuration, font_size = 16)
-      stamp_path = Common::FileHelpers.random_file_path
+      stamp_path = Rails.root.join(Common::FileHelpers.random_file_path)
       Prawn::Document.generate(stamp_path, margin: [0, 0]) do |pdf|
         page_configuration.each do |config|
           case config[:type]
@@ -94,7 +94,7 @@ module SimpleFormsApi
     end
 
     def self.perform_multistamp(stamped_template_path, stamp_path)
-      out_path = "#{Common::FileHelpers.random_file_path}.pdf"
+      out_path = Rails.root.join("#{Common::FileHelpers.random_file_path}.pdf")
       pdftk = PdfFill::Filler::PDF_FORMS
       pdftk.multistamp(stamped_template_path, stamp_path, out_path)
       Common::FileHelpers.delete_file_if_exists(stamped_template_path)

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -36,8 +36,8 @@ describe SimpleFormsApi::PdfFiller do
     forms.each do |file_name|
       context "when mapping the pdf data given JSON file: #{file_name}" do
         let(:form_number) { file_name.gsub('-min', '') }
-        let(:expected_pdf_path) { "tmp/#{name}-tmp.pdf" }
-        let(:expected_stamped_path) { "tmp/#{name}-stamped.pdf" }
+        let(:expected_pdf_path) { Rails.root.join("tmp/#{name}-tmp.pdf") }
+        let(:expected_stamped_path) { Rails.root.join("tmp/#{name}-stamped.pdf") }
         let(:data) { JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{file_name}.json")) }
         let(:form) { "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
         let(:name) { SecureRandom.hex }


### PR DESCRIPTION
## Summary
We've been seeing flaky errors from our PDF Stamper and I have a hunch that these randomly-generated paths are not correct. Based on this Stack Overflow question, I think supplying `Rails.root` might help it. The question is very old but I notice that someone updated it in 2023 saying that in Rails 7, the behavior still works this way so I'm hopeful.

I should note that if this actually resolves the problem fully, I'd be a little surprised since I'd think this would fail 100% of the time. But it only fails 10% of the time. Somehow relative paths work most of the time but not all the time? Seems odd...

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88703
