### PR TITLE
Remove status improvement canceled toggle flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1258,10 +1258,6 @@ features:
     actor_type: user
     description: Toggle for new mobile facility service v2 endpoints
     enable_in_development: true
-  va_online_scheduling_status_improvement_canceled:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle to display canceled booked appointments
   va_online_scheduling_vaos_v2_next:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION

## Summary

This PR removes the feature toggle flag `va_online_scheduling_status_improvement_canceled`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#89130

## Testing done

n/a

## Screenshots
n/a

## What areas of the site does it impact?
VAOS feature toggle flag

## Acceptance criteria

- [ ]  Remove the feature toggle flag `va_online_scheduling_status_improvement_canceled`


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
