### PR TITLE
fix: Add timeout to search typeahead

### DIFF
--- a/lib/search_typeahead/configuration.rb
+++ b/lib/search_typeahead/configuration.rb
@@ -4,22 +4,12 @@ require 'common/client/configuration/rest'
 
 module SearchTypeahead
   class Configuration < Common::Client::Configuration::REST
-    self.read_timeout = 2
-    self.open_timeout = 2
-
     def base_path
       "#{Settings.search_typeahead.url}/suggestions"
     end
 
     def service_name
       'SearchTypeahead'
-    end
-
-    def connection
-      Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
-        conn.adapter Faraday.default_adapter
-      end
     end
   end
 end

--- a/lib/search_typeahead/configuration.rb
+++ b/lib/search_typeahead/configuration.rb
@@ -4,7 +4,8 @@ require 'common/client/configuration/rest'
 
 module SearchTypeahead
   class Configuration < Common::Client::Configuration::REST
-    self.read_timeout = 30
+    self.read_timeout = 2
+    self.open_timeout = 2
 
     def base_path
       "#{Settings.search_typeahead.url}/suggestions"
@@ -12,6 +13,13 @@ module SearchTypeahead
 
     def service_name
       'SearchTypeahead'
+    end
+
+    def connection
+      Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
+        conn.use :breakers
+        conn.adapter Faraday.default_adapter
+      end
     end
   end
 end

--- a/lib/search_typeahead/service.rb
+++ b/lib/search_typeahead/service.rb
@@ -27,7 +27,10 @@ module SearchTypeahead
     #
     def suggestions
       with_monitoring do
-        perform(:get, suggestions_url, query_params)
+        Faraday.get(suggestions_url, query_params) do |req|
+          req.options.timeout = 2
+          req.options.open_timeout = 2
+        end
       end
     rescue => e
       e

--- a/lib/search_typeahead/service.rb
+++ b/lib/search_typeahead/service.rb
@@ -27,7 +27,7 @@ module SearchTypeahead
     #
     def suggestions
       with_monitoring do
-        Faraday.get(suggestions_url, query_params)
+        perform(:get, suggestions_url, query_params)
       end
     rescue => e
       e


### PR DESCRIPTION
SearchTypeaheadController is causing site-wide latency for the vets-api-web bulkhead.

<img width="949" alt="image" src="https://github.com/user-attachments/assets/e557f0e8-b7e0-43a2-a2aa-e150eb53cd3b">

For an endpoint like Search Typeahead, the result should be nearly instantaneous and not require a long timeout. Lowering to [a sane value](https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts?tab=readme-ov-file#faraday).