### PR TITLE
Fix typos, fix bugs in disability transformation methods

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -68,9 +68,9 @@ module ClaimsApi
       form_data['servicePay']['separationPay']['receivedDate'] = transform_separation_pay_received_date if separation_pay_received_date? # rubocop:disable Layout/LineLength
       form_data['veteran']['changeOfAddress'] = transform_change_of_address_type_case if change_of_address_provided?
       form_data['veteran']['changeOfAddress'] = transform_change_of_address_ending_date if invalid_change_of_address_ending_date? # rubocop:disable Layout/LineLength
-      form_data['disabilites'] = transform_disability_approximate_begin_dates
-      form_data['disabilites'] = massage_invalid_disability_names
-      form_data['disabilites'] = remove_special_issues_from_secondary_disabilities
+      form_data['disabilities'] = transform_disability_approximate_begin_dates
+      form_data['disabilities'] = massage_invalid_disability_names
+      form_data['disabilities'] = remove_special_issues_from_secondary_disabilities
       form_data['treatments'] = transform_treatment_dates if treatments?
       form_data['treatments'] = transform_treatment_center_names if treatments?
       form_data['serviceInformation'] = transform_service_branch
@@ -165,6 +165,7 @@ module ClaimsApi
 
         disability
       end
+      disabilities
     end
 
     def resolve_special_issue_mappings!
@@ -341,6 +342,7 @@ module ClaimsApi
 
         disability
       end
+      disabilities
     end
 
     def truncate_disability_name(name:)
@@ -447,7 +449,7 @@ module ClaimsApi
     # Rather than break the API by removing 'specialIssues' from the 'secondaryDisabilities' schema,
     # just detect the invalid case and remove the 'specialIssues' before sending to EVSS.
     def remove_special_issues_from_secondary_disabilities
-      disabilities = form_data['disabilites']
+      disabilities = form_data['disabilities']
 
       disabilities.map do |disability|
         next if disability['secondaryDisabilities'].blank?
@@ -458,6 +460,7 @@ module ClaimsApi
           secondary
         end
       end
+      disabilities
     end
 
     def change_of_address_provided?

--- a/spec/support/vcr_cassettes/claims_api/disability_comp.yml
+++ b/spec/support/vcr_cassettes/claims_api/disability_comp.yml
@@ -1816,7 +1816,7 @@ http_interactions:
         by a service-connected disability\\nLengthy description"}]}],"standardClaim":false,"autoCestPDFGenerationDisabled":true,"claimDate":"1990-01-03T00:00:00+00:00","applicationExpirationDate":"2055-08-28T19:53:45+00:00","serviceInformation":{"servicePeriods":[{"activeDutyEndDate":"1990-01-02","serviceBranch":"Air
         Force","activeDutyBeginDate":"1980-02-05"},{"activeDutyEndDate":"1999-01-01","serviceBranch":"Air
         Force","activeDutyBeginDate":"1990-04-05"}],"reservesNationalGuardService":{"obligationTermOfServiceFromDate":"2000-01-01","obligationTermOfServiceToDate":"2000-01-02","unitName":"A
-        name, with commas, and  double  spaces"}},"claimSubmissionSource":"LH-B","disabilites":[[{"name":"PTSD
+        name, with commas, and  double  spaces"}},"claimSubmissionSource":"LH-B","disabilities":[[{"name":"PTSD
         personal trauma","disabilityActionType":"SECONDARY","serviceRelevance":"Caused
         by a service-connected disability\\nLengthy description"}]]}}'
     headers:

--- a/spec/support/vcr_cassettes/claims_api/evss/submit.yml
+++ b/spec/support/vcr_cassettes/claims_api/evss/submit.yml
@@ -13,7 +13,7 @@ http_interactions:
         by a service-connected disability\\nLengthy description"}]}],"standardClaim":false,"autoCestPDFGenerationDisabled":true,"claimDate":"1990-01-03T00:00:00+00:00","applicationExpirationDate":"2055-08-28T19:53:45+00:00","serviceInformation":{"servicePeriods":[{"activeDutyEndDate":"1990-01-02","serviceBranch":"Air
         Force","activeDutyBeginDate":"1980-02-05"},{"activeDutyEndDate":"1999-01-01","serviceBranch":"Air
         Force","activeDutyBeginDate":"1990-04-05"}],"reservesNationalGuardService":{"obligationTermOfServiceFromDate":"2000-01-01","obligationTermOfServiceToDate":"2000-01-02","unitName":"A
-        name, with commas, and  double  spaces"}},"claimSubmissionSource":"LH-B","disabilites":[[{"name":"PTSD
+        name, with commas, and  double  spaces"}},"claimSubmissionSource":"LH-B","disabilities":[[{"name":"PTSD
         personal trauma","disabilityActionType":"SECONDARY","serviceRelevance":"Caused
         by a service-connected disability\\nLengthy description"}]]}}'
     headers:


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Fixed typo in AutoEstablishedClaim.to_internal method, misspelling of "disabilities".
- Fixed bugs in disability transformation methods where we weren't returning a value, resulting in nil being set for the form_data disabilities section.

## Related issue(s)

[API-39152](https://jira.devops.va.gov/browse/API-39152)

## Testing done

- [x] *New code is covered by unit tests*
- Ran rspec tests locally
- Ran local Postman tests on v1 526 endpoints to exercise AutoEstablishedClaim.to_internal logic:{{uri}}/services/claims/v1/forms/526/validate 
{{uri}}/services/claims/v1/forms/526

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
526 v1 validate and submit

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
