### PR TITLE
Replace EligibleDataClassesSerializer AMS with JSONAPI 

### DIFF
--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -12,9 +12,8 @@ module V0
     def eligible_data_classes
       resource = client.get_eligible_data_classes
 
-      render json: resource.data,
-             serializer: EligibleDataClassesSerializer,
-             meta: resource.metadata
+      options = { meta: resource.metadata, is_collection: false }
+      render json: EligibleDataClassesSerializer.new(resource.data, options)
     end
 
     def create

--- a/app/serializers/eligible_data_classes_serializer.rb
+++ b/app/serializers/eligible_data_classes_serializer.rb
@@ -2,15 +2,13 @@
 
 require 'digest'
 
-class EligibleDataClassesSerializer < ActiveModel::Serializer
-  type 'eligible_data_classes'
-  attribute :data_classes
+class EligibleDataClassesSerializer
+  include JSONAPI::Serializer
 
-  def data_classes
+  set_id { '' }
+  set_type 'eligible_data_classes'
+
+  attribute :data_classes do |object|
     object.map(&:name)
-  end
-
-  def id
-    nil
   end
 end

--- a/spec/serializers/eligible_data_classes_serializer_spec.rb
+++ b/spec/serializers/eligible_data_classes_serializer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'bb/generate_report_request_form'
 
 describe EligibleDataClassesSerializer, type: :serializer do
-  subject { serialize(eligible_data_classes, serializer_class: described_class) }
+  subject { serialize(eligible_data_classes, { serializer_class: described_class, is_collection: false }) }
 
   let(:eligible_data_classes) { build_list(:eligible_data_class, 3) }
   let(:data) { JSON.parse(subject)['data'] }


### PR DESCRIPTION
## Summary

Switched the following to JSONAPI::Serializer:

- EligibleDataClassesSerializer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87047

## Testing done

- [x]  No tests added or updated
	
## Acceptance criteria

- [x] Each serializer uses jsonapi-serializer 
- [x] Each serializer has 100% coverage