### PR TITLE
API-38962-hardocode-VnpProcServiceV2 

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -223,6 +223,37 @@ module ClaimsApi
             )
         end
       end
+
+      ##
+      # VnpProcWebServiceBeanV2
+      #
+      module VnpProcWebServiceBeanV2
+        DEFINITION =
+          Bean.new(
+            path: 'VnpProcWebServiceBeanV2',
+            namespaces: Namespaces.new(
+              target: 'http://procService.services.v2.vonapp.vba.va.gov/',
+              data: nil
+            )
+          )
+      end
+
+      module VnpProcServiceV2
+        DEFINITION =
+          Service.new(
+            bean: VnpProcWebServiceBeanV2::DEFINITION,
+            path: 'VnpProcServiceV2'
+          )
+
+        module VnpProcCreate
+          DEFINITION =
+            Action.new(
+              service: VnpProcServiceV2::DEFINITION,
+              name: 'vnpProcCreate',
+              key: 'return'
+            )
+        end
+      end
     end
   end
 end

--- a/modules/claims_api/lib/bgs_service/local_bgs.rb
+++ b/modules/claims_api/lib/bgs_service/local_bgs.rb
@@ -14,7 +14,8 @@ require 'bgs_service/local_bgs_refactored'
 
 module ClaimsApi
   class LocalBGS
-    CACHED_SERVICES = %w[ClaimantServiceBean/ClaimantWebService].freeze
+    CACHED_SERVICES = %w[ClaimantServiceBean/ClaimantWebService
+                         VnpProcWebServiceBeanV2/VnpProcServiceV2].freeze
 
     # rubocop:disable Metrics/MethodLength
     def initialize(external_uid:, external_key:)

--- a/modules/claims_api/spec/lib/claims_api/find_definitions_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/find_definitions_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'bgs_service/local_bgs_refactored/find_definition'
+
+describe ClaimsApi::LocalBGSRefactored::FindDefinition do
+  subject { described_class }
+
+  before do
+    Flipper.disable(:lighthouse_claims_api_hardcode_wsdl)
+  end
+
+  describe '#for_action' do
+    context 'hardcoded WSDL' do
+      before do
+        Flipper.enable(:lighthouse_claims_api_hardcode_wsdl)
+      end
+
+      context 'VnpProcWebServiceBeanV2' do
+        let(:endpoint) { 'VnpProcWebServiceBeanV2/VnpProcServiceV2' }
+        let(:action) { 'vnpProcCreate' }
+        let(:key) { 'return' }
+
+        it 'response with the correct attributes' do
+          result = subject.for_action(endpoint, action)
+          parsed_result = JSON.parse(result.to_json)
+          expect(parsed_result['service']['bean']['path']).to eq 'VnpProcWebServiceBeanV2'
+          expect(parsed_result['service']['path']).to eq 'VnpProcServiceV2'
+          expect(parsed_result['service']['bean']['namespaces']['target']).to eq 'http://procService.services.v2.vonapp.vba.va.gov/'
+        end
+      end
+    end
+  end
+
+  describe '#for_service' do
+    context 'hardcoded WSDL' do
+      before do
+        Flipper.enable(:lighthouse_claims_api_hardcode_wsdl)
+      end
+
+      context 'VnpProcWebServiceBeanV2' do
+        let(:endpoint) { 'VnpProcWebServiceBeanV2/VnpProcServiceV2' }
+
+        it 'response with the correct namespace' do
+          result = subject.for_service(endpoint)
+          parsed_result = JSON.parse(result.to_json)
+          expect(parsed_result['bean']['path']).to eq 'VnpProcWebServiceBeanV2'
+          expect(parsed_result['path']).to eq 'VnpProcServiceV2'
+          expect(parsed_result['bean']['namespaces']['target']).to eq 'http://procService.services.v2.vonapp.vba.va.gov/'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds VnpProcServiceV2 to definitions. 
- Adds VnpProcServiceV2 to cached_services. 
- Adds tests for VnpProcServiceV2

## Related issue(s)

- [API-38962](https://jira.devops.va.gov/browse/API-38962)

## Testing done

- [X] *New code is covered by unit tests*
- rails c
```
@ssl_verify_mode =
if Settings.bgs.ssl_verify_mode == 'none'
OpenSSL::SSL::VERIFY_NONE
else
OpenSSL::SSL::VERIFY_PEER
end

ClaimsApi::LocalBGS.new(external_uid:'a', external_key:'b').fetch_namespace(Faraday::Connection.new(ssl: { verify_mode: @ssl_verify_mode }), 'VnpProcWebServiceBeanV2/VnpProcServiceV2
')
```


## What areas of the site does it impact?
	modified:   modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
	modified:   modules/claims_api/lib/bgs_service/local_bgs.rb
	new file:   modules/claims_api/spec/lib/claims_api/find_definitions_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature