### PR TITLE
89619 icn scrub

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -311,9 +311,12 @@ module VAOS
         icn&.gsub(/V[\d]{6}$/, '')
       end
 
-      # Scrubs the ICN of non-alphanumeric values
+      # Scrubs the ICN of any values that produce an invalid format.
+      # The ICN format consists of 17 alpha-numeric characters (10 digits + "V" + 6 digits) with
+      # V being a deliminator, and the 6 trailing digits a checksum.
+      #
       def scrub_icn(icn)
-        icn&.gsub(/[^0-9a-z]/i, '')
+        icn&.gsub(/[^0-9V]/, '')
       end
 
       # Checks equality between two ICNs (Integration Control Numbers)

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1379,4 +1379,28 @@ describe VAOS::V2::AppointmentsService do
       end
     end
   end
+
+  describe '#scrub_icn' do
+    context 'with a valid icn' do
+      it 'returns an unmodified icn' do
+        valid_icn = '0123456789'
+        expect(subject.send(:scrub_icn, valid_icn)).to eq(valid_icn)
+      end
+    end
+
+    context 'with a valid icn (including checksum)' do
+      it 'returns an unmodified icn' do
+        valid_icn = '0123456789V123456'
+        expect(subject.send(:scrub_icn, valid_icn)).to eq(valid_icn)
+      end
+    end
+
+    context 'with an icn containing non-alphanumeric characters' do
+      it 'scrubs the icn' do
+        invalid_icn = '0123456789.'
+        scrubbed_icn = '0123456789'
+        expect(subject.send(:scrub_icn, invalid_icn)).to eq(scrubbed_icn)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- This work is to perform a sanity check in vets-api to scrub ICNs of non-alphanumeric values before sending them in the requests.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89619

## Testing done

- New unit tests
- Regression tests
