### PR TITLE
[MHV 60168] added feature flag for allergies.

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -870,6 +870,10 @@ features:
     actor_type: user
     description: Enables/disables documentation-related content for Medications on VA.gov
     enable_in_development: true
+  mhv_medications_display_allergies:
+    actor_type: user
+    description: Enables/disables allergies and reactions data
+    enable_in_development: true
   mhv_to_logingov_account_transition:
     actor_type: cookie_id
     description: Enables/disables MHV to Login.gov account transfer experience (Identity)
@@ -1647,6 +1651,6 @@ features:
   merge_1995_and_5490:
     actore_type: user
     description: Activating the combined 1995 and 5490 form
-  mgib_verifications_maintenance: 
+  mgib_verifications_maintenance:
     actor_type: user
     description: Used to show  maintenance alert for MGIB Verifications


### PR DESCRIPTION
## Summary

added feature flag to hold off on showing allergies data until medical records app goes into phase 1

## Related issue(s)

[Change content and add link for allergies](https://jira.devops.va.gov/browse/MHV-60168)
![image](https://github.com/user-attachments/assets/08f16472-d5a0-464b-bb32-d8b7df548965)

## Testing done

manually checked that the flag was displaying on the flipper ui

## Screenshots
![image](https://github.com/user-attachments/assets/a97f63fd-e876-4eca-bf3f-04e8a191f752)


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
