### PR TITLE
[VI-293] Update terms of use calls to sign up service to use ICN off MPI response

### DIFF
--- a/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
+++ b/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
@@ -35,17 +35,25 @@ module TermsOfUse
 
       return unless sec_id?
 
+      log_updated_icn
       terms_of_use_agreement.accepted? ? accept : decline
     end
 
     private
 
+    def log_updated_icn
+      if user_account.icn != mpi_profile.icn
+        Rails.logger.info("#{LOG_TITLE} Detected changed ICN for user",
+                          { icn: user_account.icn, mpi_icn: mpi_profile.icn })
+      end
+    end
+
     def accept
-      MAP::SignUp::Service.new.agreements_accept(icn:, signature_name:, version:)
+      MAP::SignUp::Service.new.agreements_accept(icn: mpi_profile.icn, signature_name:, version:)
     end
 
     def decline
-      MAP::SignUp::Service.new.agreements_decline(icn:)
+      MAP::SignUp::Service.new.agreements_decline(icn: mpi_profile.icn)
     end
 
     def sec_id?
@@ -54,20 +62,19 @@ module TermsOfUse
         return true
       end
 
-      Rails.logger.info("#{LOG_TITLE} Sign Up Service not updated due to user missing sec_id", { icn: })
+      Rails.logger.info("#{LOG_TITLE} Sign Up Service not updated due to user missing sec_id",
+                        { icn: user_account.icn })
       false
     end
 
     def validate_multiple_sec_ids
-      Rails.logger.info("#{LOG_TITLE} Multiple sec_id values detected", { icn: }) if mpi_profile.sec_ids.many?
+      if mpi_profile.sec_ids.many?
+        Rails.logger.info("#{LOG_TITLE} Multiple sec_id values detected", { icn: user_account.icn })
+      end
     end
 
     def user_account
       @user_account ||= UserAccount.find(user_account_uuid)
-    end
-
-    def icn
-      @icn ||= user_account.icn
     end
 
     def terms_of_use_agreement
@@ -79,7 +86,7 @@ module TermsOfUse
     end
 
     def mpi_profile
-      @mpi_profile ||= MPI::Service.new.find_profile_by_identifier(identifier: icn,
+      @mpi_profile ||= MPI::Service.new.find_profile_by_identifier(identifier: user_account.icn,
                                                                    identifier_type: MPI::Constants::ICN)&.profile
     end
   end

--- a/spec/sidekiq/terms_of_use/sign_up_service_updater_job_spec.rb
+++ b/spec/sidekiq/terms_of_use/sign_up_service_updater_job_spec.rb
@@ -120,11 +120,30 @@ RSpec.describe TermsOfUse::SignUpServiceUpdaterJob, type: :job do
           allow(service_instance).to receive(:agreements_accept)
         end
 
+        context 'and user account icn does not equal the mpi profile icn' do
+          let(:expected_log) do
+            '[TermsOfUse][SignUpServiceUpdaterJob] Detected changed ICN for user'
+          end
+          let(:mpi_profile) { build(:mpi_profile, icn: mpi_icn, sec_id:, given_names:, family_name:) }
+          let(:mpi_icn) { 'some-mpi-icn' }
+
+          before do
+            allow(Rails.logger).to receive(:info)
+          end
+
+          it 'logs a detected changed ICN message' do
+            job.perform(user_account_uuid, version)
+
+            expect(MAP::SignUp::Service).to have_received(:new)
+            expect(Rails.logger).to have_received(:info).with(expected_log, { icn:, mpi_icn: })
+          end
+        end
+
         it 'updates the terms of use agreement in sign up service' do
           job.perform(user_account_uuid, version)
 
           expect(MAP::SignUp::Service).to have_received(:new)
-          expect(service_instance).to have_received(:agreements_accept).with(icn: user_account.icn,
+          expect(service_instance).to have_received(:agreements_accept).with(icn: mpi_profile.icn,
                                                                              signature_name: common_name,
                                                                              version:)
         end
@@ -137,11 +156,30 @@ RSpec.describe TermsOfUse::SignUpServiceUpdaterJob, type: :job do
           allow(service_instance).to receive(:agreements_decline)
         end
 
+        context 'and user account icn does not equal the mpi profile icn' do
+          let(:expected_log) do
+            '[TermsOfUse][SignUpServiceUpdaterJob] Detected changed ICN for user'
+          end
+          let(:mpi_profile) { build(:mpi_profile, icn: mpi_icn, sec_id:, given_names:, family_name:) }
+          let(:mpi_icn) { 'some-mpi-icn' }
+
+          before do
+            allow(Rails.logger).to receive(:info)
+          end
+
+          it 'logs a detected changed ICN message' do
+            job.perform(user_account_uuid, version)
+
+            expect(MAP::SignUp::Service).to have_received(:new)
+            expect(Rails.logger).to have_received(:info).with(expected_log, { icn:, mpi_icn: })
+          end
+        end
+
         it 'updates the terms of use agreement in sign up service' do
           job.perform(user_account_uuid, version)
 
           expect(MAP::SignUp::Service).to have_received(:new)
-          expect(service_instance).to have_received(:agreements_decline).with(icn: user_account.icn)
+          expect(service_instance).to have_received(:agreements_decline).with(icn: mpi_profile.icn)
         end
       end
     end


### PR DESCRIPTION
## Summary

- This PR updates the terms of use agreements/decline to Sign up Service to use MPI ICN instead of UserAccount ICN. This is necessary because sometimes the MPI ICN changes and the Sign Up Service update will fail when this happens

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-293

## Testing done

- Authenticated with a user, accepted terms with a mocked SuS failure. 
- Next, changed the user's ICN on the mocked MPI response, then change the mocked SuS failure to a success
- Confirmed the next successful SuS call used the proper updated ICN


## What areas of the site does it impact?
Terms of Use

## Acceptance criteria

- [x] In mockdata repo, change `vets-api-mockdata/map/sign_up_service/agreements_accept/default.yml` to return a non-200 status
- [x] Start `vets-api` server with sidekiq enabled
- [x] Authenticate with a user that has not accepted terms of use
- [x] Accept terms of use
- [x] Confirm sidekiq job is failing
- [x] Update underlying mocked MPI response to return a new ICN for the user. This can be done by finding the mocked MPI record with a field like: `<id root="2.16.840.1.113883.4.349" extension="<ICN>^NI^200M^USVHA^P"/>` and updating `<ICN>` with a new value
- [x] Update the `vets-api-mockdata/map/sign_up_service/agreements_accept/default.yml` to return a `201` as it originally did
- [x] Confirm the next SuS call from sidekiq uses the new ICN on the MPI response
