### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part 14

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@ app/controllers/concerns/failed_request_loggable.rb @department-of-veterans-affa
 app/controllers/concerns/form_attachment_create.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/headers.rb @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/instrumentation.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/concerns/json_api_pagination_links.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/mhv_controller_concerns.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sentry_controller_logging.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sign_in @department-of-veterans-affairs/octo-identity

--- a/app/controllers/concerns/json_api_pagination_links.rb
+++ b/app/controllers/concerns/json_api_pagination_links.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module JsonApiPaginationLinks
+  extend ActiveSupport::Concern
+
+  private
+
+  def pagination_links(collection)
+    total_size = collection.try(:size) || collection.data.size
+    per_page = pagination_params[:per_page].try(:to_i) || total_size
+    current_page = pagination_params[:page].try(:to_i) || 1
+    total_pages = (total_size.to_f / per_page).ceil
+
+    {
+      self: build_page_url(current_page, per_page),
+      first: build_page_url(1, per_page),
+      prev: prev_link(current_page, per_page),
+      next: next_link(current_page, per_page, total_pages),
+      last: build_page_url(total_pages, per_page)
+    }
+  end
+
+  def prev_link(current_page, per_page)
+    return nil if current_page <= 1
+
+    build_page_url(current_page - 1, per_page)
+  end
+
+  def next_link(current_page, per_page, total_pages)
+    return nil if current_page >= total_pages
+
+    build_page_url(current_page + 1, per_page)
+  end
+
+  def build_page_url(page_number, per_page)
+    url_params = {
+      page: page_number,
+      per_page:,
+      query_parameters: request.query_parameters
+    }
+    path_partial = URI.parse(request.original_url).path
+    url = "#{base_path}#{path_partial}?#{url_params.to_query}"
+    URI.parse(url).to_s
+  end
+
+  def base_path
+    "#{Rails.application.config.protocol}://#{Rails.application.config.hostname}"
+  end
+end

--- a/app/controllers/rx_controller.rb
+++ b/app/controllers/rx_controller.rb
@@ -5,6 +5,7 @@ require 'rx/client'
 class RxController < ApplicationController
   include ActionController::Serialization
   include MHVControllerConcerns
+  include JsonApiPaginationLinks
   service_tag 'legacy-mhv'
 
   protected

--- a/app/controllers/v0/profile/valid_va_file_numbers_controller.rb
+++ b/app/controllers/v0/profile/valid_va_file_numbers_controller.rb
@@ -9,7 +9,7 @@ module V0
       def show
         response = BGS::People::Request.new.find_person_by_participant_id(user: current_user)
 
-        valid_file_number =  valid_va_file_number_data(response)
+        valid_file_number = valid_va_file_number_data(response)
         render json: ValidVAFileNumberSerializer.new(valid_file_number)
       end
 

--- a/app/controllers/v0/profile/valid_va_file_numbers_controller.rb
+++ b/app/controllers/v0/profile/valid_va_file_numbers_controller.rb
@@ -9,10 +9,8 @@ module V0
       def show
         response = BGS::People::Request.new.find_person_by_participant_id(user: current_user)
 
-        render(
-          json: valid_va_file_number_data(response),
-          serializer: ValidVAFileNumberSerializer
-        )
+        valid_file_number =  valid_va_file_number_data(response)
+        render json: ValidVAFileNumberSerializer.new(valid_file_number)
       end
 
       private

--- a/app/controllers/v0/trackings_controller.rb
+++ b/app/controllers/v0/trackings_controller.rb
@@ -12,10 +12,10 @@ module V0
       resource = client.get_tracking_history_rx(params[:prescription_id])
       resource = resource.sort(params[:sort])
       resource = resource.paginate(**pagination_params)
-      render json: resource.data,
-             serializer: CollectionSerializer,
-             each_serializer: TrackingSerializer,
-             meta: resource.metadata
+
+      links = pagination_links(resource)
+      options = { meta: resource.metadata, links: }
+      render json: TrackingSerializer.new(resource.data, options)
     end
   end
 end

--- a/app/controllers/v0/triage_teams_controller.rb
+++ b/app/controllers/v0/triage_teams_controller.rb
@@ -9,10 +9,8 @@ module V0
       resource = resource.sort(params[:sort])
 
       # Even though this is a collection action we are not going to paginate
-      render json: resource.data,
-             serializer: CollectionSerializer,
-             each_serializer: TriageTeamSerializer,
-             meta: resource.metadata
+      options = { meta: resource.metadata }
+      render json: TriageTeamSerializer.new(resource.data, options)
     end
   end
 end

--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -9,12 +9,8 @@ module V0
     def show
       pre_serialized_profile = Users::Profile.new(current_user, @session_object).pre_serialize
 
-      render(
-        json: pre_serialized_profile,
-        status: pre_serialized_profile.status,
-        serializer: UserSerializer,
-        meta: { errors: pre_serialized_profile.errors }
-      )
+      options = {  meta: { errors: pre_serialized_profile.errors } }
+      render json: UserSerializer.new(pre_serialized_profile, options), status: pre_serialized_profile.status
     end
 
     def icn

--- a/app/serializers/tracking_serializer.rb
+++ b/app/serializers/tracking_serializer.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
-class TrackingSerializer < ActiveModel::Serializer
-  def id
-    object.tracking_number
+class TrackingSerializer
+  include JSONAPI::Serializer
+  singleton_class.include Rails.application.routes.url_helpers
+
+  set_id :tracking_number
+  set_type :trackings
+
+  link :self do |object|
+    v0_prescription_trackings_url(object.prescription_id)
   end
 
-  link(:self) { v0_prescription_trackings_url(object.prescription_id) }
-  link(:prescription) { v0_prescription_url(object.prescription_id) }
-  link(:tracking_url) do
+  link :prescription do |object|
+    v0_prescription_url(object.prescription_id)
+  end
+
+  link :tracking_url do |object|
     case object.delivery_service.upcase
     when 'UPS'
       "https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=#{object.tracking_number}"

--- a/app/serializers/triage_team_serializer.rb
+++ b/app/serializers/triage_team_serializer.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class TriageTeamSerializer < ActiveModel::Serializer
-  def id
-    object.triage_team_id
-  end
+class TriageTeamSerializer
+  include JSONAPI::Serializer
+
+  set_id :triage_team_id
+  set_type :triage_teams
 
   attribute :triage_team_id
   attribute :name

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -3,25 +3,13 @@
 require 'backend_services'
 require 'common/client/concerns/service_status'
 
-class UserSerializer < ActiveModel::Serializer
+class UserSerializer
+  include JSONAPI::Serializer
   include Common::Client::Concerns::ServiceStatus
+
+  set_id { '' }
 
   attributes :services, :account, :profile, :va_profile, :veteran_status,
              :in_progress_forms, :prefills_available, :vet360_contact_information,
              :session, :onboarding
-
-  def id
-    nil
-  end
-
-  delegate :account, to: :object
-  delegate :profile, to: :object
-  delegate :vet360_contact_information, to: :object
-  delegate :va_profile, to: :object
-  delegate :veteran_status, to: :object
-  delegate :in_progress_forms, to: :object
-  delegate :prefills_available, to: :object
-  delegate :services, to: :object
-  delegate :session, to: :object
-  delegate :onboarding, to: :object
 end

--- a/app/serializers/valid_va_file_number_serializer.rb
+++ b/app/serializers/valid_va_file_number_serializer.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
-class ValidVAFileNumberSerializer < ActiveModel::Serializer
-  type :valid_va_file_number
+class ValidVAFileNumberSerializer
+  include JSONAPI::Serializer
 
-  attribute :valid_va_file_number
+  set_id { '' }
+  set_type :valid_va_file_number
 
-  def id
-    nil
-  end
-
-  def valid_va_file_number
+  attribute :valid_va_file_number do |object|
     object[:file_nbr]
   end
 end

--- a/spec/serializers/tracking_serializer_spec.rb
+++ b/spec/serializers/tracking_serializer_spec.rb
@@ -14,6 +14,10 @@ describe TrackingSerializer, type: :serializer do
     expect(data['id']).to eq tracking.tracking_number.to_s
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq 'trackings'
+  end
+
   it 'includes :tracking_number' do
     expect(attributes['tracking_number']).to eq tracking.tracking_number
   end

--- a/spec/serializers/triage_team_serializer_spec.rb
+++ b/spec/serializers/triage_team_serializer_spec.rb
@@ -9,12 +9,16 @@ RSpec.describe TriageTeamSerializer, type: :serializer do
   let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }
 
-  it 'includes id' do
+  it 'includes :id' do
     expect(data['id'].to_i).to eq(triage_team.triage_team_id)
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq('triage_teams')
+  end
+
   it 'includes triage_team_id' do
-    expect(attributes['triage_team_id'].to_i).to eq(triage_team.triage_team_id)
+    expect(attributes['triage_team_id']).to eq(triage_team.triage_team_id)
   end
 
   it "includes the team's name" do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -18,45 +18,47 @@ RSpec.describe UserSerializer do
   end
 
   it 'returns serialized #services data' do
-    expect(attributes['services']).to be_present
+    expect(attributes['services']).to eq pre_serialized_profile.services
   end
 
   it 'returns serialized #account data' do
-    expect(attributes['account']).to be_present
+    expect(attributes['account']).to eq pre_serialized_profile.account.deep_stringify_keys
   end
 
   it 'returns serialized #profile data' do
-    expect(attributes['profile']).to be_present
+    expect(attributes['profile']).to eq JSON.parse(pre_serialized_profile.profile.to_json)
   end
 
   it 'returns serialized #va_profile data' do
-    expect(attributes['va_profile']).to be_present
+    expect(attributes['va_profile']).to eq pre_serialized_profile.va_profile.deep_stringify_keys
   end
 
   it 'returns serialized #onboarding data' do
-    expect(attributes['onboarding']).to be_present
+    expect(attributes['onboarding']).to eq pre_serialized_profile.onboarding.deep_stringify_keys
   end
 
   it 'returns serialized #veteran_status data' do
     VCR.use_cassette('va_profile/veteran_status/va_profile_veteran_status_200', match_requests_on: %i[body],
                                                                                 allow_playback_repeats: true) do
-      expect(attributes['veteran_status']).to be_present
+      expect(attributes['veteran_status']).to eq pre_serialized_profile.veteran_status.deep_stringify_keys
     end
   end
 
   it 'returns serialized #in_progress_forms data' do
-    expect(attributes['in_progress_forms']).to be_present
+    in_progress_form = pre_serialized_profile.in_progress_forms.first.deep_stringify_keys
+    expect(attributes['in_progress_forms'].first).to eq in_progress_form
   end
 
   it 'returns serialized #prefills_available data' do
-    expect(attributes['prefills_available']).to be_present
+    expect(attributes['prefills_available']).to eq pre_serialized_profile.prefills_available
   end
 
   it 'returns serialized #vet360_contact_information data' do
-    expect(attributes['vet360_contact_information']).to be_present
+    vet360_contact_information = JSON.parse(pre_serialized_profile.vet360_contact_information.to_json)
+    expect(attributes['vet360_contact_information']).to eq vet360_contact_information
   end
 
   it 'returns serialized #session data' do
-    expect(attributes['session']).to be_present
+    expect(attributes['session']).to eq pre_serialized_profile.session.deep_stringify_keys
   end
 end


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- TrackingSerializer
- TriageTeamSerializer
- UserSerializer
- ValidVAFileNumberSerializer

TrackingSerializer require pagination, so `JsonApiPaginationLinks` was added as a concern to `RxController`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage