### PR TITLE
90153: Don't make fileNumber a requirement

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/metadata_validator.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/metadata_validator.rb
@@ -28,6 +28,8 @@ module IvcChampva
     end
 
     def self.validate_file_number(metadata)
+      return metadata if metadata['fileNumber'].blank?
+
       validate_presence_and_stringiness(metadata['fileNumber'], 'file number')
       unless metadata['fileNumber'].match?(/^\d{8,9}$/)
         raise ArgumentError, 'file number is invalid. It must be 8 or 9 digits'

--- a/modules/ivc_champva/spec/services/metadata_validator_spec.rb
+++ b/modules/ivc_champva/spec/services/metadata_validator_spec.rb
@@ -185,6 +185,24 @@ describe IvcChampva::MetadataValidator do
         end.to raise_error(ArgumentError, 'file number is invalid. It must be 8 or 9 digits')
       end
     end
+
+    describe 'missing' do
+      it 'succeeds' do
+        metadata = {
+          'veteranFirstName' => 'John',
+          'veteranLastName' => 'Doe',
+          'fileNumber' => '',
+          'zipCode' => '12345',
+          'source' => 'VA Platform Digital Forms',
+          'docType' => '21-0845',
+          'businessLine' => 'CMP'
+        }
+
+        validated_metadata = IvcChampva::MetadataValidator.validate(metadata)
+
+        expect(validated_metadata).to eq(metadata)
+      end
+    end
   end
 
   describe 'zip code is malformed' do


### PR DESCRIPTION
We have a few of forms that don't have a File Number so we don't want to require it


## Summary

- Add guard clause to method
- Add test

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90153