### PR TITLE
VI-265: Handle malformed responses in MAP SuS service

### DIFF
--- a/lib/map/sign_up/configuration.rb
+++ b/lib/map/sign_up/configuration.rb
@@ -63,9 +63,10 @@ module MAP
           request: request_options
         ) do |conn|
           conn.use :breakers
-          conn.response :betamocks if Settings.map_services.sign_up_service.mock
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
+          conn.response :json, content_type: /\bjson/
+          conn.response :betamocks if Settings.map_services.sign_up_service.mock
         end
       end
     end

--- a/lib/map/sign_up/service.rb
+++ b/lib/map/sign_up/service.rb
@@ -10,11 +10,11 @@ module MAP
 
       def status(icn:)
         response = perform(:get, config.status_unauthenticated_path(icn), nil)
-        Rails.logger.info("#{config.logging_prefix} status success, icn: #{icn}")
+        logger.info("#{logging_prefix} status success, icn: #{icn}")
         build_response(response.body)
       rescue Common::Client::Errors::ParsingError => e
-        message = "#{config.logging_prefix} status response parsing error"
-        Rails.logger.error(message, { icn: })
+        message = "#{logging_prefix} status response parsing error"
+        logger.error(message, { icn: })
         raise e, "#{message}, response unknown, icn: #{icn}"
       rescue Common::Client::Errors::ClientError => e
         parse_and_raise_error(e, icn, 'status')
@@ -25,10 +25,10 @@ module MAP
                 config.patients_agreements_path(icn),
                 agreements_body(icn, signature_name, version),
                 authenticated_header(icn))
-        Rails.logger.info("#{config.logging_prefix} agreements accept success, icn: #{icn}")
+        logger.info("#{logging_prefix} agreements accept success, icn: #{icn}")
       rescue Common::Client::Errors::ParsingError => e
-        message = "#{config.logging_prefix} agreements accept response parsing error"
-        Rails.logger.error(message, { icn: })
+        message = "#{logging_prefix} agreements accept response parsing error"
+        logger.error(message, { icn: })
         raise e, "#{message}, response unknown, icn: #{icn}"
       rescue Common::Client::Errors::ClientError => e
         parse_and_raise_error(e, icn, 'agreements accept')
@@ -36,10 +36,10 @@ module MAP
 
       def agreements_decline(icn:)
         perform(:delete, config.patients_agreements_path(icn), nil, authenticated_header(icn))
-        Rails.logger.info("#{config.logging_prefix} agreements decline success, icn: #{icn}")
+        logger.info("#{logging_prefix} agreements decline success, icn: #{icn}")
       rescue Common::Client::Errors::ParsingError => e
-        message = "#{config.logging_prefix} agreements decline response parsing error"
-        Rails.logger.error(message, { icn: })
+        message = "#{logging_prefix} agreements decline response parsing error"
+        logger.error(message, { icn: })
         raise e, "#{message}, response unknown, icn: #{icn}"
       rescue Common::Client::Errors::ClientError => e
         parse_and_raise_error(e, icn, 'agreements decline')
@@ -52,8 +52,8 @@ module MAP
                            config.authenticated_provisioning_header)
         successful_update_provisioning_response(response, icn)
       rescue Common::Client::Errors::ParsingError => e
-        message = "#{config.logging_prefix} update provisioning response parsing error"
-        Rails.logger.error(message, { icn: })
+        message = "#{logging_prefix} update provisioning response parsing error"
+        logger.error(message, { icn: })
         raise e, "#{message}, response unknown, icn: #{icn}"
       rescue Common::Client::Errors::ClientError => e
         if config.provisioning_acceptable_status.include?(e.status)
@@ -92,8 +92,8 @@ module MAP
       def successful_update_provisioning_response(response, icn)
         parsed_response = build_response(response.body)
 
-        Rails.logger.info("#{config.logging_prefix} update provisioning success," \
-                          " icn: #{icn}, parsed_response: #{parsed_response}")
+        logger.info("#{logging_prefix} update provisioning success," \
+                    " icn: #{icn}, parsed_response: #{parsed_response}")
 
         parsed_response
       end
@@ -108,7 +108,7 @@ module MAP
           message: parsed_body['message'],
           trace_id: parsed_body['traceId']
         }.compact
-        raise e, "#{config.logging_prefix} #{action} failed, client error, status: #{status}," \
+        raise e, "#{logging_prefix} #{action} failed, client error, status: #{status}," \
                  " icn: #{icn}, context: #{context}"
       end
 
@@ -119,6 +119,14 @@ module MAP
           cerner_provisioned: response_body['cernerProvisioned'],
           bypass_eligible: response_body['bypassEligible']
         }
+      end
+
+      def logger
+        Rails.logger
+      end
+
+      def logging_prefix
+        config.logging_prefix
       end
     end
   end

--- a/spec/support/vcr_cassettes/map/sign_up_service_200_malformed_responses.yml
+++ b/spec/support/vcr_cassettes/map/sign_up_service_200_malformed_responses.yml
@@ -1,0 +1,279 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cerner.apps-staging.va.gov/signup/v1/patients/10101V964144/status/summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - allow-from https://nextgenid-mbetenantworkflow.azurewebsites.net
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - frame-ancestors https://nextgenid-mbetenantworkflow.azurewebsites.net
+      Etag:
+      - W/"dba68a519b00d7f452e79971a398650f"
+      X-Request-Id:
+      - 5b1d220c-4b01-4409-b9a5-367ab3c99ca9
+      X-Runtime:
+      - '0.026178'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Node:
+      - sandbox-core-02.idmeinc.net
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Content-Length:
+      - '14658'
+      Connection:
+      - keep-alive
+      Server-Timing:
+      - ak_p; desc="1690401366974_1752320020_1303469004_11342_12901_31_-_-";dur=1
+      - cdn-cache; desc=MISS
+      - edge; dur=68
+      - origin; dur=46
+    body:
+      encoding: UTF-8
+      string: 'Not valid JSON'
+  recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
+- request:
+    method: post
+    uri: https://cerner.apps-staging.va.gov/signup/v1/patients/10101V964144/agreements
+    body:
+      encoding: US-ASCII
+      string: '{"responseDate":"2023-01-01T12:00:00.000Z","icn":"10101V964144","signatureName":"some-signature-name","version":3,"legalDisplayVersion":1.0}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - allow-from https://nextgenid-mbetenantworkflow.azurewebsites.net
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - frame-ancestors https://nextgenid-mbetenantworkflow.azurewebsites.net
+      Etag:
+      - W/"dba68a519b00d7f452e79971a398650f"
+      X-Request-Id:
+      - 5b1d220c-4b01-4409-b9a5-367ab3c99ca9
+      X-Runtime:
+      - '0.026178'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Node:
+      - sandbox-core-02.idmeinc.net
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Content-Length:
+      - '14658'
+      Connection:
+      - keep-alive
+      Server-Timing:
+      - ak_p; desc="1690401366974_1752320020_1303469004_11342_12901_31_-_-";dur=1
+      - cdn-cache; desc=MISS
+      - edge; dur=68
+      - origin; dur=46
+    body:
+      encoding: UTF-8
+      string: 'Not valid JSON'
+  recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
+- request:
+    method: delete
+    uri: https://cerner.apps-staging.va.gov/signup/v1/patients/10101V964144/agreements
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - allow-from https://nextgenid-mbetenantworkflow.azurewebsites.net
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - frame-ancestors https://nextgenid-mbetenantworkflow.azurewebsites.net
+      Etag:
+      - W/"dba68a519b00d7f452e79971a398650f"
+      X-Request-Id:
+      - 5b1d220c-4b01-4409-b9a5-367ab3c99ca9
+      X-Runtime:
+      - '0.026178'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Node:
+      - sandbox-core-02.idmeinc.net
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Content-Length:
+      - '14658'
+      Connection:
+      - keep-alive
+      Server-Timing:
+      - ak_p; desc="1690401366974_1752320020_1303469004_11342_12901_31_-_-";dur=1
+      - cdn-cache; desc=MISS
+      - edge; dur=68
+      - origin; dur=46
+    body:
+      encoding: UTF-8
+      string: 'Not valid JSON'
+  recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
+- request:
+    method: put
+    uri: https://cerner.apps-staging.va.gov/signup/v1/patients/1012667145V762142/provisioning/cerner
+    body:
+      encoding: UTF-8
+      string: '{"provisionUser":true,"gcids":"1012667145V762142^NI^200M^USVHA^P|1005490754^NI^200DOD^USDOD^A|600043201^PI^200CORP^USVBA^A|123456^PI^200ESR^USVHA^A|123456^PI^648^USVHA^A|123456^PI^200BRLS^USVBA^A","firstName":"Tamara","lastName":"Ellis"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - allow-from https://nextgenid-mbetenantworkflow.azurewebsites.net
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - frame-ancestors https://nextgenid-mbetenantworkflow.azurewebsites.net
+      Etag:
+      - W/"dba68a519b00d7f452e79971a398650f"
+      X-Request-Id:
+      - 5b1d220c-4b01-4409-b9a5-367ab3c99ca9
+      X-Runtime:
+      - '0.026178'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Node:
+      - sandbox-core-02.idmeinc.net
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Content-Length:
+      - '14658'
+      Connection:
+      - keep-alive
+      Server-Timing:
+      - ak_p; desc="1690401366974_1752320020_1303469004_11342_12901_31_-_-";dur=1
+      - cdn-cache; desc=MISS
+      - edge; dur=68
+      - origin; dur=46
+    body:
+      encoding: UTF-8
+      string: 'Not valid JSON'
+  recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary

This PR updates the MAP SuS configuration class to include application/json content type header and update the service to handle parsing errors.

## Related issue(s)

https://jira.devops.va.gov/browse/VI-265

## Testing done

* Start up a Rails console and require the MAP SuS service
```ruby
require 'map/sign_up/service'
```
* Instantiate a client
```ruby
client = MAP::SignUp::Service.new
```

### Status

* Make a call to the status endpoint
```ruby
client.status(icn: '1234')
```
* Verify the response is successful
```
2024-08-07 12:54:58.337053 I [54381:12260 service.rb:13] Rails -- [MAP][SignUp][Service] status success, icn: 1234
=> {:agreement_signed=>true, :opt_out=>false, :cerner_provisioned=>false, :bypass_eligible=>false}
```
* Modify the mock data response for the status call (`vets-api-mockdata/map/sign_up_service/status/default.yml`) to return invalid JSON in the response body.
* Make the call to the status endpoint again.
* Verify the response logs and raises the error
```
2024-08-07 12:55:51.203771 E [54381:12260 service.rb:17] Rails -- [MAP][SignUp][Service] status response parsing error -- { :icn => "1234" }
lib/common/client/base.rb:126:in `rescue in request': [MAP][SignUp][Service] status response parsing error, response unknown, icn: 1234 (Common::Client::Errors::ParsingError)
```

### Agreements accept

* Make a call to the agreements accept endpoint.
```ruby
client.agreements_accept(icn: '1234', signature_name: 'Foobar', version: '1')
```
* Verify the response is successful
```
2024-08-07 13:01:54.864865 I [54381:12260 service.rb:28] Rails -- [MAP][SignUp][Service] agreements accept success, icn: 1234
```
* Modify the mock data response for the call (`vets-api-mockdata/map/sign_up_service/agreements_accept/default.yml`) to return invalid JSON in the response body.
* Make the call again.
* Verify the response logs and raises the error
```ruby
2024-08-07 13:04:39.618259 E [54381:12260 service.rb:31] Rails -- [MAP][SignUp][Service] agreements accept response parsing error -- { :icn => "1234" }
lib/common/client/base.rb:126:in `rescue in request': [MAP][SignUp][Service] agreements accept response parsing error, response unknown, icn: 1234 (Common::Client::Errors::ParsingError)
```

### Agreements decline

* Make a call to the agreements decline endpoint
```ruby
client.agreements_decline(icn: '1234')
```
* Verify the response is successful
```
2024-08-07 13:09:33.370874 I [54381:12260 service.rb:39] Rails -- [MAP][SignUp][Service] agreements decline success, icn: 1234
```
* Modify the mock data response for the call (`vets-api-mockdata/map/sign_up_service/agreements_decline/default.yml`) to return invalid JSON in the response body.
* Make the call again.
* Verify the response logs and raises the error
```
2024-08-07 13:12:23.793305 E [54381:12260 service.rb:42] Rails -- [MAP][SignUp][Service] agreements decline response parsing error -- { :icn => "1234" }
lib/common/client/base.rb:126:in `rescue in request': [MAP][SignUp][Service] agreements decline response parsing error, response unknown, icn: 1234 (Common::Client::Errors::ParsingError)
```

### Update provisioning

* Make a call to the update provisioning endpoint
```ruby
client.update_provisioning(icn: '1234', first_name: 'foo', last_name: 'bar', mpi_gcids: 'baz')
```
* Verify the response is successful
```
2024-08-07 13:16:06.755477 I [54381:12260 service.rb:95] Rails -- [MAP][SignUp][Service] update provisioning success, icn: 1234, parsed_response: {:agreement_signed=>true, :opt_out=>false, :cerner_provisioned=>false, :bypass_eligible=>true}
=> {:agreement_signed=>true, :opt_out=>false, :cerner_provisioned=>false, :bypass_eligible=>true}
```
* Modify the mock data response for the call (`vets-api-mockdata/map/sign_up_service/update_provisioning/default.yml`) to return invalid JSON in the response body.
* Make the call again
* Verify the response logs and raises the error
```
2024-08-07 13:17:47.771446 E [54381:12260 service.rb:56] Rails -- [MAP][SignUp][Service] update provisioning response parsing error -- { :icn => "1234" }
lib/common/client/base.rb:126:in `rescue in request': [MAP][SignUp][Service] update provisioning response parsing error, response unknown, icn: 1234 (Common::Client::Errors::ParsingError)
```


## Screenshots

Not relevant.

## What areas of the site does it impact?

Calls to Sign-up Service.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

None.
