### PR TITLE
fix: Remove nested caching for feature toggles

### DIFF
--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -37,33 +37,19 @@ module V0
 
     def fetch_features_with_gate_keys
       Rails.cache.fetch('features_with_gate_keys', expires_in: 1.minute) do
-        Rails.cache.fetch(cache_key_for_features_with_gate_keys, expires_in: 24.hours) do
-          FLIPPER_FEATURE_CONFIG['features']
-            .map { |name, config| { name:, enabled: false, actor_type: config['actor_type'] } }
-            .tap do |features|
-              # Update enabled to true if globally enabled
-              feature_gates.each do |row|
-                feature = features.find { |f| f[:name] == row['feature_name'] }
-                next unless feature # Ignore features not in config/features.yml
+        FLIPPER_FEATURE_CONFIG['features']
+          .map { |name, config| { name:, enabled: false, actor_type: config['actor_type'] } }
+          .tap do |features|
+            # Update enabled to true if globally enabled
+            feature_gates.each do |row|
+              feature = features.find { |f| f[:name] == row['feature_name'] }
+              next unless feature # Ignore features not in config/features.yml
 
-                feature[:gate_key] = row['gate_key'] # Add gate_key for use in add_feature_gate_values
-                feature[:enabled] = true if row['gate_key'] == 'boolean' && row['value'] == 'true'
-              end
+              feature[:gate_key] = row['gate_key'] # Add gate_key for use in add_feature_gate_values
+              feature[:enabled] = true if row['gate_key'] == 'boolean' && row['value'] == 'true'
             end
-        end
+          end
       end
-    end
-
-    def cache_key_for_features_with_gate_keys
-      result = ActiveRecord::Base.connection.select_all(<<-SQL.squish).first
-        SELECT
-          (SELECT MAX(updated_at) FROM flipper_features) AS last_feature_updated_at,
-          (SELECT MAX(updated_at) FROM flipper_gates WHERE key = 'boolean') AS last_gate_updated_at
-      SQL
-
-      last_feature_updated_at = result['last_feature_updated_at'].to_time.to_formatted_s(:number)
-      last_gate_updated_at = result['last_gate_updated_at'].to_time.to_formatted_s(:number)
-      "features_with_gate_keys/#{last_feature_updated_at}/#{last_gate_updated_at}"
     end
 
     def add_feature_gate_values(features)
@@ -106,10 +92,6 @@ module V0
         FROM flipper_features
         LEFT JOIN flipper_gates ON flipper_features.key = flipper_gates.feature_key
       SQL
-    end
-
-    def flipper_id
-      params[:cookie_id] || @current_user&.flipper_id
     end
   end
 end


### PR DESCRIPTION
The cache key was based on the last time a feature's gate changed. Unfortunately this won't work for features that are enabled for everyone and then disabled as the key would not bust the cache properly.

This is because Flipper doesn't set the gate to false but DELETEs the gate completely thus making the next `MAX(updated_at)` in line the cache key.

I suppose this could be fixed by touching the feature_toggle when the related gate is deleted. The code change in this PR would not need to be done.  The performance hit here isn't enough for me to go down that path at the moment.

## Testing

Try this out on master and this branch:

```shell
# Restart Rails
echo "Restarting Rails Server..."; kill -USR2 $(cat tmp/pids/server.pid); sleep 6

# Set up a fresh cache
redis-cli flushall; rm tmp/caching-dev.txt 2> /dev/null; rails dev:cache

# Enable two flags
bin/rails runner 'Flipper.enable :this_is_only_a_test; Flipper.enable :va_dependents_v2' &> /dev/null

# Check the current value (should be true)
curl -s http://localhost:3000/v0/feature_toggles |
  jq '.data.features[] | select(.name == "this_is_only_a_test")'

# Disable the first flag we enabled earlier (the gate with the older updated_at)
bin/rails runner 'Flipper.disable :this_is_only_a_test' &> /dev/null

# Sleep 60s for cache invalidation
for i in {60..1}; do echo -ne "\rSleeping ${i}s "; sleep 1; done; echo -ne "\rSlept 60s   \n"

# Check the value again (should be false)
curl -s http://localhost:3000/v0/feature_toggles |
  jq '.data.features[] | select(.name == "this_is_only_a_test")'
echo "The last value should be false ^^"

# Clean up
bin/rails runner 'puts Flipper.disable :va_dependents_v2' 2>/dev/null | tail -1
redis-cli flushall; rm tmp/caching-dev.txt
```

You'll need `bin/rails s` running. And run `setopt interactivecomments` to tell zsh to ignore the comments.

The value that should be false will be true on master:
![Screenshot 2024-08-02 at 20 30 28@2x](https://github.com/user-attachments/assets/2c6c90b7-f12f-4129-be1b-d3daea2d44d2)

This branch/PR should fix it:
![Screenshot 2024-08-02 at 20 32 07@2x](https://github.com/user-attachments/assets/d1da8bc6-0a95-4497-9f3b-db12be032b19)
