### PR TITLE
Add retry logic for docker commands

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -61,8 +61,13 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Setup Database
-        run: |
-             docker compose -f docker-compose.test.yml run web bash \
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 20
+          retry_wait_seconds: 3 # Seconds
+          max_attempts: 3
+          command: |
+            docker compose -f docker-compose.test.yml run web bash \
              -c "CI=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_test -n 13 -e 'bin/rails db:reset'"
 
       - name: Get changed files
@@ -73,7 +78,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run service tags audit controllers task
-        run: |
-             docker compose -f docker-compose.test.yml run -e CHANGED_FILES=${{ env.CHANGED_FILES }} web bash \
-             -c "CI=true DISABLE_BOOTSNAP=true bundle exec rake service_tags:audit_controllers_ci"
-
+        timeout-minutes: 20
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 20
+          retry_wait_seconds: 3 # Seconds
+          max_attempts: 3
+          command: |
+            docker compose -f docker-compose.test.yml run -e CHANGED_FILES=${{ env.CHANGED_FILES }} web bash \
+              -c "CI=true DISABLE_BOOTSNAP=true bundle exec rake service_tags:audit_controllers_ci"

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -79,15 +79,25 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Setup Database
-        run: |
-          docker compose -f docker-compose.test.yml run web bash \
-          -c "CI=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_test -n 13 -e 'bin/rails db:reset'"
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 20
+          retry_wait_seconds: 3 # Seconds
+          max_attempts: 3
+          command: |
+            docker compose -f docker-compose.test.yml run web bash \
+              -c "CI=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_test -n 13 -e 'bin/rails db:reset'"
 
       - name: Run Specs
         timeout-minutes: 20
-        run: |
-          docker compose -f docker-compose.test.yml run web bash \
-          -c "CI=true DISABLE_BOOTSNAP=true bundle exec parallel_rspec spec/ modules/ -n 13 -o '--color --tty'"
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 20
+          retry_wait_seconds: 3 # Seconds
+          max_attempts: 3
+          command: |
+            docker compose -f docker-compose.test.yml run web bash \
+              -c "CI=true DISABLE_BOOTSNAP=true bundle exec parallel_rspec spec/ modules/ -n 13 -o '--color --tty'"
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Because our github actions sometimes run into rate limiting from docker hub and AWS ECR, we want  to retry when this happens.

## Related Issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89959
