### PR TITLE
[10-10CG] Correctly parse the access_token

### DIFF
--- a/lib/carma/client/mule_soft_auth_token_client.rb
+++ b/lib/carma/client/mule_soft_auth_token_client.rb
@@ -24,7 +24,7 @@ module CARMA
                              token_headers,
                              { timeout: config.timeout })
 
-          return response.body[:access_token] if response.status == 200
+          return JSON.parse(response.body)['access_token'] if response.status == 200
 
           raise GetAuthTokenError, "Response: #{response}"
         end

--- a/spec/lib/carma/client/mule_soft_auth_token_client_spec.rb
+++ b/spec/lib/carma/client/mule_soft_auth_token_client_spec.rb
@@ -45,8 +45,12 @@ describe CARMA::Client::MuleSoftAuthTokenClient do
 
     let(:options) { { timeout: } }
 
-    let(:access_token) { 'my-token' }
-    let(:mock_token_response) { Faraday::Response.new(response_body: { access_token: }, status: 200) }
+    let(:token) { 'my-token' }
+    let(:response_body) do
+      "{\"token_type\":\"Bearer\",\"expires_in\":3600,\"access_token\":\"#{token}\",\"scope\":\"DTCWriteResource\"}"
+    end
+
+    let(:mock_token_response) { Faraday::Response.new(response_body:, status: 200) }
 
     context 'successfully gets token' do
       it 'calls perform with expected params' do
@@ -58,7 +62,7 @@ describe CARMA::Client::MuleSoftAuthTokenClient do
           )
           .and_return(mock_token_response)
 
-        expect(subject).to eq access_token
+        expect(subject).to eq token
       end
     end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- The response from okta is a json string. This change parses that string to get the `access_token` to use for the 10-10CG Submission request.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86425

## Testing done

- [x] *New code is covered by unit tests*
- [x] Validated the response from okta matches what we are expecting. Manually tested in in the dev environment using the changes in this PR. 

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

