### PR TITLE
[API-38801] Omit `claimId` when nil from BD upload

### DIFF
--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -177,10 +177,10 @@ module ClaimsApi
       data = {
         systemName: options[:system_name].presence || 'VA.gov',
         docType: options[:doc_type],
-        claimId: options[:claim_id],
         fileName: options[:file_name],
         trackedItemIds: options[:tracked_item_ids].presence || []
       }
+      data[:claimId] = options[:claim_id] unless options[:claim_id].nil?
       data[:participantId] = options[:participant_id] unless options[:participant_id].nil?
       data[:fileNumber] = options[:file_number] unless options[:file_number].nil?
       { data: }

--- a/modules/claims_api/spec/lib/claims_api/bd_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bd_spec.rb
@@ -106,8 +106,8 @@ describe ClaimsApi::BD do
           expect(json_body['data']['fileName']).to end_with('21-22.pdf')
         end
 
-        it 'the claimId is nil' do
-          expect(json_body['data']['claimId']).to be_nil
+        it 'the claimId is not present' do
+          expect(json_body['data']).not_to have_key('claimId')
         end
       end
 
@@ -133,8 +133,8 @@ describe ClaimsApi::BD do
           expect(json_body['data']['fileName']).to end_with('21-22a.pdf')
         end
 
-        it 'the claimId is nil' do
-          expect(json_body['data']['claimId']).to be_nil
+        it 'the claimId is not present' do
+          expect(json_body['data']).not_to have_key('claimId')
         end
       end
     end


### PR DESCRIPTION
## Summary

We see a null Associated Claim in VBMS when uploading a POA form via BD. Omit `claimId` from POA requests such that no Associated Claim is present in VBMS.

## Related issue(s)

[API-38801](https://jira.devops.va.gov/browse/API-38801)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Power of Attorney Benefits Document upload

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A