### PR TITLE
Add Rubocop cop for ActiveModelSerializer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ require:
   - rubocop-factory_bot
   - rubocop-rspec_rails
   - rubocop-thread_safety
+  - './lib/rubocop/cops/ams_serializer.rb'
+
 
 AllCops:
   NewCops: disable
@@ -367,3 +369,6 @@ Lint/EmptyBlock:
 
 Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
+
+AmsSerializer:
+  Enabled: true

--- a/lib/rubocop/cops/ams_serializer.rb
+++ b/lib/rubocop/cops/ams_serializer.rb
@@ -1,0 +1,23 @@
+module RuboCop
+  module Cop
+    class AmsSerializer < RuboCop::Cop::Base
+
+      MSG = 'Use JSONAPI::Serializer instead of ActiveModel::Serializer'.freeze
+
+      def_node_matcher :active_model_serializer?, <<~PATTERN
+        (class
+          (const _ _)
+          {
+            (const (const {nil? (cbase)} :ActiveModel) :Serializer)
+            (const (const (const {nil? (cbase)} :ActiveModel) :Serializer) :CollectionSerializer)
+          }
+          ...
+        )
+      PATTERN
+
+      def on_class(node)
+        add_offense(node.children[1]) if active_model_serializer?(node)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add rubocop cop to prevent future use of ActiveModelSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88389

## Testing done

- [ ] manual testing with `rubocop --only AmsSerializer`
- [ ] manual testing works with `rubocop` command 

## Screenshots

<img width="1027" alt="Screenshot 2024-07-26 at 10 17 20 AM" src="https://github.com/user-attachments/assets/e0a5640c-57bf-4160-8dd0-15a506cb2dc9">

## Acceptance criteria

- [ ]  When a AMS serializer is added the cop reports a warning
- [ ]  The cop doesn't report a warning for other types of serializers
- [ ] The cop doesn't autocorrect