### PR TITLE
Replace Root AMS serializers with JSONAPI serializers - Part Message

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@ app/controllers/concerns/failed_request_loggable.rb @department-of-veterans-affa
 app/controllers/concerns/form_attachment_create.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/headers.rb @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/instrumentation.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/concerns/json_api_pagination_links.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/mhv_controller_concerns.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sentry_controller_logging.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sign_in @department-of-veterans-affairs/octo-identity

--- a/app/controllers/concerns/json_api_pagination_links.rb
+++ b/app/controllers/concerns/json_api_pagination_links.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module JsonApiPaginationLinks
+  extend ActiveSupport::Concern
+
+  private
+
+  def pagination_links(collection)
+    total_size = collection.try(:size) || collection.data.size
+    per_page = pagination_params[:per_page].try(:to_i) || total_size
+    current_page = pagination_params[:page].try(:to_i) || 1
+    total_pages = (total_size.to_f / per_page).ceil
+
+    {
+      self: build_page_url(current_page, per_page),
+      first: build_page_url(1, per_page),
+      prev: prev_link(current_page, per_page),
+      next: next_link(current_page, per_page, total_pages),
+      last: build_page_url(total_pages, per_page)
+    }
+  end
+
+  def prev_link(current_page, per_page)
+    return nil if current_page <= 1
+
+    build_page_url(current_page - 1, per_page)
+  end
+
+  def next_link(current_page, per_page, total_pages)
+    return nil if current_page >= total_pages
+
+    build_page_url(current_page + 1, per_page)
+  end
+
+  def build_page_url(page_number, per_page)
+    url_params = {
+      page: page_number,
+      per_page:,
+      query_parameters: request.query_parameters
+    }
+    path_partial = URI.parse(request.original_url).path
+    url = "#{base_path}#{path_partial}?#{url_params.to_query}"
+    URI.parse(url).to_s
+  end
+
+  def base_path
+    "#{Rails.application.config.protocol}://#{Rails.application.config.hostname}"
+  end
+end

--- a/app/controllers/sm_controller.rb
+++ b/app/controllers/sm_controller.rb
@@ -5,6 +5,7 @@ require 'sm/client'
 class SMController < ApplicationController
   include ActionController::Serialization
   include MHVControllerConcerns
+  include JsonApiPaginationLinks
   service_tag 'legacy-mhv'
 
   protected

--- a/app/controllers/v0/folders_controller.rb
+++ b/app/controllers/v0/folders_controller.rb
@@ -6,10 +6,9 @@ module V0
       resource = client.get_folders(@current_user.uuid, use_cache? || true)
       resource = resource.paginate(**pagination_params)
 
-      render json: resource.data,
-             serializer: CollectionSerializer,
-             each_serializer: FolderSerializer,
-             meta: resource.metadata
+      links = pagination_links(resource)
+      options = { meta: resource.metadata, links: }
+      render json: FolderSerializer.new(resource.data, options)
     end
 
     def show
@@ -17,9 +16,8 @@ module V0
       resource = client.get_folder(id)
       raise Common::Exceptions::RecordNotFound, id if resource.blank?
 
-      render json: resource,
-             serializer: FolderSerializer,
-             meta: resource.metadata
+      options = { meta: resource.metadata }
+      render json: FolderSerializer.new(resource, options)
     end
 
     def create
@@ -28,10 +26,8 @@ module V0
 
       resource = client.post_create_folder(folder.name)
 
-      render json: resource,
-             serializer: FolderSerializer,
-             meta: resource.metadata,
-             status: :created
+      options = { meta: resource.metadata }
+      render json: FolderSerializer.new(resource, options), status: :created
     end
 
     def destroy

--- a/app/controllers/v0/message_drafts_controller.rb
+++ b/app/controllers/v0/message_drafts_controller.rb
@@ -4,9 +4,7 @@ module V0
   class MessageDraftsController < SMController
     def create
       draft_response = client.post_create_message_draft(draft_params)
-      render json: draft_response,
-             serializer: MessageSerializer,
-             status: :created
+      render json: MessageSerializer.new(draft_response), status: :created
     end
 
     def update
@@ -16,9 +14,7 @@ module V0
 
     def create_reply_draft
       draft_response = client.post_create_message_draft_reply(params[:reply_id], reply_draft_params)
-      render json: draft_response,
-             serializer: MessageSerializer,
-             status: :created
+      render json: MessageSerializer.new(draft_response), status: :created
     end
 
     def update_reply_draft

--- a/app/controllers/v0/messages_controller.rb
+++ b/app/controllers/v0/messages_controller.rb
@@ -12,7 +12,8 @@ module V0
       resource = resource.sort(params[:sort])
       resource = resource.paginate(**pagination_params)
 
-      options = { meta: resource.metadata }
+      links = pagination_links(resource)
+      options = { meta: resource.metadata, links: }
       render json: MessagesSerializer.new(resource.data, options)
     end
 

--- a/app/controllers/v0/messages_controller.rb
+++ b/app/controllers/v0/messages_controller.rb
@@ -12,10 +12,8 @@ module V0
       resource = resource.sort(params[:sort])
       resource = resource.paginate(**pagination_params)
 
-      render json: resource.data,
-             serializer: CollectionSerializer,
-             each_serializer: MessagesSerializer,
-             meta: resource.metadata
+      options = { meta: resource.metadata }
+      render json: MessagesSerializer.new(resource.data, options)
     end
 
     def show
@@ -24,10 +22,10 @@ module V0
 
       raise Common::Exceptions::RecordNotFound, message_id if response.blank?
 
-      render json: response,
-             serializer: MessageSerializer,
-             include: 'attachments',
-             meta: response.metadata
+      options = {
+        meta: response.metadata
+      }
+      render json: MessageSerializer.new(response, options)
     end
 
     def create
@@ -42,11 +40,9 @@ module V0
                         else
                           client.post_create_message(message_params)
                         end
-
-      render json: client_response,
-             serializer: MessageSerializer,
-             include: 'attachments',
-             meta: {}
+      options = { meta: {} }
+      options[:include] = [:attachments] if client_response.attachment
+      render json: MessageSerializer.new(client_response, options)
     end
 
     def destroy
@@ -59,10 +55,8 @@ module V0
       resource = client.get_message_history(message_id)
       raise Common::Exceptions::RecordNotFound, message_id if resource.blank?
 
-      render json: resource.data,
-             serializer: CollectionSerializer,
-             each_serializer: MessagesSerializer,
-             meta: resource.metadata
+      options = { meta: resource.metadata }
+      render json: MessagesSerializer.new(resource.data, options)
     end
 
     def reply
@@ -77,11 +71,9 @@ module V0
                         else
                           client.post_create_message_reply(params[:id], message_params)
                         end
-
-      render json: client_response,
-             serializer: MessageSerializer,
-             include: 'attachments',
-             status: :created
+      options = { meta: {} }
+      options[:include] = [:attachments] if client_response.attachment
+      render json: MessageSerializer.new(client_response, options), status: :created
     end
 
     def categories

--- a/app/controllers/v0/messaging_preferences_controller.rb
+++ b/app/controllers/v0/messaging_preferences_controller.rb
@@ -4,8 +4,7 @@ module V0
   class MessagingPreferencesController < SMController
     def show
       resource = client.get_preferences
-      render json: resource,
-             serializer: MessagingPreferenceSerializer
+      render json: MessagingPreferenceSerializer.new(resource)
     end
 
     # Set secure messaging email notification preferences.
@@ -13,8 +12,7 @@ module V0
     # @param frequency - one of 'none', 'each_message', or 'daily'
     def update
       resource = client.post_preferences(params.permit(:email_address, :frequency))
-      render json: resource,
-             serializer: MessagingPreferenceSerializer
+      render json: MessagingPreferenceSerializer.new(resource)
     end
   end
 end

--- a/app/serializers/attachment_serializer.rb
+++ b/app/serializers/attachment_serializer.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
-class AttachmentSerializer < ActiveModel::Serializer
-  attribute :id
+class AttachmentSerializer
+  include JSONAPI::Serializer
+  singleton_class.include Rails.application.routes.url_helpers
+
+  set_type :attachments
+
   attribute :name
   attribute :message_id
   attribute :attachment_size
 
-  link(:download) { v0_message_attachment_url(object.message_id, object.id) }
+  link :download do |object|
+    v0_message_attachment_url(object.message_id, object.id)
+  end
 end

--- a/app/serializers/folder_serializer.rb
+++ b/app/serializers/folder_serializer.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
-class FolderSerializer < ActiveModel::Serializer
-  attribute :id
+class FolderSerializer
+  include JSONAPI::Serializer
+  singleton_class.include Rails.application.routes.url_helpers
 
-  attribute(:folder_id) { object.id }
+  set_type :folders
+
+  attribute :folder_id, &:id
   attribute :name
   attribute :count
   attribute :unread_count
   attribute :system_folder
 
-  link(:self) { v0_folder_url(object.id) }
+  link :self do |object|
+    v0_folder_url(object.id)
+  end
 end

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 class MessageSerializer < MessagesSerializer
-  has_many :attachments, each_serializer: AttachmentSerializer
+  include JSONAPI::Serializer
+
+  set_type :messages
+
+  has_many :attachments, serializer: AttachmentSerializer, &:attachments
 end

--- a/app/serializers/messages_serializer.rb
+++ b/app/serializers/messages_serializer.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class MessagesSerializer < ActiveModel::Serializer
-  attribute :id
+class MessagesSerializer
+  include JSONAPI::Serializer
+  singleton_class.include Rails.application.routes.url_helpers
 
-  attribute(:message_id) { object.id }
+  attribute :message_id, &:id
   attribute :category
   attribute :subject
   attribute :body
@@ -17,5 +18,7 @@ class MessagesSerializer < ActiveModel::Serializer
   attribute :triage_group_name
   attribute :proxy_sender_name
 
-  link(:self) { v0_message_url(object.id) }
+  link :self do |object|
+    v0_message_url(object.id)
+  end
 end

--- a/app/serializers/messaging_preference_serializer.rb
+++ b/app/serializers/messaging_preference_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-class MessagingPreferenceSerializer < ActiveModel::Serializer
+class MessagingPreferenceSerializer
+  include JSONAPI::Serializer
+
   attributes :email_address, :frequency
 end

--- a/spec/serializers/attachment_serializer_spec.rb
+++ b/spec/serializers/attachment_serializer_spec.rb
@@ -16,6 +16,10 @@ describe AttachmentSerializer do
     expect(data['id']).to eq attachment.id.to_s
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq 'attachments'
+  end
+
   it 'includes :name' do
     expect(attributes['name']).to eq attachment.name
   end

--- a/spec/serializers/message_serializer_spec.rb
+++ b/spec/serializers/message_serializer_spec.rb
@@ -3,11 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe MessageSerializer, type: :serializer do
-  subject { serialize(message, serializer_class: described_class) }
+  subject { serialize(message, { serializer_class: described_class, include: [:attachments] }) }
 
   let(:message) { build_stubbed(:message, :with_attachments) }
   let(:data) { JSON.parse(subject)['data'] }
   let(:relationships) { data['relationships'] }
+
+  it 'includes :id' do
+    expect(data['id'].to_i).to eq(message.id)
+  end
+
+  it 'includes :type' do
+    expect(data['type']).to eq 'messages'
+  end
 
   it 'includes :attachments' do
     expect(relationships['attachments']['data'].size).to eq message.attachments.size


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- AttachmentSerializer
- FolderSerializer
- MessageSerializer
- MessagesSerializer
- MessagingPreferenceSerializer

Added `JsonApiPaginationLinks` for `FoldersController` and `MessagesController`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage