### PR TITLE
Extract entire reason code text as patientComment for CC requests and appointments

### DIFF
--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       community_cares_base
       status { 'proposed' }
       reason_code do
-        { 'text': 'station id: 983|preferred modality: FACE TO FACE|phone number: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:test' } # rubocop:disable Layout/LineLength
+        { 'text': 'test request' }
       end
     end
 
@@ -295,7 +295,7 @@ FactoryBot.define do
       with_direct_scheduling_base
 
       reason_code do
-        { 'text': 'station id: 983|preferred modality: FACE TO FACE|phone number: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:test' } # rubocop:disable Layout/LineLength
+        { 'text': 'test booked' }
       end
     end
 

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -26,7 +26,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :community_cares_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
-      expect(appt[:patient_comments]).to be_nil
+      expect(appt[:patient_comments]).to eq('test request')
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
     end
@@ -35,7 +35,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :ds_cc_booked_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
-      expect(appt[:patient_comments]).to be_nil
+      expect(appt[:patient_comments]).to eq('test booked')
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is part of the api consolidation effort and adds the missing logic for parsing patientComments for cc requests and booked cc appointments, see source logic [here](https://github.com/department-of-veterans-affairs/vets-website/blob/d85eec388ea3b822dabb449158132ed35f9aad7a/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js#L24-L29).
- This is work by the Appointments team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90106

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior returns the information as part of the reason code text and reasonForAppointment field is non existent.
- Tested API response to ensure it matches with ACs

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
