### PR TITLE
[DBEX] add body request matcher

### DIFF
--- a/spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb
+++ b/spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Lighthouse::Form526DocumentUploadPollingJob, type: :job do
 
   describe '#perform' do
     shared_examples 'document status updates' do |state, request_id, cassette|
-      around { |example| VCR.use_cassette(cassette) { example.run } }
+      around { |example| VCR.use_cassette(cassette, match_requests_on: [:body]) { example.run } }
 
       let!(:document) { create(:lighthouse526_document_upload, lighthouse_document_request_id: request_id) }
 
@@ -63,7 +63,8 @@ RSpec.describe Lighthouse::Form526DocumentUploadPollingJob, type: :job do
       end
 
       around do |example|
-        VCR.use_cassette('lighthouse/benefits_claims/documents/form526_document_upload_status_not_found') do
+        VCR.use_cassette('lighthouse/benefits_claims/documents/form526_document_upload_status_not_found',
+                         match_requests_on: [:body]) do
           example.run
         end
       end
@@ -87,7 +88,8 @@ RSpec.describe Lighthouse::Form526DocumentUploadPollingJob, type: :job do
       let!(:unknown_document) { create(:lighthouse526_document_upload, lighthouse_document_request_id: '21') }
 
       around do |example|
-        VCR.use_cassette('lighthouse/benefits_claims/documents/form526_document_upload_with_request_ids_not_found') do
+        VCR.use_cassette('lighthouse/benefits_claims/documents/form526_document_upload_with_request_ids_not_found',
+                         match_requests_on: [:body]) do
           example.run
         end
       end


### PR DESCRIPTION
## Summary

- User [VCR's request matching on body](https://benoittgt.github.io/vcr/#/request_matching/body) option in an effort to address failing, flaky tests
- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- Responsible team: Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/17660
- https://github.com/department-of-veterans-affairs/vets-api/pull/17674

## Testing done

- [x] *Updated code is covered by unit tests*

## What areas of the site does it impact?

- spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb

## Acceptance criteria

- [x]  I **fixed**|~updated~|~added~ unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
