### PR TITLE
90041 Remove date of birth from 10-7959c test data - form 10-7959c

### DIFF
--- a/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959c.json
+++ b/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959c.json
@@ -13,7 +13,6 @@
     "middle": "I",
     "last": "Surname"
   },
-  "applicant_dob": "1958-01-01",
   "applicant_address": {
     "country": "USA",
     "street": "456 Street Circle",


### PR DESCRIPTION
## Summary

This PR removes the applicant date of birth test data property from a form 10-7959c mock data file. This property is no longer collected on the frontend (see [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/31333)), so we don't need it in our dummy data.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/31333
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90041

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA