### PR TITLE
HOTFIX: Make sure file_Name is  orrect before S3/DB insertion

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -14,8 +14,9 @@ module IvcChampva
       results = @attachment_ids.zip(@file_paths).map do |attachment_id, file_path|
         next unless attachment_id != 'Form ID'
 
-        response_status = upload_file(attachment_id, file_path)
-        insert_form(file_path.gsub('tmp/', '').gsub('-tmp', ''), response_status.to_s) if @insert_db_row
+        file_name = File.basename(file_path).gsub('-tmp', '')
+        response_status = upload_file(attachment_id, file_name, file_path)
+        insert_form(file_name, response_status.to_s) if @insert_db_row
 
         response_status
       end.compact
@@ -47,8 +48,7 @@ module IvcChampva
       Rails.logger.error("Database Insertion Error for #{@metadata['uuid']}: #{e.message}")
     end
 
-    def upload_file(attachment_id, file_path)
-      file_name = file_path.gsub('tmp/', '').gsub('-tmp', '')
+    def upload_file(attachment_id, file_name, file_path)
       upload(file_name, file_path, attachment_ids: [attachment_id])
     end
 


### PR DESCRIPTION
The file_path was getting too long with the RAils.root.join() update the file_name to match before inserting into S3 and DB


## Summary

- update `file_uploader`

## Screenshot

<img width="660" alt="Screenshot 2024-08-08 at 10 52 00 AM" src="https://github.com/user-attachments/assets/e83d2866-9514-4560-a1d6-01f4594086bb">

