### PR TITLE
Replace MyHealth AMS serializers with JSONAPI serializers - Messages Part 2

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
@@ -104,7 +104,7 @@ module MyHealth
           resource[:data] =
             { signature_name: nil, include_signature: false, signature_title: nil }
         end
-        render json: resource, each_serializer: MessageSignatureSerializer
+        render json: resource
       end
 
       def move

--- a/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
@@ -104,6 +104,7 @@ module MyHealth
           resource[:data] =
             { signature_name: nil, include_signature: false, signature_title: nil }
         end
+        # see MessageSignatureSerializer for more information
         render json: resource
       end
 

--- a/modules/my_health/app/controllers/my_health/v1/messaging_preferences_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/messaging_preferences_controller.rb
@@ -5,8 +5,7 @@ module MyHealth
     class MessagingPreferencesController < SMController
       def show
         resource = client.get_preferences
-        render json: resource,
-               serializer: MessagingPreferenceSerializer
+        render json: MessagingPreferenceSerializer.new(resource)
       end
 
       # Set secure messaging email notification preferences.
@@ -14,8 +13,7 @@ module MyHealth
       # @param frequency - one of 'none', 'each_message', or 'daily'
       def update
         resource = client.post_preferences(params.permit(:email_address, :frequency))
-        render json: resource,
-               serializer: MessagingPreferenceSerializer
+        render json: MessagingPreferenceSerializer.new(resource)
       end
     end
   end

--- a/modules/my_health/app/serializers/my_health/v1/message_signature_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/message_signature_serializer.rb
@@ -2,8 +2,21 @@
 
 module MyHealth
   module V1
-    class MessageSignatureSerializer < ActiveModel::Serializer
-      attributes :signature_name, :signature_title, :include_signature
+    class MessageSignatureSerializer
+      include JSONAPI::Serializer
+
+      set_id { '' }
+
+      attributes :signature_name do |object|
+        object[:data][:signature_name]
+      end
+
+      attributes :signature_title do |object|
+        object[:data][:signature_title]
+      end
+      attributes :include_signature do |object|
+        object[:data][:include_signature]
+      end
     end
   end
 end

--- a/modules/my_health/app/serializers/my_health/v1/message_signature_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/message_signature_serializer.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# This serializer was used intended to be used in
+# MyHealth::V1::MessagesController#signature
+# However, it's not actually being used because the call doesn't
+# follow JSON:API specs and just uses "object" itself
+
+# I'm not deleting the serializer so the mhv team can update the
+# controller and frontend at a later date.
 module MyHealth
   module V1
     class MessageSignatureSerializer

--- a/modules/my_health/app/serializers/my_health/v1/messaging_preference_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/messaging_preference_serializer.rb
@@ -2,7 +2,9 @@
 
 module MyHealth
   module V1
-    class MessagingPreferenceSerializer < ActiveModel::Serializer
+    class MessagingPreferenceSerializer
+      include JSONAPI::Serializer
+
       attributes :email_address, :frequency
     end
   end

--- a/modules/my_health/spec/serializer/v1/message_signature_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/message_signature_serializer_spec.rb
@@ -2,40 +2,36 @@
 
 require 'rails_helper'
 
-class Signature
-  attr_accessor :id, :signature_name, :include_signature, :signature_title
+describe MyHealth::V1::MessageSignatureSerializer, type: :serializer do
+  subject { serialize(signature, serializer_class: described_class) }
 
-  def initialize(signature_name:, include_signature:, signature_title:)
-    @id = nil
-    @signature_name = signature_name
-    @include_signature = include_signature
-    @signature_title = signature_title
-  end
-
-  def read_attribute_for_serialization(attr)
-    send(attr)
-  end
-end
-
-describe MyHealth::V1::MessageSignatureSerializer do
   let(:signature) do
-    Signature.new(signature_name: 'Test Name', include_signature: false, signature_title: 'Test')
+    {
+      data: {
+        signature_name: 'test-api Name',
+        include_signature: true,
+        signature_title: 'test-api title'
+      },
+      errors: {},
+      metadata: {}
+    }
   end
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(signature, { serializer: described_class }).as_json
+  it 'includes :id' do
+    expect(data['id']).to be_blank
   end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
 
   it 'includes :signature_name' do
-    expect(rendered_attributes[:signature_name]).to eq signature.signature_name
+    expect(attributes['signature_name']).to eq signature[:data][:signature_name]
   end
 
   it 'includes :signature_title' do
-    expect(rendered_attributes[:signature_title]).to eq signature.signature_title
+    expect(attributes['signature_title']).to eq signature[:data][:signature_title]
   end
 
   it 'includes :include_signature' do
-    expect(rendered_attributes[:include_signature]).to eq signature.include_signature
+    expect(attributes['include_signature']).to eq signature[:data][:include_signature]
   end
 end

--- a/modules/my_health/spec/serializer/v1/messaging_preference_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/messaging_preference_serializer_spec.rb
@@ -2,19 +2,18 @@
 
 require 'rails_helper'
 
-describe MyHealth::V1::MessagingPreferenceSerializer do
-  let(:messaging_preference) { build_stubbed(:messaging_preference) }
+describe MyHealth::V1::MessagingPreferenceSerializer, type: :serializer do
+  subject { serialize(messaging_preference, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(messaging_preference, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:messaging_preference) { build_stubbed(:messaging_preference) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
 
   it 'includes :email_address' do
-    expect(rendered_attributes[:email_address]).to eq messaging_preference.email_address
+    expect(attributes['email_address']).to eq messaging_preference.email_address
   end
 
   it 'includes :frequency' do
-    expect(rendered_attributes[:frequency]).to eq messaging_preference.frequency
+    expect(attributes['frequency']).to eq messaging_preference.frequency
   end
 end


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- MessageSignatureSerializer
- MessagingPreferenceSerializer

Note:

- _Per conversation with Oleskii Morgun:_ MessageSignatureSerializer is not using JSON:API serializer and the mhv team will update it and the FE in the future
    
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86385

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage