### PR TITLE
API-38830-errored-submissions-db

### DIFF
--- a/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
@@ -20,7 +20,7 @@ module ClaimsApi
         if pdf_string.empty?
           log_service_progress(auto_claim.id, 'pdf',
                                '526EZ PDF generator failed to return PDF string for claim')
-
+          set_error_response(auto_claim)
           set_errored_state_on_claim(auto_claim)
         elsif pdf_string
           log_service_progress(auto_claim.id, 'pdf',

--- a/modules/claims_api/app/services/claims_api/service.rb
+++ b/modules/claims_api/app/services/claims_api/service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lib/claims_api/v2/error/error_base'
+
 module ClaimsApi
   class Service
     def self.process(**args)
@@ -40,6 +42,15 @@ module ClaimsApi
 
     def set_errored_state_on_claim(auto_claim)
       save_auto_claim!(auto_claim, ClaimsApi::AutoEstablishedClaim::ERRORED)
+    end
+
+    def error_base(error)
+      ClaimsApi::V2::Error::ErrorBase.new(error)
+    end
+
+    def set_error_response(auto_claim)
+      auto_claim.evss_response = error_base(e).get_error_message
+      auto_claim.save
     end
   end
 end

--- a/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
@@ -44,12 +44,12 @@ module ClaimsApi
       queue_special_issues_updater(auto_claim.special_issues, auto_claim)
     rescue ::Common::Exceptions::BackendServiceException => e
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED
-      auto_claim.evss_response = get_error_message(e)
+      auto_claim.evss_response = error_base(error).get_error_message(e)
       auto_claim.form_data = orig_form_data
       auto_claim.save
     rescue => e
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED
-      auto_claim.evss_response = get_error_message(e)
+      auto_claim.evss_response = error_base(error).get_error_message(e)
       auto_claim.form_data = orig_form_data
       auto_claim.save
       raise e

--- a/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_benefits_documents_uploader.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_benefits_documents_uploader.rb
@@ -30,7 +30,7 @@ module ClaimsApi
                          'BD upload succeeded, Claim workflow finished')
       # Temporary errors (returning HTML, connection timeout), retry call
       rescue => e
-        error_message = get_error_message(e)
+        error_message = error_base(e).get_error_message
         log_job_progress(claim_id,
                          "BD failure #{e.class}: #{error_message}")
         log_exception_to_sentry(e)

--- a/modules/claims_api/lib/claims_api/v2/error/error_base.rb
+++ b/modules/claims_api/lib/claims_api/v2/error/error_base.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'error_message'
+
+module ClaimsApi
+  module V2
+    module Error
+      class ErrorBase
+        MESSAGES = [ClaimsApi::V2::Error::OriginalBody.new(error),
+                    ClaimsApi::V2::Error::Messages.new(error),
+                    ClaimsApi::V2::Error::Errors.new(error),
+                    ClaimsApi::V2::Error::DetailedMessage.new(error)].freeze
+
+        def initialize(error)
+          @error = error
+        end
+
+        def get_error_message
+          MESSAGES.each(&:message)
+        end
+      end
+    end
+  end
+end

--- a/modules/claims_api/lib/claims_api/v2/error/error_message.rb
+++ b/modules/claims_api/lib/claims_api/v2/error/error_message.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  module V2
+    module Error
+      class ErrorMessage
+        def initialize(error)
+          @error = error
+        end
+
+        def message
+          'default - An error has occurred'
+        end
+      end
+
+      class OriginalBody < ErrorMessage
+        def message
+          @error.original_body
+        end
+      end
+
+      class Messages < ErrorMessage
+        def message
+          @error.messages
+        end
+      end
+
+      class Errors < ErrorMessage
+        def message
+          @error.errors
+        end
+      end
+
+      class DetailedMessage < ErrorMessage
+        def message
+          @error.detailed_message
+        end
+      end
+    end
+  end
+end

--- a/modules/claims_api/lib/evss_service/base.rb
+++ b/modules/claims_api/lib/evss_service/base.rb
@@ -4,6 +4,7 @@ require 'claims_api/v2/benefits_documents/service'
 require 'claims_api/claim_logger'
 require 'common/client/errors'
 require 'custom_error'
+require 'lib/claims_api/v2/error/error_base'
 
 module ClaimsApi
   ##
@@ -96,6 +97,15 @@ module ClaimsApi
 
       def error_handler(error, async = true) # rubocop:disable Style/OptionalBooleanParameter
         ClaimsApi::CustomError.new(error, async).build_error
+      end
+
+      def error_base(error)
+        ClaimsApi::V2::Error::ErrorBase.new(error)
+      end
+
+      def set_error_response(auto_claim)
+        auto_claim.evss_response = error_base(e).get_error_message
+        auto_claim.save
       end
     end
   end


### PR DESCRIPTION
## Summary

- Creates classes in favor of polymorphism, rather than conditionals with manual dispatchers.

## Related issue(s)

- [API-38830](https://jira.devops.va.gov/browse/API-38830)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
	modified:   modules/claims_api/app/services/claims_api/service.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/service_base.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_benefits_documents_uploader.rb
	new file:   modules/claims_api/lib/claims_api/v2/error/error_base.rb
	new file:   modules/claims_api/lib/claims_api/v2/error/error_message.rb
	modified:   modules/claims_api/lib/evss_service/base.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature