### PR TITLE
Api 38685 code modifications & tests

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/claims_controller.rb
@@ -522,7 +522,11 @@ module ClaimsApi
           @supporting_documents = []
 
           docs = if benefits_documents_enabled?
-                   file_number = local_bgs_service.find_by_ssn(target_veteran.ssn)&.dig(:file_nbr) # rubocop:disable Rails/DynamicFindBy
+                   file_number = if use_birls_id_file_number?
+                                   target_veteran.birls_id
+                                 else
+                                   local_bgs_service.find_by_ssn(target_veteran.ssn)&.dig(:file_nbr) # rubocop:disable Rails/DynamicFindBy
+                                 end
 
                    if file_number.nil?
                      claims_v2_logging('benefits_documents',
@@ -599,6 +603,10 @@ module ClaimsApi
 
         def benefits_documents_enabled?
           Flipper.enabled? :claims_status_v2_lh_benefits_docs_service_enabled
+        end
+
+        def use_birls_id_file_number?
+          Flipper.enabled? :lighthouse_claims_api_use_birls_id
         end
       end
     end

--- a/modules/claims_api/spec/requests/v2/veterans/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/claims_request_spec.rb
@@ -614,6 +614,7 @@ RSpec.describe 'Claims', type: :request do
 
       it 'uses BD when it should', vcr: 'claims_api/v2/claims_show' do
         allow(Flipper).to receive(:enabled?).with(:claims_status_v2_lh_benefits_docs_service_enabled).and_return true
+        allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_use_birls_id).and_return false
         lh_claim = create(:auto_established_claim, status: 'PENDING', veteran_icn: veteran_id,
                                                    evss_id: '111111111')
         mock_ccg(scopes) do |auth_header|
@@ -833,6 +834,8 @@ RSpec.describe 'Claims', type: :request do
                     VCR.use_cassette('claims_api/evss/documents/get_claim_documents') do
                       allow_any_instance_of(ClaimsApi::V2::Veterans::ClaimsController)
                         .to receive(:benefits_documents_enabled?).and_return(true)
+                      allow_any_instance_of(ClaimsApi::V2::Veterans::ClaimsController)
+                        .to receive(:use_birls_id_file_number?).and_return(false)
 
                       local_bgs_service = double
                       allow_any_instance_of(ClaimsApi::V2::Veterans::ClaimsController)
@@ -847,6 +850,58 @@ RSpec.describe 'Claims', type: :request do
 
                       json_response = JSON.parse(response.body)
 
+                      expect(json_response['data']['attributes']['supportingDocuments']).to eq([])
+                      expect(response.status).not_to eq(404)
+                    end
+                  end
+                end
+              end
+            end
+          end
+
+          describe 'when BD is enabled, and using birls_id as the file number' do
+            context 'when the file_number is nil' do
+              let(:no_ssn_target_veteran) do
+                OpenStruct.new(
+                  icn: '1012832025V743496',
+                  first_name: 'Wesley',
+                  last_name: 'Ford',
+                  birth_date: '19630211',
+                  loa: { current: 3, highest: 3 },
+                  edipi: '2536798',
+                  ssn: nil,
+                  participant_id: '600061742',
+                  birls_id: nil,
+                  mpi: OpenStruct.new(
+                    icn: '1012832025V743496',
+                    profile: OpenStruct.new(ssn: '796043735', birls_id: nil)
+                  )
+                )
+              end
+
+              it 'returns an empty array and not a 404' do
+                mock_ccg(scopes) do |auth_header|
+                  VCR.use_cassette('claims_api/bgs/tracked_items/find_tracked_items') do
+                    VCR.use_cassette('claims_api/evss/documents/get_claim_documents') do
+                      allow_any_instance_of(ClaimsApi::V2::Veterans::ClaimsController)
+                        .to receive(:benefits_documents_enabled?).and_return(true)
+                      allow_any_instance_of(ClaimsApi::V2::Veterans::ClaimsController)
+                        .to receive(:use_birls_id_file_number?).and_return(true)
+                      allow_any_instance_of(ClaimsApi::V2::Veterans::ClaimsController)
+                        .to receive(:target_veteran).and_return(no_ssn_target_veteran)
+
+                      local_bgs_service = double
+                      allow_any_instance_of(ClaimsApi::V2::Veterans::ClaimsController)
+                        .to receive(:local_bgs_service)
+                        .and_return(local_bgs_service)
+
+                      allow(local_bgs_service)
+                        .to receive_messages(find_benefit_claim_details_by_benefit_claim_id: bgs_claim,
+                                             find_by_ssn: nil, find_tracked_items: { dvlpmt_items: [] })
+
+                      get claim_by_id_path, headers: auth_header
+
+                      json_response = JSON.parse(response.body)
                       expect(json_response['data']['attributes']['supportingDocuments']).to eq([])
                       expect(response.status).not_to eq(404)
                     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Adds logic to claims controller to conditionally use the birls_id from MPI/target_veteran as the file_number parameter to the BDS /search endpoint, to reduce errors in cases where the MPI ssn record is incorrect.
- When flipper feature lighthouse_claims_api_use_birls_id is enabled, the controller will not make BGS request to BGS findPersonBySSN to retrieve file number, but instead use the birls_id as the file_number.

## Related issue(s)

[API-38685](https://jira.devops.va.gov/browse/API-38685)

## Testing done

- [x] *New code is covered by unit tests*
- Tested locally via Postman, calling claims /show with the feature flag enabled/disabled to confirm the correct controller logic is executed to get the file_number parameter for BDS /search.

## What areas of the site does it impact?
Claims /show endpoint

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
