### PR TITLE
[API-35496] Decouple BGS POA verifier from ClaimsApi

### DIFF
--- a/spec/support/poa_stub.rb
+++ b/spec/support/poa_stub.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require 'bgs/power_of_attorney_verifier'
-
 def stub_poa_verification
-  verifier_stub = instance_double('BGS::PowerOfAttorneyVerifier')
-  allow(BGS::PowerOfAttorneyVerifier).to receive(:new) { verifier_stub }
-  allow(verifier_stub).to receive(:verify)
-  allow(verifier_stub).to receive(:current_poa).and_return('A01')
+  veteran_user_stub = instance_double('Veteran::User')
+  allow(Veteran::User).to receive(:new).and_return(veteran_user_stub)
+
+  poa_stub = instance_double('PowerOfAttorney', code: 'A01')
+  allow(veteran_user_stub).to receive(:power_of_attorney).and_return(poa_stub)
 end


### PR DESCRIPTION
## Summary

We currently have duplicate validation logic in BGS and ClaimsApi. Since we are migrating away from BGS, decouple ClaimsApi from BGS validation method. Only use the ClaimsApi validation logic within ClaimsApi.

## Related issue(s)

[API-35496](https://jira.devops.va.gov/browse/API-35496)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
POA Verification

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
