### PR TITLE
88208: Add tracking for email usage

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -63,8 +63,10 @@ module IvcChampva
         applicant_rounded_number = total_applicants_count.positive? ? total_applicants_count.ceil : total_applicants_count.floor
 
         form = form_class.new(parsed_form_data)
+        # DataDog Tracking
         form.track_user_identity
         form.track_current_user_loa(@current_user)
+        form.track_email_usage
 
         attachment_ids = generate_attachment_ids(form_id, applicant_rounded_number)
         attachment_ids.concat(supporting_document_ids(parsed_form_data))

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -65,6 +65,12 @@ module IvcChampva
       Rails.logger.info('IVC ChampVA Forms - 10-10D Current User LOA', current_user_loa:)
     end
 
+    def track_email_usage
+      email_used = metadata&.dig('primaryContactInfo', 'email') ? 'yes' : 'no'
+      StatsD.increment("#{STATS_KEY}.#{email_used}")
+      Rails.logger.info('IVC ChampVA Forms - 10-10D Email Used', email_used:)
+    end
+
     def method_missing(_, *args)
       args&.first
     end

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -38,6 +38,12 @@ module IvcChampva
       Rails.logger.info('IVC ChampVA Forms - 10-7959A Submission User Identity', identity:)
     end
 
+    def track_email_usage
+      email_used = metadata&.dig('primaryContactInfo', 'email') ? 'yes' : 'no'
+      StatsD.increment("#{STATS_KEY}.#{email_used}")
+      Rails.logger.info('IVC ChampVA Forms - 10-7959A Email Used', email_used:)
+    end
+
     # rubocop:disable Naming/BlockForwarding,Style/HashSyntax
     def method_missing(method_name, *args, &block)
       super unless respond_to_missing?(method_name)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -45,6 +45,12 @@ module IvcChampva
       Rails.logger.info('IVC ChampVA Forms - 10-7959C Current User LOA', current_user_loa:)
     end
 
+    def track_email_usage
+      email_used = metadata&.dig('primaryContactInfo', 'email') ? 'yes' : 'no'
+      StatsD.increment("#{STATS_KEY}.#{email_used}")
+      Rails.logger.info('IVC ChampVA Forms - 10-7959C Email Used', email_used:)
+    end
+
     # rubocop:disable Naming/BlockForwarding,Style/HashSyntax
     def method_missing(method_name, *args, &block)
       super unless respond_to_missing?(method_name)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -43,6 +43,12 @@ module IvcChampva
       Rails.logger.info('IVC ChampVA Forms - 10-7959F-1 Current User LOA', current_user_loa:)
     end
 
+    def track_email_usage
+      email_used = metadata&.dig('primaryContactInfo', 'email') ? 'yes' : 'no'
+      StatsD.increment("#{STATS_KEY}.#{email_used}")
+      Rails.logger.info('IVC ChampVA Forms - 10-7959F-1 Email Used', email_used:)
+    end
+
     def method_missing(_, *args)
       args&.first
     end


### PR DESCRIPTION
Add DataDog tracking for when an applicant adds an email or not per form


## Summary

- Add new method to all models
- Add method to uploads_controller

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88208

## Testing done

- Manual

## Screenshots
<img width="943" alt="Screenshot 2024-07-31 at 4 26 08 PM" src="https://github.com/user-attachments/assets/f9bf915f-8b3d-4653-9f18-382ebe4acc8a">


## Acceptance criteria
- I can see percentages for a given time span for the percentage of users who are including at least 1 email* versus leaving email blank
- Since datadog is under our control and we want this metric available at go live, we should plan on including it there
