### PR TITLE
[API-39186] Remove bracket stripping from disabilitiesʼ names

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
@@ -65,13 +65,9 @@ module ClaimsApi
         disability.delete(:serviceRelevance) if disability&.dig(:serviceRelevance).blank?
         disability.delete(:classificationCode) if disability&.dig(:classificationCode).nil? # blank is ok
 
-        disability[:name] = disability[:name].gsub(/\[|\]/, '') if disability[:name].present?
-
         if disability&.dig(:secondaryDisabilities).present?
           disability[:secondaryDisabilities] = disability[:secondaryDisabilities]&.map do |secondary|
             secondary.delete(:classificationCode) if secondary&.dig(:classificationCode).nil? # blank is ok
-
-            secondary[:name] = secondary[:name].gsub(/\[|\]/, '') if secondary[:name].present?
 
             secondary.except(:exposureOrEventOrInjury, :approximateDate)
           end

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_evss_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_evss_mapper_spec.rb
@@ -225,38 +225,6 @@ describe ClaimsApi::V2::DisabilityCompensationEvssMapper do
           expect(disability[:classificationCode]).to eq(nil)
         end
       end
-
-      context 'When the disability name has brackets' do
-        let(:disability) { evss_data[:disabilities][0] }
-
-        it 'strips the brackets from the name' do
-          disability[:name] = 'osteoarthritis, right knee with chondromalacia' \
-                              ' [previously rated as bilateral chondromalacia, diagnostic code 5010]'
-          form_data['data']['attributes']['disabilities'][0] = disability
-          auto_claim = create(:auto_established_claim, form_data: form_data['data']['attributes'])
-          evss_data = ClaimsApi::V2::DisabilityCompensationEvssMapper.new(auto_claim, file_number).map_claim[:form526]
-          disability_name = evss_data[:disabilities][0][:name]
-          stripped_name = 'osteoarthritis, right knee with chondromalacia' \
-                          ' previously rated as bilateral chondromalacia, diagnostic code 5010'
-
-          expect(disability_name).to eq(stripped_name)
-        end
-      end
-
-      context 'When the secondary disability name has brackets' do
-        it 'strips the brackets from the name' do
-          secondary_disability[:name] = 'osteoarthritis, right knee with chondromalacia' \
-                                        ' [previously rated as bilateral chondromalacia, diagnostic code 5010]'
-          form_data['data']['attributes']['disabilities'][0]['secondaryDisabilities'][0] = secondary_disability
-          auto_claim = create(:auto_established_claim, form_data: form_data['data']['attributes'])
-          evss_data = ClaimsApi::V2::DisabilityCompensationEvssMapper.new(auto_claim, file_number).map_claim[:form526]
-          secondary_disability_name = evss_data[:disabilities][0][:secondaryDisabilities][0][:name]
-          stripped_name = 'osteoarthritis, right knee with chondromalacia' \
-                          ' previously rated as bilateral chondromalacia, diagnostic code 5010'
-
-          expect(secondary_disability_name).to eq(stripped_name)
-        end
-      end
     end
 
     context '526 section 6, service information: service periods' do


### PR DESCRIPTION
## Summary

Remove bracket stripping in Disability Compensation EVSS mapper. The EVSS Docker now accepts brackets in the disability name and secondary disability name.

## Related issue(s)

[API-39186](https://jira.devops.va.gov/browse/API-39186)

## Testing done

- Manual submission to EVSS Docker with brackets in disabilitiesʼ name and secondaryDisabilitiesʼ name with successful responses.

## Screenshots

N/A

## What areas of the site does it impact?

Disability compensation EVSS mapper.

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A