### PR TITLE
Generate preferred modality from appointment request reasoncode.text

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -12,6 +12,13 @@ module VAOS
         'OTHER_REASON' => 'My reason isn’t listed'
       }.freeze
 
+      # Preferred modality text
+      MODALITY_TEXT = {
+        'FACE TO FACE' => 'In person',
+        'VIDEO' => 'Video',
+        'TELEPHONE' => 'Phone'
+      }.freeze
+
       # Input format for preferred dates
       # Example: "07/18/2024 AM"
       INPUT_FORMAT = '%m/%d/%Y %p'
@@ -24,7 +31,7 @@ module VAOS
       # Modifies the appointment, extracting individual fields from the reason code text whenever possible.
       #
       # @param appointment [Hash] the appointment to modify
-      def extract_reason_code_fields(appointment)
+      def extract_reason_code_fields(appointment) # rubocop:disable Metrics/MethodLength
         # Retrieve the reason code text, or return if it is not present
         reason_code_text = appointment&.dig(:reason_code, :text)
         return if reason_code_text.nil?
@@ -48,12 +55,14 @@ module VAOS
           comments = reason_code_hash['comments'] if reason_code_hash.key?('comments')
           reason = extract_reason_for_appointment(reason_code_hash)
           preferred_dates = extract_preferred_dates(reason_code_hash)
+          preferred_modality = extract_preferred_modality(reason_code_hash)
         end
 
         appointment[:contact] = contact unless contact.nil?
         appointment[:patient_comments] = comments unless comments.nil?
         appointment[:reason_for_appointment] = reason unless reason.nil?
         appointment[:preferred_dates] = preferred_dates unless preferred_dates.nil?
+        appointment[:preferred_modality] = preferred_modality unless preferred_modality.nil?
       end
 
       private
@@ -81,6 +90,16 @@ module VAOS
         # Direct schedule appointments also used 'reasonCode' as the key in the past so we need this as well
         elsif reason_code_hash.key?('reasonCode') && PURPOSE_TEXT.key?(reason_code_hash['reasonCode'])
           PURPOSE_TEXT[reason_code_hash['reasonCode']]
+        end
+      end
+
+      # Extract preferred modality for appointment from the reason code hash if possible.
+      #
+      # @param reason_code_hash [Hash] the hash of reason code key value pairs
+      # @return [String, nil] The preferred modality for appointment as a string, or nil if not possible.
+      def extract_preferred_modality(reason_code_hash)
+        if reason_code_hash.key?('preferred modality') && MODALITY_TEXT.key?(reason_code_hash['preferred modality'])
+          MODALITY_TEXT[reason_code_hash['preferred modality']]
         end
       end
 

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -11,6 +11,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:patient_comments]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
+      expect(appt[:preferred_modality]).to be_nil
     end
 
     it 'returns without modification if no valid reason code text fields exists' do
@@ -20,6 +21,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:patient_comments]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
+      expect(appt[:preferred_modality]).to be_nil
     end
 
     it 'returns without modification for cc request' do
@@ -29,6 +31,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:patient_comments]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
+      expect(appt[:preferred_modality]).to be_nil
     end
 
     it 'returns without modification for cc booked' do
@@ -38,6 +41,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:patient_comments]).to be_nil
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
+      expect(appt[:preferred_modality]).to be_nil
     end
 
     it 'extract valid reason code fields for booked va direct scheduling appointments' do
@@ -47,6 +51,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:patient_comments]).to eq('test')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
       expect(appt[:preferred_dates]).to be_nil
+      expect(appt[:preferred_modality]).to be_nil
     end
 
     it 'extract valid reason code fields for cancelled va direct scheduling appointments' do
@@ -56,6 +61,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:patient_comments]).to eq('test')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
       expect(appt[:preferred_dates]).to be_nil
+      expect(appt[:preferred_modality]).to be_nil
     end
 
     it 'extract valid reason code fields for va request' do
@@ -67,6 +73,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
       expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
                                             'Wed, June 26, 2024 in the afternoon'])
+      expect(appt[:preferred_modality]).to eq('In person')
     end
 
     context 'when there are valid and invalid reason code fields' do
@@ -79,6 +86,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
         expect(appt[:reason_for_appointment]).to eq(nil)
         expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
                                               'Wed, June 26, 2024 in the afternoon'])
+        expect(appt[:preferred_modality]).to eq('In person')
       end
     end
   end
@@ -96,6 +104,22 @@ describe VAOS::V2::AppointmentsReasonCodeService do
         input_hash = {}
         input_hash['reason code'] = input
         expect(subject.send(:extract_reason_for_appointment, input_hash)).to eq(output)
+      end
+    end
+  end
+
+  describe '#extract_preferred_modality' do
+    [
+      ['', nil],
+      ['NON_EXISTENT', nil],
+      ['FACE TO FACE', 'In person'],
+      ['VIDEO', 'Video'],
+      ['TELEPHONE', 'Phone']
+    ].each do |input, output|
+      it "#{input} returns #{output}" do
+        input_hash = {}
+        input_hash['preferred modality'] = input
+        expect(subject.send(:extract_preferred_modality, input_hash)).to eq(output)
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is part of the api consolidation effort and moves the logic for extracting preferred modality text information from the reason code text from the FE to BE. The source logic is [here](https://github.com/department-of-veterans-affairs/vets-website/blob/d85eec388ea3b822dabb449158132ed35f9aad7a/src/applications/vaos/services/appointment/transformers.js#L28-L40)
- This is work by the Appointments team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89773

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior returns the information as part of the reason code text and reasonForAppointment field is non existent.
- Tested API response to ensure it matches with ACs

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
