### PR TITLE
dbex/90091: beef up, refactor and test PollForm526Pdf

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -598,8 +598,8 @@ class Form526Submission < ApplicationRecord
   def poll_form526_pdf
     # In order to track the status of the 526 PDF upload via Lighthouse,
     # call poll_form526_pdf, provided we received a valid claim_id from Lighthouse
-    if saved_claim.parsed_form['startedFormVersion'].present?
-      Lighthouse::PollForm526Pdf.perform_async(id) if submitted_claim_id
+    if saved_claim.parsed_form['startedFormVersion'].present? && submitted_claim_id
+      Lighthouse::PollForm526Pdf.perform_async(id)
     end
   end
 

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -598,7 +598,9 @@ class Form526Submission < ApplicationRecord
   def poll_form526_pdf
     # In order to track the status of the 526 PDF upload via Lighthouse,
     # call poll_form526_pdf, provided we received a valid claim_id from Lighthouse
-    Lighthouse::PollForm526Pdf.perform_async(id) if id
+    if saved_claim.parsed_form['startedFormVersion'].present?
+      Lighthouse::PollForm526Pdf.perform_async(id) if submitted_claim_id
+    end
   end
 
   def cleanup

--- a/app/sidekiq/lighthouse/poll_form526_pdf.rb
+++ b/app/sidekiq/lighthouse/poll_form526_pdf.rb
@@ -112,7 +112,7 @@ module Lighthouse
             )
             return
           end
-          raise Lighthouse::PollForm526PdfError.new('Poll for form 526 PDF: Keep on retrying!')
+          raise Lighthouse::PollForm526PdfError, 'Poll for form 526 PDF: Keep on retrying!'
         end
       end
     end

--- a/app/sidekiq/lighthouse/poll_form526_pdf.rb
+++ b/app/sidekiq/lighthouse/poll_form526_pdf.rb
@@ -95,6 +95,7 @@ module Lighthouse
       with_tracking('Form526 Submission', submission.saved_claim_id, submission.id, submission.bdd?) do
         form526_pdf = get_form526_pdf(submission)
         if form526_pdf.present?
+          job_success
           Rails.logger.info('Poll for form 526 PDF: PDF found')
           return
         else
@@ -111,7 +112,7 @@ module Lighthouse
             )
             return
           end
-          raise PollForm526PdfError('Poll for form 526 PDF: Keep on retrying!')
+          raise Lighthouse::PollForm526PdfError.new('Poll for form 526 PDF: Keep on retrying!')
         end
       end
     end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -965,6 +965,10 @@ RSpec.describe Form526Submission do
 
         it 'queues polling job' do
           expect do
+            form = subject.saved_claim.parsed_form
+            form['startedFormVersion'] = '2022'
+            subject.update(submitted_claim_id: 1)
+            subject.saved_claim.update(form: form.to_json)
             subject.perform_ancillary_jobs(first_name)
           end.to change(Lighthouse::PollForm526Pdf.jobs, :size).by(1)
         end

--- a/spec/sidekiq/lighthouse/poll_form526_pdf_spec.rb
+++ b/spec/sidekiq/lighthouse/poll_form526_pdf_spec.rb
@@ -7,10 +7,59 @@ RSpec.describe Lighthouse::PollForm526Pdf, type: :job do
 
   before do
     Sidekiq::Job.clear_all
+    allow_any_instance_of(BenefitsClaims::Service).to receive(:get_claim)
+      .and_return({ 'data' => { 'attributes' => { 'supportingDocuments' => [] } } })
   end
 
   describe '.perform_async' do
-    let(:form526_submission) { create(:form526_submission) }
+    let(:form526_submission) { create(:form526_submission, submitted_claim_id: 1) }
+
+    it 'transitions to pdf_not_found status if submission is older than 2 days' do
+      form526_submission.update(created_at: 3.days.ago)
+      subject.perform_sync(form526_submission.id)
+      form526_submission.reload
+      job_status = form526_submission.form526_job_statuses.find_by(job_class: 'PollForm526Pdf')
+      job_status.reload
+      expect(job_status.status).to eq 'pdf_not_found'
+    end
+
+    it 'calls polling only for startedFormVersion present and does not retry because the form is there' do
+      allow_any_instance_of(BenefitsClaims::Service).to receive(:get_claim)
+        .and_return(
+          { 'data' =>
+              { 'attributes' =>
+                  { 'supportingDocuments' =>
+                      [{ 'documentTypeLabel' =>
+                           'VA 21-526 Veterans Application for Compensation or Pension' }] } } }
+        )
+      allow(Lighthouse::PollForm526Pdf).to receive(:perform_async).with(form526_submission.id).and_call_original
+
+      expect(Lighthouse::PollForm526Pdf).to receive(:perform_async).with(form526_submission.id)
+
+      form526_submission.send(:poll_form526_pdf)
+
+      expect do
+        Lighthouse::PollForm526Pdf.drain
+        job_status = form526_submission.form526_job_statuses.find_by(job_class: 'PollForm526Pdf')
+        job_status.reload
+        expect(job_status.status).to eq 'success'
+      end.not_to raise_error
+    end
+
+    it 'calls polling only for startedFormVersion present' do
+      allow(Lighthouse::PollForm526Pdf).to receive(:perform_async).with(form526_submission.id).and_call_original
+
+      expect(Lighthouse::PollForm526Pdf).to receive(:perform_async).with(form526_submission.id)
+
+      form526_submission.send(:poll_form526_pdf)
+
+      expect do
+        Lighthouse::PollForm526Pdf.drain
+        job_status = form526_submission.form526_job_statuses.find_by(job_class: 'PollForm526Pdf')
+        job_status.reload
+        expect(job_status.status).to eq 'try'
+      end.to raise_error(Lighthouse::PollForm526PdfError)
+    end
 
     context 'when all retries are exhausted' do
       let(:form526_job_status) { create(:form526_job_status, :poll_form526_pdf, form526_submission:, job_id: 1) }
@@ -24,17 +73,6 @@ RSpec.describe Lighthouse::PollForm526Pdf, type: :job do
         end
         form526_job_status.reload
         expect(form526_job_status.status).to eq 'pdf_not_found'
-      end
-
-      it 'transitions to pdf_not_found status if submission is older than 2 days' do
-        allow_any_instance_of(BenefitsClaims::Service).to receive(:get_claim)
-          .and_return({ 'data' => { 'attributes' => { 'supportingDocuments' => [] } } })
-        form526_submission.update(created_at: 3.days.ago)
-        subject.perform_sync(form526_submission.id)
-        form526_submission.reload
-        job_status = form526_submission.form526_job_statuses.find_by(job_class: 'PollForm526Pdf')
-        job_status.reload
-        expect(job_status.status).to eq 'pdf_not_found'
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- checks the correct parameters to call the Poll526Pdf job from the primary submission path

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#90091

## Testing done

- [x] *New code is covered by unit tests*
- make a form526submission record without `startedFormVersion` in the saved_claim form 
- call `poll_form526_pdf` on the submission record
-- the polling job should _**not be called**_
- make a form526submission record _**with**_ the `startedFormVersion` in the saved_claim form
- call `poll_form526_pdf` on the submission record
-- the polling job **_should_** be called

## Screenshots
n/a

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

