### PR TITLE
Use custom serializer for EVSSSeparationLocationSerializer

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -43,8 +43,7 @@ module V0
         )
         api_provider.get_separation_locations
       end
-      render json: response,
-             each_serializer: EVSSSeparationLocationSerializer
+      render json: EVSSSeparationLocationSerializer.new(response)
     end
 
     def suggested_conditions

--- a/app/serializers/evss_separation_location_serializer.rb
+++ b/app/serializers/evss_separation_location_serializer.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
-# NOT USING JSON:API Specification
-# app/controllers/v0/disability_compensation_forms_controller.rb
-class EVSSSeparationLocationSerializer < ActiveModel::Serializer
-  attribute :separation_locations
+class EVSSSeparationLocationSerializer
 
-  def id
-    nil
+  def initialize(resource)
+    @resource = resource
+  end
+
+  def to_json(options = {})
+    Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
+  end
+
+  def serializable_hash
+    {
+      status: @resource.status,
+      separation_locations: @resource.separation_locations
+    }
   end
 end

--- a/app/serializers/evss_separation_location_serializer.rb
+++ b/app/serializers/evss_separation_location_serializer.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class EVSSSeparationLocationSerializer
-
   def initialize(resource)
     @resource = resource
   end
 
-  def to_json(options = {})
+  def to_json(*)
     Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
   end
 

--- a/spec/serializers/evss_separation_location_serializer_spec.rb
+++ b/spec/serializers/evss_separation_location_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe EVSSSeparationLocationSerializer, type: :serializer do
-  subject { serialize(intake_sites_response, serializer_class: described_class) }
+  subject { described_class.new(intake_sites_response).to_json }
 
   let(:separation_locations) do
     [
@@ -16,15 +16,15 @@ RSpec.describe EVSSSeparationLocationSerializer, type: :serializer do
     DisabilityCompensation::ApiProvider::IntakeSitesResponse.new(status: 200, separation_locations:)
   end
 
-  let(:data) { JSON.parse(subject)['data'] }
+  let(:data) { JSON.parse(subject) }
   let(:attributes) { data['attributes'] }
 
-  it 'includes :id' do
-    expect(data['id']).to be_blank
+  it 'includes :status' do
+    expect(data['status']).to eq intake_sites_response.status
   end
 
   it 'includes :separation_locations as an array' do
-    expect(attributes['separation_locations'].size).to eq intake_sites_response.separation_locations.size
-    expect(attributes['separation_locations'].first['code']).to eq intake_sites_response.separation_locations.first.code
+    expect(data['separation_locations'].size).to eq intake_sites_response.separation_locations.size
+    expect(data['separation_locations'].first['code']).to eq intake_sites_response.separation_locations.first.code
   end
 end


### PR DESCRIPTION
## Summary

In an effort to remove AMS serializers, this non-JSON:API serializer needs a custom serializer

- Convert AMS serializer to custom serializer
- The response is identical to the AMS serializer response

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88861

## Testing done

- [x] Verified response is identical 

## Acceptance criteria

- [x] Unit specs don't rely on AMS or jsonapi-serializers
- [x] Serializers don't use AMS, jsonapi-serializers, or blueprinter
- [x] Each serializer has `to_json` and `serializable_hash` methods