### PR TITLE
EZR: Removes the TERA enabled toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -85,10 +85,6 @@ features:
     actor_type: user
     description: Enables access to the 10-10EZR application in prod for the purposes of conducting user reasearch
     enable_in_development: true
-  ezr_tera_enabled:
-    actor_type: user
-    description: Enables Toxic Exposure questions for 10-10EZR applicants.
-    enable_in_development: true
   ezr_upload_enabled:
     actor_type: user
     description: Enables Toxic Exposure File Upload for 10-10EZR applicants.


### PR DESCRIPTION
Removes the `ezr_tera_enabled` toggle

## Related issue(s)
- [85114](https://github.com/department-of-veterans-affairs/va.gov-team/issues/85114)

## What areas of the site does it impact?
Form 10-10 EZR

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
