### PR TITLE
Fix 10-7959A back end mappings

### DIFF
--- a/modules/ivc_champva/app/form_mappings/vha_10_7959a.json.erb
+++ b/modules/ivc_champva/app/form_mappings/vha_10_7959a.json.erb
@@ -4,7 +4,7 @@
   "form1[0].#subform[0].LastNme-ptnt[0]":                                     "<%= form.data.dig('applicant_name', 'last') %>",
   "form1[0].#subform[0].SSN-ptnt[0]":                                         "<%= form.data.dig('applicant_member_number') %>",
   "form1[0]":                                                                 "<%= form.data.dig('form1') %>",
-  "form1[0].#subform[0].ZIPCode-ptnt[0]":                                     "<%= form.data.dig('applicant_address', 'zip_code') %>",
+  "form1[0].#subform[0].ZIPCode-ptnt[0]":                                     "<%= form.data.dig('applicant_address', 'postal_code') %>",
   "form1[0].#subform[0].State-ptnt[0]":                                       "<%= form.data.dig('applicant_address', 'state') %>",
   "form1[0].#subform[0].City-ptnt[0]":                                        "<%= form.data.dig('applicant_address', 'city') %>",
   "form1[0].#subform[0].StreetAddrss-ptnt[0]":                                "<%= form.data.dig('applicant_address', 'street') %>",
@@ -14,16 +14,16 @@
   "form1[0].#subform[0].LastNme-spnsr[0]":                                    "<%= form.data.dig('sponsor_name', 'last') %>",
   "form1[0].#subform[0].FirstNme-spnsr[0]":                                   "<%= form.data.dig('sponsor_name', 'first') %>",
   "form1[0].#subform[0].MiddleInit-spnsr[0]":                                 "<%= form.data.dig('sponsor_name', 'middle') %>",
-  "form1[0].#subform[0].NameOHI-1[0]":                                        "<%= form.data['policies'][0]&.dig('name') %>",
-  "form1[0].#subform[0].Phone-OHI-1[0]":                                      "<%= form.data['policies'][0]&.dig('provider_phone') %>",
-  "form1[0].#subform[0].OHIPolicyNmbr-1[0]":                                  "<%= form.data['policies'][0]&.dig('policy_num') %>",
-  "form1[0].#subform[0].NameOHI-2[0]":                                        "<%= form.data['policies'][1]&.dig('name') %>",
-  "form1[0].#subform[0].OHIPolicyNmbr-2[0]":                                  "<%= form.data['policies'][1]&.dig('policy_num') %>",
-  "form1[0].#subform[0].Phone-OHI-2[0]":                                      "<%= form.data['policies'][1]&.dig('provider_phone') %>",
+  "form1[0].#subform[0].NameOHI-1[0]":                                        "<%= form.data['policies']&.first&.dig('name') %>",
+  "form1[0].#subform[0].Phone-OHI-1[0]":                                      "<%= form.data['policies']&.first&.dig('provider_phone') %>",
+  "form1[0].#subform[0].OHIPolicyNmbr-1[0]":                                  "<%= form.data['policies']&.first&.dig('policy_num') %>",
+  "form1[0].#subform[0].NameOHI-2[0]":                                        "<%= form.data['policies']&.second&.dig('name') %>",
+  "form1[0].#subform[0].OHIPolicyNmbr-2[0]":                                  "<%= form.data['policies']&.second&.dig('policy_num') %>",
+  "form1[0].#subform[0].Phone-OHI-2[0]":                                      "<%= form.data['policies']&.second&.dig('provider_phone') %>",
   "form1[0].#subform[0].#area[2].WorkRelatedTreat[0]":                        "<%= form.data.dig('claim_is_work_related') ? 1 : 0 %>",
   "form1[0].#subform[0].#area[0].OutsdWrkAccdnt[0]":                          "<%= form.data.dig('claim_is_auto_related') ? 1 : 0 %>",
   "form1[0].#subform[0].PtntCverage[0]":                                      "<%= form.data.dig('has_ohi') ? 1 : 0 %>",
-  "form1[0].#subform[0].#area[1].RadioButtonList[0]":                         "<%= form.data.dig('type') === 'group' ? 1 : 
+  "form1[0].#subform[0].#area[1].RadioButtonList[0]":                         "<%= form.data.dig('type') === 'group' ? 1 :
                                                                                    form.data.dig('type') === 'non_group' ? 2 :
                                                                                    form.data.dig('type') === 'medicare' ? 3 :
                                                                                    form.data.dig('type') === 'other' ? 4 : 0 %>",
@@ -31,13 +31,13 @@
   "form1[0].#subform[0].SignatureMiddleInitial[0]":                           "<%= form.data.dig('certifier_name', 'middle') %>",
   "form1[0].#subform[0].SignatureFirstName[0]":                               "<%= form.data.dig('certifier_name', 'first') %>",
   "form1[0].#subform[0].SignatureLastName[0]":                                "<%= form.data.dig('certifier_name', 'last') %>",
-  "form1[0].#subform[0].relationshipToApplicant[0]":                          "<%= form.data.dig('certifier_relationship') != 'other' ? 
-                                                                                   form.data.dig('certifier_relationship') : 
+  "form1[0].#subform[0].relationshipToApplicant[0]":                          "<%= form.data.dig('certifier_relationship') != 'other' ?
+                                                                                   form.data.dig('certifier_relationship') :
                                                                                    form.data.dig('certifier_other_relationship') %>",
   "form1[0].#subform[0].SignatureTelephoneNumber[0]":                         "<%= form.data.dig('certifier_phone') %>",
   "form1[0].#subform[0].SignatureZipCode[0]":                                 "<%= form.data.dig('certifier_address', 'zip_code') %>",
   "form1[0].#subform[0].SignatureState[0]":                                   "<%= form.data.dig('certifier_address', 'state') %>",
   "form1[0].#subform[0].SignatureCity[0]":                                    "<%= form.data.dig('certifier_address', 'city') %>",
   "form1[0].#subform[0].SignatureStreetAddress[0]":                           "<%= form.data.dig('certifier_address', 'street') %>",
-  "form1[0].#subform[0].SignatureDateOfBirth2[0]":                            "<%= form.data.dig('certificationDate', 'street') %>"
+  "form1[0].#subform[0].SignatureDateOfBirth2[0]":                            "<%= form.data.dig('certification_date') %>"
 }

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -25,12 +25,26 @@ module IvcChampva
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
         'ssn_or_tin' => @data['applicant_member_number'],
-        'member_number' => @data['applicant_member_number'],
         'fileNumber' => @data['applicant_member_number'],
         'country' => @data.dig('applicant_address', 'country') || 'USA',
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info']
       }
+    end
+
+    def desired_stamps
+      [{ coords: [250, 105], text: data['statement_of_truth_signature'], page: 0 }]
+    end
+
+    def submission_date_stamps
+      [
+        {
+          coords: [300, 105],
+          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          page: 1,
+          font_size: 12
+        }
+      ]
     end
 
     def track_user_identity

--- a/modules/ivc_champva/app/services/ivc_champva/pdf_stamper.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/pdf_stamper.rb
@@ -4,7 +4,7 @@ require 'central_mail/datestamp_pdf'
 
 module IvcChampva
   class PdfStamper
-    FORM_REQUIRES_STAMP = %w[10-10D 10-7959F-1].freeze
+    FORM_REQUIRES_STAMP = %w[10-10D 10-7959F-1 10-7959A].freeze
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
     SUBMISSION_DATE_TITLE = 'Application Submitted:'
 

--- a/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959a.json
+++ b/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959a.json
@@ -1,55 +1,60 @@
 {
   "form_number": "10-7959A",
-  "veteran": {
-    "full_name": {
-      "first": "Veteran",
-      "middle": "B",
-      "last": "Surname"
-    },
-    "ssn_or_tin": "222554444",
-    "address": {
-      "country": "USA",
-      "street": "1 First Ln",
-      "city": "Place",
-      "state": "AL",
-      "zip_code": "12345"
-    },
-    "phone_number": "5555555555",
-    "dob": "1980-01-01",
-    "checkifnew": true
-  },
-  "sponsor": {
-    "full_name": {
-      "first": "Sponsor",
-      "middle": "B",
-      "last": "Surname"
+  "primary_contact_info": {
+    "name": {
+      "first": "GI",
+      "last": "Joe"
     }
   },
-  "insurance_1": "Insurance 1",
-  "insurance_2": "Insurance 2",
-  "insurance_1_policy": "123456789",
-  "insurance_2_policy": "987654321",
-  "insurance_1_phone": "5555555555",
-  "insurance_2_phone": "5555555555",
-  "WorkRelatedTreat": true,
-  "OutsdWrkAccdnt": true,
-  "RadioButtonList": false,
-  "SpecifyOtherPrimaryHealthInsurance": "Other Primary Health Insurance",
-  "PtntCverage": true,
-  "signatureperson": {
-    "full_name": {
-      "first": "Veteran",
-      "last": "Surname",
-      "middle": "B"
+  "applicant_dob": "11/18/2001",
+  "applicant_phone": "215-355-5555",
+  "applicant_address": {
+    "country": "USA",
+    "street": "123 Street Road",
+    "city": "Philadelphia",
+    "state": "PA",
+    "postal_code": "19020"
+  },
+  "applicant_new_address": "",
+  "applicant_member_number": "12345678",
+  "applicant_name": {
+    "first": "GI",
+    "last": "Joe"
+  },
+  "sponsor_name": {
+    "first": "GI",
+    "last": "Joe"
+  },
+  "policies": [
+    {
+      "name": "Michael",
+      "provider_phone": "215-355-5555",
+      "policy_num": "12345"
     },
-    "relationshipToApplicant": "Self",
-    "address": {
+    {
+      "name": "Jordan",
+      "provider_phone": "215-355-5555",
+      "policy_num": "54321"
+    }
+  ],
+  "claim_is_auto_related": false,
+  "claim_is_work_related": false,
+  "claim_type": "FILTERED",
+  "has_ohi": false,
+  "certifier_relationship": "other",
+  "certifier_name": {
+    "first": "Veteran",
+    "last": "Surname",
+    "middle": "B"
+    },
+    "certifier_address": {
       "country": "USA",
       "street": "1 First Ln",
       "city": "Place",
       "state": "AL",
       "zip_code": "12345"
     },
-    "phone_number": "5555555555"
-  }
+    "certifier_phone": "5555555555",
+    "certification_date": "10/31/2000",
+  "statement_of_truth_signature": "GI Joe"
 }

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe IvcChampva::VHA107959a do
         'source' => 'VA Platform Digital Forms',
         'docType' => '10-7959A',
         'ssn_or_tin' => '123456789',
-        'member_number' => '123456789',
+        'fileNumber' => '123456789',
         'businessLine' => 'CMP',
         'primaryContactInfo' => {
           'name' => {

--- a/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
@@ -7,14 +7,17 @@ RSpec.describe 'Forms uploader', type: :request do
   form_numbers_and_classes = {
     '10-10D' => IvcChampva::VHA1010d,
     '10-7959C' => IvcChampva::VHA107959c,
-    '10-7959F-2' => IvcChampva::VHA107959f2
+    '10-7959F-2' => IvcChampva::VHA107959f2,
+    '10-7959F-1' => IvcChampva::VHA107959f1,
+    '10-7959A' => IvcChampva::VHA107959a
   }
 
   forms = [
     'vha_10_10d.json',
     'vha_10_7959f_1.json',
     'vha_10_7959f_2.json',
-    'vha_10_7959c.json'
+    'vha_10_7959c.json',
+    'vha_10_7959a.json'
   ]
 
   before do


### PR DESCRIPTION
10-7959A wasn't properly mapped to the right JSON from the form.

## Summary

- Update mapping logic to avoid errors if something is missing
- Update JSON fixture
- Add 10-7959A to uploads_spec
- Add form number to pdf_stamper
- Add stamping coords for signature and date

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90056#issuecomment-2276926941

## Screenshot
<img width="610" alt="Screenshot 2024-08-09 at 4 49 51 PM" src="https://github.com/user-attachments/assets/4a85dbab-b324-4a24-a746-bfa5cac95c41">
