### PR TITLE
89790: Add metadata columns to saved_claims table

### DIFF
--- a/db/migrate/20240808215701_add_column_metadata_to_saved_claims.rb
+++ b/db/migrate/20240808215701_add_column_metadata_to_saved_claims.rb
@@ -1,0 +1,5 @@
+class AddColumnMetadataToSavedClaims < ActiveRecord::Migration[7.1]
+  def change
+    add_column :saved_claims, :metadata, :string
+  end
+end

--- a/db/migrate/20240808215701_add_column_metadata_to_saved_claims.rb
+++ b/db/migrate/20240808215701_add_column_metadata_to_saved_claims.rb
@@ -1,5 +1,6 @@
 class AddColumnMetadataToSavedClaims < ActiveRecord::Migration[7.1]
   def change
-    add_column :saved_claims, :metadata, :string
+    add_column :saved_claims, :metadata, :text
+    add_column :saved_claims, :metadata_updated_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_30_174253) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_08_215701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -1034,6 +1034,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_30_174253) do
     t.datetime "itf_datetime"
     t.datetime "form_start_date"
     t.datetime "delete_date"
+    t.string "metadata"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1034,7 +1034,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_215701) do
     t.datetime "itf_datetime"
     t.datetime "form_start_date"
     t.datetime "delete_date"
-    t.string "metadata"
+    t.text "metadata"
+    t.datetime "metadata_updated_at"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"


### PR DESCRIPTION
## Summary

- Generate migration to add `metadata` and `metadata_updated_at` to SavedClaim table

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/89790

## Testing done
* Migration verified locally

## What areas of the site does it impact?
* This impacts the SavedClaim table in vets-api as it adds a new column (nullable string column)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
