### PR TITLE
allow e for variable name

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -9,3 +9,6 @@ detectors:
     enabled: false # rubocop takes care of this
   UtilityFunction:
     public_methods_only: true
+  UncommunicativeVariableName:
+    accept:
+      - e


### PR DESCRIPTION
## Summary

- `e` as a variable name is used for rescues and should be allowed 
- rubocop requires rescues to use `e` [rubocop docs](https://docs.rubocop.org/rubocop/cops_naming.html#namingrescuedexceptionsvariablename)

## Related issue(s)

- n/a

## Acceptance criteria

- [x]  `e` is allow for a variable name