### PR TITLE
84332: Add DR SavedClaim status updater jobs with hourly schedule

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -34,8 +34,6 @@ module DecisionReview
       Rails.logger.error("#{self.class.name} error", e.message)
     end
 
-    private
-
     def decision_review_service
       @service = DecisionReviewV1::Service.new
     end

--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -10,7 +10,6 @@ module DecisionReview
     # No need to retry since the schedule will run this every hour
     sidekiq_options retry: false, unique_for: 30.minutes
 
-    REQUEST_DELAY = 3
     RETENTION_PERIOD = 59.days
 
     SUCCESSFUL_STATUS = %w[complete].freeze
@@ -26,8 +25,6 @@ module DecisionReview
           hlr.update(delete_date: DateTime.now + RETENTION_PERIOD)
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
-
-        sleep REQUEST_DELAY
       end
     end
 

--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -35,6 +35,8 @@ module DecisionReview
       raise e
     end
 
+    private
+
     def decision_review_service
       @service = DecisionReviewV1::Service.new
     end

--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -22,7 +22,6 @@ module DecisionReview
         guid = hlr.guid
         status = decision_review_service.get_higher_level_review(guid).dig('data', 'attributes', 'status')
 
-        # check status of HLR and update delete_date as necessary
         if SUCCESSFUL_STATUS.include? status
           hlr.update(delete_date: DateTime.now + RETENTION_PERIOD)
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
@@ -30,15 +29,12 @@ module DecisionReview
 
         sleep REQUEST_DELAY
       end
-    rescue => e
-      Rails.logger.error("#{self.class.name} error", e.message)
-      raise e
     end
 
     private
 
     def decision_review_service
-      @service = DecisionReviewV1::Service.new
+      @service ||= DecisionReviewV1::Service.new
     end
 
     def higher_level_reviews

--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -32,6 +32,7 @@ module DecisionReview
       end
     rescue => e
       Rails.logger.error("#{self.class.name} error", e.message)
+      raise e
     end
 
     def decision_review_service
@@ -39,7 +40,7 @@ module DecisionReview
     end
 
     def higher_level_reviews
-      @higher_level_reviews ||= SavedClaim::HigherLevelReview.where(delete_date: nil).order(created_at: :asc)
+      @higher_level_reviews ||= ::SavedClaim::HigherLevelReview.where(delete_date: nil).order(created_at: :asc)
     end
 
     def enabled?

--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+require 'decision_review_v1/service'
+
+module DecisionReview
+  class SavedClaimHlrStatusUpdaterJob
+    include Sidekiq::Job
+
+    # No need to retry since the schedule will run this every hour
+    sidekiq_options retry: false, unique_for: 30.minutes
+
+    REQUEST_DELAY = 3
+    RETENTION_PERIOD = 59.days
+
+    SUCCESSFUL_STATUS = %w[complete].freeze
+
+    def perform
+      return unless enabled? && higher_level_reviews.present?
+
+      higher_level_reviews.each do |hlr|
+        guid = hlr.guid
+        status = decision_review_service.get_higher_level_review(guid).dig('data', 'attributes', 'status')
+
+        # check status of HLR and update delete_date as necessary
+        if SUCCESSFUL_STATUS.include? status
+          hlr.update(delete_date: DateTime.now + RETENTION_PERIOD)
+          Rails.logger.info("#{self.class.name} updated delete_date", guid:)
+        end
+
+        sleep REQUEST_DELAY
+      end
+    rescue => e
+      Rails.logger.error("#{self.class.name} error", e.message)
+    end
+
+    private
+
+    def decision_review_service
+      @service = DecisionReviewV1::Service.new
+    end
+
+    def higher_level_reviews
+      @higher_level_reviews ||= SavedClaim::HigherLevelReview.where(delete_date: nil).order(created_at: :asc)
+    end
+
+    def enabled?
+      Flipper.enabled? :decision_review_saved_claim_hlr_status_updater_job_enabled
+    end
+  end
+end

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -22,7 +22,6 @@ module DecisionReview
         guid = nod.guid
         status = decision_review_service.get_notice_of_disagreement(guid).dig('data', 'attributes', 'status')
 
-        # check status of NOD and update delete_date as necessary
         if SUCCESSFUL_STATUS.include? status
           nod.update(delete_date: DateTime.now + RETENTION_PERIOD)
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
@@ -30,9 +29,6 @@ module DecisionReview
 
         sleep REQUEST_DELAY
       end
-    rescue => e
-      Rails.logger.error("#{self.class.name} error", e.message)
-      raise e
     end
 
     private

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+require 'decision_review_v1/service'
+
+module DecisionReview
+  class SavedClaimNodStatusUpdaterJob
+    include Sidekiq::Job
+
+    # No need to retry since the schedule will run this every hour
+    sidekiq_options retry: false, unique_for: 30.minutes
+
+    REQUEST_DELAY = 3
+    RETENTION_PERIOD = 59.days
+
+    SUCCESSFUL_STATUS = %w[complete].freeze
+
+    def perform
+      return unless enabled? && notice_of_disagreements.present?
+
+      notice_of_disagreements.each do |nod|
+        guid = nod.guid
+        status = decision_review_service.get_notice_of_disagreement(guid).dig('data', 'attributes', 'status')
+
+        # check status of NOD and update delete_date as necessary
+        if SUCCESSFUL_STATUS.include? status
+          nod.update(delete_date: DateTime.now + RETENTION_PERIOD)
+          Rails.logger.info("#{self.class.name} updated delete_date", guid:)
+        end
+
+        sleep REQUEST_DELAY
+      end
+    rescue => e
+      Rails.logger.error("#{self.class.name} error", e.message)
+    end
+
+    private
+
+    def decision_review_service
+      @service ||= DecisionReviewV1::Service.new
+    end
+
+    def notice_of_disagreements
+      @notice_of_disagreements ||= SavedClaim::NoticeOfDisagreement.where(delete_date: nil).order(created_at: :asc)
+    end
+
+    def enabled?
+      Flipper.enabled? :decision_review_saved_claim_nod_status_updater_job_enabled
+    end
+  end
+end

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -32,6 +32,7 @@ module DecisionReview
       end
     rescue => e
       Rails.logger.error("#{self.class.name} error", e.message)
+      raise e
     end
 
     private
@@ -41,7 +42,7 @@ module DecisionReview
     end
 
     def notice_of_disagreements
-      @notice_of_disagreements ||= SavedClaim::NoticeOfDisagreement.where(delete_date: nil).order(created_at: :asc)
+      @notice_of_disagreements ||= ::SavedClaim::NoticeOfDisagreement.where(delete_date: nil).order(created_at: :asc)
     end
 
     def enabled?

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -10,7 +10,6 @@ module DecisionReview
     # No need to retry since the schedule will run this every hour
     sidekiq_options retry: false, unique_for: 30.minutes
 
-    REQUEST_DELAY = 3
     RETENTION_PERIOD = 59.days
 
     SUCCESSFUL_STATUS = %w[complete].freeze
@@ -26,8 +25,6 @@ module DecisionReview
           nod.update(delete_date: DateTime.now + RETENTION_PERIOD)
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
-
-        sleep REQUEST_DELAY
       end
     end
 

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -10,7 +10,6 @@ module DecisionReview
     # No need to retry since the schedule will run this every hour
     sidekiq_options retry: false, unique_for: 30.minutes
 
-    REQUEST_DELAY = 3
     RETENTION_PERIOD = 59.days
 
     SUCCESSFUL_STATUS = %w[complete].freeze
@@ -27,8 +26,6 @@ module DecisionReview
           sc.update(delete_date: DateTime.now + RETENTION_PERIOD)
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
-
-        sleep REQUEST_DELAY
       end
     end
 

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -22,7 +22,7 @@ module DecisionReview
         guid = sc.guid
         status = decision_review_service.get_supplemental_claim(guid).dig('data', 'attributes', 'status')
 
-        # check status of SC and update delete_date as necessary
+        # check status of SC and update delete_date
         if SUCCESSFUL_STATUS.include? status
           sc.update(delete_date: DateTime.now + RETENTION_PERIOD)
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
@@ -30,15 +30,12 @@ module DecisionReview
 
         sleep REQUEST_DELAY
       end
-    rescue => e
-      Rails.logger.error("#{self.class.name} error", e.message)
-      raise e
     end
 
     private
 
     def decision_review_service
-      @service = DecisionReviewV1::Service.new
+      @service ||= DecisionReviewV1::Service.new
     end
 
     def supplemental_claims

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+require 'decision_review_v1/service'
+
+module DecisionReview
+  class SavedClaimScStatusUpdaterJob
+    include Sidekiq::Job
+
+    # No need to retry since the schedule will run this every hour
+    sidekiq_options retry: false, unique_for: 30.minutes
+
+    REQUEST_DELAY = 3
+    RETENTION_PERIOD = 59.days
+
+    SUCCESSFUL_STATUS = %w[complete].freeze
+
+    def perform
+      return unless enabled? && supplemental_claims.present?
+
+      supplemental_claims.each do |sc|
+        guid = sc.guid
+        status = decision_review_service.get_supplemental_claim(guid).dig('data', 'attributes', 'status')
+
+        # check status of SC and update delete_date as necessary
+        if SUCCESSFUL_STATUS.include? status
+          sc.update(delete_date: DateTime.now + RETENTION_PERIOD)
+          Rails.logger.info("#{self.class.name} updated delete_date", guid:)
+        end
+
+        sleep REQUEST_DELAY
+      end
+    rescue => e
+      Rails.logger.error("#{self.class.name} error", e.message)
+    end
+
+    private
+
+    def decision_review_service
+      @service = DecisionReviewV1::Service.new
+    end
+
+    def supplemental_claims
+      @supplemental_claims ||= SavedClaim::SupplementalClaim.where(delete_date: nil).order(created_at: :asc)
+    end
+
+    def enabled?
+      Flipper.enabled? :decision_review_saved_claim_sc_status_updater_job_enabled
+    end
+  end
+end

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -32,6 +32,7 @@ module DecisionReview
       end
     rescue => e
       Rails.logger.error("#{self.class.name} error", e.message)
+      raise e
     end
 
     private
@@ -41,7 +42,7 @@ module DecisionReview
     end
 
     def supplemental_claims
-      @supplemental_claims ||= SavedClaim::SupplementalClaim.where(delete_date: nil).order(created_at: :asc)
+      @supplemental_claims ||= ::SavedClaim::SupplementalClaim.where(delete_date: nil).order(created_at: :asc)
     end
 
     def enabled?

--- a/config/features.yml
+++ b/config/features.yml
@@ -365,12 +365,15 @@ features:
   decision_review_saved_claim_hlr_status_updater_job_enabled:
     actor_type: user
     description: Enable job to set delete_date for completed SavedClaim::HigherLevelReviews
+    enable_in_development: true
   decision_review_saved_claim_nod_status_updater_job_enabled:
     actor_type: user
     description: Enable job to set delete_date for completed SavedClaim::NoticeOfDisagreements
+    enable_in_development: true
   decision_review_saved_claim_sc_status_updater_job_enabled:
     actor_type: user
     description: Enable job to set delete_date for completed SavedClaim::SupplementalClaims
+    enable_in_development: true
   dependency_verification:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.

--- a/config/features.yml
+++ b/config/features.yml
@@ -362,6 +362,15 @@ features:
     actor_type: user
     description: Enable storage of SavedClaim records for Decision Review forms (HLR, NOD, SC)
     enable_in_development: true
+  decision_review_saved_claim_hlr_status_updater_job_enabled:
+    actor_type: user
+    description: Enable job to set delete_date for completed SavedClaim::HigherLevelReviews
+  decision_review_saved_claim_nod_status_updater_job_enabled:
+    actor_type: user
+    description: Enable job to set delete_date for completed SavedClaim::NoticeOfDisagreements
+  decision_review_saved_claim_sc_status_updater_job_enabled:
+    actor_type: user
+    description: Enable job to set delete_date for completed SavedClaim::SupplementalClaims
   dependency_verification:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.

--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -176,9 +176,6 @@ PERIODIC_JOBS = lambda { |mgr|
   # Every 15min job that sends missing Pega statuses to DataDog
   mgr.register('*/15 * * * *', 'IvcChampva::MissingFormStatusJob')
 
-  # Daily 2am job that sends missing Pega statuses to DataDog
-  mgr.register('0 2 * * *', 'IvcChampva::MissingFormStatusJob')
-
   # Hourly jobs that update DR SavedClaims with delete_date
   mgr.register('20 * * * *', 'DecisionReview::SavedClaimHlrStatusUpdaterJob')
   mgr.register('30 * * * *', 'DecisionReview::SavedClaimNodStatusUpdaterJob')

--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -175,5 +175,13 @@ PERIODIC_JOBS = lambda { |mgr|
 
   # Every 15min job that sends missing Pega statuses to DataDog
   mgr.register('*/15 * * * *', 'IvcChampva::MissingFormStatusJob')
+
+  # Daily 2am job that sends missing Pega statuses to DataDog
+  mgr.register('0 2 * * *', 'IvcChampva::MissingFormStatusJob')
+
+  # Hourly jobs that update DR SavedClaims with delete_date
+  mgr.register('20 * * * *', 'DecisionReview::SavedClaimHlrStatusUpdaterJob')
+  mgr.register('30 * * * *', 'DecisionReview::SavedClaimNodStatusUpdaterJob')
+  mgr.register('40 * * * *', 'DecisionReview::SavedClaimScStatusUpdaterJob')
 }
 # rubocop:enable Metrics/BlockLength

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
   end
 
   before do
-    stub_const('DecisionReview::SavedClaimHlrStatusUpdaterJob::REQUEST_DELAY', 0)
-
     allow(DecisionReviewV1::Service).to receive(:new).and_return(service)
   end
 

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'decision_review_v1/service'
+
+RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
+  subject { described_class }
+
+  around do |example|
+    Sidekiq::Testing.inline!(&example)
+  end
+
+  let(:service) { instance_double(DecisionReviewV1::Service) }
+
+  let(:guid1) { SecureRandom.uuid }
+  let(:guid2) { SecureRandom.uuid }
+  let(:guid3) { SecureRandom.uuid }
+
+  let(:response_complete) do
+    JSON.parse('{"data":{"attributes":{"status":"complete"}}}')
+  end
+
+  let(:response_pending) do
+    JSON.parse('{"data":{"attributes":{"status":"pending"}}}')
+  end
+
+  before do
+    stub_const('DecisionReview::SavedClaimHlrStatusUpdaterJob::REQUEST_DELAY', 0)
+
+    allow(DecisionReviewV1::Service).to receive(:new).and_return(service)
+  end
+
+  describe 'perform' do
+    context 'with flag enabled' do
+      before do
+        Flipper.enable :decision_review_saved_claim_hlr_status_updater_job_enabled
+      end
+
+      context 'SavedClaim records are present' do
+        before do
+          SavedClaim::HigherLevelReview.create(guid: guid1, form: '{}')
+          SavedClaim::HigherLevelReview.create(guid: guid2, form: '{}')
+          SavedClaim::HigherLevelReview.create(guid: guid3, form: '{}', delete_date: DateTime.new(2024, 2, 1).utc)
+          SavedClaim::SupplementalClaim.create(form: '{}')
+          SavedClaim::NoticeOfDisagreement.create(form: '{}')
+        end
+
+        it 'updates SavedClaim::HigherLevelReview delete_date for completed records without a delete_date' do
+          expect(service).to receive(:get_higher_level_review).with(guid1).and_return(response_complete)
+          expect(service).to receive(:get_higher_level_review).with(guid2).and_return(response_pending)
+          expect(service).not_to receive(:get_higher_level_review).with(guid3)
+
+          expect(service).not_to receive(:get_notice_of_disagreement)
+          expect(service).not_to receive(:get_supplemental_claim)
+
+          frozen_time = DateTime.new(2024, 1, 1).utc
+
+          Timecop.freeze(frozen_time) do
+            subject.new.perform
+
+            claim1 = SavedClaim::HigherLevelReview.find_by(guid: guid1)
+            expect(claim1.delete_date).to eq frozen_time + 59.days
+
+            claim2 = SavedClaim::HigherLevelReview.find_by(guid: guid2)
+            expect(claim2.delete_date).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'with flag disabled' do
+      before do
+        Flipper.disable :decision_review_saved_claim_hlr_status_updater_job_enabled
+      end
+
+      it 'does not query SavedClaim::HigherLevelReview records' do
+        expect(SavedClaim::HigherLevelReview).not_to receive(:where)
+
+        subject.new.perform
+      end
+    end
+  end
+end

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
           expect(service).not_to receive(:get_notice_of_disagreement)
           expect(service).not_to receive(:get_supplemental_claim)
 
-          subject.new.perform
+          subject.perform_async
 
           claim1 = SavedClaim::HigherLevelReview.find_by(guid: guid1)
           expect(claim1.delete_date).not_to be_nil

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -6,10 +6,6 @@ require 'decision_review_v1/service'
 RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
   subject { described_class }
 
-  around do |example|
-    Sidekiq::Testing.inline!(&example)
-  end
-
   let(:service) { instance_double(DecisionReviewV1::Service) }
 
   let(:guid1) { SecureRandom.uuid }
@@ -31,7 +27,7 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
   end
 
   describe 'perform' do
-    context 'with flag enabled' do
+    context 'with flag enabled', :aggregate_failures do
       before do
         Flipper.enable :decision_review_saved_claim_hlr_status_updater_job_enabled
       end

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -6,10 +6,6 @@ require 'decision_review_v1/service'
 RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
   subject { described_class }
 
-  around do |example|
-    Sidekiq::Testing.inline!(&example)
-  end
-
   let(:service) { instance_double(DecisionReviewV1::Service) }
 
   let(:guid1) { SecureRandom.uuid }
@@ -31,7 +27,7 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
   end
 
   describe 'perform' do
-    context 'with flag enabled' do
+    context 'with flag enabled', :aggregate_failures do
       before do
         Flipper.enable :decision_review_saved_claim_nod_status_updater_job_enabled
       end

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'decision_review_v1/service'
+
+RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
+  subject { described_class }
+
+  around do |example|
+    Sidekiq::Testing.inline!(&example)
+  end
+
+  let(:service) { instance_double(DecisionReviewV1::Service) }
+
+  let(:guid1) { SecureRandom.uuid }
+  let(:guid2) { SecureRandom.uuid }
+  let(:guid3) { SecureRandom.uuid }
+
+  let(:response_complete) do
+    JSON.parse('{"data":{"attributes":{"status":"complete"}}}')
+  end
+
+  let(:response_pending) do
+    JSON.parse('{"data":{"attributes":{"status":"pending"}}}')
+  end
+
+  before do
+    stub_const('DecisionReview::SavedClaimNodStatusUpdaterJob::REQUEST_DELAY', 0)
+
+    allow(DecisionReviewV1::Service).to receive(:new).and_return(service)
+  end
+
+  describe 'perform' do
+    context 'with flag enabled' do
+      before do
+        Flipper.enable :decision_review_saved_claim_nod_status_updater_job_enabled
+      end
+
+      context 'SavedClaim records are present' do
+        before do
+          SavedClaim::NoticeOfDisagreement.create(guid: guid1, form: '{}')
+          SavedClaim::NoticeOfDisagreement.create(guid: guid2, form: '{}')
+          SavedClaim::NoticeOfDisagreement.create(guid: guid3, form: '{}', delete_date: DateTime.new(2024, 2, 1).utc)
+          SavedClaim::HigherLevelReview.create(form: '{}')
+          SavedClaim::SupplementalClaim.create(form: '{}')
+        end
+
+        it 'updates SavedClaim::SupplementalClaim delete_date for completed records without a delete_date' do
+          expect(service).to receive(:get_notice_of_disagreement).with(guid1).and_return(response_complete)
+          expect(service).to receive(:get_notice_of_disagreement).with(guid2).and_return(response_pending)
+          expect(service).not_to receive(:get_notice_of_disagreement).with(guid3)
+
+          expect(service).not_to receive(:get_higher_level_review)
+          expect(service).not_to receive(:get_supplemental_claim)
+
+          frozen_time = DateTime.new(2024, 1, 1).utc
+
+          Timecop.freeze(frozen_time) do
+            subject.new.perform
+
+            claim1 = SavedClaim::NoticeOfDisagreement.find_by(guid: guid1)
+            expect(claim1.delete_date).to eq frozen_time + 59.days
+
+            claim2 = SavedClaim::NoticeOfDisagreement.find_by(guid: guid2)
+            expect(claim2.delete_date).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'with flag disabled' do
+      before do
+        Flipper.disable :decision_review_saved_claim_nod_status_updater_job_enabled
+      end
+
+      it 'does not query SavedClaim::HigherLevelReview records' do
+        expect(SavedClaim::NoticeOfDisagreement).not_to receive(:where)
+
+        subject.new.perform
+      end
+    end
+  end
+end

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
   end
 
   before do
-    stub_const('DecisionReview::SavedClaimNodStatusUpdaterJob::REQUEST_DELAY', 0)
-
     allow(DecisionReviewV1::Service).to receive(:new).and_return(service)
   end
 

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'decision_review_v1/service'
+
+RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
+  subject { described_class }
+
+  around do |example|
+    Sidekiq::Testing.inline!(&example)
+  end
+
+  let(:service) { instance_double(DecisionReviewV1::Service) }
+
+  let(:guid1) { SecureRandom.uuid }
+  let(:guid2) { SecureRandom.uuid }
+  let(:guid3) { SecureRandom.uuid }
+
+  let(:response_complete) do
+    JSON.parse('{"data":{"attributes":{"status":"complete"}}}')
+  end
+
+  let(:response_pending) do
+    JSON.parse('{"data":{"attributes":{"status":"pending"}}}')
+  end
+
+  before do
+    stub_const('DecisionReview::SavedClaimScStatusUpdaterJob::REQUEST_DELAY', 0)
+
+    allow(DecisionReviewV1::Service).to receive(:new).and_return(service)
+  end
+
+  describe 'perform' do
+    context 'with flag enabled' do
+      before do
+        Flipper.enable :decision_review_saved_claim_sc_status_updater_job_enabled
+      end
+
+      context 'SavedClaim records are present' do
+        before do
+          SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}')
+          SavedClaim::SupplementalClaim.create(guid: guid2, form: '{}')
+          SavedClaim::SupplementalClaim.create(guid: guid3, form: '{}', delete_date: DateTime.new(2024, 2, 1).utc)
+          SavedClaim::HigherLevelReview.create(form: '{}')
+          SavedClaim::NoticeOfDisagreement.create(form: '{}')
+        end
+
+        it 'updates SavedClaim::SupplementalClaim delete_date for completed records without a delete_date' do
+          expect(service).to receive(:get_supplemental_claim).with(guid1).and_return(response_complete)
+          expect(service).to receive(:get_supplemental_claim).with(guid2).and_return(response_pending)
+          expect(service).not_to receive(:get_supplemental_claim).with(guid3)
+
+          expect(service).not_to receive(:get_higher_level_review)
+          expect(service).not_to receive(:get_notice_of_disagreement)
+
+          frozen_time = DateTime.new(2024, 1, 1).utc
+
+          Timecop.freeze(frozen_time) do
+            subject.new.perform
+
+            claim1 = SavedClaim::SupplementalClaim.find_by(guid: guid1)
+            expect(claim1.delete_date).to eq frozen_time + 59.days
+
+            claim2 = SavedClaim::SupplementalClaim.find_by(guid: guid2)
+            expect(claim2.delete_date).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'with flag disabled' do
+      before do
+        Flipper.disable :decision_review_saved_claim_sc_status_updater_job_enabled
+      end
+
+      it 'does not query SavedClaim::HigherLevelReview records' do
+        expect(SavedClaim::HigherLevelReview).not_to receive(:where)
+
+        subject.new.perform
+      end
+    end
+  end
+end

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
   end
 
   before do
-    stub_const('DecisionReview::SavedClaimScStatusUpdaterJob::REQUEST_DELAY', 0)
-
     allow(DecisionReviewV1::Service).to receive(:new).and_return(service)
   end
 

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -6,10 +6,6 @@ require 'decision_review_v1/service'
 RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
   subject { described_class }
 
-  around do |example|
-    Sidekiq::Testing.inline!(&example)
-  end
-
   let(:service) { instance_double(DecisionReviewV1::Service) }
 
   let(:guid1) { SecureRandom.uuid }
@@ -31,7 +27,7 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
   end
 
   describe 'perform' do
-    context 'with flag enabled' do
+    context 'with flag enabled', :aggregate_failures do
       before do
         Flipper.enable :decision_review_saved_claim_sc_status_updater_job_enabled
       end
@@ -45,8 +41,7 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
           SavedClaim::NoticeOfDisagreement.create(form: '{}')
         end
 
-        # rubocop:disable Layout/LineLength
-        it 'updates SavedClaim::SupplementalClaim delete_date for completed records without a delete_date', :aggregate_failures do
+        it 'updates SavedClaim::SupplementalClaim delete_date for completed records without a delete_date' do
           expect(service).to receive(:get_supplemental_claim).with(guid1).and_return(response_complete)
           expect(service).to receive(:get_supplemental_claim).with(guid2).and_return(response_pending)
           expect(service).not_to receive(:get_supplemental_claim).with(guid3)

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
           SavedClaim::NoticeOfDisagreement.create(form: '{}')
         end
 
-        it 'updates SavedClaim::SupplementalClaim delete_date for completed records without a delete_date' do
+        # rubocop:disable Layout/LineLength
+        it 'updates SavedClaim::SupplementalClaim delete_date for completed records without a delete_date', :aggregate_failures do
           expect(service).to receive(:get_supplemental_claim).with(guid1).and_return(response_complete)
           expect(service).to receive(:get_supplemental_claim).with(guid2).and_return(response_pending)
           expect(service).not_to receive(:get_supplemental_claim).with(guid3)


### PR DESCRIPTION
## Summary
Adds scheduled jobs to set the `delete_date` of completed DR `SavedClaim` records:
* `SavedClaim::HigherLevelReview`
* `SavedClaim::NoticeOfDisagreement`
* `SavedClaim::SupplementalClaim`

Each job to update a particular class is behind a separate flipper flag:
* `decision_review_saved_claim_hlr_status_updater_job_enabled` - HigherLevelReview
* `decision_review_saved_claim_nod_status_updater_job_enabled` - NoticeOfDisagreement
* `decision_review_saved_claim_sc_status_updater_job_enabled` - SupplementalClaim

Each job is scheduled to run once every hour, with an offset of 10 min between each job (`xx:20`, `xx:30`, `xx:40`)

This is owned by the Benefits Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84332

## Testing done

- [x] *New code is covered by unit tests*
This has been tested locally and in rspec.
Flipper flags will be used to test in staging before enabling in production.

## What areas of the site does it impact?
This PR impacts the `saved_claims` table and also runs sidekiq jobs every hour

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature