### PR TITLE
API-39187-526-sync-raise-e 

### DIFF
--- a/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
@@ -29,6 +29,7 @@ module ClaimsApi
         auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED
         auto_claim.evss_response = e.errors if e.methods.include?(:errors)
         auto_claim.save
+        raise e
       end
 
       private


### PR DESCRIPTION
## Summary

- Adds raise for errors in docker container service. 
- Adjusts test.

## Related issue(s)

- [API-39187](https://jira.devops.va.gov/browse/API-39187)

## Testing done

- [ ] *New code is covered by unit tests*
- Postman
using this request_body:
```
{
    "data": {
        "type": "form/526",
        "attributes": {
            "claimProcessType": "STANDARD_CLAIM_PROCESS",
            "veteranIdentification": {
                "mailingAddress": {
                    "addressLine1": "1234 Couch Street",
                    "city": "Portland",
                    "state": "OR",
                    "country": "USA",
                    "zipFirstFive": "12345"
                },
                "currentVaEmployee": false
            },
            "disabilities": [
                {
                    "disabilityActionType": "INCREASE",
                    "name": "osteoarthritis, right knee with chondromalacia [previously rated as bilateral chondromalacia, diagnostic code 5010]",
                    "classificationCode": "8997",
                    "serviceRelevance": "",
                    "ratedDisabilityId": "1234567",
                    "diagnosticCode": 5260,
                    "isRelatedToToxicExposure": null,
                    "secondaryDisabilities": []
                },
                {
                    "disabilityActionType": "NEW",
                    "name": "osteoarthritis, right knee with chondromalacia [previously rated as bilateral chondromalacia, diagnostic code 5010]",
                    "classificationCode": "8997",
                    "serviceRelevance": "new disability testing with brackets",
                    "ratedDisabilityId": "1234567",
                    "diagnosticCode": 5260,
                    "isRelatedToToxicExposure": null,
                    "secondaryDisabilities": []
                },
                {
                    "disabilityActionType": "NONE",
                    "name": "headaches",
                    "serviceRelevance": "Explanation of primary disability service connection",
                    "approximateDate": "2019-11-04",
                    "ratedDisabilityId": "1234567",
                    "diagnosticCode": 3130,
                    "isRelatedToToxicExposure": false,
                    "secondaryDisabilities": [
                        {
                            "name": "osteoarthritis, right knee with chondromalacia [previously rated as bilateral chondromalacia, diagnostic code 5010]",
                            "disabilityActionType": "SECONDARY",
                            "classificationCode": "9014",
                            "serviceRelevance": "How this secondary disability relates to the primary disability",
                            "approximateDate": "2008-06-11"
                        }
                    ]
                }
            ],
            "serviceInformation": {
                "servicePeriods": [
                    {
                        "serviceBranch": "Air Force",
                        "serviceComponent": "Active",
                        "activeDutyBeginDate": "2015-11-14",
                        "activeDutyEndDate": "2018-11-30"
                    }
                ]
            },
            "claimantCertification": true
        }
    }
}
```
You should get a 422

## Screensh
![Screenshot 2024-08-19 at 3 10 57 PM](https://github.com/user-attachments/assets/3083962a-1008-4c61-94c0-d0f0673ae14f)
ots

## What areas of the site does it impact?
	modified:   modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
	modified:   modules/claims_api/spec/services/disability_compensation/docker_container_service_spec.rb



## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

I don't trust the adjustment I made on the test