### PR TITLE
89790: Populate metadata for DR SavedClaim records

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -23,10 +23,11 @@ module DecisionReview
         status = response.dig('data', 'attributes', 'status')
         attributes = response.dig('data', 'attributes')
 
-        params = { metadata: attributes.to_json, metadata_updated_at: DateTime.now }
+        timestamp = DateTime.now
+        params = { metadata: attributes.to_json, metadata_updated_at: timestamp }
 
         if SUCCESSFUL_STATUS.include? status
-          params[:delete_date] = DateTime.now + RETENTION_PERIOD
+          params[:delete_date] = timestamp + RETENTION_PERIOD
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
 

--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -19,13 +19,23 @@ module DecisionReview
 
       higher_level_reviews.each do |hlr|
         guid = hlr.guid
-        status = decision_review_service.get_higher_level_review(guid).dig('data', 'attributes', 'status')
+        response = decision_review_service.get_higher_level_review(guid)
+        status = response.dig('data', 'attributes', 'status')
+        attributes = response.dig('data', 'attributes')
+
+        params = { metadata: attributes.to_json, metadata_updated_at: DateTime.now }
 
         if SUCCESSFUL_STATUS.include? status
-          hlr.update(delete_date: DateTime.now + RETENTION_PERIOD)
+          params[:delete_date] = DateTime.now + RETENTION_PERIOD
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
+
+        hlr.update(params)
+      rescue => e
+        Rails.logger.error('DecisionReview::SavedClaimHlrStatusUpdaterJob error', { guid:, message: e.message })
       end
+
+      nil
     end
 
     private

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -23,10 +23,11 @@ module DecisionReview
         status = response.dig('data', 'attributes', 'status')
         attributes = response.dig('data', 'attributes')
 
-        params = { metadata: attributes.to_json, metadata_updated_at: DateTime.now }
+        timestamp = DateTime.now
+        params = { metadata: attributes.to_json, metadata_updated_at: timestamp }
 
         if SUCCESSFUL_STATUS.include? status
-          params[:delete_date] = DateTime.now + RETENTION_PERIOD
+          params[:delete_date] = timestamp + RETENTION_PERIOD
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
 

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -19,14 +19,23 @@ module DecisionReview
 
       supplemental_claims.each do |sc|
         guid = sc.guid
-        status = decision_review_service.get_supplemental_claim(guid).dig('data', 'attributes', 'status')
+        response = decision_review_service.get_supplemental_claim(guid)
+        status = response.dig('data', 'attributes', 'status')
+        attributes = response.dig('data', 'attributes')
 
-        # check status of SC and update delete_date
+        params = { metadata: attributes.to_json, metadata_updated_at: DateTime.now }
+
         if SUCCESSFUL_STATUS.include? status
-          sc.update(delete_date: DateTime.now + RETENTION_PERIOD)
+          params[:delete_date] = DateTime.now + RETENTION_PERIOD
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
+
+        sc.update(params)
+      rescue => e
+        Rails.logger.error('DecisionReview::SavedClaimScStatusUpdaterJob error', { guid:, message: e.message })
       end
+
+      nil
     end
 
     private

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -23,10 +23,11 @@ module DecisionReview
         status = response.dig('data', 'attributes', 'status')
         attributes = response.dig('data', 'attributes')
 
-        params = { metadata: attributes.to_json, metadata_updated_at: DateTime.now }
+        timestamp = DateTime.now
+        params = { metadata: attributes.to_json, metadata_updated_at: timestamp }
 
         if SUCCESSFUL_STATUS.include? status
-          params[:delete_date] = DateTime.now + RETENTION_PERIOD
+          params[:delete_date] = timestamp + RETENTION_PERIOD
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
 

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -56,9 +56,13 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
 
             claim1 = SavedClaim::HigherLevelReview.find_by(guid: guid1)
             expect(claim1.delete_date).to eq frozen_time + 59.days
+            expect(claim1.metadata).to include 'complete'
+            expect(claim1.metadata_updated_at).to eq frozen_time
 
             claim2 = SavedClaim::HigherLevelReview.find_by(guid: guid2)
             expect(claim2.delete_date).to be_nil
+            expect(claim2.metadata).to include 'pending'
+            expect(claim2.metadata_updated_at).to eq frozen_time
           end
         end
       end

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -56,9 +56,13 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
 
             claim1 = SavedClaim::NoticeOfDisagreement.find_by(guid: guid1)
             expect(claim1.delete_date).to eq frozen_time + 59.days
+            expect(claim1.metadata).to include 'complete'
+            expect(claim1.metadata_updated_at).to eq frozen_time
 
             claim2 = SavedClaim::NoticeOfDisagreement.find_by(guid: guid2)
             expect(claim2.delete_date).to be_nil
+            expect(claim2.metadata).to include 'pending'
+            expect(claim2.metadata_updated_at).to eq frozen_time
           end
         end
       end

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -56,9 +56,13 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
 
             claim1 = SavedClaim::SupplementalClaim.find_by(guid: guid1)
             expect(claim1.delete_date).to eq frozen_time + 59.days
+            expect(claim1.metadata).to include 'complete'
+            expect(claim1.metadata_updated_at).to eq frozen_time
 
             claim2 = SavedClaim::SupplementalClaim.find_by(guid: guid2)
             expect(claim2.delete_date).to be_nil
+            expect(claim2.metadata).to include 'pending'
+            expect(claim2.metadata_updated_at).to eq frozen_time
           end
         end
       end


### PR DESCRIPTION
## Summary

Updates scheduled jobs to set the `metadata` and `metadata_updated_at` values for DR `SavedClaim` records:
* `SavedClaim::HigherLevelReview`
* `SavedClaim::NoticeOfDisagreement`
* `SavedClaim::SupplementalClaim`

Adds error handling to better handle temporary issues with GET endpoints

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/89790
#17752

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
This PR impacts the `saved_claims` table and the associated sidekiq jobs run every hour

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
