### PR TITLE
Tweak max rating eligibility based on primary diagnostic code

### DIFF
--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -67,11 +67,10 @@ module ClaimFastTracking
     def self.eligible_for_request?(rated_disability)
       return false if %i[infectious_disease missing_diagnostic_code].include?(diagnostic_code_type(rated_disability))
 
-      return false if EXCLUDED_DIGESTIVE_CODES.include?(rated_disability.diagnostic_code)
+      dc = rated_disability.diagnostic_code
+      return false if EXCLUDED_DIGESTIVE_CODES.include?(dc)
 
-      return true if Flipper.enabled?(:disability_526_maximum_rating_api_all_conditions)
-
-      SELECT_DISABILITIES.include?(rated_disability.diagnostic_code)
+      Flipper.enabled?(:disability_526_maximum_rating_api_all_conditions) || SELECT_DISABILITIES.include?(dc)
     end
 
     private_class_method :get_ratings

--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -5,6 +5,7 @@ require 'virtual_regional_office/client'
 module ClaimFastTracking
   class MaxRatingAnnotator
     SELECT_DISABILITIES = [ClaimFastTracking::DiagnosticCodes::TINNITUS].freeze
+    EXCLUDED_DIGESTIVE_CODES = [7318, 7319, 7327, 7336, 7346].freeze
 
     def self.annotate_disabilities(rated_disabilities_response)
       return if rated_disabilities_response.rated_disabilities.blank?
@@ -13,9 +14,8 @@ module ClaimFastTracking
 
       diagnostic_codes = rated_disabilities_response.rated_disabilities
                                                     .compact # filter out nil entries in rated_disabilities
+                                                    .select { |rd| eligible_for_request?(rd) } # select only eligible
                                                     .map(&:diagnostic_code) # map to diagnostic_code field in rating
-                                                    .select { |dc| dc.is_a?(Integer) } # select only integer values
-                                                    .select { |dc| eligible_for_request?(dc) } # select only eligible
       return rated_disabilities_response if diagnostic_codes.empty?
 
       ratings = get_ratings(diagnostic_codes)
@@ -64,10 +64,16 @@ module ClaimFastTracking
       nil
     end
 
-    def self.eligible_for_request?(dc)
-      Flipper.enabled?(:disability_526_maximum_rating_api_all_conditions) || SELECT_DISABILITIES.include?(dc)
+    def self.eligible_for_request?(rated_disability)
+      return false if %i[infectious_disease missing_diagnostic_code].include?(diagnostic_code_type(rated_disability))
+
+      return false if EXCLUDED_DIGESTIVE_CODES.include?(rated_disability.diagnostic_code)
+
+      return true if Flipper.enabled?(:disability_526_maximum_rating_api_all_conditions)
+
+      SELECT_DISABILITIES.include?(rated_disability.diagnostic_code)
     end
 
-    private_class_method :get_ratings, :eligible_for_request?
+    private_class_method :get_ratings
   end
 end

--- a/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
+++ b/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
@@ -214,4 +214,28 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
       it { is_expected.to eq(:primary_max_rating) }
     end
   end
+
+  describe 'eligible_for_request?' do
+    subject { described_class.eligible_for_request?(rated_disability) }
+
+    let(:rated_disability) { DisabilityCompensation::ApiProvider::RatedDisability.new(**rd_hash) }
+
+    context 'when rated disability is for an infectious disease' do
+      let(:rd_hash) { { diagnostic_code: 6354 } }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when rated disability is for an excluded digestive condition' do
+      let(:rd_hash) { { diagnostic_code: 7346 } }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when rated disability is for a non-excluded digestive condition' do
+      let(:rd_hash) { { diagnostic_code: 7347 } }
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This PR excludes certain diagnostic codes from displaying a 526 Max Rating notice, based on research specific to digestive system and infectious disease diagnostic codes.
- I'm on the Employee Experience team, which works with the 526 DBEX team that maintains this component.

## Related issue(s)

- department-of-veterans-affairs/abd-vro#3230

## Testing done

- [x] *New code is covered by unit tests*
- Old behavior: all diagnostic codes were sent to the Max Rating API to determine if the Max Rating notice should be displayed.
- New behavior: infectious disease codes and certain digestive system codes are excluded.
- The DC-specific logic has been broken out into a method that now has its own RSpec tests to cover each scenario.

## What areas of the site does it impact?
* User education displayed on 526 Rated Disabilities screen; no user functionality is affected.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
