### PR TITLE
Replace MyHealth AMS serializers with JSONAPI serializers - Part 3

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/threads_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/threads_controller.rb
@@ -14,10 +14,8 @@ module Mobile
 
         raise Common::Exceptions::RecordNotFound, params[:folder_id] if resource.blank?
 
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: MyHealth::V1::ThreadsSerializer,
-               meta: resource.metadata
+        options = { meta: resource.metadata }
+        render json: MyHealth::V1::ThreadsSerializer.new(resource.data, options)
       end
     end
   end

--- a/modules/my_health/app/controllers/my_health/rx_controller.rb
+++ b/modules/my_health/app/controllers/my_health/rx_controller.rb
@@ -7,6 +7,7 @@ module MyHealth
   class RxController < ApplicationController
     include ActionController::Serialization
     include MyHealth::MHVControllerConcerns
+    include JsonApiPaginationLinks
     service_tag 'mhv-medications'
 
     protected

--- a/modules/my_health/app/controllers/my_health/v1/threads_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/threads_controller.rb
@@ -7,10 +7,8 @@ module MyHealth
         resource = fetch_folder_threads
         raise Common::Exceptions::RecordNotFound, params[:folder_id] if resource.blank?
 
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: ThreadsSerializer,
-               meta: resource.metadata
+        options = { meta: resource.metadata }
+        render json: ThreadsSerializer.new(resource.data, options)
       end
 
       def move

--- a/modules/my_health/app/controllers/my_health/v1/trackings_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/trackings_controller.rb
@@ -13,10 +13,10 @@ module MyHealth
         resource = client.get_tracking_history_rx(params[:prescription_id])
         resource = resource.sort(params[:sort])
         resource = resource.paginate(**pagination_params)
-        render json: resource.data,
-               serializer: CollectionSerializer,
-               each_serializer: TrackingSerializer,
-               meta: resource.metadata
+
+        links = pagination_links(resource)
+        options = { meta: resource.metadata, links: }
+        render json: TrackingSerializer.new(resource.data, options)
       end
     end
   end

--- a/modules/my_health/app/serializers/my_health/v1/threads_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/threads_serializer.rb
@@ -7,6 +7,8 @@ module MyHealth
 
       set_id :thread_id
 
+      set_type :message_threads
+
       attribute :thread_id
       attribute :folder_id
       attribute :message_id

--- a/modules/my_health/app/serializers/my_health/v1/threads_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/threads_serializer.rb
@@ -2,10 +2,10 @@
 
 module MyHealth
   module V1
-    class ThreadsSerializer < ActiveModel::Serializer
-      def id
-        object.thread_id
-      end
+    class ThreadsSerializer
+      include JSONAPI::Serializer
+
+      set_id :thread_id
 
       attribute :thread_id
       attribute :folder_id
@@ -21,12 +21,14 @@ module MyHealth
       attribute :sender_name
       attribute :recipient_name
       attribute :recipient_id
-      attribute :proxySender_name
+      attribute :proxy_sender_name, &:proxySender_name
       attribute :has_attachment
       attribute :unsent_drafts
       attribute :unread_messages
 
-      link(:self) { MyHealth::UrlHelper.new.v1_thread_url(object.thread_id) }
+      link :self do |object|
+        MyHealth::UrlHelper.new.v1_thread_url(object.thread_id)
+      end
     end
   end
 end

--- a/modules/my_health/app/serializers/my_health/v1/tracking_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/tracking_serializer.rb
@@ -2,14 +2,21 @@
 
 module MyHealth
   module V1
-    class TrackingSerializer < ActiveModel::Serializer
-      def id
-        object.tracking_number
+    class TrackingSerializer
+      include JSONAPI::Serializer
+
+      set_id :tracking_number
+      set_type :trackings
+
+      link :self do |object|
+        MyHealth::UrlHelper.new.v1_prescription_trackings_url(object.prescription_id)
       end
 
-      link(:self) { MyHealth::UrlHelper.new.v1_prescription_trackings_url(object.prescription_id) }
-      link(:prescription) { MyHealth::UrlHelper.new.v1_prescription_url(object.prescription_id) }
-      link(:tracking_url) do
+      link :prescription do |object|
+        MyHealth::UrlHelper.new.v1_prescription_url(object.prescription_id)
+      end
+
+      link :tracking_url do |object|
         case object.delivery_service.upcase
         when 'UPS'
           "https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=#{object.tracking_number}"

--- a/modules/my_health/spec/serializer/v1/thread_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/thread_serializer_spec.rb
@@ -2,92 +2,92 @@
 
 require 'rails_helper'
 
-describe MyHealth::V1::ThreadsSerializer do
-  let(:thread) { build(:message_thread) }
+describe MyHealth::V1::ThreadsSerializer, type: :serializer do
+  subject { serialize(thread, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(thread, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:thread) { build(:message_thread) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+  let(:links) { data['links'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq thread.thread_id.to_s
+    expect(data['id']).to eq thread.thread_id.to_s
   end
 
   it 'includes :thread_id' do
-    expect(rendered_attributes[:thread_id]).to eq thread.thread_id
+    expect(attributes['thread_id']).to eq thread.thread_id
   end
 
   it 'includes :folder_id' do
-    expect(rendered_attributes[:folder_id]).to eq thread.folder_id
+    expect(attributes['folder_id']).to eq thread.folder_id
   end
 
   it 'includes :message_id' do
-    expect(rendered_attributes[:message_id]).to eq thread.message_id
+    expect(attributes['message_id']).to eq thread.message_id
   end
 
   it 'includes :thread_page_size' do
-    expect(rendered_attributes[:thread_page_size]).to eq thread.thread_page_size
+    expect(attributes['thread_page_size']).to eq thread.thread_page_size
   end
 
   it 'includes :message_count' do
-    expect(rendered_attributes[:message_count]).to eq thread.message_count
+    expect(attributes['message_count']).to eq thread.message_count
   end
 
   it 'includes :category' do
-    expect(rendered_attributes[:category]).to eq thread.category
+    expect(attributes['category']).to eq thread.category
   end
 
   it 'includes :subject' do
-    expect(rendered_attributes[:subject]).to eq thread.subject
+    expect(attributes['subject']).to eq thread.subject
   end
 
   it 'includes :triage_group_name' do
-    expect(rendered_attributes[:triage_group_name]).to eq thread.triage_group_name
+    expect(attributes['triage_group_name']).to eq thread.triage_group_name
   end
 
   it 'includes :sent_date' do
-    expect(rendered_attributes[:sent_date]).to eq thread.sent_date
+    expect_time_eq(attributes['sent_date'], thread.sent_date)
   end
 
   it 'includes :draft_date' do
-    expect(rendered_attributes[:draft_date]).to eq thread.draft_date
+    expect_time_eq(attributes['draft_date'], thread.draft_date)
   end
 
   it 'includes :sender_id' do
-    expect(rendered_attributes[:sender_id]).to eq thread.sender_id
+    expect(attributes['sender_id']).to eq thread.sender_id
   end
 
   it 'includes :sender_name' do
-    expect(rendered_attributes[:sender_name]).to eq thread.sender_name
+    expect(attributes['sender_name']).to eq thread.sender_name
   end
 
   it 'includes :recipient_name' do
-    expect(rendered_attributes[:recipient_name]).to eq thread.recipient_name
+    expect(attributes['recipient_name']).to eq thread.recipient_name
   end
 
   it 'includes :recipient_id' do
-    expect(rendered_attributes[:recipient_id]).to eq thread.recipient_id
+    expect(attributes['recipient_id']).to eq thread.recipient_id
   end
 
   it 'includes :proxySender_name' do
-    expect(rendered_attributes[:proxy_sender_name]).to eq thread.proxySender_name
+    expect(attributes['proxy_sender_name']).to eq thread.proxySender_name
   end
 
   it 'includes :has_attachment' do
-    expect(rendered_attributes[:has_attachment]).to eq thread.has_attachment
+    expect(attributes['has_attachment']).to eq thread.has_attachment
   end
 
   it 'includes :unsent_drafts' do
-    expect(rendered_attributes[:unsent_drafts]).to eq thread.unsent_drafts
+    expect(attributes['unsent_drafts']).to eq thread.unsent_drafts
   end
 
   it 'includes :unread_messages' do
-    expect(rendered_attributes[:unread_messages]).to eq thread.unread_messages
+    expect(attributes['unread_messages']).to eq thread.unread_messages
   end
 
   it 'includes :self link' do
     expected_url = MyHealth::UrlHelper.new.v1_thread_url(thread.thread_id)
-    expect(rendered_hash[:data][:links][:self]).to eq expected_url
+    expect(links['self']).to eq expected_url
   end
 end

--- a/modules/my_health/spec/serializer/v1/thread_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/thread_serializer_spec.rb
@@ -14,6 +14,10 @@ describe MyHealth::V1::ThreadsSerializer, type: :serializer do
     expect(data['id']).to eq thread.thread_id.to_s
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq 'message_threads'
+  end
+
   it 'includes :thread_id' do
     expect(attributes['thread_id']).to eq thread.thread_id
   end

--- a/modules/my_health/spec/serializer/v1/tracking_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/tracking_serializer_spec.rb
@@ -2,86 +2,84 @@
 
 require 'rails_helper'
 
-describe MyHealth::V1::TrackingSerializer do
-  let(:tracking) { build(:tracking) }
+describe MyHealth::V1::TrackingSerializer, type: :serializer do
+  subject { serialize(tracking, serializer_class: described_class) }
 
-  let(:rendered_hash) do
-    ActiveModelSerializers::SerializableResource.new(tracking, { serializer: described_class }).as_json
-  end
-  let(:rendered_attributes) { rendered_hash[:data][:attributes] }
+  let(:tracking) { build(:tracking) }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+  let(:links) { data['links'] }
 
   it 'includes :id' do
-    expect(rendered_hash[:data][:id]).to eq tracking.tracking_number.to_s
+    expect(data['id']).to eq tracking.tracking_number.to_s
+  end
+
+  it 'includes :type' do
+    expect(data['type']).to eq 'trackings'
   end
 
   it 'includes :tracking_number' do
-    expect(rendered_attributes[:tracking_number]).to eq tracking.tracking_number
+    expect(attributes['tracking_number']).to eq tracking.tracking_number
   end
 
   it 'includes :prescription_id' do
-    expect(rendered_attributes[:prescription_id]).to eq tracking.prescription_id
+    expect(attributes['prescription_id']).to eq tracking.prescription_id
   end
 
   it 'includes :prescription_number' do
-    expect(rendered_attributes[:prescription_number]).to eq tracking.prescription_number
+    expect(attributes['prescription_number']).to eq tracking.prescription_number
   end
 
   it 'includes :prescription_name' do
-    expect(rendered_attributes[:prescription_name]).to eq tracking.prescription_name
+    expect(attributes['prescription_name']).to eq tracking.prescription_name
   end
 
   it 'includes :facility_name' do
-    expect(rendered_attributes[:facility_name]).to eq tracking.facility_name
+    expect(attributes['facility_name']).to eq tracking.facility_name
   end
 
   it 'includes :rx_info_phone_number' do
-    expect(rendered_attributes[:rx_info_phone_number]).to eq tracking.rx_info_phone_number
+    expect(attributes['rx_info_phone_number']).to eq tracking.rx_info_phone_number
   end
 
   it 'includes :ndc_number' do
-    expect(rendered_attributes[:ndc_number]).to eq tracking.ndc_number
+    expect(attributes['ndc_number']).to eq tracking.ndc_number
   end
 
   it 'includes :shipped_date' do
-    expect(rendered_attributes[:shipped_date]).to eq tracking.shipped_date
+    expect_time_eq(attributes['shipped_date'], tracking.shipped_date)
   end
 
   it 'includes :delivery_service' do
-    expect(rendered_attributes[:delivery_service]).to eq tracking.delivery_service
+    expect(attributes['delivery_service']).to eq tracking.delivery_service
   end
 
   it 'includes :other_prescriptions' do
-    expect(rendered_attributes[:other_prescriptions]).to eq tracking.other_prescriptions
+    expect(attributes['other_prescriptions']).to eq tracking.other_prescriptions
   end
 
   context 'when delivery service is UPS' do
     it 'includes :tracking_url link' do
       expected_url = "https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=#{tracking.tracking_number}"
-      expect(rendered_hash[:data][:links][:tracking_url]).to eq expected_url
+      expect(links['tracking_url']).to eq expected_url
     end
   end
 
   context 'when delivery service is USPS' do
-    let(:tracking_usps) { build(:tracking, delivery_service: 'USPS') }
-    let(:rendered_hash_usps) do
-      ActiveModelSerializers::SerializableResource.new(tracking_usps, { serializer: described_class }).as_json
-    end
+    let(:tracking) { build(:tracking, delivery_service: 'USPS') }
 
     it 'includes :tracking_url link' do
       expected_url = "https://tools.usps.com/go/TrackConfirmAction?tLabels=#{tracking.tracking_number}"
-      expect(rendered_hash_usps[:data][:links][:tracking_url]).to eq expected_url
+      expect(links['tracking_url']).to eq expected_url
     end
   end
 
   context 'when delivery service is else' do
-    let(:tracking_dhl) { build(:tracking, delivery_service: 'DHL') }
-    let(:rendered_hash_dhl) do
-      ActiveModelSerializers::SerializableResource.new(tracking_dhl, { serializer: described_class }).as_json
-    end
+    let(:tracking) { build(:tracking, delivery_service: 'DHL') }
 
     it 'includes :tracking_url link' do
       expected_url = ''
-      expect(rendered_hash_dhl[:data][:links][:tracking_url]).to eq expected_url
+      expect(links['tracking_url']).to eq expected_url
     end
   end
 end


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- ThreadsSerializer
- TrackingSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86385

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage