### PR TITLE
[DBX-89297] bump in_process window to 3 weeks for edge cases

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -123,8 +123,9 @@ class Form526Submission < ApplicationRecord
   FLASHES = 'flashes'
   BIRLS_KEY = 'va_eauth_birlsfilenumber'
   SUBMIT_FORM_526_JOB_CLASSES = %w[SubmitForm526AllClaim SubmitForm526].freeze
-  # MAX_PENDING_TIME aligns with the farthest out expectation given in the LH BI docs
-  MAX_PENDING_TIME = 2.weeks
+  # MAX_PENDING_TIME aligns with the farthest out expectation given in the LH BI docs,
+  # plus 1 week to accomodate for edge cases and our sidekiq jobs
+  MAX_PENDING_TIME = 3.weeks
 
   # Called when the DisabilityCompensation form controller is ready to hand off to the backend
   # submission process. Currently this passes directly to the retryable EVSS workflow, but if any

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -275,8 +275,8 @@ FactoryBot.define do
     submitted_claim_id { SecureRandom.rand(900_000_000) }
   end
 
-  trait :created_more_than_2_weeks_ago do
-    created_at { (2.weeks + 1.day).ago }
+  trait :created_more_than_3_weeks_ago do
+    created_at { (3.weeks + 1.day).ago }
   end
 
   trait :remediated do

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe Form526Submission do
 
   describe 'scopes' do
     let!(:in_process) { create(:form526_submission) }
-    let!(:expired) { create(:form526_submission, :created_more_than_2_weeks_ago) }
+    let!(:expired) { create(:form526_submission, :created_more_than_3_weeks_ago) }
     let!(:happy_path_success) { create(:form526_submission, :with_submitted_claim_id) }
     let!(:pending_backup) { create(:form526_submission, :backup_path) }
     let!(:accepted_backup) { create(:form526_submission, :backup_path, :backup_accepted) }
     let!(:rejected_backup) { create(:form526_submission, :backup_path, :backup_rejected) }
     let!(:remediated) { create(:form526_submission, :remediated) }
-    let!(:remediated_and_expired) { create(:form526_submission, :remediated, :created_more_than_2_weeks_ago) }
+    let!(:remediated_and_expired) { create(:form526_submission, :remediated, :created_more_than_3_weeks_ago) }
     let!(:remediated_and_rejected) { create(:form526_submission, :remediated, :backup_path, :backup_rejected) }
     let!(:no_longer_remediated) { create(:form526_submission, :no_longer_remediated) }
     let!(:paranoid_success) { create(:form526_submission, :backup_path, :paranoid_success) }
@@ -1475,8 +1475,8 @@ RSpec.describe Form526Submission do
         end
       end
 
-      context 'and the record was created more than 3 days ago' do
-        subject { create(:form526_submission, :created_more_than_2_weeks_ago) }
+      context 'and the record was created more than 3 weeks ago' do
+        subject { create(:form526_submission, :created_more_than_3_weeks_ago) }
 
         it 'returns false' do
           expect(subject).not_to be_in_process
@@ -1517,7 +1517,7 @@ RSpec.describe Form526Submission do
     end
 
     context 'when the submission is neither a success type nor in process' do
-      subject { create(:form526_submission, :created_more_than_2_weeks_ago) }
+      subject { create(:form526_submission, :created_more_than_3_weeks_ago) }
 
       it 'returns true' do
         expect(subject).to be_failure_type


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Update the 'in process' window for 526 backup path polling from 2 weeks to 3 weeks. This accounts for edge cases, the 24 hour delay in BI polling (it's a nightly job), as well as the 2 days of Sidekiq runtime that may proceed the start of polling
- This is not a user facing change. This unblocks upcoming monitoring work

## Related issue(s)
- [Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/89297)
- [Document about this work](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/untouched_submission_audit/526_state_repair_tdd.md)

## Testing done

- [x] *New code is covered by unit tests*
- Nothing to test apart from syntax, which is verified working. This code reflects scripts being used in production for reporting, this change allows us to not use the production command line for this logic

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
