### PR TITLE
89776 do not log chip 404s to sentry

### DIFF
--- a/modules/check_in/app/services/v2/chip/client.rb
+++ b/modules/check_in/app/services/v2/chip/client.rb
@@ -100,7 +100,7 @@ module V2
 
       ##
       # HTTP POST call to the CHIP API to set pre check-in started status. Any downstream error (non HTTP 200 response)
-      # is handled by logging to Sentry and returning the original status and body.
+      # is handled by returning the original status and body.
       #
       # @return [Faraday::Response]
       #
@@ -109,13 +109,6 @@ module V2
           req.headers = default_headers.merge('Authorization' => "Bearer #{token}")
         end
       rescue => e
-        log_exception_to_sentry(e,
-                                {
-                                  original_body: e.original_body,
-                                  original_status: e.original_status,
-                                  uuid: check_in_session.uuid
-                                },
-                                { external_service: service_name, team: 'check-in' })
         Faraday::Response.new(response_body: e.original_body, status: e.original_status)
       end
 
@@ -167,11 +160,6 @@ module V2
         connection.post("/#{base_path}/actions/refresh-precheckin/#{check_in_session.uuid}") do |req|
           req.headers = default_headers.merge('Authorization' => "Bearer #{token}")
         end
-      rescue => e
-        log_message_to_sentry(e.original_body, :error,
-                              { uuid: check_in_session.uuid },
-                              { external_service: service_name, team: 'check-in' })
-        raise e
       end
 
       ##

--- a/modules/check_in/config/locales/exceptions.en.yml
+++ b/modules/check_in/config/locales/exceptions.en.yml
@@ -52,6 +52,7 @@ en:
         code: 'CHIP-API_404'
         detail: 'Not Found'
         status: 404
+        sentry_type: none
       CHIP-API_500:
         <<: *external_defaults
         title: 'Internal Server Error'

--- a/modules/check_in/spec/services/v2/chip/client_spec.rb
+++ b/modules/check_in/spec/services/v2/chip/client_spec.rb
@@ -160,8 +160,6 @@ describe V2::Chip::Client do
       end
 
       it 'handles the exception and returns original error' do
-        expect_any_instance_of(SentryLogging).to receive(:log_exception_to_sentry)
-
         response = subject.set_precheckin_started(token:)
         expect(response.status).to eq(resp.status)
         expect(response.body).to eq(resp.body)


### PR DESCRIPTION
## Summary
Removes sentry logging for CHIP 404s as they are normal error scenarios when the veteran clicks on an old link.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89776

## Testing done
- [x] rspecs

## What areas of the site does it impact?
* check in experience

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).

