### PR TITLE
VI-35 Update sidekiq to provide unique ToU requests

### DIFF
--- a/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
+++ b/app/sidekiq/terms_of_use/sign_up_service_updater_job.rb
@@ -9,7 +9,7 @@ module TermsOfUse
 
     LOG_TITLE = '[TermsOfUse][SignUpServiceUpdaterJob]'
 
-    sidekiq_options retry_for: 48.hours
+    sidekiq_options(unique_for: 4.minutes, retry_for: 5.minutes)
 
     sidekiq_retries_exhausted do |job, exception|
       user_account = UserAccount.find_by(id: job['args'].first)

--- a/spec/sidekiq/terms_of_use/sign_up_service_updater_job_spec.rb
+++ b/spec/sidekiq/terms_of_use/sign_up_service_updater_job_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe TermsOfUse::SignUpServiceUpdaterJob, type: :job do
       allow(MPI::Service).to receive(:new).and_return(mpi_service)
     end
 
-    it 'retries for 47 hours after failure' do
-      expect(described_class.get_sidekiq_options['retry_for']).to eq(48.hours)
+    it 'retries for 1 minute after failure' do
+      expect(described_class.get_sidekiq_options['retry_for']).to eq(5.minutes)
     end
 
     context 'when retries have been exhausted' do
@@ -50,7 +50,7 @@ RSpec.describe TermsOfUse::SignUpServiceUpdaterJob, type: :job do
 
       before do
         allow(Rails.logger).to receive(:warn)
-        Timecop.travel(47.hours.from_now)
+        Timecop.travel(241.seconds.from_now)
       end
 
       context 'when the attr_package is found' do


### PR DESCRIPTION
## Summary

- This PR updates the terms of use agreements/decline within the sign up service to only allow one sidekiq request for to be queued for the the SignUpServiceUpdaterJob.

## Related issue(s)

- There is a [front-end ticket](https://jira.devops.va.gov/browse/VI-211) to prevent a user from clicking the agree/decline button multiple times.
- This PR's [ticket](https://jira.devops.va.gov/browse/VI-35).

## Testing done

- [ ] Without code changes, confirmed that multiple jobs could be queued.
- [ ] Made sure only one sidekiq job was queued with changes by modifying `sidekiq_options`.
- [ ] Without code changes, confirmed that multiple jobs could be queued.
- [ ] Tested frontend portion of recreating a repeated button click by copying the `/accept` request from the network tab as curl and submitting that several times in a local terminal.

## Screenshots
This is a SS of the queue without this PR's changes when submitting 3 requests within 5 seconds.
![image](https://github.com/user-attachments/assets/803a0e16-955c-4f81-a87f-738fccf9a662)

This is a SS of the queue with the PR's changes when submitting 3 requests within 5 seconds.
![image](https://github.com/user-attachments/assets/289450e3-e3e3-4c9f-842b-d81d6b25900b)


## What areas of the site does it impact?
- Terms of Use

## Acceptance criteria

- [ ]  You will need a user from the mockdata table [here](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/vagov-users/test_users.md). I just used one of the first ones in the table.
- [ ]  Set line 13 in `config/initializers/sidekiq.rb` to allow for local development testing.
- [ ]  In `app/sidekiq/terms_of_use/sign_up_service_updater_job.rb` add `sleep(30.seconds)` in the `accept` method before the service code.
- [ ]  Start `vets-api` `vets-website` locally. For `vets-api` you'll need to start a sidekiq container to test.
- [ ]  We want to test for multiple sidekiq requests for an accept/decline from the SignUpServiceUpdaterJob to make sure that before we apply the changes.
- [ ]  Open a rails console. Set a `user = UserAccount.find("29bf2f0d-61d3-46e4-a0db-331b45c1d069")`
- [ ]  Run `TermsOfUse::Acceptor.new(user_account: user, version: 'v1').perform!` several times (I did like 3 times within 5 seconds). You shouldn't see 3 jobs queued [here](http://localhost:3000/sidekiq/busy) with the new changes. You should only see one.
- [ ]  To test the bug, remove this PR's changes and do the above 2 bullets again (but keep the time delay fro the accept action and the testing env addition for the sidekiq config; it should just be removing the `unique_for` portion). After doing this, you should see however many requests pop into the [sidekiq](http://localhost:3000/sidekiq/busy) tab.

## Requested Feedback
- Are there any opinions on if this should be done another way?
