### PR TITLE
Dependents Card Extra Information

### DIFF
--- a/app/controllers/v0/dependents_applications_controller.rb
+++ b/app/controllers/v0/dependents_applications_controller.rb
@@ -24,6 +24,7 @@ module V0
 
     def show
       dependents = dependent_service.get_dependents
+      dependents[:diaries] = dependency_verification_service.read_diaries
       render json: DependentsSerializer.new(dependents)
     rescue => e
       log_exception_to_sentry(e)
@@ -57,6 +58,10 @@ module V0
 
     def dependent_service
       @dependent_service ||= BGS::DependentService.new(current_user)
+    end
+
+    def dependency_verification_service
+      @dependency_verification_service ||= BGS::DependencyVerificationService.new(current_user)
     end
 
     def stats_key

--- a/app/serializers/dependents_serializer.rb
+++ b/app/serializers/dependents_serializer.rb
@@ -18,7 +18,7 @@ module DependentsHelper
     decision[:award_event_id] == award_event_id && in_future(decision)
   end
 
-  def remove_excess_space(str)
+  def trim_whitespace(str)
     str&.gsub(/\s+/, ' ')
   end
 
@@ -31,7 +31,7 @@ module DependentsHelper
   def dependent_benefit_types(decisions)
     decisions.transform_values do |decs|
       dec = decs.find { |d| START_EVENTS.include?(d[:dependency_decision_type]) }
-      dec && remove_excess_space(dec[:dependency_status_type_description])
+      dec && trim_whitespace(dec[:dependency_status_type_description])
     end
   end
 
@@ -88,7 +88,7 @@ class DependentsSerializer
       upcoming_removal = person[:upcoming_removal] = upcoming_removals(decisions)[person[:ptcpnt_id]]
       if upcoming_removal
         person[:upcoming_removal_date] = Time.zone.parse(upcoming_removal[:award_effective_date])
-        person[:upcoming_removal_reason] = remove_excess_space(upcoming_removal[:dependency_decision_type_description])
+        person[:upcoming_removal_reason] = trim_whitespace(upcoming_removal[:dependency_decision_type_description])
       end
 
       person[:dependent_benefit_type] = dependent_benefit_types(decisions)[person[:ptcpnt_id]]

--- a/app/serializers/dependents_serializer.rb
+++ b/app/serializers/dependents_serializer.rb
@@ -1,6 +1,62 @@
 # frozen_string_literal: true
 
+module DependentsHelper
+  def still_pending(award_event_id)
+    lambda { |decision|
+      decision[:award_event_id] == award_event_id &&
+        Time.zone.parse(decision[:award_effective_date]) > Time.zone.now
+    }
+  end
+
+  def upcoming_removals(decisions)
+    decisions.transform_values do |decs|
+      decs.filter { |dec| %w[T18 SCHATTT].include?(dec[:dependency_decision_type]) }
+          .max { |a, b| a[:award_effective_date] <=> b[:award_effective_date] }
+    end
+  end
+
+  def dependent_benefit_types(decisions)
+    decisions.transform_values do |decs|
+      dec = decs.find { |d| %w[EMC SCHATTB].include?(d[:dependency_decision_type]) }
+      dec && dec[:dependency_status_type_description]&.gsub(/\s+/, ' ')
+    end
+  end
+
+  def current_and_pending_decisions(diaries)
+    # Filter by eligible minor child or school attendance types and if they are the current or future decisions
+    decisions = dependency_decisions(diaries)
+                .filter do |dec|
+      date = Time.zone.parse(dec[:award_effective_date])
+      (%w[EMC SCHATTB].include?(dec[:dependency_decision_type]) && date <= Time.zone.now) ||
+        (%w[T18 SCHATTT].include?(dec[:dependency_decision_type]) && date > Time.zone.now)
+    end
+
+    decisions.group_by { |dec| dec[:person_id] }
+             .transform_values do |decs|
+      # get only most recent active decision and add back to array
+      active =
+        decs.filter do |dec|
+          %w[EMC SCHATTB].include?(dec[:dependency_decision_type]) &&
+            decs.any?(&still_pending(dec[:award_event_id]))
+        end
+      most_recent = active.max { |a, b| a[:award_effective_date] <=> b[:award_effective_date] }
+      # include future school attendance
+      (decs.filter { |dec|
+        %w[T18 SCHATTB SCHATTT].include?(dec[:dependency_decision_type])
+      } + [most_recent]).compact
+    end
+  end
+
+  def dependency_decisions(diaries)
+    decisions = diaries && diaries[:dependency_decs]
+    return if decisions.nil?
+
+    decisions.is_a?(Hash) ? [decisions] : decisions
+  end
+end
+
 class DependentsSerializer
+  extend DependentsHelper
   include JSONAPI::Serializer
 
   set_id { '' }
@@ -9,6 +65,21 @@ class DependentsSerializer
   attribute :persons do |object|
     next [object[:persons]] if object[:persons].instance_of?(Hash)
 
-    object[:persons]
+    arr = object[:persons].instance_of?(Hash) ? [object[:persons]] : object[:persons]
+    diaries = object[:diaries]
+
+    next arr if dependency_decisions(diaries).blank?
+
+    decisions = current_and_pending_decisions(diaries)
+
+    arr.each do |person|
+      upcoming_removal = person[:upcoming_removal] = upcoming_removals(decisions)[person[:ptcpnt_id]]
+      if upcoming_removal
+        person[:upcoming_removal_date] = Time.zone.parse(upcoming_removal[:award_effective_date])
+        person[:upcoming_removal_reason] = upcoming_removal[:dependency_decision_type_description].gsub(/\s+/, ' ')
+      end
+
+      person[:dependent_benefit_type] = dependent_benefit_types(decisions)[person[:ptcpnt_id]]
+    end
   end
 end

--- a/app/serializers/dependents_serializer.rb
+++ b/app/serializers/dependents_serializer.rb
@@ -24,7 +24,7 @@ module DependentsHelper
 
   def upcoming_removals(decisions)
     decisions.transform_values do |decs|
-      decs.filter { |dec| END_EVENTS.include?(dec[:dependency_decision_type]) }.max(&max_time)
+      decs.filter { |dec| END_EVENTS.include?(dec[:dependency_decision_type]) }.max { |a, b| max_time(a, b) }
     end
   end
 
@@ -51,7 +51,7 @@ module DependentsHelper
           START_EVENTS.include?(dec[:dependency_decision_type]) &&
             decs.any? { |d| still_pending(d, dec[:award_event_id]) }
         end
-      most_recent = active.max(&max_time)
+      most_recent = active.max { |a, b| max_time(a, b) }
       # include all future events (including school attendance begins)
       (decs.filter { |dec|
         FUTURE_EVENTS.include?(dec[:dependency_decision_type]) && in_future(dec)

--- a/app/serializers/dependents_serializer.rb
+++ b/app/serializers/dependents_serializer.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 module DependentsHelper
-  def still_pending(award_event_id)
-    lambda { |decision|
-      decision[:award_event_id] == award_event_id &&
-        Time.zone.parse(decision[:award_effective_date]) > Time.zone.now
-    }
+  def still_pending(decision, award_event_id)
+    decision[:award_event_id] == award_event_id &&
+      Time.zone.parse(decision[:award_effective_date]) > Time.zone.now
   end
 
   def upcoming_removals(decisions)
@@ -37,7 +35,7 @@ module DependentsHelper
       active =
         decs.filter do |dec|
           %w[EMC SCHATTB].include?(dec[:dependency_decision_type]) &&
-            decs.any?(&still_pending(dec[:award_event_id]))
+            decs.any? { |d| still_pending(d, dec[:award_event_id]) }
         end
       most_recent = active.max { |a, b| a[:award_effective_date] <=> b[:award_effective_date] }
       # include future school attendance

--- a/spec/serializers/dependents_serializer_spec.rb
+++ b/spec/serializers/dependents_serializer_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe DependentsSerializer, type: :serializer do
     end
   end
 
-  context 'current benefits out of range range' do
+  context 'current benefits out of range' do
     let(:current_diary) do
       {
         person_id:,

--- a/spec/serializers/dependents_serializer_spec.rb
+++ b/spec/serializers/dependents_serializer_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe DependentsSerializer, type: :serializer do
   subject { serialize(dependents, serializer_class: described_class) }
 
+  let(:person_id) { '600140899' }
   let(:person) do
     {
       award_indicator: 'N',
@@ -20,12 +21,36 @@ RSpec.describe DependentsSerializer, type: :serializer do
       veteran_indicator: 'N'
     }
   end
+
+  let(:expiring_diary) do
+    {
+      person_id:,
+      dependency_decision_type: 'T18',
+      dependency_decision_type_description: 'Turns 18',
+      dependency_status_type_description: 'Not an Award Dependent',
+      award_effective_date: 2.days.from_now.iso8601
+    }
+  end
+  let(:current_diary) do
+    {
+      person_id:,
+      dependency_decision_type: 'EMC',
+      dependency_decision_type_description: 'Eligible Minor Child',
+      dependency_status_type_description: 'Minor Child',
+      award_effective_date: 2.years.ago.iso8601
+    }
+  end
+
   let(:dependents) do
     {
       number_of_records: '2',
       persons: [person],
       return_code: 'SHAR 9999',
-      return_message: 'Records found'
+      return_message: 'Records found',
+      diaries: {
+        dependency_decs: [expiring_diary,
+                          current_diary]
+      }
     }
   end
 
@@ -42,7 +67,8 @@ RSpec.describe DependentsSerializer, type: :serializer do
         number_of_records: '2',
         persons: person,
         return_code: 'SHAR 9999',
-        return_message: 'Records found'
+        return_message: 'Records found',
+        diaries: {}
       }
     end
     let(:response_persons_hash) { serialize(persons_hash, serializer_class: described_class) }
@@ -75,5 +101,55 @@ RSpec.describe DependentsSerializer, type: :serializer do
       'ssn' => '222883214',
       'veteran_indicator' => 'N'
     )
+  end
+
+  context 'upcoming removal date within range' do
+    it 'returns date and reason' do
+      expect(attributes['persons'].first).to include('upcoming_removal_date')
+      expect(attributes['persons'].first).to include('upcoming_removal_reason' => 'Turns 18')
+    end
+  end
+
+  context 'upcoming removal expired' do
+    let(:expiring_diary) do
+      {
+        person_id:,
+        dependency_decision_type: 'T18',
+        dependency_decision_type_description: 'Turns 18',
+        dependency_status_type_description: 'Not an Award Dependent',
+        award_effective_date: 2.days.ago.iso8601
+      }
+    end
+
+    it 'does not return expired date and reason' do
+      expect(attributes['persons'].first['upcoming_removal_date']).to be_nil
+      expect(attributes['persons'].first['upcoming_removal_reason']).to be_nil
+    end
+
+    it 'does not display current benefits date and reason' do
+      expect(attributes['persons'].first['dependent_benefit_type']).to be_nil
+    end
+  end
+
+  context 'current benefits within range' do
+    it 'returns benefits description' do
+      expect(attributes['persons'].first).to include('dependent_benefit_type' => 'Minor Child')
+    end
+  end
+
+  context 'current benefits out of range range' do
+    let(:current_diary) do
+      {
+        person_id:,
+        dependency_decision_type: 'EMC',
+        dependency_decision_type_description: 'Eligible Minor Child',
+        dependency_status_type_description: 'Minor Child',
+        award_effective_date: 2.days.from_now.iso8601
+      }
+    end
+
+    it 'does not return date and reason' do
+      expect(attributes['persons'].first['dependent_benefit_type']).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **NO**
- Adds two extra fields to dependents index api call
  - `upcoming_renewal`
  - `dependent_benefit_type`
- The fields above are to help veterans understand information about their dependents

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/87272

## Testing done
- Tested through console multiple variations of dependents info to verify the fields are left nil or filled as appropriate

## What areas of the site does it impact?
This will impact the dependents page for veterans after the frontend has added the corresponding fields

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  ~I added a screenshot of the developed feature~

## Requested Feedback

