### PR TITLE
Add error message logging to Form526 document failure mailers

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
@@ -13,6 +13,7 @@ module EVSS
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']
         error_class = msg['error_class']
+        error_message = msg['error_message']
         timestamp = Time.now.utc
         form526_submission_id = msg['args'].first
 
@@ -34,7 +35,13 @@ module EVSS
 
         Rails.logger.warn(
           'Form4142DocumentUploadFailureEmail retries exhausted',
-          { job_id:, timestamp:, form526_submission_id:, error_class: }
+          {
+            job_id:,
+            timestamp:,
+            form526_submission_id:,
+            error_class:,
+            error_message:
+          }
         )
 
         StatsD.increment("#{STATSD_METRIC_PREFIX}.exhausted")
@@ -43,9 +50,11 @@ module EVSS
           'Failure in Form4142DocumentUploadFailureEmail#sidekiq_retries_exhausted',
           {
             job_id:,
+            messaged_content: e.message,
             submission_id: form526_submission_id,
             pre_exhaustion_failure: {
-              error_class:
+              error_class:,
+              error_message:
             }
           }
         )

--- a/spec/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form4142DocumentUploadFailureEm
       {
         'jid' => 123,
         'error_class' => 'JennyNotFound',
+        'error_message' => 'I tried to call you before but I lost my nerve',
         'args' => [form526_submission.id]
       }
     end
@@ -101,6 +102,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form4142DocumentUploadFailureEm
             {
               job_id: 123,
               error_class: 'JennyNotFound',
+              error_message: 'I tried to call you before but I lost my nerve',
               timestamp: exhaustion_time,
               form526_submission_id: form526_submission.id
             }

--- a/spec/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526DocumentUploadFailureEma
       {
         'jid' => 123,
         'error_class' => 'JennyNotFound',
+        'error_message' => 'I tried to call you before but I lost my nerve',
         'args' => [form526_submission.id, form_attachment.guid]
       }
     end
@@ -128,6 +129,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526DocumentUploadFailureEma
             {
               job_id: 123,
               error_class: 'JennyNotFound',
+              error_message: 'I tried to call you before but I lost my nerve',
               timestamp: exhaustion_time,
               form526_submission_id: form526_submission.id,
               supporting_evidence_attachment_guid: form_attachment.guid


### PR DESCRIPTION
## Summary
The retry and error logging for these jobs didn't include the actual error message in addition to the class as is done in other jobs; we need this information if we're to debug issues with these mailers

- *This work is behind a feature toggle (flipper): YES the jobs themselves are hidden behind a flipper; only the Form 526 evidence job is on in production but its failing when attempting to send the mailer through VA Notify so I need the additional logging to investigate
- *(Which team do you work for, does your team own the maintenance of this component?)* Disability Benefits


## Related issue(s)
N/A

## Testing done

- [X] *New code is covered by unit tests*


## Screenshots
N/A

## What areas of the site does it impact?
N/A this is in a sidekiq mailer job
## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X  Events are being sent to the appropriate logging solution]
- [ ]  Documentation has been updated (link to documentation) N/A
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [X]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [X]  I added a screenshot of the developed feature N/A

## Requested Feedback
While I was able to build tests for the retry logic, there is no automated tests for a catastrophic mailer failure (if the retry logic explodes) but as far as I can tell there is no way in RSpec to do this in the Sidekiq retry block; the rescue block will re-raise an error so that would presumably get logged regardless. If someone knows how to do this let me know, I tried several iterations of different RSpec syntaxes
