### PR TITLE
Revert "Only skip authentication if we're on an unauthenticated form (#18040)"

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -8,8 +8,8 @@ require 'lighthouse/benefits_intake/service'
 module SimpleFormsApi
   module V1
     class UploadsController < ApplicationController
-      skip_before_action :authenticate, if: -> { UNAUTHENTICATED_FORMS.include?(params[:form_number]) }
-      before_action :load_user, if: -> { UNAUTHENTICATED_FORMS.include?(params[:form_number]) }
+      skip_before_action :authenticate
+      before_action :load_user
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {
@@ -26,8 +26,6 @@ module SimpleFormsApi
         '40-10007' => 'vba_40_10007',
         '20-10207' => 'vba_20_10207'
       }.freeze
-
-      UNAUTHENTICATED_FORMS = %w[40-0247 21-10210 21P-0847 40-10007].freeze
 
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -30,9 +30,8 @@ RSpec.describe 'Forms uploader', type: :request do
     'vba_20_10207-non-veteran.json'
   ]
 
-  unauthenticated_forms = %w[vba_40_0247.json vba_21_10210.json vba_21p_0847.json
-                             vba_40_10007.json]
-  authenticated_forms = forms - unauthenticated_forms
+  authenticated_forms = forms - %w[vba_40_0247.json vba_21_10210.json vba_21p_0847.json
+                                   vba_40_10007.json]
 
   describe '#submit' do
     context 'going to Lighthouse Benefits Intake API' do
@@ -57,7 +56,7 @@ RSpec.describe 'Forms uploader', type: :request do
         Flipper.enable(:simple_forms_email_confirmations)
       end
 
-      unauthenticated_forms.each do |form|
+      forms.each do |form|
         fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', form)
         data = JSON.parse(fixture_path.read)
 
@@ -117,55 +116,6 @@ RSpec.describe 'Forms uploader', type: :request do
             user = create(:user)
             sign_in_as(user)
             create(:in_progress_form, user_uuid: user.uuid, form_id: data['form_number'])
-          end
-
-          fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', form)
-          data = JSON.parse(fixture_path.read)
-
-          context 'through the SimpleFormsApiSubmission::Service' do
-            it 'makes the request' do
-              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
-
-              post '/simple_forms_api/v1/simple_forms', params: data
-
-              expect(SimpleFormsApiSubmission::MetadataValidator).to have_received(:validate)
-              expect(response).to have_http_status(:ok)
-            end
-
-            it 'saves a FormSubmissionAttempt' do
-              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
-
-              expect do
-                post '/simple_forms_api/v1/simple_forms', params: data
-              end.to change(FormSubmissionAttempt, :count).by(1)
-            end
-          end
-
-          context 'through the Lighthouse BenefitsIntake::Service' do
-            before do
-              Flipper.enable(:simple_forms_lighthouse_benefits_intake_service)
-            end
-
-            after do
-              Flipper.disable(:simple_forms_lighthouse_benefits_intake_service)
-            end
-
-            it 'makes the request' do
-              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
-
-              post '/simple_forms_api/v1/simple_forms', params: data
-
-              expect(SimpleFormsApiSubmission::MetadataValidator).to have_received(:validate)
-              expect(response).to have_http_status(:ok)
-            end
-
-            it 'saves a FormSubmissionAttempt' do
-              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
-
-              expect do
-                post '/simple_forms_api/v1/simple_forms', params: data
-              end.to change(FormSubmissionAttempt, :count).by(1)
-            end
           end
 
           it 'clears the InProgressForm' do
@@ -253,6 +203,30 @@ RSpec.describe 'Forms uploader', type: :request do
             end
           end
         end
+
+        context 'unauthenticated' do
+          let(:expiration_date) { Time.zone.now }
+
+          before do
+            allow_any_instance_of(ActiveSupport::TimeZone).to receive(:now).and_return(expiration_date)
+          end
+
+          it 'returns an expiration date' do
+            Flipper.disable(:form21_0966_confirmation_email)
+
+            fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
+                                           'vba_21_0966.json')
+            data = JSON.parse(fixture_path.read)
+
+            post '/simple_forms_api/v1/simple_forms', params: data
+
+            parsed_response_body = JSON.parse(response.body)
+            parsed_expiration_date = Time.zone.parse(parsed_response_body['expiration_date'])
+            expect(parsed_expiration_date.to_s).to eq (expiration_date + 1.year).to_s
+
+            Flipper.enable(:form21_0966_confirmation_email)
+          end
+        end
       end
 
       context 'request with attached documents' do
@@ -304,10 +278,6 @@ RSpec.describe 'Forms uploader', type: :request do
       end
 
       context 'transliterating fields' do
-        before do
-          sign_in
-        end
-
         context 'transliteration succeeds' do
           it 'responds with ok' do
             Flipper.disable(:form21_0966_confirmation_email)
@@ -382,10 +352,6 @@ RSpec.describe 'Forms uploader', type: :request do
     end
 
     describe 'failed requests scrub PII from error messages' do
-      before do
-        sign_in
-      end
-
       describe 'unhandled form' do
         it 'makes the request and expects a failure' do
           fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
@@ -516,10 +482,6 @@ RSpec.describe 'Forms uploader', type: :request do
   end
 
   describe '#submit_supporting_documents' do
-    before do
-      sign_in
-    end
-
     it 'renders the attachment as json' do
       clamscan = double(safe?: true)
       allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
@@ -651,10 +613,6 @@ RSpec.describe 'Forms uploader', type: :request do
   end
 
   describe 'email confirmations' do
-    before do
-      sign_in
-    end
-
     let(:confirmation_number) { 'some_confirmation_number' }
 
     describe '21_4142' do


### PR DESCRIPTION

This reverts commit 2847f03795efc4a38c3cfb4b5517964676d09494.

## Summary
This revert is necessary because I accidentally didn't take into account the distinction between two param keys, `form_number` and `form_id`, which are used depending on which action is being used. I need to think of a better way to do this.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1573
