### PR TITLE
Use custom serializer for VYE serializers

### DIFF
--- a/modules/vye/app/controllers/vye/v1/user_infos_controller.rb
+++ b/modules/vye/app/controllers/vye/v1/user_infos_controller.rb
@@ -6,10 +6,7 @@ module Vye
       def show
         authorize user_info, policy_class: Vye::UserInfoPolicy
 
-        render json: user_info,
-               serializer: Vye::UserInfoSerializer,
-               adapter: :json,
-               include: %i[latest_address pending_documents verifications pending_verifications].freeze
+        render json: Vye::UserInfoSerializer.new(user_info)
       end
     end
   end

--- a/modules/vye/app/serializers/vye/address_change_serializer.rb
+++ b/modules/vye/app/serializers/vye/address_change_serializer.rb
@@ -1,18 +1,26 @@
 # frozen_string_literal: true
 
 module Vye
-  class AddressChangeSerializer < ActiveModel::Serializer
-    attributes(
-      :veteran_name,
-      :address1,
-      :address2,
-      :address3,
-      :address4,
-      :address5,
-      :city,
-      :state,
-      :zip_code,
-      :origin
-    )
+  class AddressChangeSerializer
+    def initialize(resource)
+      @resource = resource
+    end
+    def to_json(*)
+      Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
+    end
+    def serializable_hash
+      {
+        veteran_name: @resource.veteran_name,
+        address1: @resource.address1,
+        address2: @resource.address2,
+        address3: @resource.address3,
+        address4: @resource.address4,
+        address5: @resource.address5,
+        city: @resource.city,
+        state: @resource.state,
+        zip_code: @resource.zip_code,
+        origin: @resource.origin
+      }
+    end
   end
 end

--- a/modules/vye/app/serializers/vye/address_change_serializer.rb
+++ b/modules/vye/app/serializers/vye/address_change_serializer.rb
@@ -5,9 +5,11 @@ module Vye
     def initialize(resource)
       @resource = resource
     end
+
     def to_json(*)
       Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
     end
+
     def serializable_hash
       {
         veteran_name: @resource.veteran_name,

--- a/modules/vye/app/serializers/vye/pending_document_serializer.rb
+++ b/modules/vye/app/serializers/vye/pending_document_serializer.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 module Vye
-  class PendingDocumentSerializer < ActiveModel::Serializer
-    attributes :doc_type, :queue_date
+  class PendingDocumentSerializer
+    def initialize(resource)
+      @resource = resource
+    end
+    def to_json(*)
+      Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
+    end
+    def serializable_hash
+      {
+        doc_type: @resource.doc_type,
+        queue_date: @resource.queue_date
+      }
+    end
   end
 end

--- a/modules/vye/app/serializers/vye/pending_document_serializer.rb
+++ b/modules/vye/app/serializers/vye/pending_document_serializer.rb
@@ -5,9 +5,11 @@ module Vye
     def initialize(resource)
       @resource = resource
     end
+
     def to_json(*)
       Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
     end
+
     def serializable_hash
       {
         doc_type: @resource.doc_type,

--- a/modules/vye/app/serializers/vye/user_info_serializer.rb
+++ b/modules/vye/app/serializers/vye/user_info_serializer.rb
@@ -1,20 +1,54 @@
 # frozen_string_literal: true
 
 module Vye
-  class UserInfoSerializer < ActiveModel::Serializer
-    attributes(
-      :rem_ent,
-      :cert_issue_date,
-      :del_date,
-      :date_last_certified,
-      :payment_amt,
-      :indicator,
-      :zip_code
-    )
+  class UserInfoSerializer
 
-    has_one :latest_address, serializer: Vye::AddressChangeSerializer
-    has_many :pending_documents, serializer: Vye::PendingDocumentSerializer
-    has_many :verifications, serializer: Vye::VerificationSerializer
-    has_many :pending_verifications, serializer: Vye::VerificationSerializer
+    def initialize(resource)
+      @resource = resource
+    end
+    def to_json(*)
+      Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
+    end
+    def serializable_hash
+      {
+        "vye/user_info": {
+          rem_ent: @resource.rem_ent,
+          cert_issue_date: @resource.cert_issue_date,
+          del_date: @resource.del_date,
+          date_last_certified: @resource.date_last_certified,
+          payment_amt: @resource.payment_amt,
+          indicator: @resource.indicator,
+          zip_code: @resource.zip_code,
+          latest_address: serialized_latest_address,
+          pending_documents: serialized_pending_documents,
+          verifications: serialized_verifications,
+          pending_verifications: serialized_pending_verifications,
+        }
+      }
+    end
+
+    private
+
+    def serialized_latest_address
+      Vye::AddressChangeSerializer.new(@resource.latest_address).serializable_hash
+    end
+
+    def serialized_pending_documents
+      @resource.pending_documents.map do |pending_document|
+        Vye::PendingDocumentSerializer.new(pending_document).serializable_hash
+      end
+    end
+
+    def serialized_verifications
+      @resource.verifications.map do |verification|
+        Vye::VerificationSerializer.new(verification).serializable_hash
+      end
+    end
+
+    def serialized_pending_verifications
+      @resource.pending_verifications.map do |pending_verification|
+        Vye::VerificationSerializer.new(pending_verification).serializable_hash
+      end
+    end
   end
 end

--- a/modules/vye/app/serializers/vye/user_info_serializer.rb
+++ b/modules/vye/app/serializers/vye/user_info_serializer.rb
@@ -2,16 +2,17 @@
 
 module Vye
   class UserInfoSerializer
-
     def initialize(resource)
       @resource = resource
     end
+
     def to_json(*)
       Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
     end
+
     def serializable_hash
       {
-        "vye/user_info": {
+        'vye/user_info': {
           rem_ent: @resource.rem_ent,
           cert_issue_date: @resource.cert_issue_date,
           del_date: @resource.del_date,
@@ -22,7 +23,7 @@ module Vye
           latest_address: serialized_latest_address,
           pending_documents: serialized_pending_documents,
           verifications: serialized_verifications,
-          pending_verifications: serialized_pending_verifications,
+          pending_verifications: serialized_pending_verifications
         }
       }
     end

--- a/modules/vye/app/serializers/vye/verification_serializer.rb
+++ b/modules/vye/app/serializers/vye/verification_serializer.rb
@@ -1,12 +1,23 @@
 # frozen_string_literal: true
 
 module Vye
-  class VerificationSerializer < ActiveModel::Serializer
-    attributes(
-      :award_id,
-      :act_begin, :act_end,
-      :transact_date,
-      :monthly_rate, :number_hours, :source_ind
-    )
+  class VerificationSerializer
+    def initialize(resource)
+      @resource = resource
+    end
+    def to_json(*)
+      Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
+    end
+    def serializable_hash
+      {
+        award_id: @resource.award_id,
+        act_begin: @resource.act_begin,
+        act_end: @resource.act_end,
+        transact_date: @resource.transact_date,
+        monthly_rate: @resource.monthly_rate,
+        number_hours: @resource.number_hours,
+        source_ind: @resource.source_ind,
+      }
+    end
   end
 end

--- a/modules/vye/app/serializers/vye/verification_serializer.rb
+++ b/modules/vye/app/serializers/vye/verification_serializer.rb
@@ -5,9 +5,11 @@ module Vye
     def initialize(resource)
       @resource = resource
     end
+
     def to_json(*)
       Oj.dump(serializable_hash, mode: :compat, time_format: :ruby)
     end
+
     def serializable_hash
       {
         award_id: @resource.award_id,
@@ -16,7 +18,7 @@ module Vye
         transact_date: @resource.transact_date,
         monthly_rate: @resource.monthly_rate,
         number_hours: @resource.number_hours,
-        source_ind: @resource.source_ind,
+        source_ind: @resource.source_ind
       }
     end
   end

--- a/modules/vye/spec/requests/vye/v1/show_spec.rb
+++ b/modules/vye/spec/requests/vye/v1/show_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe Vye::V1::UserInfosController, type: :request do
 
           it 'returns the user_info' do
             get '/vye/v1'
+
+            json = JSON.parse(response.body)
+
+            expect(json['vye/user_info']).to be_present
+
+            %w[cert_issue_date del_date date_last_certified].each do |attribute|
+              expect(json['vye/user_info'][attribute]).to eq user_info.send(attribute.to_sym).to_s
+            end
+
+            expected_veteran_name = user_info.latest_address.veteran_name
+            expect(json['vye/user_info'].keys).to include('latest_address')
+            expect(json['vye/user_info']['latest_address']['veteran_name']).to eq expected_veteran_name
+
+            expect_doc_type = user_info.pending_documents.first.doc_type
+            expect_queue_date = user_info.pending_documents.first.queue_date.to_s
+            expect(json['vye/user_info']['pending_documents'].class).to eq Array
+            expect(json['vye/user_info']['pending_documents'][0]['doc_type']).to eq expect_doc_type
+            expect(json['vye/user_info']['pending_documents'][0]['queue_date']).to eq expect_queue_date
+
+            expect(json['vye/user_info']['verifications'].class).to eq Array
+            expect(json['vye/user_info']['pending_verifications'].class).to eq Array
+
             expect(response).to have_http_status(:ok)
           end
         end

--- a/modules/vye/spec/requests/vye/v1/show_spec.rb
+++ b/modules/vye/spec/requests/vye/v1/show_spec.rb
@@ -49,3 +49,26 @@ RSpec.describe Vye::V1::UserInfosController, type: :request do
     end
   end
 end
+
+# "vye/user_info"=>
+#   {"rem_ent"=>"2421128",
+#    "cert_issue_date"=>"2021-04-18",
+#    "del_date"=>"2025-04-14",
+#    "date_last_certified"=>"2024-06-04",
+#    "payment_amt"=>"7274.33",
+#    "indicator"=>"A",
+#    "zip_code"=>"11187",
+#    "latest_address"=>
+#     {"veteran_name"=>"Cristy Leannon",
+#      "address1"=>"1604 Daniel Points",
+#      "address2"=>nil,
+#      "address3"=>nil,
+#      "address4"=>nil,
+#      "address5"=>nil,
+#      "city"=>"New Shelton",
+#      "state"=>"NV",
+#      "zip_code"=>"11187",
+#      "origin"=>"backend"},
+#    "pending_documents"=>[{"doc_type"=>"quia", "queue_date"=>"2024-07-19"}, {"doc_type"=>"adipisci", "queue_date"=>"2024-07-19"}, {"doc_type"=>"eum", "queue_date"=>"2024-07-16"}],
+#    "verifications"=>[],
+#    "pending_verifications"=>[]}}

--- a/modules/vye/spec/requests/vye/v1/show_spec.rb
+++ b/modules/vye/spec/requests/vye/v1/show_spec.rb
@@ -49,26 +49,3 @@ RSpec.describe Vye::V1::UserInfosController, type: :request do
     end
   end
 end
-
-# "vye/user_info"=>
-#   {"rem_ent"=>"2421128",
-#    "cert_issue_date"=>"2021-04-18",
-#    "del_date"=>"2025-04-14",
-#    "date_last_certified"=>"2024-06-04",
-#    "payment_amt"=>"7274.33",
-#    "indicator"=>"A",
-#    "zip_code"=>"11187",
-#    "latest_address"=>
-#     {"veteran_name"=>"Cristy Leannon",
-#      "address1"=>"1604 Daniel Points",
-#      "address2"=>nil,
-#      "address3"=>nil,
-#      "address4"=>nil,
-#      "address5"=>nil,
-#      "city"=>"New Shelton",
-#      "state"=>"NV",
-#      "zip_code"=>"11187",
-#      "origin"=>"backend"},
-#    "pending_documents"=>[{"doc_type"=>"quia", "queue_date"=>"2024-07-19"}, {"doc_type"=>"adipisci", "queue_date"=>"2024-07-19"}, {"doc_type"=>"eum", "queue_date"=>"2024-07-16"}],
-#    "verifications"=>[],
-#    "pending_verifications"=>[]}}

--- a/modules/vye/spec/serializers/address_change_serializer_spec.rb
+++ b/modules/vye/spec/serializers/address_change_serializer_spec.rb
@@ -4,49 +4,48 @@ require 'rails_helper'
 require Vye::Engine.root / 'spec/rails_helper'
 
 describe Vye::AddressChangeSerializer, type: :serializer do
-  subject { serialize(address_change, serializer_class: described_class) }
+  subject { described_class.new(address_change).to_json }
 
   let(:address_change) { build_stubbed(:vye_address_change) }
-  let(:data) { JSON.parse(subject)['data'] }
-  let(:attributes) { data['attributes'] }
+  let(:data) { JSON.parse(subject) }
 
   it 'includes :veteran_name' do
-    expect(attributes['veteran_name']).to eq address_change.veteran_name
+    expect(data['veteran_name']).to eq address_change.veteran_name
   end
 
   it 'includes :address1' do
-    expect(attributes['address1']).to eq address_change.address1
+    expect(data['address1']).to eq address_change.address1
   end
 
   it 'includes :address2' do
-    expect(attributes['address2']).to eq address_change.address2
+    expect(data['address2']).to eq address_change.address2
   end
 
   it 'includes :address3' do
-    expect(attributes['address3']).to eq address_change.address3
+    expect(data['address3']).to eq address_change.address3
   end
 
   it 'includes :address4' do
-    expect(attributes['address4']).to eq address_change.address4
+    expect(data['address4']).to eq address_change.address4
   end
 
   it 'includes :address5' do
-    expect(attributes['address5']).to eq address_change.address5
+    expect(data['address5']).to eq address_change.address5
   end
 
   it 'includes :city' do
-    expect(attributes['city']).to eq address_change.city
+    expect(data['city']).to eq address_change.city
   end
 
   it 'includes :state' do
-    expect(attributes['state']).to eq address_change.state
+    expect(data['state']).to eq address_change.state
   end
 
   it 'includes :zip_code' do
-    expect(attributes['zip_code']).to eq address_change.zip_code
+    expect(data['zip_code']).to eq address_change.zip_code
   end
 
   it 'includes :origin' do
-    expect(attributes['origin']).to eq address_change.origin
+    expect(data['origin']).to eq address_change.origin
   end
 end

--- a/modules/vye/spec/serializers/pending_document_serializer_spec.rb
+++ b/modules/vye/spec/serializers/pending_document_serializer_spec.rb
@@ -4,17 +4,16 @@ require 'rails_helper'
 require Vye::Engine.root / 'spec/rails_helper'
 
 describe Vye::PendingDocumentSerializer, type: :serializer do
-  subject { serialize(pending_document, serializer_class: described_class) }
+  subject { described_class.new(pending_document).to_json }
 
   let(:pending_document) { build_stubbed(:vye_pending_document) }
-  let(:data) { JSON.parse(subject)['data'] }
-  let(:attributes) { data['attributes'] }
+  let(:data) { JSON.parse(subject) }
 
   it 'includes :doc_type' do
-    expect(attributes['doc_type']).to eq pending_document.doc_type
+    expect(data['doc_type']).to eq pending_document.doc_type
   end
 
   it 'includes :queue_date' do
-    expect(attributes['queue_date']).to eq pending_document.queue_date.to_s
+    expect(data['queue_date']).to eq pending_document.queue_date.to_s
   end
 end

--- a/modules/vye/spec/serializers/user_info_serializer_spec.rb
+++ b/modules/vye/spec/serializers/user_info_serializer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require Vye::Engine.root / 'spec/rails_helper'
 
 describe Vye::UserInfoSerializer, type: :serializer do
-  subject { serialize(user_info, serializer_class: described_class) }
+  subject { described_class.new(user_info).to_json }
 
   before do
     user_profile = user_info.user_profile
@@ -14,51 +14,49 @@ describe Vye::UserInfoSerializer, type: :serializer do
   end
 
   let(:user_info) { create(:vye_user_info) }
-  let(:data) { JSON.parse(subject)['data'] }
-  let(:attributes) { data['attributes'] }
-  let(:relationships) { data['relationships'] }
+  let(:data) { JSON.parse(subject)['vye/user_info'] }
 
   it 'includes :rem_ent' do
-    expect(attributes['rem_ent']).to eq user_info.rem_ent
+    expect(data['rem_ent']).to eq user_info.rem_ent
   end
 
   it 'includes :cert_issue_date' do
-    expect(attributes['cert_issue_date']).to eq user_info.cert_issue_date.to_s
+    expect(data['cert_issue_date']).to eq user_info.cert_issue_date.to_s
   end
 
   it 'includes :del_date' do
-    expect(attributes['del_date']).to eq user_info.del_date.to_s
+    expect(data['del_date']).to eq user_info.del_date.to_s
   end
 
   it 'includes :date_last_certified' do
-    expect(attributes['date_last_certified']).to eq user_info.date_last_certified.to_s
+    expect(data['date_last_certified']).to eq user_info.date_last_certified.to_s
   end
 
   it 'includes :payment_amt' do
-    expect(attributes['payment_amt']).to eq user_info.payment_amt.to_s
+    expect(data['payment_amt']).to eq user_info.payment_amt.to_s
   end
 
   it 'includes :indicator' do
-    expect(attributes['indicator']).to eq user_info.indicator
+    expect(data['indicator']).to eq user_info.indicator
   end
 
   it 'includes :zip_code' do
-    expect(attributes['zip_code']).to eq user_info.zip_code
+    expect(data['zip_code']).to eq user_info.zip_code
   end
 
   it 'includes :latest_address' do
-    expect(relationships['latest_address']['data']['id']).to eq user_info.latest_address.id.to_s
+    expect(data['latest_address']['veteran_name']).to eq user_info.latest_address.veteran_name
   end
 
   it 'includes :pending_documents' do
-    expect(relationships['pending_documents']['data'][0]['id']).to eq user_info.pending_documents.first.id.to_s
+    expect(data['pending_documents'][0]['doc_type']).to eq user_info.pending_documents.first.doc_type
   end
 
   it 'includes :verifications' do
-    expect(relationships['verifications']['data'][0]['id']).to eq user_info.verifications.first.id.to_s
+    expect(data['verifications'][0]['award_id']).to eq user_info.verifications.first.award_id
   end
 
   it 'includes :pending_verifications' do
-    expect(relationships['pending_verifications']['data'][0]['id']).to eq user_info.pending_verifications.first.id.to_s
+    expect(data['pending_verifications'][0]['award_id']).to eq user_info.pending_verifications.first.award_id
   end
 end

--- a/modules/vye/spec/serializers/verification_serializer_spec.rb
+++ b/modules/vye/spec/serializers/verification_serializer_spec.rb
@@ -4,38 +4,36 @@ require 'rails_helper'
 require Vye::Engine.root / 'spec/rails_helper'
 
 RSpec.describe Vye::VerificationSerializer, type: :serializer do
-  subject { serialize(verification, serializer_class: described_class) }
+  subject { described_class.new(verification).to_json }
 
   let(:verification) { build_stubbed(:vye_verification) }
-  let(:data) { JSON.parse(subject)['data'] }
-  let(:attributes) { data['attributes'] }
-  let(:relationships) { data['relationships'] }
+  let(:data) { JSON.parse(subject) }
 
   it 'includes :award_id' do
-    expect(attributes['award_id']).to eq verification.award_id
+    expect(data['award_id']).to eq verification.award_id
   end
 
   it 'includes :act_begin' do
-    expect(attributes['act_begin']).to eq verification.act_begin
+    expect(data['act_begin']).to eq verification.act_begin
   end
 
   it 'includes :act_end' do
-    expect(attributes['act_end']).to eq verification.act_end
+    expect(data['act_end']).to eq verification.act_end
   end
 
   it 'includes :transact_date' do
-    expect(attributes['transact_date']).to eq verification.transact_date.to_s
+    expect(data['transact_date']).to eq verification.transact_date.to_s
   end
 
   it 'includes :monthly_rate' do
-    expect(attributes['monthly_rate']).to eq verification.monthly_rate
+    expect(data['monthly_rate']).to eq verification.monthly_rate
   end
 
   it 'includes :number_hours' do
-    expect(attributes['number_hours']).to eq verification.number_hours
+    expect(data['number_hours']).to eq verification.number_hours
   end
 
   it 'includes :source_ind' do
-    expect(attributes['source_ind']).to eq verification.source_ind
+    expect(data['source_ind']).to eq verification.source_ind
   end
 end


### PR DESCRIPTION
## Summary

In an effort to remove AMS serializers, this non-JSON:API serializer needs a custom serializer

- Convert AMS serializer to custom serializer
- The response is identical to the AMS serializer response

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88861

## Testing done

- [x] Verified response is identical 

## Acceptance criteria

- [x] Unit specs don't rely on AMS or jsonapi-serializers
- [x] Serializers don't use AMS, jsonapi-serializers, or blueprinter
- [x] Each serializer has `to_json` and `serializable_hash` methods
