### PR TITLE
EZR: Feature toggle for emergency contacts and next of kin experience

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -100,6 +100,14 @@ features:
     actor_type: user
     description: Enables the auth-only experience, allowing only authenticated users to view any part of the form.
     enable_in_development: true
+  ezr_emergency_contacts_enabled:
+    actor_type: user
+    description: Enables emergency contact experience for 10-10EZR applicants.
+    enable_in_development: true
+  ezr_next_of_kin_enabled:
+    actor_type: user
+    description: Enables next of kin experience for 10-10EZR applicants.
+    enable_in_development: true
   cerner_override_653:
     actor_type: user
     description: This will show the Cerner facility 653 as `isCerner`.


### PR DESCRIPTION
Adds a feature toggle for the emergency contacts experience on the 10-10EZR form

`ezr_emergency_contacts_enabled`
`ezr_next_of_kin_enabled`

## Related issue(s)
- [89331](https://github.com/department-of-veterans-affairs/va.gov-team/issues/89331)

## What areas of the site does it impact?
Form 10-10 EZR

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
