### PR TITLE
Btsss add support for dual sub keys

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -28,7 +28,6 @@ module TravelPay
     #
     def request_btsss_token(veis_token, sts_token)
       btsss_url = Settings.travel_pay.base_url
-      api_key = Settings.travel_pay.subscription_key
       client_number = Settings.travel_pay.client_number
 
       response = connection(server_url: btsss_url).post('api/v1/Auth/access-token') do |req|
@@ -188,7 +187,6 @@ module TravelPay
 
     def request_claims(veis_token, btsss_token)
       btsss_url = Settings.travel_pay.base_url
-      api_key = Settings.travel_pay.subscription_key
 
       connection(server_url: btsss_url).get('api/v1/claims') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"

--- a/modules/travel_pay/spec/services/client_spec.rb
+++ b/modules/travel_pay/spec/services/client_spec.rb
@@ -17,6 +17,24 @@ describe TravelPay::Client do
     allow_any_instance_of(TravelPay::Client).to receive(:connection).and_return(conn)
   end
 
+  context 'prod settings' do
+    it 'returns both subscription keys in headers' do
+      headers =
+        {
+          'Content-Type' => 'application/json',
+          'Ocp-Apim-Subscription-Key-E' => 'e_key',
+          'Ocp-Apim-Subscription-Key-S' => 's_key'
+        }
+
+      with_settings(Settings, vsp_environment: 'production') do
+        with_settings(Settings.travel_pay,
+                      { subscription_key_e: 'e_key', subscription_key_s: 's_key' }) do
+          expect(subject.send(:claim_headers)).to eq(headers)
+        end
+      end
+    end
+  end
+
   context 'request_veis_token' do
     it 'returns veis token from proper endpoint' do
       tenant_id = Settings.travel_pay.veis.tenant_id

--- a/modules/travel_pay/spec/services/client_spec.rb
+++ b/modules/travel_pay/spec/services/client_spec.rb
@@ -54,6 +54,23 @@ describe TravelPay::Client do
       expect(token).to eq('fake_btsss_token')
       @stubs.verify_stubbed_calls
     end
+
+    it 'uses both subscription key headers if prod' do
+      original_env = Settings.vsp_environment
+      Settings.vsp_environment = 'production'
+
+      @stubs.post('/api/v1/Auth/access-token', json_request_body) do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          '{"data": {"accessToken": "fake_btsss_token"}}'
+        ]
+      end
+
+      client = TravelPay::Client.new
+      token = client.request_btsss_token('fake_veis_token', vagov_token)
+
+    end
   end
 
   context 'ping' do

--- a/modules/travel_pay/spec/services/client_spec.rb
+++ b/modules/travel_pay/spec/services/client_spec.rb
@@ -72,23 +72,6 @@ describe TravelPay::Client do
       expect(token).to eq('fake_btsss_token')
       @stubs.verify_stubbed_calls
     end
-
-    it 'uses both subscription key headers if prod' do
-      original_env = Settings.vsp_environment
-      Settings.vsp_environment = 'production'
-
-      @stubs.post('/api/v1/Auth/access-token', json_request_body) do
-        [
-          200,
-          { 'Content-Type': 'application/json' },
-          '{"data": {"accessToken": "fake_btsss_token"}}'
-        ]
-      end
-
-      client = TravelPay::Client.new
-      token = client.request_btsss_token('fake_veis_token', vagov_token)
-
-    end
   end
 
   context 'ping' do


### PR DESCRIPTION
Adding extra headers if environment is production to facilitate load balancing on the Travel Pay API (external).

```mermaid
flowchart
  vets-api --> prodCheck{Is Prod?}
  prodCheck -->|no| lower[Lower Env Instance]
  prodCheck -->|yes| eislb[EIS Load Balancer]
  eislb -->|needs subscription key E| tpapi1[Travel Pay API East]
  eislb -->|needs subscription key S| tpapi2[Travel Pay API South]
  
```

closes department-of-veterans-affairs/va.gov-team#90699