### PR TITLE
chore: Remove use_new_get_all_features feature

### DIFF
--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -30,8 +30,6 @@ module V0
     end
 
     def get_all_features
-      return old_get_all_features unless Flipper.enabled?(:use_new_get_all_features)
-
       features = fetch_features_with_gate_keys
       add_feature_gate_values(features)
       format_features(features)
@@ -112,25 +110,6 @@ module V0
 
     def flipper_id
       params[:cookie_id] || @current_user&.flipper_id
-    end
-
-    def old_get_all_features
-      features = []
-
-      FLIPPER_FEATURE_CONFIG['features'].collect do |feature_name, values|
-        flipper_enabled = if Settings.flipper.mute_logs
-                            ActiveRecord::Base.logger.silence do
-                              Flipper.enabled?(feature_name, resolve_actor(values['actor_type']))
-                            end
-                          else
-                            Flipper.enabled?(feature_name, resolve_actor(values['actor_type']))
-                          end
-        # returning both camel and snakecase for uniformity on FE
-        features << { name: feature_name.camelize(:lower), value: flipper_enabled }
-        features << { name: feature_name, value: flipper_enabled }
-      end
-
-      features
     end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1629,9 +1629,6 @@ features:
   merge_1995_and_5490:
     actore_type: user
     description: Activating the combined 1995 and 5490 form
-  use_new_get_all_features:
-    actor_type: user
-    description: Used to test new feature toggle code. Removal ETA July 15, 2024
   mgib_verifications_maintenance: 
     actor_type: user
     description: Used to show  maintenance alert for MGIB Verifications

--- a/spec/controllers/v0/feature_toggles_controller_spec.rb
+++ b/spec/controllers/v0/feature_toggles_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
     @feature_name_camel = @feature_name.camelize(:lower)
     @cached_enabled_val = Flipper.enabled?(@feature_name)
     Flipper.enable(@feature_name)
-    Flipper.enable(:use_new_get_all_features)
   end
 
   after(:all) do


### PR DESCRIPTION
New feature toggle logic is working well in production. Clean up old code/feature toggle.