### PR TITLE
Bump fugit to 1.11.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,7 @@ GEM
       zeitwerk (~> 2.6)
     einhorn (1.0.0)
     erubi (1.13.0)
-    et-orbi (1.2.7)
+    et-orbi (1.2.11)
       tzinfo
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -476,8 +476,8 @@ GEM
       sanitize (< 7)
     foreman (0.88.1)
     formatador (1.1.0)
-    fugit (1.9.0)
-      et-orbi (~> 1, >= 1.2.7)
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     fuubar (2.5.1)
       rspec-core (~> 3.0)
@@ -512,6 +512,11 @@ GEM
       faraday (>= 1.0, < 3.a)
     google-protobuf (4.27.3)
       bigdecimal
+      rake (>= 13)
+    google-protobuf (4.27.3-java)
+      bigdecimal
+      ffi (~> 1)
+      ffi-compiler (~> 1)
       rake (>= 13)
     googleauth (1.11.0)
       faraday (>= 1.0, < 3.a)


### PR DESCRIPTION
## Summary

- Update `fugit` to `v1.11.1` to address security vulnerability
- https://github.com/floraison/fugit/security/advisories/GHSA-2m96-52r3-2f3g