### PR TITLE
fix: Update rexml 3.3.2->3.3.4 for CVE-2024-41946

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -866,7 +866,7 @@ GEM
       hashie (>= 1.2.0, < 6.0)
       jwt (>= 1.5.6)
     retriable (3.1.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rgeo (3.0.1)
     rgeo-activerecord (7.0.1)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946/

There is a DoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2024-41946](https://www.cve.org/CVERecord?id=CVE-2024-41946). We strongly recommend upgrading the REXML gem.

When parsing an XML that has many entity expansions with SAX2 or pull parser API, REXML gem may take long time.

Please update REXML gem to version 3.3.3 or later.

Affected versions:
- REXML gem 3.3.2 or prior