### PR TITLE
add email tracker test

### DIFF
--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -64,4 +64,29 @@ RSpec.describe IvcChampva::VHA1010d do
       )
     end
   end
+
+  describe '#track_email_usage' do
+  let(:statsd_key) { 'api.ivc_champva_form.10_10d' }
+  let(:vha_10_10d) { described_class.new(data) }
+  context 'when email is used' do
+    let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
+
+    it 'increments the StatsD for email used and logs the info' do
+      expect(StatsD).to receive(:increment).with("#{statsd_key}.yes")
+      expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-10D Email Used', email_used: 'yes')
+      vha_10_10d.track_email_usage
+    end
+  end
+
+  context 'when email is not used' do
+    let(:data) { { 'primary_contact_info' => {} } }
+
+    it 'increments the StatsD for email not used and logs the info' do
+      expect(StatsD).to receive(:increment).with("#{statsd_key}.no")
+      expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-10D Email Used', email_used: 'no')
+      vha_10_10d.track_email_usage
+    end
+  end
+end
+
 end

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -66,20 +66,20 @@ RSpec.describe IvcChampva::VHA1010d do
   end
 
   describe '#track_email_usage' do
-  let(:statsd_key) { 'api.ivc_champva_form.10_10d' }
-  let(:vha_10_10d) { described_class.new(data) }
+    let(:statsd_key) { 'api.ivc_champva_form.10_10d' }
+    let(:vha_10_10d) { described_class.new(data) }
 
-  context 'when email is used' do
+    context 'when email is used' do
     let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
 
-    it 'increments the StatsD for email used and logs the info' do
-      expect(StatsD).to receive(:increment).with("#{statsd_key}.yes")
-      expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-10D Email Used', email_used: 'yes')
-      vha_10_10d.track_email_usage
+      it 'increments the StatsD for email used and logs the info' do
+        expect(StatsD).to receive(:increment).with("#{statsd_key}.yes")
+        expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-10D Email Used', email_used: 'yes')
+        vha_10_10d.track_email_usage
+      end
     end
-  end
 
-  context 'when email is not used' do
+    context 'when email is not used' do
     let(:data) { { 'primary_contact_info' => {} } }
 
       it 'increments the StatsD for email not used and logs the info' do

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe IvcChampva::VHA1010d do
   describe '#track_email_usage' do
   let(:statsd_key) { 'api.ivc_champva_form.10_10d' }
   let(:vha_10_10d) { described_class.new(data) }
+
   context 'when email is used' do
     let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
 
@@ -81,12 +82,11 @@ RSpec.describe IvcChampva::VHA1010d do
   context 'when email is not used' do
     let(:data) { { 'primary_contact_info' => {} } }
 
-    it 'increments the StatsD for email not used and logs the info' do
-      expect(StatsD).to receive(:increment).with("#{statsd_key}.no")
-      expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-10D Email Used', email_used: 'no')
-      vha_10_10d.track_email_usage
+      it 'increments the StatsD for email not used and logs the info' do
+        expect(StatsD).to receive(:increment).with("#{statsd_key}.no")
+        expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-10D Email Used', email_used: 'no')
+        vha_10_10d.track_email_usage
+      end
     end
   end
-end
-
 end

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe IvcChampva::VHA1010d do
     let(:vha_10_10d) { described_class.new(data) }
 
     context 'when email is used' do
-    let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
+      let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
 
       it 'increments the StatsD for email used and logs the info' do
         expect(StatsD).to receive(:increment).with("#{statsd_key}.yes")
@@ -80,7 +80,7 @@ RSpec.describe IvcChampva::VHA1010d do
     end
 
     context 'when email is not used' do
-    let(:data) { { 'primary_contact_info' => {} } }
+      let(:data) { { 'primary_contact_info' => {} } }
 
       it 'increments the StatsD for email not used and logs the info' do
         expect(StatsD).to receive(:increment).with("#{statsd_key}.no")

--- a/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
@@ -78,4 +78,29 @@ RSpec.describe IvcChampva::VHA107959c do
       expect(result).to eq(["#{uuid}_vha_10_7959c-tmp.pdf"])
     end
   end
+
+
+  describe '#track_email_usage' do
+    let(:statsd_key) { 'api.ivc_champva_form.10_7959c' }
+    let(:vha_10_7959c) { described_class.new(data) }
+    context 'when email is used' do
+      let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
+
+      it 'increments the StatsD for email used and logs the info' do
+        expect(StatsD).to receive(:increment).with("#{statsd_key}.yes")
+        expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-7959C Email Used', email_used: 'yes')
+        vha_10_7959c.track_email_usage
+      end
+    end
+
+    context 'when email is not used' do
+      let(:data) { { 'primary_contact_info' => {} } }
+
+      it 'increments the StatsD for email not used and logs the info' do
+        expect(StatsD).to receive(:increment).with("#{statsd_key}.no")
+        expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-7959C Email Used', email_used: 'no')
+        vha_10_7959c.track_email_usage
+      end
+    end
+  end
 end

--- a/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe IvcChampva::VHA107959c do
   describe '#track_email_usage' do
     let(:statsd_key) { 'api.ivc_champva_form.10_7959c' }
     let(:vha_10_7959c) { described_class.new(data) }
+
     context 'when email is used' do
       let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
 

--- a/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe IvcChampva::VHA107959c do
     end
   end
 
-
   describe '#track_email_usage' do
     let(:statsd_key) { 'api.ivc_champva_form.10_7959c' }
     let(:vha_10_7959c) { described_class.new(data) }

--- a/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
@@ -68,9 +68,11 @@ RSpec.describe IvcChampva::VHA107959f1 do
     end
   end
 
+  #rubocop:disable Naming/VariableNumber
   describe '#track_email_usage' do
     let(:statsd_key) { 'api.ivc_champva_form.10_7959f_1' }
     let(:vha_10_7959f_1) { described_class.new(data) }
+
     context 'when email is used' do
       let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
 
@@ -91,4 +93,5 @@ RSpec.describe IvcChampva::VHA107959f1 do
       end
     end
   end
+  #rubocop:enable Naming/VariableNumber
 end

--- a/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
@@ -67,4 +67,28 @@ RSpec.describe IvcChampva::VHA107959f1 do
       expect(result).to eq(["#{uuid}_vha_10_7959f_1-tmp.pdf"])
     end
   end
+
+  describe '#track_email_usage' do
+    let(:statsd_key) { 'api.ivc_champva_form.10_7959f_1' }
+    let(:vha_10_7959f_1) { described_class.new(data) }
+    context 'when email is used' do
+      let(:data) { { 'primary_contact_info' => { 'email' => 'test@example.com' } } }
+
+      it 'increments the StatsD for email used and logs the info' do
+        expect(StatsD).to receive(:increment).with("#{statsd_key}.yes")
+        expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-7959F-1 Email Used', email_used: 'yes')
+        vha_10_7959f_1.track_email_usage
+      end
+    end
+
+    context 'when email is not used' do
+      let(:data) { { 'primary_contact_info' => {} } }
+
+      it 'increments the StatsD for email not used and logs the info' do
+        expect(StatsD).to receive(:increment).with("#{statsd_key}.no")
+        expect(Rails.logger).to receive(:info).with('IVC ChampVA Forms - 10-7959F-1 Email Used', email_used: 'no')
+        vha_10_7959f_1.track_email_usage
+      end
+    end
+  end
 end

--- a/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe IvcChampva::VHA107959f1 do
     end
   end
 
-  #rubocop:disable Naming/VariableNumber
+  # rubocop:disable Naming/VariableNumber
   describe '#track_email_usage' do
     let(:statsd_key) { 'api.ivc_champva_form.10_7959f_1' }
     let(:vha_10_7959f_1) { described_class.new(data) }
@@ -93,5 +93,5 @@ RSpec.describe IvcChampva::VHA107959f1 do
       end
     end
   end
-  #rubocop:enable Naming/VariableNumber
+  # rubocop:enable Naming/VariableNumber
 end


### PR DESCRIPTION

## Summary
Add more unit test to 7959C, 1010D, 7959F1 to meet 80% or above code coverage.
7959F2 does not have email tracker

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-api/pull/18035/files

## Testing done

- [ ] *New code is covered by unit tests*
