### PR TITLE
89625 add mapping for LoROTA 403 exceptions

### DIFF
--- a/modules/check_in/config/locales/exceptions.en.yml
+++ b/modules/check_in/config/locales/exceptions.en.yml
@@ -27,6 +27,13 @@ en:
         detail: 'Authentication Error'
         status: 401
         sentry_type: none
+      LOROTA-API_403:
+        <<: *external_defaults
+        title: Data has expired
+        code: 'LOROTA-API_403'
+        detail: 'Data has expired'
+        status: 403
+        sentry_type: none
       CIE-VETS-API_404:
         <<: *external_defaults
         title: Data Not Found


### PR DESCRIPTION
## Summary
We see quite a few 403 'data has expired' errors from LoROTA, mostly stemming from the fact that the veteran sat on the page too long after logging in. LoROTA expires the entry after some time and returns a 403 in this case. We don't want to log this to sentry as there's no action to be taken on our end.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/89625

## Testing done
- [x] all specs pass
- [x] validated locally with vets-website as well 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
