### PR TITLE
remove shoulda-matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -185,7 +185,6 @@ group :test do
   gem 'rspec-sidekiq'
   gem 'rubocop-junit-formatter'
   gem 'rufus-scheduler'
-  gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'super_diff'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -974,8 +974,6 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shellany (0.0.1)
-    shoulda-matchers (6.3.0)
-      activesupport (>= 5.2.0)
     shrine (3.6.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
@@ -1261,7 +1259,6 @@ DEPENDENCIES
   savon
   seedbank
   sentry-ruby
-  shoulda-matchers
   shrine
   sidekiq (~> 7.2.0)
   sidekiq-ent!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -197,10 +197,3 @@ BGS.configure do |config|
 end
 
 Gem::Deprecate.skip = true
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
-  end
-end


### PR DESCRIPTION
## Summary

- This gem does not appear to be used anywhere, so it should be removed
- Remove `shoulda-matchers` gem
- Remove `Shoulda::Matchers` configuration

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90460

## Testing done

- [ ] run all tests

## Acceptance criteria

- [ ]  All tests pass