### PR TITLE
Add Code Smell CI check

### DIFF
--- a/.github/workflows/code_health_report.yml
+++ b/.github/workflows/code_health_report.yml
@@ -1,0 +1,26 @@
+name: Code Health Report
+on:
+  pull_request:
+    branches:
+      - '*'
+    types:
+      - opened
+      - synchronize
+      - reopened
+jobs:
+  pronto:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@1d0e911f615a112e322369596f10ee0b95b010ae
+      - name: Setup pronto
+        run: gem install pronto pronto-reek
+      - name: Run Pronto
+        env:
+          PRONTO_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
+          PRONTO_GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: pronto run -f github_status github_pr_review -c origin/${{ github.base_ref }}

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,11 @@
+---
+
+### https://github.com/troessner/reek
+
+detectors:
+  IrresponsibleModule:
+    enabled: false
+  UnusedParameters:
+    enabled: false # rubocop takes care of this
+  UtilityFunction:
+    public_methods_only: true


### PR DESCRIPTION
## Summary

- Add Code Smell Check to CI 
- Non-blocking 
- Uses Pronto & Reek

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89902

## Testing done

- [ ] Manual testing in separate PR

## Screenshots

![Screenshot 2024-08-02 at 12 41 25 PM](https://github.com/user-attachments/assets/e99b52bc-7de6-4965-b4cd-a1d49453dc6a)

## Acceptance criteria

- [x] annotates code changes with code smells
- [x] only code diff is checked
- [x] doesn't block merging