### PR TITLE
Sign-in Service Configs: Ensure params match expected attributes  

### DIFF
--- a/app/controllers/sign_in/client_configs_controller.rb
+++ b/app/controllers/sign_in/client_configs_controller.rb
@@ -45,9 +45,11 @@ module SignIn
     private
 
     def client_config_params
-      params.require(:client_config).permit(:client_id, :authentication, :anti_csrf, :redirect_uri, :description,
-                                            :access_token_duration, :access_token_audience, :refresh_token_duration,
-                                            :logout_redirect_uri, :pkce, :refresh_token_path, certificates: [])
+      params.require(:client_config).permit(:client_id, :authentication, :redirect_uri, :refresh_token_duration,
+                                            :access_token_duration, :access_token_audience, :logout_redirect_uri,
+                                            :pkce, :terms_of_use_url, :enforced_terms, :shared_sessions, :anti_csrf,
+                                            :description, certificates: [], access_token_attributes: [],
+                                                          service_levels: [], credential_service_providers: [])
     end
 
     def set_client_config

--- a/spec/controllers/sign_in/client_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/client_configs_controller_spec.rb
@@ -113,4 +113,20 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
       end
     end
   end
+
+  describe 'permitted params' do
+    let(:client_config) { build(:client_config) }
+    let(:attributes) { client_config.attributes.symbolize_keys }
+
+    let(:expected_permitted_params) do
+      array_params, params = attributes.excluding(:id, :created_at, :updated_at)
+                                       .partition { |_, v| v.is_a?(Array) }
+      params.to_h.keys << array_params.to_h.transform_values { [] }
+    end
+
+    it 'returns the expected permitted params' do
+      expect(subject).to permit(*expected_permitted_params)
+        .for(:create, params: { client_config: attributes })
+    end
+  end
 end

--- a/spec/controllers/sign_in/service_account_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/service_account_configs_controller_spec.rb
@@ -175,4 +175,20 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
       end
     end
   end
+
+  describe 'permitted params' do
+    let(:service_account_config) { build(:service_account_config) }
+    let(:attributes) { service_account_config.attributes.symbolize_keys }
+
+    let(:expected_permitted_params) do
+      array_params, params = attributes.excluding(:id, :created_at, :updated_at)
+                                       .partition { |_, v| v.is_a?(Array) }
+      params.to_h.keys << array_params.to_h.transform_values { [] }
+    end
+
+    it 'permits the expected params' do
+      expect(subject).to permit(*expected_permitted_params)
+        .for(:create, params: { service_account_config: attributes })
+    end
+  end
 end


### PR DESCRIPTION
# Summary
 - Update ClientConfigsController permitted params to match database columns
 - Add tests to `ClientConfigsController` and `ServiceAccountConfigsController` to ensure permitted params match the expected columns

# Testing
## Setup
migrate and seed the database
- `rails db:migrate`
- `rails db:seed`

Start the server
- `rails s`
- start a rails console - `rails c`

Update the service account config used to request an access token
- `rails c`
```ruby
SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').update!(scopes: ['http://localhost:3000/sign_in/service_account_configs', 'http://localhost:3000/sign_in/client_configs'])
```

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/service_account_configs', 'http://localhost:3000/sign_in/client_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```

## Client Configs:
The response body should include everything you sent
### POST - Create
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    client_id: 'sample_client_config_new',
    description: 'Sample Client Config',
    authentication: 'cookie',
    redirect_uri: 'http://localhost:3000/sessions/callback',
    refresh_token_duration: 1800,
    access_token_duration: 300,
    logout_redirect_uri: 'http://localhost:3000/sessions/logout_callback',
    pkce: true,
    terms_of_use_url: 'http://localhost:3000/terms_of_use',
    enforced_terms: 'VA',
    shared_sessions: true,
    anti_csrf: true,
    certificates: ['certificate'],
    access_token_attributes: ['first_name', 'last_name'],
    service_levels: ['ial1', 'ial2'],
    credential_service_providers: ['logingov']
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

## Service Account Configs
The response body should include everything you sent

### POST - Create
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: ['http://localhost:3000'],
    certificates: ['certificate'],
    access_token_user_attributes: ['icn']
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

## What areas of the site does it impact?
Sign-in Service
