### PR TITLE
[API-39194] Remove warnings from errors array

### DIFF
--- a/modules/claims_api/lib/custom_error.rb
+++ b/modules/claims_api/lib/custom_error.rb
@@ -53,24 +53,19 @@ module ClaimsApi
     def get_error_info
       all_errors = []
 
-      @original_body&.[](:messages)&.each do |err|
+      @original_body&.fetch(:messages)&.each do |err|
         symbolized_error = err.deep_symbolize_keys
-        all_errors << collect_errors(symbolized_error)
+        all_errors << munge_error(symbolized_error) unless symbolized_error[:severity] == 'WARN'
       end
       all_errors
     end
 
-    def collect_errors(symbolized_error)
-      details = get_details(symbolized_error)
-      severity = symbolized_error[:severity] || nil
-      detail = details || nil
-      text = symbolized_error[:text] || nil
-      key = symbolized_error[:key] || nil
+    def munge_error(symbolized_error)
       {
-        key:,
-        severity:,
-        detail:,
-        text:
+        key: symbolized_error[:key],
+        severity: symbolized_error[:severity],
+        detail: get_details(symbolized_error),
+        text: symbolized_error[:text]
       }
     end
 

--- a/modules/claims_api/spec/sidekiq/claim_custom_error_spec.rb
+++ b/modules/claims_api/spec/sidekiq/claim_custom_error_spec.rb
@@ -125,5 +125,43 @@ RSpec.describe ClaimsApi::CustomError, type: :job do
         expect(e.errors[0][:detail]).to eq(string_error)
       end
     end
+
+    context 'when warning messages are returned' do
+      error_original_body = {
+        messages: [
+          {
+            'key' => 'form526.disabilities[1].isDuplicate',
+            'severity' => 'WARN',
+            'text' => 'Claimant has added a duplicate disability'
+          },
+          {
+            'key' => 'form526.disabilities[2].disabilityActionTypeNONE.ratedDisability.isInvalid',
+            'severity' => 'ERROR',
+            'text' => 'An attempt was made to add a secondary disability to an existing rated Disability. The rated ' \
+                      'Disability could not be found'
+          }
+        ]
+      }
+
+      let(:backend_error) do
+        Common::Exceptions::BackendServiceException.new(
+          backtrace.backtrace,
+          {},
+          400,
+          error_original_body
+        )
+      end
+
+      let(:backend_error_submit) { ClaimsApi::CustomError.new(backend_error) }
+
+      it 'excludes warnings but includes errors in the response' do
+        backend_error_submit.build_error
+      rescue => e
+        expect(e.errors.length).to eq(1)
+        expect(e.errors[0][:title]).to eq('Backend Service Exception')
+        expect(e.errors[0][:detail]).to eq('An attempt was made to add a secondary disability to an existing rated ' \
+                                           'Disability. The rated Disability could not be found')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

_Warnings_, which do not block claim submission, can confuse consumers. Remove _warnings_ from the `errors` response such that only _errors_ are included.

## Related issue(s)

[API-39194](https://jira.devops.va.gov/browse/API-39194)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

Claims API custom error response.

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A