### PR TITLE
added default error message if #errors method does not exist in thrown exception

### DIFF
--- a/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
+++ b/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
@@ -31,7 +31,7 @@ module BenefitsClaims
           itf_type:,
           form_start_date:,
           user_account_uuid:,
-          errors: e.errors
+          errors: e.try(:errors) || e&.message
         }
         Rails.logger.warn("Lighthouse::CreateIntentToFileJob create #{itf_type} ITF failed", context)
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- The previously added change to the logger attempted to call the #errors method on the thrown exception. But this method is only defined within the custom `ClaimsApi::Common::Exceptions::Lighthouse::UnprocessableEntity` exception. Standard Ruby exceptions do not contain this function, so when a standard exception is thrown, the code would error out and not log the true error properly.
- The code should attempt to call the #errors method using a try function to prevent errors from being thrown if the #errors function isn't defined for the thrown exception. If no #error function is defined, then default to the #message function of the thrown exception.
- Pension team to own this change.

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://app.zenhub.com/workspaces/benefits-pension-64e775aaa6b1ca1ed49b2ede/issues/gh/department-of-veterans-affairs/va.gov-team/88936)
- [*Link to previous change of the code/bug*](https://github.com/department-of-veterans-affairs/vets-api/pull/17643)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
