### PR TITLE
Add correlation ID to logs for debugging

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -29,11 +29,13 @@ module TravelPay
     def request_btsss_token(veis_token, sts_token)
       btsss_url = Settings.travel_pay.base_url
       client_number = Settings.travel_pay.client_number
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
       response = connection(server_url: btsss_url).post('api/v1/Auth/access-token') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-API-Client-Number'] = client_number.to_s
-        req.headers['X-Correlation-ID'] = SecureRandom.uuid
+        req.headers['X-Correlation-ID'] = correlation_id
         req.headers.merge(claim_headers)
         req.body = { authJwt: sts_token }
       end
@@ -187,11 +189,13 @@ module TravelPay
 
     def request_claims(veis_token, btsss_token)
       btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
       connection(server_url: btsss_url).get('api/v1/claims') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['X-Correlation-ID'] = SecureRandom.uuid
+        req.headers['X-Correlation-ID'] = correlation_id
         req.headers.merge(claim_headers)
       end
     end


### PR DESCRIPTION
Logs the `correlation-id` at a DEBUG level for end-to-end tracing.

Closes department-of-veterans-affairs/va.gov-team#90963