### PR TITLE
Logging and other small tweaks around filling and stamping PDFs

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -20,12 +20,12 @@ module SimpleFormsApi
     def generate(current_loa = nil)
       template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
       generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf").to_s
-      stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf")
+      stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf").to_s
       pdftk = PdfForms.new(Settings.binaries.pdftk)
 
       # Tempfile workaround inspired by this:
       #   https://github.com/actions/runner-images/issues/4443#issuecomment-965391736
-      tempfile = Tempfile.new(['tmp', '.pdf']).tap do |tmpfile|
+      tempfile = Tempfile.new(['', '.pdf'], Rails.root.join('tmp')).tap do |tmpfile|
         IO.copy_stream(template_form_path, tmpfile)
         tmpfile.close
       end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -87,10 +87,13 @@ module SimpleFormsApi
         page_configuration = get_page_configuration(page, coords)
         verified_multistamp(stamped_template_path, text, page_configuration, font_size)
       else
+        Rails.logger.info('Calling CentralMail::DatestampPdf', current_file_path:, stamped_template_path:)
         datestamp_instance = CentralMail::DatestampPdf.new(current_file_path, append_to_stamp:)
         current_file_path = datestamp_instance.run(text:, x:, y:, text_only:, size: 9)
         File.rename(current_file_path, stamped_template_path)
       end
+    rescue => e
+      raise StandardError, "An error occurred while stamping the PDF: #{e}"
     end
 
     def self.perform_multistamp(stamped_template_path, stamp_path)


### PR DESCRIPTION
## Summary
This PR does a couple small things:
- Call `to_s` on `stamped_template_path` just in case `CentralMail::DatestampPdf` needs it to be a string.
- Add Rails.root.join to where we create a temp file for my previous workaround.
- Add logging/exception catching to the stamper.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/88703
