### PR TITLE
fix: Sidekiq Health check only runs on Enterprise

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -13,7 +13,7 @@ Rails.application.reloader.to_prepare do
   Sidekiq::Enterprise.unique! if Rails.env.production?
 
   Sidekiq.configure_server do |config|
-    config.health_check('0.0.0.0:7433')
+    config.health_check('0.0.0.0:7433') if config.respond_to? :health_check
     config.redis = REDIS_CONFIG[:sidekiq]
     # super_fetch! is only available in sidekiq-pro and will cause
     #   "undefined method `super_fetch!'"


### PR DESCRIPTION
Fixes issues for people who run Sidekiq locally w/o Sidekiq Enterprise.