### PR TITLE
Add features flags for upcoming HCA initiatives

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -75,9 +75,16 @@ features:
   hca_performance_alert_enabled:
     actor_type: user
     description: Enables alert notifying users of a potential issue with application performance.
+  hca_reg_only_enabled:
+    actor_type: user
+    description: Enables the registration-only path for the Health Care Application
+    enable_in_development: true
   hca_sigi_enabled:
     actor_type: user
     description: Enables Self-Identifying Gender Identity question for health care applicants.
+  hca_tera_branching_enabled:
+    actor_type: user
+    description: Enables branching logic for the Toxic Exposure questionset in the Health Care Application
   hca_use_facilities_API:
     actor_type: user
     description: Allow list of medical care facilites to be fetched by way of the Facilities API.


### PR DESCRIPTION
## Summary

This PR adds two new feature flags that will be utilized in upcoming initiatives on the Health Care Application for the 1010 team. The initiatives are linked below.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#81103
- department-of-veterans-affairs/va.gov-team#87452

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs