### PR TITLE
Add military history prefill feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -909,6 +909,9 @@ features:
    actor_type: user
    description: >
      [Front-end only] When enabled, 21P-527EZ will display additional explanations for the medical evidence requirement.
+  pension_military_prefill:
+    actor_type: user
+    description: 'When enabled, 21P-527EZ will prefill military information.'
   pre_entry_covid19_screener:
     actor_type: user
     description: >


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds a feature flag for prefilling military history in the Pensions form

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88432

## Testing done

- Ran vets-api and toggled on http://localhost:3000/flipper/features/pension_military_prefill

## What areas of the site does it impact?
Pensions

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
