### PR TITLE
[API-38690] Preserve original 526 form data

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
@@ -104,7 +104,7 @@ module ClaimsApi
 
           unless claims_load_testing # || sandbox_request(request)
             pdf_generation_service.generate(auto_claim&.id, veteran_middle_initial) unless mocking
-            docker_container_service.upload(auto_claim)
+            docker_container_service.upload(auto_claim&.id)
             queue_flash_updater(auto_claim.flashes, auto_claim&.id)
             start_bd_uploader_job(auto_claim) if auto_claim.status != errored_state_value
             auto_claim.reload

--- a/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
@@ -7,20 +7,22 @@ require 'evss_service/base'
 module ClaimsApi
   module DisabilityCompensation
     class DockerContainerService < ClaimsApi::Service
-      def upload(auto_claim)
-        log_service_progress(auto_claim.id, 'docker_service',
+      def upload(claim_id)
+        log_service_progress(claim_id, 'docker_service',
                              'Docker container service started')
+
+        auto_claim = get_claim(claim_id)
 
         update_auth_headers(auto_claim) if auto_claim.transaction_id.present?
 
         evss_data = get_evss_data(auto_claim)
 
-        log_service_progress(auto_claim.id, 'docker_service',
+        log_service_progress(claim_id, 'docker_service',
                              'Submitting mapped data to Docker container')
 
         evss_res = evss_service.submit(auto_claim, evss_data, false)
 
-        log_service_progress(auto_claim.id, 'docker_service',
+        log_service_progress(claim_id, 'docker_service',
                              "Successfully submitted to Docker container with response: #{evss_res}")
         # update with the evss_id returned
         auto_claim.update!(evss_id: evss_res[:claimId])

--- a/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
@@ -10,6 +10,7 @@ module ClaimsApi
 
       def generate(claim_id, middle_initial) # rubocop:disable Metrics/MethodLength
         auto_claim = get_claim(claim_id)
+        original_form_data = Marshal.load(Marshal.dump(auto_claim.form_data))
 
         log_service_progress(auto_claim.id, 'pdf',
                              "526EZ PDF generator started for claim #{auto_claim.id}")
@@ -38,6 +39,8 @@ module ClaimsApi
                                "526EZ PDF generator Uploaded 526EZ PDF #{file_name} to S3")
 
           auto_claim.set_file_data!(upload, EVSS_DOCUMENT_TYPE)
+          auto_claim.form_data = original_form_data
+          auto_claim.save!
 
           ::Common::FileHelpers.delete_file_if_exists(path)
         end

--- a/modules/claims_api/spec/services/disability_compensation/docker_container_service_spec.rb
+++ b/modules/claims_api/spec/services/disability_compensation/docker_container_service_spec.rb
@@ -44,13 +44,13 @@ describe ClaimsApi::DisabilityCompensation::DockerContainerService do
   describe '#upload' do
     it 'has a upload method that returns a claim id' do
       VCR.use_cassette('/claims_api/evss/submit') do
-        expect(docker_container_service.send(:upload, claim)).to eq(true)
+        expect(docker_container_service.send(:upload, claim.id)).to eq(true)
       end
     end
 
     it 'adds the transaction_id to the headers' do
       VCR.use_cassette('/claims_api/evss/submit') do
-        docker_container_service.send(:upload, claim_with_transaction_id)
+        docker_container_service.send(:upload, claim_with_transaction_id.id)
         claim_with_transaction_id.reload
         expect(claim_with_transaction_id.auth_headers['va_eauth_service_transaction_id'])
           .to eq(claim_with_transaction_id.transaction_id)


### PR DESCRIPTION
## Summary

_WIP_

We still want to save the original form data, so make a deep copy before running through the PDF Generation Mapping Service. After generating the PDF (which alters the form data), persist the original form data.

Revert changes in #17824.

## Related issue(s)

[API-38690](https://jira.devops.va.gov/browse/API-38690)

## Testing done

- [ ] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

Disability compensation waiver PDF generation.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
