### PR TITLE
Add fileNumber property to pass metadata validation - form 10-7959a

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -26,6 +26,7 @@ module IvcChampva
         'businessLine' => 'CMP',
         'ssn_or_tin' => @data['applicant_member_number'],
         'member_number' => @data['applicant_member_number'],
+        'fileNumber' => @data['applicant_member_number'],
         'country' => @data.dig('applicant_address', 'country') || 'USA',
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info']


### PR DESCRIPTION
## Summary

This PR adds the `fileNumber` property to the metadata of form 10-7959a. It is the same value used for the `ssn_or_tin` and `member_number` properties. This form is still in development so some or all of these properties may be combined/removed, but for the time being we need them in place for the metadata validator and the PEGA reception logic.

Not having `fileNumber` was causing the form to throw an error on metadata violation that prevented submitting.

## Related issue(s)

- NA

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
NA

## What areas of the site does it impact?
This form only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA