### PR TITLE
[DR-89020] Update encryption for Supplemental Claims 4142 processing to prevent `stack level too deep` error

### DIFF
--- a/app/sidekiq/decision_review/form4142_submit.rb
+++ b/app/sidekiq/decision_review/form4142_submit.rb
@@ -6,6 +6,7 @@ require 'decision_review_v1/service'
 module DecisionReview
   class Form4142Submit
     include Sidekiq::Job
+    include DecisionReviewV1::Appeals::Helpers
 
     STATSD_KEY_PREFIX = 'worker.decision_review.form4142_submit'
 
@@ -14,7 +15,7 @@ module DecisionReview
     sidekiq_options retry: 13
 
     def decrypt_form(encrypted_payload)
-      JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_payload))
+      JSON.parse(DecisionReviewV1::Appeals::Helpers::DR_LOCKBOX.decrypt(encrypted_payload))
     end
 
     def perform(appeal_submission_id, encrypted_payload, submitted_appeal_uuid)

--- a/lib/decision_review_v1/utilities/helpers.rb
+++ b/lib/decision_review_v1/utilities/helpers.rb
@@ -11,6 +11,8 @@ module DecisionReviewV1
       # in the future.
       include DecisionReviewV1::Appeals::LoggingUtils
 
+      DR_LOCKBOX = Lockbox.new(key: Settings.lockbox.master_key, encode: true)
+
       def middle_initial(user)
         user.middle_name.to_s.strip.presence&.first&.upcase
       end
@@ -18,7 +20,7 @@ module DecisionReviewV1
       # Takes original payload (or anything that responds to to_json)
       # Then encrypts it so that there is no PII in the sidekiq args
       def payload_encrypted_string(payload)
-        KmsEncrypted::Box.new.encrypt(payload.to_json)
+        DR_LOCKBOX.encrypt(payload.to_json)
       end
 
       def get_and_rejigger_required_info(request_body:, form4142:, user:)

--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
           Flipper.enable :decision_review_sc_use_lighthouse_api_for_form4142
         end
 
+        it '#decrypt_form properly decrypts encrypted payloads' do
+          form4142 = request_body['form4142']
+          payload = get_and_rejigger_required_info(
+            request_body:, form4142:, user:
+          )
+          enc_payload = payload_encrypted_string(payload)
+          expect(subject.new.decrypt_form(enc_payload)).to eq(payload)
+        end
+
         it 'generates a 4142 PDF and sends it to Lighthouse API' do
           VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
             VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do


### PR DESCRIPTION
## Summary
This should fix an exception we're seeing that leads to a `stack level too deep` error when we try to create an PersonalInformationLog for the original exception that was raised:
```
1 validation error detected: Value at 'plaintext' failed to satisfy constraint: Member must have length less than or equal to 4096
```
Another team [fixed this](https://github.com/department-of-veterans-affairs/vets-api/pull/14013) in their code by replacing their calls that used`KmsEncrypted` with Lockbox, so this is implementing essentially the same fix

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/89020

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Decision Reviews backend

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

