### PR TITLE
[10-10CG] Update handling access_token response 

### DIFF
--- a/lib/carma/client/mule_soft_auth_token_client.rb
+++ b/lib/carma/client/mule_soft_auth_token_client.rb
@@ -24,7 +24,7 @@ module CARMA
                              token_headers,
                              { timeout: config.timeout })
 
-          return response.body[:access_token] if response.status == 201
+          return response.body[:access_token] if response.status == 200
 
           raise GetAuthTokenError, "Response: #{response}"
         end

--- a/spec/lib/carma/client/mule_soft_auth_token_client_spec.rb
+++ b/spec/lib/carma/client/mule_soft_auth_token_client_spec.rb
@@ -46,7 +46,7 @@ describe CARMA::Client::MuleSoftAuthTokenClient do
     let(:options) { { timeout: } }
 
     let(:access_token) { 'my-token' }
-    let(:mock_token_response) { double('FaradayResponse', status: 201, body: { access_token: }) }
+    let(:mock_token_response) { Faraday::Response.new(response_body: { access_token: }, status: 200) }
 
     context 'successfully gets token' do
       it 'calls perform with expected params' do
@@ -58,12 +58,12 @@ describe CARMA::Client::MuleSoftAuthTokenClient do
           )
           .and_return(mock_token_response)
 
-        subject
+        expect(subject).to eq access_token
       end
     end
 
     context 'error getting token' do
-      let(:mock_error_token_response) { double('FaradayResponse', status: 500, body: { sad: true }) }
+      let(:mock_error_token_response) { Faraday::Response.new(response_body: { sad: true }, status: 400) }
 
       it 'raises error' do
         expect(client).to receive(:perform)


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Return access_token on 200 response instead of 201 since that is what we are getting back from the token server.
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86425

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
