### PR TITLE
Simple Forms - Add logging around errors in loading attachments

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -82,6 +82,12 @@ module SimpleFormsApi
         combined_pdf << CombinePDF.load(file_path)
         attachments.each do |attachment|
           combined_pdf << CombinePDF.load(attachment, allow_optional_content: true)
+        rescue => e
+          Rails.logger.error(
+            'Simple forms api - failed to load attachment for 20-10207',
+            { message: e.message, attachment: attachment.inspect }
+          )
+          raise
         end
 
         combined_pdf.save file_path

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -60,6 +60,12 @@ module SimpleFormsApi
         combined_pdf << CombinePDF.load(file_path)
         attachments.each do |attachment|
           combined_pdf << CombinePDF.load(attachment)
+        rescue => e
+          Rails.logger.error(
+            'Simple forms api - failed to load attachment for 40-0247',
+            { message: e.message, attachment: attachment.inspect }
+          )
+          raise
         end
 
         combined_pdf.save file_path

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
@@ -224,6 +224,12 @@ module SimpleFormsApi
 
       attachments.each do |attachment|
         combined_pdf << CombinePDF.load(attachment)
+      rescue => e
+        Rails.logger.error(
+          'Simple forms api - failed to load attachment for 40-10007',
+          { message: e.message, attachment: attachment.inspect }
+        )
+        raise
       end
 
       combined_pdf.save file_path


### PR DESCRIPTION
## Summary
We're seeing `index out of range` errors in this spot of code across these three forms. I can't reproduce it locally so this PR is adding some logging to hopefully shed more light on the situation.
