### PR TITLE
[10-10CG] Add content-type application/json to mulesoft submission request

### DIFF
--- a/lib/carma/client/mule_soft_client.rb
+++ b/lib/carma/client/mule_soft_client.rb
@@ -70,7 +70,7 @@ module CARMA
             :post,
             resource,
             get_body(payload),
-            { Authorization: "Bearer #{bearer_token}" },
+            headers,
             { timeout: config.settings.async_timeout }
           )
 
@@ -80,6 +80,13 @@ module CARMA
 
       def bearer_token
         @bearer_token ||= CARMA::Client::MuleSoftAuthTokenClient.new.new_bearer_token
+      end
+
+      def headers
+        {
+          'Authorization' => "Bearer #{bearer_token}",
+          'Content-Type' => 'application/json'
+        }
       end
 
       def get_body(payload)

--- a/spec/lib/carma/client/mule_soft_client_spec.rb
+++ b/spec/lib/carma/client/mule_soft_client_spec.rb
@@ -58,7 +58,12 @@ describe CARMA::Client::MuleSoftClient do
 
         context 'successfully gets token' do
           let(:bearer_token) { 'my-bearer-token' }
-          let(:headers) { { Authorization: "Bearer #{bearer_token}" } }
+          let(:headers) do
+            {
+              'Authorization' => "Bearer #{bearer_token}",
+              'Content-Type' => 'application/json'
+            }
+          end
 
           before do
             allow(mulesoft_auth_token_client).to receive(:new_bearer_token).and_return(bearer_token)


### PR DESCRIPTION

## Summary

- This work is behind a feature toggle (flipper): YES
- Since we refactored how we build the mulesoft request, we now need to set the content-type in the request headers when we build it. Right now we are getting a 415 response. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86425

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

