### PR TITLE
[DBX] bump max 526 pending time to 2 weeks

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -123,7 +123,8 @@ class Form526Submission < ApplicationRecord
   FLASHES = 'flashes'
   BIRLS_KEY = 'va_eauth_birlsfilenumber'
   SUBMIT_FORM_526_JOB_CLASSES = %w[SubmitForm526AllClaim SubmitForm526].freeze
-  MAX_PENDING_TIME = 3.days
+  # MAX_PENDING_TIME aligns with the farthest out expectation given in the LH BI docs
+  MAX_PENDING_TIME = 2.weeks
 
   # Called when the DisabilityCompensation form controller is ready to hand off to the backend
   # submission process. Currently this passes directly to the retryable EVSS workflow, but if any

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -275,8 +275,8 @@ FactoryBot.define do
     submitted_claim_id { SecureRandom.rand(900_000_000) }
   end
 
-  trait :created_more_than_3_days_ago do
-    created_at { 4.days.ago }
+  trait :created_more_than_2_weeks_ago do
+    created_at { (2.weeks + 1.day).ago }
   end
 
   trait :remediated do

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe Form526Submission do
 
   describe 'scopes' do
     let!(:in_process) { create(:form526_submission) }
-    let!(:expired) { create(:form526_submission, :created_more_than_3_days_ago) }
+    let!(:expired) { create(:form526_submission, :created_more_than_2_weeks_ago) }
     let!(:happy_path_success) { create(:form526_submission, :with_submitted_claim_id) }
     let!(:pending_backup) { create(:form526_submission, :backup_path) }
     let!(:accepted_backup) { create(:form526_submission, :backup_path, :backup_accepted) }
     let!(:rejected_backup) { create(:form526_submission, :backup_path, :backup_rejected) }
     let!(:remediated) { create(:form526_submission, :remediated) }
-    let!(:remediated_and_expired) { create(:form526_submission, :remediated, :created_more_than_3_days_ago) }
+    let!(:remediated_and_expired) { create(:form526_submission, :remediated, :created_more_than_2_weeks_ago) }
     let!(:remediated_and_rejected) { create(:form526_submission, :remediated, :backup_path, :backup_rejected) }
     let!(:no_longer_remediated) { create(:form526_submission, :no_longer_remediated) }
     let!(:paranoid_success) { create(:form526_submission, :backup_path, :paranoid_success) }
@@ -1476,7 +1476,7 @@ RSpec.describe Form526Submission do
       end
 
       context 'and the record was created more than 3 days ago' do
-        subject { create(:form526_submission, :created_more_than_3_days_ago) }
+        subject { create(:form526_submission, :created_more_than_2_weeks_ago) }
 
         it 'returns false' do
           expect(subject).not_to be_in_process
@@ -1517,7 +1517,7 @@ RSpec.describe Form526Submission do
     end
 
     context 'when the submission is neither a success type nor in process' do
-      subject { create(:form526_submission, :created_more_than_3_days_ago) }
+      subject { create(:form526_submission, :created_more_than_2_weeks_ago) }
 
       it 'returns true' do
         expect(subject).to be_failure_type


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- UPdate the `MAX_PENDING_TIME` used to define 526 submissions as 'in process' from 3 days to 2 weeks.
- 3 days was an intial naive guess to get us started. According to the Benefits Intake API docs, submissions can take up to two weeks to receive a pollable status, which is what this window is accounting for

## Related issue(s)

- [Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/89297)
- [Relevant API docs](https://developer.va.gov/explore/api/benefits-intake/docs?version=current)
  - We care specifically about this bit: 
<img width="854" alt="Screenshot 2024-07-25 at 8 51 52 AM" src="https://github.com/user-attachments/assets/bf0a1744-6b1c-4e6f-8e96-bdaa112029a2">
- [Document  about why we care](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#1-repair-our-backup-submission-polling-job) (this work is part of our 'state repair')

## Testing done

- [x] *New code is covered by unit tests*
- Any 526 submissions that had gone to Benefits Intake (backup path) that were older than 3 days and didn't have a status were considered 'failure type'. this was premature. Now we stretch that window to 2 weeks.
- This work comes from a script we have been using in production in months. By codifying these changes, we are simply elimintating the need for our already well veted code via command line.
- *If this work is behind a flipper:* NO
- [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*: n/a

## What areas of the site does it impact?
Unblocks Datadog monitoring of 526 holistic state (see 'why we care doc' for more)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  [Documentation has been updated](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md#update-on-implementation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
