### PR TITLE
88263: Add logic for DataDog current user tracking

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -64,6 +64,7 @@ module IvcChampva
 
         form = form_class.new(parsed_form_data)
         form.track_user_identity
+        form.track_current_user_loa(@current_user) if @current_user
 
         attachment_ids = generate_attachment_ids(form_id, applicant_rounded_number)
         attachment_ids.concat(supporting_document_ids(parsed_form_data))

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -64,7 +64,7 @@ module IvcChampva
 
         form = form_class.new(parsed_form_data)
         form.track_user_identity
-        form.track_current_user_loa(@current_user) if @current_user
+        form.track_current_user_loa(@current_user)
 
         attachment_ids = generate_attachment_ids(form_id, applicant_rounded_number)
         attachment_ids.concat(supporting_document_ids(parsed_form_data))

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -60,7 +60,7 @@ module IvcChampva
     end
 
     def track_current_user_loa(current_user)
-      current_user_loa = current_user.loa[:current]
+      current_user_loa = current_user&.loa&.[](:current) || 0
       StatsD.increment("#{STATS_KEY}.#{current_user_loa}")
       Rails.logger.info('IVC ChampVA Forms - 10-10D Current User LOA', current_user_loa:)
     end

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -59,6 +59,12 @@ module IvcChampva
       Rails.logger.info('IVC ChampVA Forms - 10-10D Submission User Identity', identity:)
     end
 
+    def track_current_user_loa(current_user)
+      current_user_loa = current_user.loa[:current]
+      StatsD.increment("#{STATS_KEY}.#{current_user_loa}")
+      Rails.logger.info('IVC ChampVA Forms - 10-10D Current User LOA', current_user_loa:)
+    end
+
     def method_missing(_, *args)
       args&.first
     end

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -2,6 +2,8 @@
 
 module IvcChampva
   class VHA107959a
+    STATS_KEY = 'api.ivc_champva_form.10_7959a'
+
     include Virtus.model(nullify_blank: true)
     include Attachments
 
@@ -28,6 +30,12 @@ module IvcChampva
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info']
       }
+    end
+
+    def track_user_identity
+      identity = data['certifier_role']
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('IVC ChampVA Forms - 10-7959A Submission User Identity', identity:)
     end
 
     # rubocop:disable Naming/BlockForwarding,Style/HashSyntax

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -2,6 +2,8 @@
 
 module IvcChampva
   class VHA107959c
+    STATS_KEY = 'api.ivc_champva_form.10_7959c'
+
     include Virtus.model(nullify_blank: true)
     include Attachments
 
@@ -29,6 +31,18 @@ module IvcChampva
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info']
       }
+    end
+
+    def track_user_identity
+      identity = data['certifier_role']
+      StatsD.increment("#{STATS_KEY}.#{identity}")
+      Rails.logger.info('IVC ChampVA Forms - 10-7959C Submission User Identity', identity:)
+    end
+
+    def track_current_user_loa(current_user)
+      current_user_loa = current_user.loa[:current]
+      StatsD.increment("#{STATS_KEY}.#{current_user_loa}")
+      Rails.logger.info('IVC ChampVA Forms - 10-7959C Current User LOA', current_user_loa:)
     end
 
     # rubocop:disable Naming/BlockForwarding,Style/HashSyntax

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -40,7 +40,7 @@ module IvcChampva
     end
 
     def track_current_user_loa(current_user)
-      current_user_loa = current_user.loa[:current]
+      current_user_loa = current_user&.loa&.[](:current) || 0
       StatsD.increment("#{STATS_KEY}.#{current_user_loa}")
       Rails.logger.info('IVC ChampVA Forms - 10-7959C Current User LOA', current_user_loa:)
     end

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -2,6 +2,8 @@
 
 module IvcChampva
   class VHA107959f1
+    STATS_KEY = 'api.ivc_champva_form.10_7959f_1'
+
     include Virtus.model(nullify_blank: true)
     include Attachments
 
@@ -33,6 +35,12 @@ module IvcChampva
 
     def desired_stamps
       [{ coords: [26, 82.5], text: data['statement_of_truth_signature'], page: 0 }]
+    end
+
+    def track_current_user_loa(current_user)
+      current_user_loa = current_user.loa[:current]
+      StatsD.increment("#{STATS_KEY}.#{current_user_loa}")
+      Rails.logger.info('IVC ChampVA Forms - 10-7959F-1 Current User LOA', current_user_loa:)
     end
 
     def method_missing(_, *args)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -38,7 +38,7 @@ module IvcChampva
     end
 
     def track_current_user_loa(current_user)
-      current_user_loa = current_user.loa[:current]
+      current_user_loa = current_user&.loa&.[](:current) || 0
       StatsD.increment("#{STATS_KEY}.#{current_user_loa}")
       Rails.logger.info('IVC ChampVA Forms - 10-7959F-1 Current User LOA', current_user_loa:)
     end


### PR DESCRIPTION
Add logic to track current user LOA

## Summary

- Add `track_current_user_loa` to a few models
- Add `track_user_identity` to a couple models missing it
- Add new method to `uploads_controller`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88263

## Screenshots
<img width="581" alt="Screenshot 2024-07-24 at 5 05 08 PM" src="https://github.com/user-attachments/assets/59a62c93-dada-4370-8c6f-173f1b4340df">

## Acceptance criteria

As a member of the IVC forms team, I want to see metrics for how many users are authenticated versus not authenticated.

If possible, include LOA level.
