### PR TITLE
VI-229: Update ClientConfig identity_dashboard values

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -86,15 +86,15 @@ sample_sts_config.update!(
 )
 
 # Create Config for VA Identity Dashboard using cookie auth
-vaid_dash = SignIn::ClientConfig.find_or_initialize_by(client_id: 'identity_dashboard')
+vaid_dash = SignIn::ClientConfig.find_or_initialize_by(client_id: 'identity_dashboard_rails')
 vaid_dash.update!(authentication: SignIn::Constants::Auth::COOKIE,
                   anti_csrf: true,
                   pkce: true,
-                  redirect_uri: 'http://localhost:3001/auth/login/callback',
+                  redirect_uri: 'http://localhost:4000/sessions/callback',
                   access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
-                  access_token_audience: 'sample_client',
+                  access_token_audience: 'identity dashboard',
                   access_token_attributes: %w[first_name last_name email],
-                  logout_redirect_uri: 'http://localhost:3001',
+                  logout_redirect_uri: 'http://localhost:4000/sessions/logout_callback',
                   refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
 
 # Create Service Account Config for VA Identity Dashboard Service Account auth


### PR DESCRIPTION
## Summary

- This PR updates the seed database for 'identity_dashboard' values for `client_id`, `redirect_uri`, `logout_redirect_uri`, `access_token_audience`.

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-229

## Testing done
- [ ] I opened a rails console to check the identity dashboard record, checked to confirm the record was made with the original values. Also checked if identity dashboard rails record existed, which it should not exist yet.
- [ ] Then after I made the changes and seeded, I checked again that identity dashboard existed (which it should exist since it was previously seeded without being destroyed). This time identity dashboard rails should exist. 
- [ ] We can check both records by opening a console to check `SignIn::ClientConfig.find_by(client_id: 'identity_dashboard'`  and `SignIn::ClientConfig.find_by(client_id: 'identity_dashboard_rails'` 
- [ ] Optionally we could `destroy` the old record if desired, but that is not in scope with this ticket so I personally left it there.
- [ ] Checked if I could start up and sign into `vets-api` and `va-identity-dashboard` locally with the new seeded data.

## What areas of the site does it impact?
Client configurations for SiS.

## Acceptance criteria
- [ ] Run the seeds file, verify the 'identity_dashboard_rails' is created with the new values. Run `SignIn::ClientConfig.find_by(client_id: 'identity_dashboard_rails'` in a rails console to check.
- [ ] Check the old record still exists by running `SignIn::ClientConfig.find_by(client_id: 'identity_dashboard'` in a rails console.
- [ ] After seeding the new value. You should be able to open `vets-api` and `va-identity-dashbaord` locally and sign into `va-identity-dashboard`.
- [ ] (Optional) Delete the old record 'identity_dashboard' if desired.

## Requested Feedback
None
