### PR TITLE
Fix: Add missing args to has_kms_key override

### DIFF
--- a/app/models/concerns/kms_encrypted_model_patch.rb
+++ b/app/models/concerns/kms_encrypted_model_patch.rb
@@ -6,10 +6,10 @@ module KmsEncryptedModelPatch
   # Update #kms_key_rotation_date method if rotation date changes from 10/12
 
   # rubocop:disable Naming/PredicateName
-  def has_kms_key
+  def has_kms_key(**args)
     # implicitly calls #has_kms_key with specified options, so that we don't need to require it
     # of future encrypted models
-    super(**kms_options)
+    super(**args.merge(kms_options))
   end
   # rubocop:enable Naming/PredicateName
 


### PR DESCRIPTION
## Summary
- An `ArgumentError` is raised in development when the app reloads after a code change.
   ```ruby
   Rails -- Exception: ArgumentError: wrong number of arguments (given 1, expected 0)
   app/models/concerns/kms_encrypted_model_patch.rb:9:in `has_kms_key'
   app/models/concerns/kms_encrypted_model_patch.rb:13:in `has_kms_key'
   ```
- Add missing arguments to overridden [has_kms_key] method.(https://github.com/ankane/kms_encrypted/blob/master/lib/kms_encrypted/model.rb#L3). 


## Testing 
Reproduce error:
1. Start server
2. navigate to http://localhost:3000
3. make and save a change anywhere in `/app` (add a comment)
4. DON'T restart the server
5. navigate to http://localhost:3000
6. You should get an ArgumentError 

## What areas of the site does it impact?
kms_encrypted

