### PR TITLE
multipart commit to ingress data from BDN in chunks instead of as one large file

### DIFF
--- a/modules/vye/lib/vye/batch_transfer/chunk.rb
+++ b/modules/vye/lib/vye/batch_transfer/chunk.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Vye
+  module BatchTransfer
+    class Chunk
+      include Vye::CloudTransfer
+
+      def initialize(offset:, block_size:, file:)
+        @offset = offset
+        @block_size = block_size
+        @file = file
+      end
+
+      def upload; end
+    end
+  end
+end

--- a/modules/vye/lib/vye/batch_transfer/chunking.rb
+++ b/modules/vye/lib/vye/batch_transfer/chunking.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Vye
+  module BatchTransfer
+    class Chunking
+      class NotReadyForUploading < StandardError; end
+
+      include Vye::CloudTransfer
+
+      def initialize(filename:, block_size:)
+        @filename = filename
+        @block_size = block_size
+        @stem, @ext = filename.match(/(.*)[.]([^.]*)/).values_at(1, 2)
+        @chunks = []
+        @flags = %i[uploaded split].index_with { |_f| false }
+      end
+
+      def split
+        return chunks if split?
+
+        download(filename) do |path|
+          path.each_line(&method(:puts))
+        end
+
+        split!
+        chunks
+      ensure
+        close_current_handle
+      end
+
+      def upload
+        return chunks if uploaded?
+        raise NotReadyForUploading unless split?
+
+        chunks.each(&:upload)
+
+        uploaded!
+        chunks
+      end
+
+      private
+
+      attr_reader :filename, :block_size, :stem, :ext, :offset, :line_num, :chunks, :done
+
+      def split! = @flags[:split] = true
+      def split? = @flags[:split]
+
+      def uploaded! = @flags[:uploaded] = true
+      def uploaded? = @flags[:uploaded]
+
+      def dirname
+        @dirname ||= tmp_dir
+      end
+
+      def current_file
+        return @current_file if @current_file.present?
+
+        @offset = offset.blank? ? 0 : offset + line_num
+        @line_num = 1
+
+        filename = "#{stem}-#{offset}.#{ext}"
+        file = dirname / filename
+        @current_file = file
+
+        @chunks << Chunk.new(offset:, block_size:, file:)
+
+        @current_file
+      end
+
+      def current_handle
+        return @current_handle if @current_handle.present?
+
+        @current_handle = current_file.open('w')
+      end
+
+      def close_current_handle
+        @current_handle.close unless @current_handle.blank? || @current_handle.closed?
+      end
+
+      def complete_current_file!
+        @current_handle.close
+        @current_handle = nil
+        @current_file = nil
+      end
+
+      def puts(line)
+        current_handle.puts line
+
+        if line_num == block_size
+          complete_current_file!
+        else
+          @line_num += 1
+        end
+      end
+    end
+  end
+end

--- a/modules/vye/lib/vye/batch_transfer/chunking.rb
+++ b/modules/vye/lib/vye/batch_transfer/chunking.rb
@@ -10,7 +10,12 @@ module Vye
       def initialize(filename:, block_size:)
         @filename = filename
         @block_size = block_size
-        @stem, @ext = filename.match(/(.*)[.]([^.]*)/).values_at(1, 2)
+        @stem, @ext =
+          if filename.include?('.')
+            filename.rpartition('.').values_at(0, 2)
+          else
+            [filename, 'noext']
+          end
         @chunks = []
         @flags = %i[uploaded split].index_with { |_f| false }
       end

--- a/modules/vye/spec/lib/vye/batch_transfer/chunk_spec.rb
+++ b/modules/vye/spec/lib/vye/batch_transfer/chunk_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Vye::BatchTransfer::Chunk do
+  it 'can be instantiated' do
+    offset = 0
+    block_size = 1000
+    file = Pathname.new('test.txt')
+
+    expect(described_class.new(offset:, block_size:, file:)).to be_a described_class
+  end
+end

--- a/modules/vye/spec/lib/vye/batch_transfer/chunking_spec.rb
+++ b/modules/vye/spec/lib/vye/batch_transfer/chunking_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Vye::BatchTransfer::Chunking do
+  let(:total_lines) { 57 }
+  let(:filename) { 'test.txt' }
+  let(:block_size) { 10 }
+  let(:block_count) { (total_lines / block_size.to_f).ceil }
+  let(:chunking) { described_class.new(filename:, block_size:) }
+
+  describe '#initialize' do
+    it 'sets the attributes' do
+      expect(chunking).to be_a described_class
+      expect(chunking.send(:filename)).to eq filename
+      expect(chunking.send(:block_size)).to eq block_size
+      expect(chunking.send(:stem)).to eq 'test'
+      expect(chunking.send(:ext)).to eq 'txt'
+      expect(chunking.send(:chunks)).to be_empty
+      expect(chunking.send(:split?)).to be false
+      expect(chunking.send(:uploaded?)).to be false
+    end
+  end
+
+  describe '#split' do
+    let(:dirname) { instance_double(Pathname) }
+    let(:dl_path) do
+      Struct.new(:total_lines) do
+        def each_line(&)
+          total_lines.to_enum(:times).map { |i| "line #{i + 1}" }.each(&)
+        end
+      end.new(total_lines:)
+    end
+    let(:io_list) { 6.times.to_h { |i| ["test-#{i * 10}.txt", StringIO.new] } }
+    let(:file_list) { 6.times.to_h { |i| ["test-#{i * 10}.txt", instance_double(Pathname)] } }
+    let(:lines_in_last_file) { total_lines % block_size }
+    let(:lines_in_file) { block_size }
+
+    it 'downloads the file and chunks it' do
+      file_list.each do |file, path|
+        expect(dirname).to receive(:/).with(file).and_return(path)
+        expect(path).to receive(:open).with('w').and_return(io_list[file])
+      end
+
+      io_list.each do |file, io|
+        if file == 'test-50.txt'
+          expect(io).to receive(:puts).exactly(lines_in_last_file).times
+        else
+          expect(io).to receive(:puts).exactly(lines_in_file).times
+        end
+
+        expect(io).to receive(:close) do
+          io.close_read
+          io.close_write
+        end
+      end
+
+      allow(chunking).to receive(:dirname).and_return(dirname)
+      expect(chunking).to receive(:download).with(filename).and_yield(dl_path)
+      expect(chunking).to receive(:puts).exactly(total_lines).times.and_call_original
+
+      expect(chunking.send(:split?)).to be(false)
+      expect(chunking.split.length).to eq(6)
+      expect(chunking.send(:split?)).to be(true)
+
+      expect(chunking.split).to all(be_a(Vye::BatchTransfer::Chunk))
+    end
+  end
+
+  describe '#upload' do
+    let(:chunks) do
+      3.times.map { instance_double(Vye::BatchTransfer::Chunk) }
+    end
+
+    it 'returns chunks if already uploaded' do
+      allow(chunking).to receive(:uploaded?).and_return(true)
+      expect(chunking).to receive(:chunks).and_return(chunks)
+      expect(chunking.upload).to eq(chunks)
+    end
+
+    it 'raises an error if not split' do
+      expect { chunking.upload }.to raise_error(described_class::NotReadyForUploading)
+    end
+
+    it 'uploads the chunks' do
+      expect(chunking).to receive(:split?).and_return(true)
+      allow(chunking).to receive(:chunks).and_return(chunks)
+      expect(chunks).to all(receive(:upload))
+
+      expect(chunking.send(:uploaded?)).to be false
+      expect(chunking.upload.length).to eq(3)
+      expect(chunking.send(:uploaded?)).to be true
+    end
+  end
+
+  describe '#close_current_handle' do
+    let(:io) { instance_double(IO) }
+
+    it 'closes the current handle' do
+      expect(io).to receive(:closed?).and_return(false)
+      expect(io).to receive(:close)
+
+      chunking.instance_variable_set(:@current_handle, io)
+      chunking.send(:close_current_handle)
+    end
+  end
+
+  describe '#split!' do
+    it 'sets the split flag' do
+      chunking.send(:split!)
+      expect(chunking.send(:split?)).to be true
+    end
+  end
+
+  describe '#dirname' do
+    let(:dirname) { instance_double(Pathname) }
+
+    it 'returns the dirname' do
+      chunking.instance_variable_set(:@dirname, dirname)
+      expect(chunking.send(:dirname)).to eq dirname
+    end
+
+    it 'creates the dirname if it does not exist' do
+      expect(chunking).to receive(:tmp_dir).and_return(dirname)
+      expect(chunking.send(:dirname)).to eq dirname
+    end
+  end
+
+  describe '#current_file' do
+    let(:dirname) { instance_double(Pathname) }
+    let(:file) { instance_double(Pathname) }
+    let(:stem) { 'test' }
+    let(:ext) { 'txt' }
+
+    it 'returns the current file' do
+      chunking.instance_variable_set(:@current_file, file)
+
+      expect(chunking.send(:current_file)).to eq file
+    end
+
+    it 'returns a new file if none exists' do
+      expect(chunking).to receive(:stem).and_return(stem)
+      expect(chunking).to receive(:ext).and_return(ext)
+      expect(chunking).to receive(:dirname).and_return(dirname)
+      expect(dirname).to receive(:/).with("#{stem}-0.#{ext}").and_return(file)
+
+      expect do
+        expect(chunking.send(:current_file)).to eq file
+      end.to change { chunking.send(:chunks).count }.by(1)
+    end
+  end
+
+  describe '#current_handle' do
+    let(:file) { instance_double(Pathname) }
+    let(:io) { instance_double(IO) }
+
+    it 'returns the current handle' do
+      chunking.instance_variable_set(:@current_handle, io)
+      expect(chunking.send(:current_handle)).to eq io
+    end
+
+    it 'creates a new handle if none exists' do
+      expect(chunking).to receive(:current_file).and_return(file)
+      expect(file).to receive(:open).with('w').and_return(io)
+
+      expect(chunking.send(:current_handle)).to eq io
+    end
+  end
+
+  describe '#puts' do
+    let(:io) { instance_double(IO) }
+
+    it 'sets up the next file if the line_num is the block_size' do
+      chunking.instance_variable_set(:@line_num, block_size)
+      chunking.instance_variable_set(:@current_handle, io)
+
+      expect(io).to receive(:puts)
+      expect(io).to receive(:close)
+
+      chunking.send(:puts, 'line')
+
+      expect(chunking.instance_variable_get(:@current_handle)).to be_nil
+    end
+
+    it "continues with the current file if the line_num isn't the block_size" do
+      chunking.instance_variable_set(:@line_num, 0)
+      chunking.instance_variable_set(:@current_handle, io)
+
+      expect(io).to receive(:puts)
+      expect(chunking.instance_variable_get(:@current_handle)).not_to be_nil
+
+      chunking.send(:puts, 'line')
+    end
+  end
+end


### PR DESCRIPTION
- *This work is behind a feature toggle (flipper): NO
- *This is a multipart commit to ingress data from BDN in chunks instead of as one large file
- *(Will break dataset from BDN in multiple parts so that it can be easily consumed by sidekiq)*
- *(I work for VYE we own the maintenance for this component.)*

## Testing done

- [X] *New code is covered by unit tests*
- Ingress was done as one large file
- The ingress job will now launch multiple chunk jobs

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
