### PR TITLE
Move Appointments minutes duration to service

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -99,7 +99,7 @@ module Mobile
             healthcare_service: nil, # set to nil until we decide what the purpose of this field was meant to be
             location:,
             physical_location: appointment[:physical_location],
-            minutes_duration: minutes_duration(appointment[:minutes_duration]),
+            minutes_duration: appointment[:minutes_duration],
             phone_only: appointment[:kind] == PHONE_KIND,
             start_date_local:,
             start_date_utc:,
@@ -448,13 +448,6 @@ module Mobile
           else
             appointment.dig(:extension, :cc_location, :practice_name)
           end
-        end
-
-        def minutes_duration(minutes_duration)
-          # not in raw data, matches va.gov default for cc appointments
-          return 60 if appointment_type == APPOINTMENT_TYPES[:cc] && minutes_duration.nil?
-
-          minutes_duration
         end
 
         def va_appointment?

--- a/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
+++ b/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
@@ -144,6 +144,7 @@
     "location_id":"984",
     "start":"2022-01-11T15:00:00Z",
     "created":"2022-01-10T22:02:08Z",
+    "minutes_duration": 60,
     "cancellation_reason":{
       "code":"other"
     },
@@ -205,6 +206,7 @@
     "service_type":"primaryCare",
     "patient_icn":"1012846043V576341",
     "location_id":"984",
+    "minutes_duration": 60,
     "practitioners":[
 
     ],

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -22,10 +22,9 @@ module VAOS
 
       # rubocop:disable Metrics/MethodLength
       def get_appointments(start_date, end_date, statuses = nil, pagination_params = {}, include = {})
-        params = date_params(start_date, end_date)
-                 .merge(page_params(pagination_params))
-                 .merge(status_params(statuses))
-                 .compact
+        params = date_params(start_date, end_date).merge(page_params(pagination_params))
+                                                  .merge(status_params(statuses))
+                                                  .compact
 
         cnp_count = 0
 
@@ -105,7 +104,6 @@ module VAOS
       end
 
       # rubocop:enable Metrics/MethodLength
-
       def update_appointment(appt_id, status)
         with_monitoring do
           if Flipper.enabled?(ORACLE_HEALTH_CANCELLATIONS, user) &&
@@ -217,6 +215,8 @@ module VAOS
         convert_appointment_time(appointment)
 
         appointment[:station], appointment[:ien] = extract_station_and_ien(appointment)
+
+        appointment[:minutes_duration] ||= 60 if appointment[:appointment_type] == 'COMMUNITY_CARE'
 
         if avs_applicable?(appointment) && Flipper.enabled?(AVS_FLIPPER, user)
           fetch_avs_and_update_appt_body(appointment)


### PR DESCRIPTION
## Summary
We are relocating another piece of business logic to the appointments service. Web doesn't currently use this field, so the new schema should not affect them

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9208

## Testing done
Existing tests cover the change

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
