### PR TITLE
fix header merge

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -36,7 +36,7 @@ module TravelPay
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-API-Client-Number'] = client_number.to_s
         req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge(claim_headers)
+        req.headers = req.headers.merge(claim_headers)
         req.body = { authJwt: sts_token }
       end
 
@@ -196,7 +196,7 @@ module TravelPay
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge(claim_headers)
+        req.headers = req.headers.merge(claim_headers)
       end
     end
 

--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -36,7 +36,7 @@ module TravelPay
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-API-Client-Number'] = client_number.to_s
         req.headers['X-Correlation-ID'] = correlation_id
-        req.headers = req.headers.merge(claim_headers)
+        req.headers.merge!(claim_headers)
         req.body = { authJwt: sts_token }
       end
 
@@ -196,7 +196,7 @@ module TravelPay
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['X-Correlation-ID'] = correlation_id
-        req.headers = req.headers.merge(claim_headers)
+        req.headers.merge!(claim_headers)
       end
     end
 


### PR DESCRIPTION
Ruby hash merges are not in place without the `!` notation. This PR makes the merge work property to send all the headers.

Associated with department-of-veterans-affairs/va.gov-team#90699