### PR TITLE
VACMS-18335-18864-11876 Remove unused flippers

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -720,9 +720,6 @@ features:
   ha_cpap_supplies_cta:
     actor_type: user
     description: Toggle CTA for reordering Hearing Aid and CPAP supplies form within static pages.
-  injected_header_web_components:
-    actor_type: user
-    description: Enable/disable import of web components to the injected header
   in_progress_form_custom_expiration:
     actor_type: user
     description: Enable/disable custom expiration dates for forms
@@ -1012,10 +1009,6 @@ features:
     description: Use VA Forms System Core for forms instead of schema based forms
     actor_type: user
     enable_in_development: true
-  pw_ehr_cta_drupal_source_of_truth:
-    actor_type: user
-    description: Enabling Public Websites-managed EHR CTAs to use Drupal EHR data, including for Cerner cutovers
-    enable_in_development: true
   pw_ehr_cta_use_slo:
     actor_type: user
     description: Use single-logout (SLO) paths for Public Websites-managed EHR CTAs
@@ -1108,9 +1101,6 @@ features:
   show_edu_benefits_5495_wizard:
     actor_type: user
     description: This determines when the wizard should show up on the 5495 introduction page
-  show_events_v2:
-    actor_type: user
-    description: Enables the events v2 page
   show_financial_status_report:
     actor_type: user
     description: Enables VA Form 5655 (Financial Status Report)


### PR DESCRIPTION
## Summary
Remove unused feature flippers:
- show_events_v2
- injected_header_web_components
- pw_ehr_cta_drupal_source_of_truth

I did an organization-wide search for each of the flippers below and you can see that it's only used in (actual source code) in vets-api.

`show_events_v2`
<img width="1125" alt="Screenshot 2024-08-16 at 4 33 18 PM" src="https://github.com/user-attachments/assets/f871effc-da07-4323-874f-fb36b1d3effd">

`injected_header_web_components`
<img width="1124" alt="Screenshot 2024-08-16 at 4 33 09 PM" src="https://github.com/user-attachments/assets/41c3e159-c02e-44f3-b163-8b3737b0b1ec">

`pw_ehr_cta_drupal_source_of_truth`
<img width="1127" alt="Screenshot 2024-08-16 at 4 33 00 PM" src="https://github.com/user-attachments/assets/a8a1596a-1d64-4a1a-842f-dd1042e6452a">


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18335
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18864
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11876