### PR TITLE
Add VAOS logging for appointment creation time

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -24,6 +24,7 @@ module VAOS
             appt[:location] = FACILITY_ERROR_MSG
           end
           scrape_appt_comments_and_log_details(appt, index_method_logging_name, PAP_COMPLIANCE_TELE)
+          log_appt_creation_time(appt)
         end
 
         serializer = VAOS::V2::VAOSSerializer.new
@@ -51,6 +52,7 @@ module VAOS
         add_location(appointment)
 
         scrape_appt_comments_and_log_details(appointment, show_method_logging_name, PAP_COMPLIANCE_TELE)
+        log_appt_creation_time(appointment)
 
         serializer = VAOS::V2::VAOSSerializer.new
         serialized = serializer.serialize(appointment, 'appointments')
@@ -169,6 +171,16 @@ module VAOS
                                                                                                      comment_content,
                                                                                                      field_name) }
         Rails.logger.info("Details for #{comment_key} appointment", appt_comment_data_entry.to_json)
+      end
+
+      def log_appt_creation_time(appt)
+        if appt.nil? || appt[:created].nil?
+          Rails.logger.info('VAOS::V2::AppointmentsController appointment creation time: unknown')
+        else
+          creation_time = appt[:created]
+          Rails.logger.info("VAOS::V2::AppointmentsController appointment creation time: #{creation_time}",
+                            { created: creation_time }.to_json)
+        end
       end
 
       def appt_comment_log_details(appt, appt_method, comment_content, field_name)

--- a/modules/vaos/spec/request/v2/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/v2/appointments_request_spec.rb
@@ -640,6 +640,7 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
         it 'has access and returns appointment - va proposed' do
           VCR.use_cassette('vaos/v2/appointments/get_appointment_200_with_facility_200',
                            match_requests_on: %i[method path query]) do
+            allow(Rails.logger).to receive(:info).at_least(:once)
             get '/vaos/v2/appointments/70060', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -648,6 +649,10 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
             expect(data['id']).to eq('70060')
             expect(data['attributes']['kind']).to eq('clinic')
             expect(data['attributes']['status']).to eq('proposed')
+            expect(Rails.logger).to have_received(:info).with(
+              'VAOS::V2::AppointmentsController appointment creation time: 2021-12-13T14:03:02Z',
+              { created: '2021-12-13T14:03:02Z' }.to_json
+            )
           end
         end
 
@@ -659,6 +664,7 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
             stub_clinics
             VCR.use_cassette('vaos/v2/appointments/get_appointment_200_no_avs',
                              match_requests_on: %i[method path query]) do
+              allow(Rails.logger).to receive(:info).at_least(:once)
               get '/vaos/v2/appointments/192308', headers: inflection_header
               expect(response).to have_http_status(:ok)
               expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -666,6 +672,10 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
 
               expect(data['id']).to eq('192308')
               expect(data['attributes']['avsPath']).to be_nil
+              expect(Rails.logger).to have_received(:info).with(
+                'VAOS::V2::AppointmentsController appointment creation time: 2023-11-01T00:00:00Z',
+                { created: '2023-11-01T00:00:00Z' }.to_json
+              )
             end
           end
         end
@@ -675,6 +685,7 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
                            match_requests_on: %i[method path query]) do
             allow_any_instance_of(VAOS::V2::MobilePPMSService).to \
               receive(:get_provider_with_cache).with('1407938061').and_return(provider_response)
+            allow(Rails.logger).to receive(:info).at_least(:once)
             get '/vaos/v2/appointments/81063', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -684,12 +695,17 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
             expect(data['attributes']['kind']).to eq('cc')
             expect(data['attributes']['status']).to eq('proposed')
             expect(data['attributes']['preferredProviderName']).to eq('DEHGHAN, AMIR')
+            expect(Rails.logger).to have_received(:info).with(
+              'VAOS::V2::AppointmentsController appointment creation time: 2022-02-22T21:46:00Z',
+              { created: '2022-02-22T21:46:00Z' }.to_json
+            )
           end
         end
 
         it 'has access and returns appointment - cc booked' do
           VCR.use_cassette('vaos/v2/appointments/get_appointment_200_JACQUELINE_M_BOOKED_with_facility_200',
                            match_requests_on: %i[method path query]) do
+            allow(Rails.logger).to receive(:info).at_least(:once)
             get '/vaos/v2/appointments/72106', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -698,6 +714,10 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
             expect(data['id']).to eq('72106')
             expect(data['attributes']['kind']).to eq('cc')
             expect(data['attributes']['status']).to eq('booked')
+            expect(Rails.logger).to have_received(:info).with(
+              'VAOS::V2::AppointmentsController appointment creation time: 2022-01-10T22:02:08Z',
+              { created: '2022-01-10T22:02:08Z' }.to_json
+            )
           end
         end
 
@@ -708,6 +728,7 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
             .and_return(service_name: 'Service Name', physical_location: 'Physical Location')
           allow_any_instance_of(VAOS::V2::MobileFacilityService).to receive(:get_facility).and_return('Location')
           allow_any_instance_of(described_class).to receive(:appointment).and_return(appointment)
+          allow(Rails.logger).to receive(:info).at_least(:once)
 
           get '/vaos/v2/appointments/70060', headers: inflection_header
 
@@ -716,6 +737,9 @@ RSpec.describe VAOS::V2::AppointmentsController, :skip_mvi, type: :request do
           expect(data['physicalLocation']).to eq('Physical Location')
           expect(data['friendlyName']).to eq('Service Name')
           expect(data['location']).to eq('Location')
+          expect(Rails.logger).to have_received(:info).with(
+            'VAOS::V2::AppointmentsController appointment creation time: unknown'
+          )
         end
       end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change adds logging for appointment creation time so we can track how regularly pre v2 appointments are being retrieved.
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88580

## Testing done

- [x] *New code is covered by unit tests*
- The new logs are covered up updating existing unit tests

## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

@cferris32 I'm curious about whether this format of the logs is acceptable and if additional tests should be added.
