### PR TITLE
stub_nm needs to be left aligned in BDN report

### DIFF
--- a/modules/vye/app/models/vye/verification.rb
+++ b/modules/vye/app/models/vye/verification.rb
@@ -39,12 +39,12 @@ module Vye
     REPORT_TEMPLATE =
       YAML.load(<<-END_OF_TEMPLATE).gsub(/\n/, '')
       |-
-        %7<stub_nm>s
-        %9<ssn>s
-        %8<transact_date>s
-        %3<rpo_code>s
-        %1<indicator>s
-        %1<source_ind>s
+        %-7<stub_nm>s
+        %-9<ssn>s
+        %-8<transact_date>s
+        %-3<rpo_code>s
+        %-1<indicator>s
+        %-1<source_ind>s
       END_OF_TEMPLATE
 
     private_constant :REPORT_TEMPLATE

--- a/modules/vye/spec/factories/vye/user_infos.rb
+++ b/modules/vye/spec/factories/vye/user_infos.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     file_number { (1..9).map(&digit).join }
     dob { Faker::Date.birthday }
-    stub_nm { Faker::Name.name }
+    stub_nm { format("#{Faker::Name.first_name[0, 1].upcase} #{Faker::Name.last_name[0, 3].upcase}") }
     mr_status { 'A' }
     rem_ent do
       months = (36 * rand).floor

--- a/modules/vye/spec/models/vye/verification_spec.rb
+++ b/modules/vye/spec/models/vye/verification_spec.rb
@@ -40,5 +40,17 @@ RSpec.describe Vye::Verification, type: :model do
 
       expect(io.string.scan("\n").count).to be(7)
     end
+
+    it 'writes out a report where the stub_nm is left aligned' do
+      io = StringIO.new
+
+      expect do
+        described_class.write_report(io)
+      end.not_to raise_error
+
+      stub_nm_list = io.string.split(/[\n]/).map { |x| x.slice(0, 7) }.flatten
+
+      expect(stub_nm_list.all? { |x| x.start_with?(/\S/) }).to be(true)
+    end
   end
 end


### PR DESCRIPTION
Update to report because BDN requires stub_nm field to be left justified.