### PR TITLE
Hotfix: Fallback to `evss_id` for `claim_id`

### DIFF
--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -85,10 +85,10 @@ module ClaimsApi
       case doc_type
       when 'L075', 'L190'
         nil
-      when 'L122'
-        claim.evss_id
       when 'L705'
         claim.claim_id
+      else
+        claim.evss_id
       end
     end
 

--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -72,7 +72,7 @@ module ClaimsApi
         'POA'
       when 'L122'
         'claim'
-      when 'L705'
+      else
         'supporting'
       end
     end

--- a/modules/claims_api/spec/lib/claims_api/bd_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bd_spec.rb
@@ -33,6 +33,7 @@ describe ClaimsApi::BD do
                                                      original_filename: 'stuff.pdf')
         js = JSON.parse(result[:parameters].read)
         expect(js['data']['docType']).to eq 'L023'
+        expect(js['data']['claimId']).to eq claim.evss_id
       end
 
       it 'uploads an attachment to BD for L122' do
@@ -40,6 +41,7 @@ describe ClaimsApi::BD do
                                                      pdf_path:)
         js = JSON.parse(result[:parameters].read)
         expect(js['data']['docType']).to eq 'L122'
+        expect(js['data']['claimId']).to eq claim.evss_id
       end
     end
 
@@ -97,6 +99,10 @@ describe ClaimsApi::BD do
         it 'the fileName ends in 21-22.pdf' do
           expect(json_body['data']['fileName']).to end_with('21-22.pdf')
         end
+
+        it 'the claimId is nil' do
+          expect(json_body['data']['claimId']).to be_nil
+        end
       end
 
       context 'when the doctype is L075' do
@@ -119,6 +125,10 @@ describe ClaimsApi::BD do
 
         it 'the fileName ends in 21-22a.pdf' do
           expect(json_body['data']['fileName']).to end_with('21-22a.pdf')
+        end
+
+        it 'the claimId is nil' do
+          expect(json_body['data']['claimId']).to be_nil
         end
       end
     end
@@ -147,6 +157,7 @@ describe ClaimsApi::BD do
                                                      pdf_path:)
         js = JSON.parse(result[:parameters].read)
         expect(js['data']['docType']).to eq 'L705'
+        expect(js['data']['claimId']).to eq ews.claim_id
       end
     end
 


### PR DESCRIPTION
## Summary

- Certain `doc_types` (e.g., `L023`) will fail to be identified without an `evss_id`. Fallback to `evss_id` for `claim_id` for `doc_types` that do not have other requirements.
- Fallback to 'supporting' for doc_types not listed.

## Related issue(s)

N/A

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?
Benefits documents upload

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A