### PR TITLE
chore: Remove unused Sidekiq config.yml

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,0 @@
----
-:concurrency: 10


### PR DESCRIPTION
This config is not referenced or used in our k8s values.yml. If we were
to use it, we should move all of our configuration inside but we already
specific queue priorities in our Sidekiq args.
