### PR TITLE
Modified docker compose commands due to Ubuntu upgrades

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Setup Database
         run: |
-             docker-compose -f docker-compose.test.yml run web bash \
+             docker compose -f docker-compose.test.yml run web bash \
              -c "CI=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_test -n 13 -e 'bin/rails db:reset'"
 
       - name: Get changed files
@@ -74,6 +74,6 @@ jobs:
 
       - name: Run service tags audit controllers task
         run: |
-             docker-compose -f docker-compose.test.yml run -e CHANGED_FILES=${{ env.CHANGED_FILES }} web bash \
+             docker compose -f docker-compose.test.yml run -e CHANGED_FILES=${{ env.CHANGED_FILES }} web bash \
              -c "CI=true DISABLE_BOOTSNAP=true bundle exec rake service_tags:audit_controllers_ci"
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -80,13 +80,13 @@ jobs:
 
       - name: Setup Database
         run: |
-          docker-compose -f docker-compose.test.yml run web bash \
+          docker compose -f docker-compose.test.yml run web bash \
           -c "CI=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_test -n 13 -e 'bin/rails db:reset'"
 
       - name: Run Specs
         timeout-minutes: 20
         run: |
-          docker-compose -f docker-compose.test.yml run web bash \
+          docker compose -f docker-compose.test.yml run web bash \
           -c "CI=true DISABLE_BOOTSNAP=true bundle exec parallel_rspec spec/ modules/ -n 13 -o '--color --tty'"
 
       - name: Upload Coverage Report


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

The docker-compose command is breaking the Audit Service Tags and Code Checks Test github action. The solution was found in this [discussion](https://github.com/orgs/community/discussions/116610).

[Failing Code Checks](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/code_checks.yml)
[Failing Audit Service Tag actions](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/audit_service_tags.yml)


The latest Ubuntu release (ubuntu-latest) in [Ubuntu 22.04 (20240730) Image Update](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2) removed Docker Compose v1 support as announced in [GitHub's blog post](https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/). The relevant issue is here: https://github.com/actions/runner-images/issues/9557

To fix this, you will need to [migrate to Docker Compose v2](https://docs.docker.com/compose/migrate/). As previously mentioned this means changing from docker-compose to docker compose.

## Testing done

This does not need a flipper. This will not impact vets-api.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
