### PR TITLE
Add benefits_intake_uuid column to form_submission_attempts table

### DIFF
--- a/db/migrate/20240821145040_add_benefits_intake_uuid_to_form_submission_attempts.rb
+++ b/db/migrate/20240821145040_add_benefits_intake_uuid_to_form_submission_attempts.rb
@@ -1,0 +1,5 @@
+class AddBenefitsIntakeUuidToFormSubmissionAttempts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :form_submission_attempts, :benefits_intake_uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_215701) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_21_145040) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -742,6 +742,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_215701) do
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "benefits_intake_uuid"
     t.index ["form_submission_id"], name: "index_form_submission_attempts_on_form_submission_id"
   end
 


### PR DESCRIPTION
## Summary
We need to do some form resubmissions because they were `expired` by Lighthouse and I realize that we need to separately track the benefits_intake_uuid on each submission attempt. The parent `FormSubmission` record will still have the benefits intake UUID, which is kind of confusing. It would be better to have the parent `FormSubmission` have no UUID and keep it all on each Attempt record but that would mean re-jiggering the data we have already. So let's leave that until later/never.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/820
