### PR TITLE
VAOS reason code should fallback to reasonCode to support DS appointments

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -36,7 +36,9 @@ module VAOS
         return if reason_code_hash.empty?
 
         # Direct Scheduling appointments
-        if appointment[:kind] == 'clinic' && appointment[:status] == 'booked'
+        # Note we check requested periods to ensure booked DS appointments and booked DS
+        # appointments that are later cancelled are both processed here.
+        if appointment[:kind] == 'clinic' && appointment[:requested_periods].blank?
           comments = reason_code_hash['comments'] if reason_code_hash.key?('comments')
           reason = extract_reason_for_appointment(reason_code_hash)
 
@@ -74,8 +76,12 @@ module VAOS
       # @param reason_code_hash [Hash] the hash of reason code key value pairs
       # @return [String, nil] The reason for appointment as a string, or nil if not possible.
       def extract_reason_for_appointment(reason_code_hash)
+        # Appointment requests used 'reason code' as the key
         if reason_code_hash.key?('reason code') && PURPOSE_TEXT.key?(reason_code_hash['reason code'])
           PURPOSE_TEXT[reason_code_hash['reason code']]
+        # Direct schedule appointments used 'reasonCode' as the key
+        elsif reason_code_hash.key?('reasonCode') && PURPOSE_TEXT.key?(reason_code_hash['reasonCode'])
+          PURPOSE_TEXT[reason_code_hash['reasonCode']]
         end
       end
 

--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -76,10 +76,9 @@ module VAOS
       # @param reason_code_hash [Hash] the hash of reason code key value pairs
       # @return [String, nil] The reason for appointment as a string, or nil if not possible.
       def extract_reason_for_appointment(reason_code_hash)
-        # Appointment requests used 'reason code' as the key
         if reason_code_hash.key?('reason code') && PURPOSE_TEXT.key?(reason_code_hash['reason code'])
           PURPOSE_TEXT[reason_code_hash['reason code']]
-        # Direct schedule appointments used 'reasonCode' as the key
+        # Direct schedule appointments also used 'reasonCode' as the key in the past so we need this as well
         elsif reason_code_hash.key?('reasonCode') && PURPOSE_TEXT.key?(reason_code_hash['reasonCode'])
           PURPOSE_TEXT[reason_code_hash['reasonCode']]
         end

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -199,7 +199,7 @@ FactoryBot.define do
 
     trait :va_cancelled_valid_reason_code_text do
       va_base
-      status { 'booked' }
+      status { 'cancelled' }
       reason_code do
         { 'text': 'reasonCode:ROUTINEVISIT|comments:test' }
       end

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -162,9 +162,8 @@ FactoryBot.define do
       end
     end
 
-    trait :va_booked_base do
+    trait :va_base do
       kind { 'clinic' }
-      status { 'booked' }
       location_id { '983' }
       clinic { '999' } # this is the clinic id for audiology
       slot do
@@ -180,7 +179,8 @@ FactoryBot.define do
     end
 
     trait :va_booked do
-      va_booked_base
+      va_base
+      status { 'booked' }
       reason_code do
         { 'coding' => [
             'code': 'Routine Follow-up'
@@ -190,9 +190,18 @@ FactoryBot.define do
     end
 
     trait :va_booked_valid_reason_code_text do
-      va_booked_base
+      va_base
+      status { 'booked' }
       reason_code do
-        { 'text': 'station id: 983|preferred modality: FACE TO FACE|phone number: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:test' } # rubocop:disable Layout/LineLength
+        { 'text': 'reasonCode:ROUTINEVISIT|comments:test' }
+      end
+    end
+
+    trait :va_cancelled_valid_reason_code_text do
+      va_base
+      status { 'booked' }
+      reason_code do
+        { 'text': 'reasonCode:ROUTINEVISIT|comments:test' }
       end
     end
 

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -40,8 +40,17 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:preferred_dates]).to be_nil
     end
 
-    it 'extract valid reason code fields for va direct scheduling appointments' do
+    it 'extract valid reason code fields for booked va direct scheduling appointments' do
       appt = FactoryBot.build(:appointment_form_v2, :va_booked_valid_reason_code_text).attributes
+      subject.extract_reason_code_fields(appt)
+      expect(appt[:contact]).to eq({})
+      expect(appt[:patient_comments]).to eq('test')
+      expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
+      expect(appt[:preferred_dates]).to be_nil
+    end
+
+    it 'extract valid reason code fields for cancelled va direct scheduling appointments' do
+      appt = FactoryBot.build(:appointment_form_v2, :va_cancelled_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
       expect(appt[:patient_comments]).to eq('test')


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is part of the api consolidation effort and solves an issue where the reason code key is `reason code` for appointment requests and `reasonCode` for DS appointments
- This is work by the Appointments team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88692

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior returns the information as part of the reason code text and reasonForAppointment field is non existent.
- Tested API response to ensure it matches with ACs

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
