### PR TITLE
[VI-223][VI-191] Sign-in Service - Update config routes params

### DIFF
--- a/app/controllers/sign_in/client_configs_controller.rb
+++ b/app/controllers/sign_in/client_configs_controller.rb
@@ -22,7 +22,7 @@ module SignIn
       if client_config.save
         render json: client_config, status: :created
       else
-        render json: client_config.errors, status: :unprocessable_entity
+        render json: { errors: client_config.errors }, status: :unprocessable_entity
       end
     end
 
@@ -30,7 +30,7 @@ module SignIn
       if @client_config.update(client_config_params)
         render json: @client_config, status: :ok
       else
-        render json: @client_config.errors, status: :unprocessable_entity
+        render json: { errors: @client_config.errors }, status: :unprocessable_entity
       end
     end
 
@@ -38,7 +38,7 @@ module SignIn
       if @client_config.destroy
         head :no_content
       else
-        render json: @client_config.errors, status: :unprocessable_entity
+        render json: { errors: @client_config.errors }, status: :unprocessable_entity
       end
     end
 
@@ -51,11 +51,11 @@ module SignIn
     end
 
     def set_client_config
-      @client_config = SignIn::ClientConfig.find(params[:id])
+      @client_config = SignIn::ClientConfig.find_by!(client_id: params[:client_id])
     end
 
     def not_found
-      render json: { error: 'Client config not found' }, status: :not_found
+      render json: { errors: { client_config: ['not found'] } }, status: :not_found
     end
   end
 end

--- a/app/controllers/sign_in/service_account_configs_controller.rb
+++ b/app/controllers/sign_in/service_account_configs_controller.rb
@@ -22,7 +22,7 @@ module SignIn
       if service_account_config.save
         render json: service_account_config, status: :created
       else
-        render json: service_account_config.errors, status: :unprocessable_entity
+        render json: { errors: service_account_config.errors }, status: :unprocessable_entity
       end
     end
 
@@ -30,7 +30,7 @@ module SignIn
       if @service_account_config.update(service_account_config_params)
         render json: @service_account_config, status: :ok
       else
-        render json: @service_account_config.errors, status: :unprocessable_entity
+        render json: { errors: @service_account_config.errors }, status: :unprocessable_entity
       end
     end
 
@@ -38,7 +38,7 @@ module SignIn
       if @service_account_config.destroy
         head :no_content
       else
-        render json: @service_account_config.errors, status: :unprocessable_entity
+        render json: { errors: @service_account_config.errors }, status: :unprocessable_entity
       end
     end
 
@@ -55,11 +55,11 @@ module SignIn
     end
 
     def set_service_account_config
-      @service_account_config = ServiceAccountConfig.find(params[:id])
+      @service_account_config = ServiceAccountConfig.find_by!(service_account_id: params[:service_account_id])
     end
 
     def not_found
-      render json: { error: 'Service account config not found' }, status: :not_found
+      render json: { errors: { service_account_config: ['not found'] } }, status: :not_found
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,8 +26,8 @@ Rails.application.routes.draw do
 
   unless Settings.vsp_environment == 'production'
     namespace :sign_in do
-      resources :client_configs
-      resources :service_account_configs
+      resources :client_configs, param: :client_id
+      resources :service_account_configs, param: :service_account_id
     end
   end
 

--- a/spec/controllers/sign_in/client_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/client_configs_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
   let(:valid_attributes) { attributes_for(:client_config) }
   let(:invalid_attributes) { { client_id: nil } }
   let(:client_config) { create(:client_config) }
+  let(:client_id) { client_config.client_id }
+  let(:response_body) { JSON.parse(response.body) }
 
   before do
     allow_any_instance_of(SignIn::ClientConfigsController).to receive(:authenticate_service_account).and_return(true)
@@ -23,28 +25,28 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
 
       it 'filters by client_ids if provided' do
         get :index, params: { client_ids: [client_config.client_id, client_config2.client_id] }
-        body = JSON.parse(response.body)
 
-        expect(body.length).to eq(2)
-        expect(body.pluck('client_id')).to include(client_config.client_id, client_config2.client_id)
+        expect(response_body.length).to eq(2)
+        expect(response_body.pluck('client_id')).to include(client_config.client_id, client_config2.client_id)
       end
     end
   end
 
   describe 'GET #show' do
     context 'when the client config does not exist' do
+      let(:client_id) { 'non_existent_client_id' }
+
       it 'returns a not found response' do
-        get :show, params: { id: 'non_existent_client_id' }
+        get :show, params: { client_id: }
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context 'when the client config exists' do
       it 'returns a success response' do
-        get :show, params: { id: client_config.id }
-        body = JSON.parse(response.body)
+        get :show, params: { client_id: }
 
-        expect(body['client_id']).to eq(client_config.client_id)
+        expect(response_body['client_id']).to eq(client_config.client_id)
       end
     end
   end
@@ -55,8 +57,7 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
         post :create, params: { client_config: valid_attributes }, as: :json
 
         expect(response).to have_http_status(:created)
-        body = JSON.parse(response.body)
-        expect(body['client_id']).to eq(valid_attributes[:client_id])
+        expect(response_body['client_id']).to eq(valid_attributes[:client_id])
       end
     end
 
@@ -67,7 +68,7 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
         end.not_to change(SignIn::ClientConfig, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)['client_id']).to include("can't be blank")
+        expect(response_body.dig('errors', 'client_id')).to include("can't be blank")
       end
     end
   end
@@ -77,7 +78,7 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
       let(:new_attributes) { { client_id: 'new_client_id' } }
 
       it 'updates the requested SignIn::ClientConfig' do
-        put :update, params: { id: client_config.id, client_config: new_attributes }, as: :json
+        put :update, params: { client_id:, client_config: new_attributes }, as: :json
         client_config.reload
         expect(client_config.client_id).to eq('new_client_id')
       end
@@ -85,18 +86,21 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
 
     context 'with invalid params' do
       it 'does not update the SignIn::ClientConfig and returns an error' do
-        put :update, params: { id: client_config.id, client_config: invalid_attributes }, as: :json
+        put :update, params: { client_id:, client_config: invalid_attributes }, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)['client_id']).to include("can't be blank")
+        expect(response_body.dig('errors', 'client_id')).to include("can't be blank")
       end
     end
   end
 
   describe 'DELETE #destroy' do
     context 'when the client config does not exist' do
+      let(:client_id) { 'non_existent_client_id' }
+
       it 'returns a not found response' do
-        delete :destroy, params: { id: 'non_existent_client_id' }
+        delete :destroy, params: { client_id: }
         expect(response).to have_http_status(:not_found)
+        expect(response_body.dig('errors', 'client_config')).to include('not found')
       end
     end
 
@@ -104,7 +108,7 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
       it 'destroys the requested SignIn::ClientConfig' do
         client_config
         expect do
-          delete :destroy, params: { id: client_config.id }
+          delete :destroy, params: { client_id:  }
         end.to change(SignIn::ClientConfig, :count).by(-1)
       end
     end

--- a/spec/controllers/sign_in/service_account_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/service_account_configs_controller_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
   describe 'GET #index' do
     context 'when authenticated' do
       it 'returns a success response' do
-        service_account_config
         get :index, params: { service_account_ids: [service_account_id] }
         expect(response).to be_successful
         expect(response_body.pluck('service_account_id')).to include(service_account_id)
@@ -40,16 +39,19 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
     context 'when authenticated' do
       context 'when the client config exists' do
         it 'returns a success response' do
-          get :show, params: { id: service_account_config.to_param }
+          get :show, params: { service_account_id: }
           expect(response).to be_successful
           expect(response_body['service_account_id']).to eq(service_account_id)
         end
       end
 
       context 'when the client config does not exist' do
+        let(:service_account_id) { 'non_existent_service_account_id' }
+
         it 'returns a not found response' do
-          get :show, params: { id: 'non_existent_service_account_id' }
+          get :show, params: { service_account_id: }
           expect(response).to have_http_status(:not_found)
+          expect(response_body.dig('errors', 'service_account_config')).to include('not found')
         end
       end
     end
@@ -58,7 +60,7 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
       let(:sts_token) { 'invalid_token' }
 
       it 'returns an unauthorized response' do
-        get :show, params: { id: service_account_config.to_param }
+        get :show, params: { service_account_id: }
         expect(response).to have_http_status(:unauthorized)
       end
     end
@@ -90,7 +92,7 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
         it 'renders an error' do
           post :create, params: { service_account_config: invalid_attributes }, as: :json
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(response_body['service_account_id']).to include("can't be blank")
+          expect(response_body.dig('errors', 'service_account_id')).to include("can't be blank")
         end
       end
     end
@@ -111,7 +113,7 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
         let(:new_attributes) { attributes_for(:service_account_config, service_account_id:) }
 
         it 'updates the requested service_account_config' do
-          put :update, params: { id: service_account_config.to_param, service_account_config: new_attributes },
+          put :update, params: { service_account_id:, service_account_config: new_attributes },
                        as: :json
           service_account_config.reload
           expect(service_account_config.service_account_id).to eq(service_account_id)
@@ -120,10 +122,10 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
 
       context 'with invalid params' do
         it 'renders an error' do
-          put :update, params: { id: service_account_config.to_param, service_account_config: invalid_attributes },
+          put :update, params: { service_account_id:, service_account_config: invalid_attributes },
                        as: :json
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(response_body['service_account_id']).to include("can't be blank")
+          expect(response_body.dig('errors', 'service_account_id')).to include("can't be blank")
         end
       end
     end
@@ -132,7 +134,7 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
       let(:sts_token) { 'invalid_token' }
 
       it 'returns an unauthorized response' do
-        put :update, params: { id: service_account_config.to_param, service_account_config: valid_attributes },
+        put :update, params: { service_account_id:, service_account_config: valid_attributes },
                      as: :json
         expect(response).to have_http_status(:unauthorized)
       end
@@ -143,21 +145,22 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
     context 'when authenticated' do
       context 'when the service_account_config exists' do
         it 'destroys the requested service_account_config' do
-          service_account_config
           expect do
-            delete :destroy, params: { id: service_account_config.to_param }
+            delete :destroy, params: { service_account_id: }
           end.to change(SignIn::ServiceAccountConfig, :count).by(-1)
         end
 
         it 'returns a no content response' do
-          delete :destroy, params: { id: service_account_config.to_param }
+          delete :destroy, params: { service_account_id: }
           expect(response).to have_http_status(:no_content)
         end
       end
 
       context 'when the service_account_config does not exist' do
+        let(:service_account_id) { 'non_existent_service_account_id' }
+
         it 'returns a not found response' do
-          delete :destroy, params: { id: 'non_existent_service_account_id' }
+          delete :destroy, params: { service_account_id: }
           expect(response).to have_http_status(:not_found)
         end
       end
@@ -167,7 +170,7 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
       let(:sts_token) { 'invalid_token' }
 
       it 'returns an unauthorized response' do
-        delete :destroy, params: { id: service_account_config.to_param }
+        delete :destroy, params: { service_account_id: }
         expect(response).to have_http_status(:unauthorized)
       end
     end


### PR DESCRIPTION
# Summary
- Update `client_configs` and `service_account_configs` routes to accept `client_id` and `service_account_id`. This makes more sense because we pretty much treat these as primary keys. I believe we originally used `:id` so it would work with `ActiveResource` but that is being replaced due to it becoming unmanageable and hacky to make it work with some of our business logic.

- update json errors for consistent parsing and messages

# Related issue(s)

- https://jira.devops.va.gov/browse/VI-223
- https://jira.devops.va.gov/browse/VI-191

# Testing
## Setup
migrate and seed the database
- `rails db:migrate`
- `rails db:seed`

Start the server
- `rails s`
- start a rails console - `rails c`

Update the service account config used to request an access token
- `rails c`
```ruby
SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').update!(scopes: ['http://localhost:3000/sign_in/service_account_configs', 'http://localhost:3000/sign_in/client_configs'])
```

## Service Account Configs:

Run these requests in the rails console - `rails c`
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/service_account_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```

### GET - Index
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
service_account_ids = %w[sample_sts_service_account 01b8ebaac5215f84640ade756b645f28]

params = { service_account_ids: service_account_ids }
uri.query = params.to_query
request = Net::HTTP::Get.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
JSON.parse(response.body)
```

### GET - Show
```ruby
service_account_id = 'sample_sts_service_account'
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{service_account_id}")
request = Net::HTTP::Get.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
JSON.parse(response.body)
```

### POST - Create
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: []
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

### PUT - Update
```ruby
service_account_id = 'sample_sts_service_account_new'
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{service_account_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    description: 'Sample STS service account updated'
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

### DELETE - Destroy
```ruby
service_account_id = 'sample_sts_service_account_new'
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{service_account_id}")
request = Net::HTTP::Delete.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
response # 204 No Content
```

## Client Configs:

Run these requests in the rails console
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/client_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```

### GET - Index
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
client_ids = %w[vaweb vamobile]

params = { client_ids: client_ids }
uri.query = params.to_query
request = Net::HTTP::Get.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
JSON.parse(response.body)
```

### GET - Show
```ruby
client_id = 'vaweb'
uri = URI.parse("http://localhost:3000/sign_in/client_configs/#{client_id}")
request = Net::HTTP::Get.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
JSON.parse(response.body)
```

### POST - Create
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    client_id: 'sample_client_config_new',
    description: 'Sample Client Config',
    authentication: 'cookie',
    anti_csrf: true,
    redirect_uri: 'http://localhost:3000/sessions/callback',
    access_token_duration: 300,
    refresh_token_duration: 1800,
    logout_redirect_uri: 'http://localhost:3000/sessions/logout_callback',
    pkce: true
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

### PUT - Update
```ruby
client_id = 'sample_client_config_new'
uri = URI.parse("http://localhost:3000/sign_in/client_configs/#{client_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    description: 'Sample Client Config updated'
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

### DELETE - Destroy
```ruby
client_id = 'sample_client_config_new'
uri = URI.parse("http://localhost:3000/sign_in/client_configs/#{client_id}")
request = Net::HTTP::Delete.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
response = http.request(request)
response # 204 No Content
```

## What areas of the site does it impact?
Sign-in Service

