### PR TITLE
chore: Decrease VA Mobile timeout

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -917,7 +917,7 @@ va_mobile:
   ppms_base_url: "https://staff.apps.va.gov"
   mock: false
   key_path: /fake/client/key/path
-  timeout: 55
+  timeout: 25
 
 vetext:
   url: "https://something.fake.va.gov"

--- a/modules/vaos/spec/services/configuration_spec.rb
+++ b/modules/vaos/spec/services/configuration_spec.rb
@@ -45,8 +45,8 @@ describe VAOS::Configuration do
   end
 
   describe '#read_timeout' do
-    it 'has a default timeout of 55 seconds' do
-      expect(VAOS::Configuration.instance.read_timeout).to eq(55)
+    it 'has a default timeout of 25 seconds' do
+      expect(VAOS::Configuration.instance.read_timeout).to eq(25)
     end
   end
 end

--- a/modules/vaos/spec/services/v1/fhir_configuration_spec.rb
+++ b/modules/vaos/spec/services/v1/fhir_configuration_spec.rb
@@ -18,8 +18,8 @@ describe VAOS::V1::FHIRConfiguration do
   end
 
   describe '#read_timeout' do
-    it 'has a default timeout of 55 seconds' do
-      expect(subject.read_timeout).to eq(55)
+    it 'has a default timeout of 25 seconds' do
+      expect(subject.read_timeout).to eq(25)
     end
   end
 end


### PR DESCRIPTION
This decreases va_mobile_timeout which is used when connecting to VAOS. The P95 for requests to VAOS is 16s during peak traffic. 25s should be plenty. Previously this value was risen from 15 seconds which is under our P95 so a good percentage would still timeout. Hopefully, this is a good middle ground.

![Screenshot 2024-08-07 at 14 05 18@2x](https://github.com/user-attachments/assets/9a70279b-c9b7-4c66-89d0-d88bedaf486f)
