### PR TITLE
88176 - Parse MAP STS server errors

### DIFF
--- a/lib/map/security_token/service.rb
+++ b/lib/map/security_token/service.rb
@@ -46,9 +46,10 @@ module MAP
 
       def parse_and_raise_error(e, icn, application)
         status = e.status
+        error_source = status >= 500 ? 'server' : 'client'
         parse_body = e.body.presence || {}
         context = { error: parse_body['error'] }
-        message = "#{config.logging_prefix} token failed, client error"
+        message = "#{config.logging_prefix} token failed, #{error_source} error"
 
         Rails.logger.error(message, status:, application:, icn:, context:)
         raise e, "#{message}, status: #{status}, application: #{application}, icn: #{icn}, context: #{context}"

--- a/spec/support/vcr_cassettes/map/security_token_service_500_response.yml
+++ b/spec/support/vcr_cassettes/map/security_token_service_500_response.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://veteran.apps-staging.va.gov/sts/oauth/v1/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=c7d6e0fc9a39&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=eyJhbGciOiJSUzUxMiJ9.eyJyb2xlIjoidmV0ZXJhbiIsInBhdGllbnRfaWQiOiJzb21lLWljbiIsInBhdGllbnRfaWRfdHlwZSI6ImljbiIsInN1YiI6ImM3ZDZlMGZjOWEzOSIsImp0aSI6IjIwODllOWFlLTZiNDctNGJkNy05NzNiLTczMzM4NjgzYTVkYiIsImlzcyI6ImM3ZDZlMGZjOWEzOSIsImF1ZCI6Imh0dHBzOi8vZ29vZ2xlLmNvbS9zdHMvb2F1dGgvdjEvdG9rZW4iLCJuYmYiOjE2OTI5MjE5NjcsImV4cCI6MTY5MjkyMjI2N30.VXzWaXBjk83TNA39VTApJQSG9inwyUioYouGXeqkEWicSP3oLb-CNFpkEgkMNccz6SpAlYIJ_KYKRFAA1rQv8Gp5LzIv_YM2WFJUYxpF02-fAhYzl6SkOLwD86Yto6a8JbFrNPL9uYxG1vmTZgl_vk2dmNFpnQ3gf8bXc2GOBAM2gc3tzNjv1M18dVtObX6zw7ZG7drxw7itzZnkDLTU9217XyOgSFQvA0czRiiRcfsXb6LIB7A1k7MpQy6KA3UDBQ7sbuXkaFZiJo2tSDG3PXScTHBtqmqejCt68906wiBf_ACeI4TQPH4ogoTrnfb9oprQyKp8xMlwwKYAMih12g
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 500
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - allow-from https://nextgenid-mbetenantworkflow.azurewebsites.net
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - frame-ancestors https://nextgenid-mbetenantworkflow.azurewebsites.net
+      Etag:
+      - W/"dba68a519b00d7f452e79971a398650f"
+      X-Request-Id:
+      - 5b1d220c-4b01-4409-b9a5-367ab3c99ca9
+      X-Runtime:
+      - '0.026178'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Node:
+      - sandbox-core-02.idmeinc.net
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Content-Length:
+      - '14658'
+      Connection:
+      - keep-alive
+      Server-Timing:
+      - ak_p; desc="1690401366974_1752320020_1303469004_11342_12901_31_-_-";dur=1
+      - cdn-cache; desc=MISS
+      - edge; dur=68
+      - origin; dur=46
+    body:
+      encoding: UTF-8
+      string: '{"error":"server_error"}'
+  recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary

This PR implements a small change that correct logs server errors for the MAP STS token service. Previously, 5XX errors were logged as "client error."

## Related issue(s)

https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/88176

## Testing done

- Modify the [mock data file](https://github.com/department-of-veterans-affairs/vets-api-mockdata/blob/master/map/secure_token_service/token.yml) locally to return a 500 status with body `{"error":"server_error"}`
- Load the MAP STS client in a rails console
- Send a request (use `:appointments` for `application` and any value for `icn`)
- Verify the rails logger logs the server error.

## Screenshots
Not relevant.

## What areas of the site does it impact?

Log entries from MAP STS.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

I opted for the simplest solution to avoid incurring additional risk. Another possible solution that we discussed was implementing a middleware, but this seemed like a more risky change. Is the current solution acceptable, or do we need to go down the middleware path?
