### PR TITLE
[VA-89225] Add server-side transform logging

### DIFF
--- a/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_controller.rb
+++ b/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_controller.rb
@@ -345,7 +345,19 @@ module DebtsApi
       end
 
       def full_transform_service
+        Rails.logger.info(full_transform_logging('info'))
         DebtsApi::V0::FsrFormTransform::FullTransformService.new(full_transform_form)
+      rescue => e
+        Rails.logger.error(full_transform_logging('error'))
+        Rails.logger.error(e.backtrace&.join('\n'))
+
+        raise e
+      end
+
+      def full_transform_logging(type)
+        user_uuid = current_user.uuid
+        submission_id = params[:submission_id]
+        "DebtsApi::V0::FsrFormTransform::FullTransformService #{type}: form ID #{submission_id} - UUID #{user_uuid}"
       end
     end
   end

--- a/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_controller.rb
+++ b/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_controller.rb
@@ -355,9 +355,8 @@ module DebtsApi
       end
 
       def full_transform_logging(type)
-        user_uuid = current_user.uuid
-        submission_id = params[:submission_id]
-        "DebtsApi::V0::FsrFormTransform::FullTransformService #{type}: form ID #{submission_id} - UUID #{user_uuid}"
+        "DebtsApi::V0::FsrFormTransform::FullTransformService #{type}: " \
+          "form ID #{params[:submission_id]} - UUID #{current_user.uuid}"
       end
     end
   end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

This adds some basic logging to track progress and potential errors with the debt server-side transform.

## Related issue(s)

[Original ticket here.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/89225)