### PR TITLE
90103: Add statsd metrics to DR SavedClaim updater and delete jobs

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -14,8 +14,12 @@ module DecisionReview
 
     SUCCESSFUL_STATUS = %w[complete].freeze
 
+    STATSD_KEY_PREFIX = 'worker.decision_review.saved_claim_nod_status_updater'
+
     def perform
       return unless enabled? && notice_of_disagreements.present?
+
+      StatsD.increment("#{STATSD_KEY_PREFIX}.processing_records", notice_of_disagreements.size)
 
       notice_of_disagreements.each do |nod|
         guid = nod.guid
@@ -28,11 +32,13 @@ module DecisionReview
 
         if SUCCESSFUL_STATUS.include? status
           params[:delete_date] = timestamp + RETENTION_PERIOD
+          StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
 
         nod.update(params)
       rescue => e
+        StatsD.increment("#{STATSD_KEY_PREFIX}.error")
         Rails.logger.error('DecisionReview::SavedClaimNodStatusUpdaterJob error', { guid:, message: e.message })
       end
 

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -14,8 +14,12 @@ module DecisionReview
 
     SUCCESSFUL_STATUS = %w[complete].freeze
 
+    STATSD_KEY_PREFIX = 'worker.decision_review.saved_claim_sc_status_updater'
+
     def perform
       return unless enabled? && supplemental_claims.present?
+
+      StatsD.increment("#{STATSD_KEY_PREFIX}.processing_records", supplemental_claims.size)
 
       supplemental_claims.each do |sc|
         guid = sc.guid
@@ -28,11 +32,13 @@ module DecisionReview
 
         if SUCCESSFUL_STATUS.include? status
           params[:delete_date] = timestamp + RETENTION_PERIOD
+          StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         end
 
         sc.update(params)
       rescue => e
+        StatsD.increment("#{STATSD_KEY_PREFIX}.error")
         Rails.logger.error('DecisionReview::SavedClaimScStatusUpdaterJob error', { guid:, message: e.message })
       end
 

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
     context 'with flag enabled', :aggregate_failures do
       before do
         Flipper.enable :decision_review_saved_claim_hlr_status_updater_job_enabled
+        allow(StatsD).to receive(:increment)
       end
 
       context 'SavedClaim records are present' do
@@ -63,7 +64,21 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
             expect(claim2.delete_date).to be_nil
             expect(claim2.metadata).to include 'pending'
             expect(claim2.metadata_updated_at).to eq frozen_time
+
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_hlr_status_updater.processing_records', 2).exactly(1).time
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_hlr_status_updater.delete_date_update').exactly(1).time
           end
+        end
+
+        it 'handles request errors and increments the statsd metric' do
+          allow(service).to receive(:get_higher_level_review).and_raise(DecisionReviewV1::ServiceException)
+
+          subject.new.perform
+
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_hlr_status_updater.error').exactly(2).times
         end
       end
     end

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
     context 'with flag enabled', :aggregate_failures do
       before do
         Flipper.enable :decision_review_saved_claim_nod_status_updater_job_enabled
+        allow(StatsD).to receive(:increment)
       end
 
       context 'SavedClaim records are present' do
@@ -64,6 +65,20 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
             expect(claim2.metadata).to include 'pending'
             expect(claim2.metadata_updated_at).to eq frozen_time
           end
+
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_nod_status_updater.processing_records', 2).exactly(1).time
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_nod_status_updater.delete_date_update').exactly(1).time
+        end
+
+        it 'handles request errors and increments the statsd metric' do
+          allow(service).to receive(:get_notice_of_disagreement).and_raise(DecisionReviewV1::ServiceException)
+
+          subject.new.perform
+
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_nod_status_updater.error').exactly(2).times
         end
       end
     end

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
     context 'with flag enabled', :aggregate_failures do
       before do
         Flipper.enable :decision_review_saved_claim_sc_status_updater_job_enabled
+        allow(StatsD).to receive(:increment)
       end
 
       context 'SavedClaim records are present' do
@@ -64,6 +65,20 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
             expect(claim2.metadata).to include 'pending'
             expect(claim2.metadata_updated_at).to eq frozen_time
           end
+
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_sc_status_updater.processing_records', 2).exactly(1).time
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_sc_status_updater.delete_date_update').exactly(1).time
+        end
+
+        it 'handles request errors and increments the statsd metric' do
+          allow(service).to receive(:get_supplemental_claim).and_raise(DecisionReviewV1::ServiceException)
+
+          subject.new.perform
+
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_sc_status_updater.error').exactly(2).times
         end
       end
     end


### PR DESCRIPTION
## Summary
This PR adds StatsD metrics to specific processing events for the SavedClaim Updater jobs to facilitate the creation of a DD dashboard to monitor the health of this service.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/90103

## Testing done
Local run + spec tests
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
This impacts StatsD, SavedClaim status updater, and SavedClaim deleter jobs.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
