### PR TITLE
feat: Use RAILS_MAX_THREADS for Sidekiq concurrency

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,2 @@
 ---
-:concurrency: 10
+:concurrency: <%= ENV.fetch('RAILS_MAX_THREADS') { 10 } %>


### PR DESCRIPTION
This allows setting Sidekiq's concurrency [via our k8s values](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3034).

When running:
```shell
RAILS_MAX_THREADS=7 bundle exec sidekiq
```

I see the expected threads (sidekiq_alive adds 2):
<img width="614" alt="image" src="https://github.com/user-attachments/assets/8f60b3b9-6789-4201-b45f-eededc35b3d3">
