### PR TITLE
Allow travel pay claims with null appointment date values, remove cla…

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/service.rb
+++ b/modules/travel_pay/app/services/travel_pay/service.rb
@@ -5,12 +5,9 @@ module TravelPay
     def get_claims(current_user)
       claims_response = client.get_claims(current_user)
       symbolized_body = claims_response.body.deep_symbolize_keys
-      parse_claim_date = ->(c) { Date.parse(c[:appointmentDateTime]) }
-
-      sorted_claims = symbolized_body[:data].sort_by(&parse_claim_date).reverse
 
       {
-        data: sorted_claims.map do |sc|
+        data: symbolized_body[:data].map do |sc|
           sc[:claimStatus] = sc[:claimStatus].underscore.titleize
           sc
         end

--- a/modules/travel_pay/spec/services/service_spec.rb
+++ b/modules/travel_pay/spec/services/service_spec.rb
@@ -62,16 +62,13 @@ describe TravelPay::Service do
     end
 
     it 'returns sorted and parsed claims' do
-      expected_ordered_ids = %w[uuid1 uuid2 uuid3 uuid4]
       expected_statuses = ['In Progress', 'In Progress', 'Incomplete', 'Claim Submitted']
 
       service = TravelPay::Service.new
       claims = service.get_claims(user)
-      actual_claim_ids = claims[:data].pluck(:id)
       actual_statuses = claims[:data].pluck(:claimStatus)
 
-      expect(actual_claim_ids).to eq(expected_ordered_ids)
-      expect(actual_statuses).to eq(expected_statuses)
+      expect(actual_statuses).to match_array(expected_statuses)
     end
   end
 end

--- a/modules/travel_pay/spec/services/service_spec.rb
+++ b/modules/travel_pay/spec/services/service_spec.rb
@@ -34,6 +34,16 @@ describe TravelPay::Service do
             'facilityName' => 'Cheyenne VA Medical Center',
             'createdOn' => '2024-01-22T21:22:34.465Z',
             'modifiedOn' => '2024-02-01T00:00:00.0Z'
+          },
+          {
+            'id' => 'uuid4',
+            'claimNumber' => '73611905-71bf-46ed-b1ec-e790593b8565',
+            'claimName' => '9d81c1a1-cd05-47c6-be97-d14dec579893',
+            'claimStatus' => 'Claim Submitted',
+            'appointmentDateTime' => nil,
+            'facilityName' => 'Tomah VA Medical Center',
+            'createdOn' => '2023-12-29T22:00:57.915Z',
+            'modifiedOn' => '2024-01-03T22:00:57.915Z'
           }
         ]
       }
@@ -52,8 +62,8 @@ describe TravelPay::Service do
     end
 
     it 'returns sorted and parsed claims' do
-      expected_ordered_ids = %w[uuid2 uuid3 uuid1]
-      expected_statuses = ['In Progress', 'Incomplete', 'In Progress']
+      expected_ordered_ids = %w[uuid1 uuid2 uuid3 uuid4]
+      expected_statuses = ['In Progress', 'In Progress', 'Incomplete', 'Claim Submitted']
 
       service = TravelPay::Service.new
       claims = service.get_claims(user)

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -41,6 +41,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<LIGHTHOUSE_BENEFITS_EDUCATION_CLIENT_ID>') do
     Settings.lighthouse.benefits_education.client_id
   end
+  c.filter_sensitive_data('<VEIS_AUTH_URL>') { Settings.travel_pay.veis.auth_url }
 
   c.before_record do |i|
     %i[response request].each do |env|

--- a/spec/support/vcr_cassettes/travel_pay/200_claims.yml
+++ b/spec/support/vcr_cassettes/travel_pay/200_claims.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.veis.gov/tenant_id/oauth2/token
+    uri: "<VEIS_AUTH_URL>/tenant_id/oauth2/token"
     body:
       encoding: US-ASCII
       string: 'client_id=client_id&client_secret=client_secret&client_info=1&grant_type=client_credentials&resource=resource_id'

--- a/spec/support/vcr_cassettes/travel_pay/200_claims.yml
+++ b/spec/support/vcr_cassettes/travel_pay/200_claims.yml
@@ -179,7 +179,7 @@ http_interactions:
             "modifiedOn": "2024-04-23T16:44:34.465Z"
           },
           {
-            "id": "claim_id_3",
+            "id": "claim_id_2",
             "claimNumber": "TC0928098228366",
             "claimStatus": "Incomplete",
             "appointmentDateTime": "2024-04-09T20:15:34.465Z",
@@ -188,7 +188,7 @@ http_interactions:
             "modifiedOn": "2024-04-09T20:29:34.465Z"
           },
           {
-            "id": "claim_id_2",
+            "id": "claim_id_3",
             "claimNumber": "TC092809828275",
             "claimStatus": "InManualReview",
             "appointmentDateTime": "2024-04-13T20:30:34.465Z",

--- a/spec/support/vcr_cassettes/travel_pay/404_claims.yml
+++ b/spec/support/vcr_cassettes/travel_pay/404_claims.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.veis.gov/tenant_id/oauth2/token
+    uri: "<VEIS_AUTH_URL>/tenant_id/oauth2/token"
     body:
       encoding: US-ASCII
       string: 'client_id=client_id&client_secret=client_secret&client_info=1&grant_type=client_credentials&resource=resource_id'

--- a/spec/support/vcr_cassettes/travel_pay/auth_ping.yml
+++ b/spec/support/vcr_cassettes/travel_pay/auth_ping.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.veis.gov/tenant_id/oauth2/token
+    uri: "<VEIS_AUTH_URL>/tenant_id/oauth2/token"
     body:
       encoding: US-ASCII
       string: 'client_id=client_id&client_secret=client_secret&client_info=1&grant_type=client_credentials&resource=resource_id'

--- a/spec/support/vcr_cassettes/travel_pay/ping.yml
+++ b/spec/support/vcr_cassettes/travel_pay/ping.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.veis.gov/tenant_id/oauth2/token
+    uri: "<VEIS_AUTH_URL>/tenant_id/oauth2/token"
     body:
       encoding: US-ASCII
       string: 'client_id=client_id&client_secret=client_secret&client_info=1&grant_type=client_credentials&resource=resource_id'


### PR DESCRIPTION
…im sorting


## Summary

Travel pay claims with `null` `appointmentDateTime` were causing errors when sorting in the `get_claims` method. This PR allows such claims to pass through. Sorting claims is already being done in the frontend, so sorting claims here is redundant.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89328

## Testing done

- [x] *New code is covered by unit tests*
- Travel pay claims shown in frontend (https://github.com/department-of-veterans-affairs/vets-website/pull/31348)

## Screenshots
![Screenshot 2024-08-12 at 1 25 56 PM](https://github.com/user-attachments/assets/1b2d9c00-9150-44bf-a2b6-5f1f40281344)
