### PR TITLE
89790: Fix data extraction issue with DR status updater job

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -19,7 +19,7 @@ module DecisionReview
 
       higher_level_reviews.each do |hlr|
         guid = hlr.guid
-        response = decision_review_service.get_higher_level_review(guid)
+        response = decision_review_service.get_higher_level_review(guid).body
         status = response.dig('data', 'attributes', 'status')
         attributes = response.dig('data', 'attributes')
 

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -19,7 +19,7 @@ module DecisionReview
 
       notice_of_disagreements.each do |nod|
         guid = nod.guid
-        response = decision_review_service.get_notice_of_disagreement(guid)
+        response = decision_review_service.get_notice_of_disagreement(guid).body
         status = response.dig('data', 'attributes', 'status')
         attributes = response.dig('data', 'attributes')
 

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -19,7 +19,7 @@ module DecisionReview
 
       supplemental_claims.each do |sc|
         guid = sc.guid
-        response = decision_review_service.get_supplemental_claim(guid)
+        response = decision_review_service.get_supplemental_claim(guid).body
         status = response.dig('data', 'attributes', 'status')
         attributes = response.dig('data', 'attributes')
 

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
   let(:response_complete) do
     response = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('HLR-SHOW-RESPONSE-200_V2').to_json) # deep copy
     response['data']['attributes']['status'] = 'complete'
-    response
+    instance_double(Faraday::Response, body: response)
   end
 
   let(:response_pending) do
-    VetsJsonSchema::EXAMPLES.fetch 'HLR-SHOW-RESPONSE-200_V2'
+    instance_double(Faraday::Response, body: VetsJsonSchema::EXAMPLES.fetch('HLR-SHOW-RESPONSE-200_V2'))
   end
 
   before do

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
   let(:response_complete) do
     response = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('NOD-SHOW-RESPONSE-200_V2').to_json) # deep copy
     response['data']['attributes']['status'] = 'complete'
-    response
+    instance_double(Faraday::Response, body: response)
   end
 
   let(:response_pending) do
-    VetsJsonSchema::EXAMPLES.fetch 'NOD-SHOW-RESPONSE-200_V2'
+    instance_double(Faraday::Response, body: VetsJsonSchema::EXAMPLES.fetch('NOD-SHOW-RESPONSE-200_V2'))
   end
 
   before do

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
   let(:response_complete) do
     response = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-SHOW-RESPONSE-200_V2').to_json) # deep copy
     response['data']['attributes']['status'] = 'complete'
-    response
+    instance_double(Faraday::Response, body: response)
   end
 
   let(:response_pending) do
-    VetsJsonSchema::EXAMPLES.fetch 'SC-SHOW-RESPONSE-200_V2'
+    instance_double(Faraday::Response, body: VetsJsonSchema::EXAMPLES.fetch('SC-SHOW-RESPONSE-200_V2'))
   end
 
   before do


### PR DESCRIPTION
## Summary
This fixes a bug with extracting data from the response object returned from the `DecisionReviewV1::Service` GET methods. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/89790
#18026

## Testing done
- [x] *New code is covered by unit tests*
Tested locally and with rspec.

## What areas of the site does it impact?
This PR impacts the saved_claims table and the associated sidekiq jobs run every hour

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
