### PR TITLE
Only skip authentication if we're on an unauthenticated form, second try

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -8,8 +8,8 @@ require 'lighthouse/benefits_intake/service'
 module SimpleFormsApi
   module V1
     class UploadsController < ApplicationController
-      skip_before_action :authenticate
-      before_action :load_user
+      skip_before_action :authenticate, if: :skip_authentication?
+      before_action :load_user, if: :skip_authentication?
       skip_after_action :set_csrf_header
 
       FORM_NUMBER_MAP = {
@@ -26,6 +26,8 @@ module SimpleFormsApi
         '40-10007' => 'vba_40_10007',
         '20-10207' => 'vba_20_10207'
       }.freeze
+
+      UNAUTHENTICATED_FORMS = %w[40-0247 21-10210 21P-0847 40-10007].freeze
 
       def submit
         Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
@@ -68,6 +70,10 @@ module SimpleFormsApi
       end
 
       private
+
+      def skip_authentication?
+        UNAUTHENTICATED_FORMS.include?(params[:form_number]) || UNAUTHENTICATED_FORMS.include?(params[:form_id])
+      end
 
       def intent_service
         @intent_service ||= SimpleFormsApi::IntentToFile.new(@current_user, params)

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe 'Forms uploader', type: :request do
     'vba_20_10207-non-veteran.json'
   ]
 
-  authenticated_forms = forms - %w[vba_40_0247.json vba_21_10210.json vba_21p_0847.json
-                                   vba_40_10007.json]
+  unauthenticated_forms = %w[vba_40_0247.json vba_21_10210.json vba_21p_0847.json
+                             vba_40_10007.json]
+  authenticated_forms = forms - unauthenticated_forms
 
   describe '#submit' do
     context 'going to Lighthouse Benefits Intake API' do
@@ -56,7 +57,7 @@ RSpec.describe 'Forms uploader', type: :request do
         Flipper.enable(:simple_forms_email_confirmations)
       end
 
-      forms.each do |form|
+      unauthenticated_forms.each do |form|
         fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', form)
         data = JSON.parse(fixture_path.read)
 
@@ -116,6 +117,55 @@ RSpec.describe 'Forms uploader', type: :request do
             user = create(:user)
             sign_in_as(user)
             create(:in_progress_form, user_uuid: user.uuid, form_id: data['form_number'])
+          end
+
+          fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', form)
+          data = JSON.parse(fixture_path.read)
+
+          context 'through the SimpleFormsApiSubmission::Service' do
+            it 'makes the request' do
+              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
+
+              post '/simple_forms_api/v1/simple_forms', params: data
+
+              expect(SimpleFormsApiSubmission::MetadataValidator).to have_received(:validate)
+              expect(response).to have_http_status(:ok)
+            end
+
+            it 'saves a FormSubmissionAttempt' do
+              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
+
+              expect do
+                post '/simple_forms_api/v1/simple_forms', params: data
+              end.to change(FormSubmissionAttempt, :count).by(1)
+            end
+          end
+
+          context 'through the Lighthouse BenefitsIntake::Service' do
+            before do
+              Flipper.enable(:simple_forms_lighthouse_benefits_intake_service)
+            end
+
+            after do
+              Flipper.disable(:simple_forms_lighthouse_benefits_intake_service)
+            end
+
+            it 'makes the request' do
+              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
+
+              post '/simple_forms_api/v1/simple_forms', params: data
+
+              expect(SimpleFormsApiSubmission::MetadataValidator).to have_received(:validate)
+              expect(response).to have_http_status(:ok)
+            end
+
+            it 'saves a FormSubmissionAttempt' do
+              allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
+
+              expect do
+                post '/simple_forms_api/v1/simple_forms', params: data
+              end.to change(FormSubmissionAttempt, :count).by(1)
+            end
           end
 
           it 'clears the InProgressForm' do
@@ -203,30 +253,6 @@ RSpec.describe 'Forms uploader', type: :request do
             end
           end
         end
-
-        context 'unauthenticated' do
-          let(:expiration_date) { Time.zone.now }
-
-          before do
-            allow_any_instance_of(ActiveSupport::TimeZone).to receive(:now).and_return(expiration_date)
-          end
-
-          it 'returns an expiration date' do
-            Flipper.disable(:form21_0966_confirmation_email)
-
-            fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
-                                           'vba_21_0966.json')
-            data = JSON.parse(fixture_path.read)
-
-            post '/simple_forms_api/v1/simple_forms', params: data
-
-            parsed_response_body = JSON.parse(response.body)
-            parsed_expiration_date = Time.zone.parse(parsed_response_body['expiration_date'])
-            expect(parsed_expiration_date.to_s).to eq (expiration_date + 1.year).to_s
-
-            Flipper.enable(:form21_0966_confirmation_email)
-          end
-        end
       end
 
       context 'request with attached documents' do
@@ -278,6 +304,10 @@ RSpec.describe 'Forms uploader', type: :request do
       end
 
       context 'transliterating fields' do
+        before do
+          sign_in
+        end
+
         context 'transliteration succeeds' do
           it 'responds with ok' do
             Flipper.disable(:form21_0966_confirmation_email)
@@ -352,6 +382,10 @@ RSpec.describe 'Forms uploader', type: :request do
     end
 
     describe 'failed requests scrub PII from error messages' do
+      before do
+        sign_in
+      end
+
       describe 'unhandled form' do
         it 'makes the request and expects a failure' do
           fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
@@ -482,6 +516,10 @@ RSpec.describe 'Forms uploader', type: :request do
   end
 
   describe '#submit_supporting_documents' do
+    before do
+      sign_in
+    end
+
     it 'renders the attachment as json' do
       clamscan = double(safe?: true)
       allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
@@ -613,6 +651,10 @@ RSpec.describe 'Forms uploader', type: :request do
   end
 
   describe 'email confirmations' do
+    before do
+      sign_in
+    end
+
     let(:confirmation_number) { 'some_confirmation_number' }
 
     describe '21_4142' do


### PR DESCRIPTION
## Summary
This PR is a second attempt at [this one](https://github.com/department-of-veterans-affairs/vets-api/pull/18040) (which has been reverted because it introduced bugs). Turns out I needed it to be sensitive both to `form_number` and `form_id` in the params.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1573
