### PR TITLE
Fix empty/blank

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -84,7 +84,7 @@ module ClaimsApi
           new_homeless_info = @pdf_data&.dig(:data, :attributes, :homeless)
 
           homeless_phone_info(homeless_info, new_homeless_info) if homeless_info && new_homeless_info
-          if @pdf_data[:data][:attributes][:homelessInformation][:pointOfContactNumber].empty?
+          if @pdf_data[:data][:attributes][:homelessInformation][:pointOfContactNumber].blank?
             @pdf_data[:data][:attributes][:homelessInformation].delete(:pointOfContactNumber)
           end
           homeless_at_risk_or_currently

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -842,6 +842,21 @@ RSpec.describe 'Disability Claims', type: :request do
             end
           end
         end
+
+        context "when only 'isCurrentlyHomeless' and 'isAtRiskOfBecomingHomeless' are provided" do
+          it 'responds with a 200' do
+            mock_ccg(scopes) do |auth_header|
+              json_data = JSON.parse data
+              params = json_data
+              params['data']['attributes']['homeless'] = {
+                isCurrentlyHomeless: false,
+                isAtRiskOfBecomingHomeless: false
+              }
+              post submit_path, params: params.to_json, headers: auth_header
+              expect(response).to have_http_status(:success)
+            end
+          end
+        end
       end
 
       context "when neither 'currentlyHomeless' nor 'riskOfBecomingHomeless' is provided" do


### PR DESCRIPTION
## Summary
- Fix calling `.empty?` on `nil` - `.blank?` does the same and works on `nil`

## Related issue(s)
- [API-38658](https://jira.devops.va.gov/browse/API-38658) (sorta)

## Testing done
- rspec
- Postman to the synchronous endpoint with:
```
{ "data": { "type": "form/526", "attributes": { "claimProcessType": "STANDARD_CLAIM_PROCESS", "claimNotes": "Some things that are important to know, and are not included in any other place.", "veteranIdentification": { "serviceNumber": "123456789", "veteranNumber": { "telephone": "5555555555" }, "mailingAddress": { "addressLine1": "123 Main Street", "addressLine2": "Unit 1", "addressLine3": "Room 2", "city": "Portland", "country": "USA", "state": "GA", "zipFirstFive": "12345", "zipLastFour": "1234" }, "emailAddress": { "email": "valid@somedomain.com", "agreeToEmailRelatedToClaim": true }, "currentVaEmployee": false }, "changeOfAddress": { "typeOfAddressChange": "TEMPORARY", "addressLine1": "456 Main Street", "addressLine2": "Unit 3", "addressLine3": "Room 4", "city": "Atlanta", "state": "GA", "country": "USA", "zipFirstFive": "42220", "zipLastFour": "9897", "dates": { "beginDate": "2025-06-04", "endDate": "2026-06-04" } }, "homeless": { "isCurrentlyHomeless": true, "isAtRiskOfBecomingHomeless": true }, "toxicExposure": { "gulfWarHazardService": { "servedInGulfWarHazardLocations": "NO" }, "herbicideHazardService": { "servedInHerbicideHazardLocations": "YES", "otherLocationsServed": "Other locations served", "serviceDates": { "beginDate": "1972-05", "endDate": "1980-10" } }, "additionalHazardExposures": { "additionalExposures": [ "OTHER" ], "specifyOtherExposures": "Agent Orange", "exposureDates": { "beginDate": "1972-05", "endDate": "1980-10" } }, "multipleExposures":[ { "hazardExposedTo":"Agent Orange", "exposureLocation":"Vietnam", "exposureDates": { "beginDate":"1972-05", "endDate":"1973-01" } }, { "hazardExposedTo":"Agent Orange", "exposureLocation":"Vietnam", "exposureDates": { "beginDate":"1979-04", "endDate":"1980-10" } } ] }, "disabilities": [ { "name": "Diabetes", "exposureOrEventOrInjury": "Agent Orange", "serviceRelevance": "Service in Vietnam War", "approximateDate": "1975-05", "disabilityActionType": "NEW", "isRelatedToToxicExposure": true }, { "name":"Hearing Loss", "exposureOrEventOrInjury":"Noise", "serviceRelevance":"Heavy equipment operator in service", "approximateDate":"1968-07", "disabilityActionType": "INCREASE", "classificationCode":"8987", "ratedDisabilityId":"1234567", "diagnosticCode":5678, "isRelatedToToxicExposure":false } ], "treatments": [ { "beginDate": "2021-04", "treatedDisabilityNames": [ "Diabetes" ], "center": { "name": "ATLANTA VA MEDICAL CENTER", "state": "GA", "city": "ATLANTA" } }, { "beginDate": "1996-03", "treatedDisabilityNames": [ "Hearing Loss" ], "center": { "name": "ATLANTA VA MEDICAL CENTER", "state": "GA", "city": "ATLANTA" } } ], "serviceInformation": { "alternateNames":[ "Jon Doe", "Jane Doe" ], "servicePeriods": [ { "serviceBranch": "Air Force", "serviceComponent": "Active", "activeDutyBeginDate": "1964-11-14", "activeDutyEndDate": "1980-10-30", "separationLocationCode": "98289" } ], "servedInActiveCombatSince911": "NO", "reservesNationalGuardService": { "component": "National Guard", "obligationTermsOfService": { "beginDate":"1990-11-24", "endDate":"1995-11-17" }, "unitName": "National Guard Unit Name", "unitAddress": "1243 Main Street", "unitPhone": { "areaCode": "555", "phoneNumber": "5555555" }, "receivingInactiveDutyTrainingPay": "YES" }, "confinements": [ { "approximateBeginDate":"1970-06-11", "approximateEndDate":"1970-09-11" } ] }, "servicePay": { "receivingMilitaryRetiredPay": "NO", "futureMilitaryRetiredPay": "YES", "futureMilitaryRetiredPayExplanation": "Explanation of future military retired pay", "militaryRetiredPay": { "branchOfService": "Air Force", "monthlyAmount": 240 }, "retiredStatus": "PERMANENT_DISABILITY_RETIRED_LIST", "favorMilitaryRetiredPay": false, "receivedSeparationOrSeverancePay": "YES", "separationSeverancePay": { "datePaymentReceived": "2018-07-31", "branchOfService": "Air Force", "preTaxAmountReceived": 179 }, "favorTrainingPay": false }, "directDeposit": { "accountNumber": "123123123123", "accountType": "CHECKING", "financialInstitutionName": "Chase", "routingNumber": "123456789" }, "claimantCertification": true } } }
```

## What areas of the site does it impact?
v2 526 (submit and validate)

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
