### PR TITLE
Add OH direct schedule and request feature toggles

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1306,6 +1306,14 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to update the Medication Review instructions on the Appointment Details page.
+  va_online_scheduling_OH_direct_schedule:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to enable direct scheduling workflow for Oracle Health appointments.
+  va_online_scheduling_OH_request:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to enable request workflow for Oracle Health appointments.
   va_burial_v2:
     actor_type: user
     description: Allows us to toggle between 21-P530 and 21-P530V2
@@ -1609,7 +1617,7 @@ features:
     description: swap order of the military details in GI search filters
   merge_1995_and_5490:
     actore_type: user
-    description: Activating the combined 1995 and 5490 form 
+    description: Activating the combined 1995 and 5490 form
   use_new_get_all_features:
     actor_type: user
     description: Used to test new feature toggle code. Removal ETA July 15, 2024


### PR DESCRIPTION
## Summary
This PR add feature toggle `va_online_scheduling_OH_direct_schedule` and `va_online_scheduling_OH_request` for controlling Oracle Health request and direct scheduling workflows.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/89139

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
VAOS

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
