### PR TITLE
[VI-384] Removing ssn and first_name requirement from SiS verified authentications

### DIFF
--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -112,10 +112,8 @@ module SignIn
         credential_attribute_check(:mhv_uuid, mhv_correlation_id)
       else
         credential_attribute_check(:dslogon_uuid, edipi) if dslogon_auth?
-        credential_attribute_check(:first_name, first_name) unless auto_uplevel
         credential_attribute_check(:last_name, last_name) unless auto_uplevel
         credential_attribute_check(:birth_date, birth_date) unless auto_uplevel
-        credential_attribute_check(:ssn, ssn) unless auto_uplevel
       end
       credential_attribute_check(:uuid, logingov_uuid || idme_uuid)
       credential_attribute_check(:email, credential_email)

--- a/lib/mpi/messages/add_person_implicit_search_message.rb
+++ b/lib/mpi/messages/add_person_implicit_search_message.rb
@@ -43,9 +43,7 @@ module MPI
 
       def validate_required_fields
         missing_values = []
-        missing_values << :first_name if first_name.blank?
         missing_values << :last_name if last_name.blank?
-        missing_values << :ssn if ssn.blank?
         missing_values << :birth_date if birth_date.blank?
         missing_values << :credential_identifier if idme_uuid.blank? && logingov_uuid.blank?
         raise Errors::ArgumentError, "Required values missing: #{missing_values}" if missing_values.present?
@@ -100,7 +98,9 @@ module MPI
                                                                 country: address[:country])
         end
         element << RequestHelper.build_identifier(identifier:, root: identifier_root)
-        element << RequestHelper.build_patient_identifier(identifier: ssn, root: ssn_root, class_code: ssn_class_code)
+        if ssn.present?
+          element << RequestHelper.build_patient_identifier(identifier: ssn, root: ssn_root, class_code: ssn_class_code)
+        end
         element << RequestHelper.build_patient_identifier(identifier:,
                                                           root: identifier_root,
                                                           class_code: identifier_class_code)

--- a/lib/mpi/messages/update_profile_message.rb
+++ b/lib/mpi/messages/update_profile_message.rb
@@ -46,9 +46,7 @@ module MPI
 
       def validate_required_fields
         missing_values = []
-        missing_values << :first_name if first_name.blank?
         missing_values << :last_name if last_name.blank?
-        missing_values << :ssn if ssn.blank?
         missing_values << :email if email.blank?
         missing_values << :birth_date if birth_date.blank?
         missing_values << :icn if icn.blank?
@@ -105,7 +103,9 @@ module MPI
         end
         element << RequestHelper.build_identifier(identifier:, root: identifier_root)
         element << RequestHelper.build_telecom(type: email_type, value: email)
-        element << RequestHelper.build_patient_identifier(identifier: ssn, root: ssn_root, class_code: ssn_class_code)
+        if ssn.present?
+          element << RequestHelper.build_patient_identifier(identifier: ssn, root: ssn_root, class_code: ssn_class_code)
+        end
         element << RequestHelper.build_patient_identifier(identifier:,
                                                           root: identifier_root,
                                                           class_code: identifier_class_code)

--- a/spec/lib/mpi/messages/add_person_implicit_search_message_spec.rb
+++ b/spec/lib/mpi/messages/add_person_implicit_search_message_spec.rb
@@ -42,23 +42,9 @@ describe MPI::Messages::AddPersonImplicitSearchMessage do
       end
     end
 
-    context 'when first name is not defined' do
-      let(:first_name) { nil }
-      let(:missing_keys) { [:first_name] }
-
-      it_behaves_like 'missing values response'
-    end
-
     context 'when last name is not defined' do
       let(:last_name) { nil }
       let(:missing_keys) { [:last_name] }
-
-      it_behaves_like 'missing values response'
-    end
-
-    context 'when ssn is not defined' do
-      let(:ssn) { nil }
-      let(:missing_keys) { [:ssn] }
 
       it_behaves_like 'missing values response'
     end

--- a/spec/lib/mpi/messages/update_profile_message_spec.rb
+++ b/spec/lib/mpi/messages/update_profile_message_spec.rb
@@ -47,23 +47,9 @@ describe MPI::Messages::UpdateProfileMessage do
       end
     end
 
-    context 'when first name is not defined' do
-      let(:first_name) { nil }
-      let(:missing_keys) { :first_name }
-
-      it_behaves_like 'error response'
-    end
-
     context 'when last name is not defined' do
       let(:last_name) { nil }
       let(:missing_keys) { :last_name }
-
-      it_behaves_like 'error response'
-    end
-
-    context 'when ssn is not defined' do
-      let(:ssn) { nil }
-      let(:missing_keys) { :ssn }
 
       it_behaves_like 'error response'
     end

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -478,8 +478,8 @@ describe MPI::Service do
     let(:first_name) { 'some-first-name' }
 
     context 'malformed request' do
-      let(:first_name) { nil }
-      let(:missing_keys) { [:first_name] }
+      let(:last_name) { nil }
+      let(:missing_keys) { [:last_name] }
       let(:expected_error) { MPI::Errors::ArgumentError }
       let(:expected_error_message) { "Required values missing: #{missing_keys}" }
 

--- a/spec/services/sign_in/attribute_validator_spec.rb
+++ b/spec/services/sign_in/attribute_validator_spec.rb
@@ -500,51 +500,6 @@ RSpec.describe SignIn::AttributeValidator do
           it_behaves_like 'missing credential attribute'
         end
 
-        context 'and credential is missing first_name' do
-          let(:first_name) { nil }
-          let(:attribute) { 'first_name' }
-
-          context 'and credential has been auto-uplevelled' do
-            let(:auto_uplevel) { true }
-            let(:find_profile_response) { create(:find_profile_response, profile: mpi_profile) }
-            let(:mpi_profile) do
-              build(:mpi_profile,
-                    id_theft_flag:,
-                    deceased_date:,
-                    ssn:,
-                    icn:,
-                    edipis:,
-                    edipi: edipis.first,
-                    mhv_ien: mhv_iens.first,
-                    mhv_iens:,
-                    birls_id: birls_ids.first,
-                    birls_ids:,
-                    participant_id: participant_ids.first,
-                    participant_ids:,
-                    birth_date:,
-                    given_names: [first_name],
-                    family_name: last_name)
-            end
-            let(:id_theft_flag) { false }
-            let(:deceased_date) { nil }
-            let(:icn) { 'some-icn' }
-            let(:edipis) { ['some-edipi'] }
-            let(:mhv_iens) { ['some-mhv-ien'] }
-            let(:participant_ids) { ['some-participant-id'] }
-            let(:birls_ids) { ['some-birls-id'] }
-
-            it 'does not raise an error' do
-              expect { subject }.not_to raise_error
-            end
-          end
-
-          context 'and credential is a verified non-auto-uplevelled credential' do
-            let(:auto_uplevel) { false }
-
-            it_behaves_like 'missing credential attribute'
-          end
-        end
-
         context 'and credential is missing last_name' do
           let(:last_name) { nil }
           let(:attribute) { 'last_name' }
@@ -593,51 +548,6 @@ RSpec.describe SignIn::AttributeValidator do
         context 'and credential is missing birth_date' do
           let(:birth_date) { nil }
           let(:attribute) { 'birth_date' }
-
-          context 'and credential has been auto-uplevelled' do
-            let(:auto_uplevel) { true }
-            let(:find_profile_response) { create(:find_profile_response, profile: mpi_profile) }
-            let(:mpi_profile) do
-              build(:mpi_profile,
-                    id_theft_flag:,
-                    deceased_date:,
-                    ssn:,
-                    icn:,
-                    edipis:,
-                    edipi: edipis.first,
-                    mhv_ien: mhv_iens.first,
-                    mhv_iens:,
-                    birls_id: birls_ids.first,
-                    birls_ids:,
-                    participant_id: participant_ids.first,
-                    participant_ids:,
-                    birth_date:,
-                    given_names: [first_name],
-                    family_name: last_name)
-            end
-            let(:id_theft_flag) { false }
-            let(:deceased_date) { nil }
-            let(:icn) { 'some-icn' }
-            let(:edipis) { ['some-edipi'] }
-            let(:mhv_iens) { ['some-mhv-ien'] }
-            let(:participant_ids) { ['some-participant-id'] }
-            let(:birls_ids) { ['some-birls-id'] }
-
-            it 'does not raise an error' do
-              expect { subject }.not_to raise_error
-            end
-          end
-
-          context 'and credential is a verified non-auto-uplevelled credential' do
-            let(:auto_uplevel) { false }
-
-            it_behaves_like 'missing credential attribute'
-          end
-        end
-
-        context 'and credential is missing ssn' do
-          let(:ssn) { nil }
-          let(:attribute) { 'ssn' }
 
           context 'and credential has been auto-uplevelled' do
             let(:auto_uplevel) { true }
@@ -718,13 +628,6 @@ RSpec.describe SignIn::AttributeValidator do
           it_behaves_like 'missing credential attribute'
         end
 
-        context 'and credential is missing first_name' do
-          let(:first_name) { nil }
-          let(:attribute) { 'first_name' }
-
-          it_behaves_like 'missing credential attribute'
-        end
-
         context 'and credential is missing last_name' do
           let(:last_name) { nil }
           let(:attribute) { 'last_name' }
@@ -735,13 +638,6 @@ RSpec.describe SignIn::AttributeValidator do
         context 'and credential is missing birth_date' do
           let(:birth_date) { nil }
           let(:attribute) { 'birth_date' }
-
-          it_behaves_like 'missing credential attribute'
-        end
-
-        context 'and credential is missing ssn' do
-          let(:ssn) { nil }
-          let(:attribute) { 'ssn' }
 
           it_behaves_like 'missing credential attribute'
         end
@@ -781,13 +677,6 @@ RSpec.describe SignIn::AttributeValidator do
           it_behaves_like 'missing credential attribute'
         end
 
-        context 'and credential is missing first_name' do
-          let(:first_name) { nil }
-          let(:attribute) { 'first_name' }
-
-          it_behaves_like 'missing credential attribute'
-        end
-
         context 'and credential is missing last_name' do
           let(:last_name) { nil }
           let(:attribute) { 'last_name' }
@@ -798,13 +687,6 @@ RSpec.describe SignIn::AttributeValidator do
         context 'and credential is missing birth_date' do
           let(:birth_date) { nil }
           let(:attribute) { 'birth_date' }
-
-          it_behaves_like 'missing credential attribute'
-        end
-
-        context 'and credential is missing ssn' do
-          let(:ssn) { nil }
-          let(:attribute) { 'ssn' }
 
           it_behaves_like 'missing credential attribute'
         end


### PR DESCRIPTION
## Summary

- This PR removes the check requiring SSN and first_name in a verified credential before allowing auth

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-384

## Testing done

- [ ] Logged in with mocked user that has no ssn/first_name in credential or MPI response
- [ ] Confirmed authentication occurred successfully

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [x] Update mock data so that chosen credential does not had first name and/or ssn
- [x] Update mock data so that corresponding MPI record does not have first name and/or ssn
- [x] Authenticate and prove you are able to authenticate successfully
