### PR TITLE
Add burials-ez

### DIFF
--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -62,6 +62,7 @@ class StatsdMiddleware
     burial-poc-v6
     burials
     burials-v2
+    burials-ez
     check-in
     claims-status
     coe


### PR DESCRIPTION
## Summary
[This monitor](https://vagov.ddog-gov.com/monitors/200229) keeps telling us about burials-ez. Fixing by adding it to `lib/statsd_middleware.rb`, as explained in the monitor's message. 
