### PR TITLE
Update Reek Configuration

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -50,10 +50,19 @@ detectors:
     enabled: false # rubocop takes care of this
   UtilityFunction:
     public_methods_only: true
+  UncommunicativeMethodName:
+    accept:
+      - "/[0-9]+$/"
+  UncommunicativeModuleName:
+    accept:
+      - "/[0-9]+$/"
+  UncommunicativeParameterName:
+    accept:
+      - "/[0-9]+$/"
   UncommunicativeVariableName:
     accept:
       - e
       - k
       - v
       - i
-      - "/\d+$/"
+      - "/[0-9]+$/"

--- a/.reek.yml
+++ b/.reek.yml
@@ -53,3 +53,4 @@ detectors:
   UncommunicativeVariableName:
     accept:
       - e
+      - "/\d+$/"

--- a/.reek.yml
+++ b/.reek.yml
@@ -53,4 +53,7 @@ detectors:
   UncommunicativeVariableName:
     accept:
       - e
+      - k
+      - v
+      - i
       - "/\d+$/"


### PR DESCRIPTION
## Summary

- Allow variable names that end in numbers considering all the form related variable names
- Allow `k`,`v`,`i` variable names

## Related issue(s)

- n/a

## Testing done

- [x] manual testing done

## Acceptance criteria

- [x]  `k`,`v`,`i` variable names are allowed
- [x] `form_123` variable name is accepted
- [x] `Form526` module name is accepted