### PR TITLE
add ARP to DataDog service catalog

### DIFF
--- a/datadog-service-catalog/datadog-service-catalog.yml
+++ b/datadog-service-catalog/datadog-service-catalog.yml
@@ -1,5 +1,43 @@
 ---
 schema-version: v2.2
+dd-service: accredited-representative-portal
+team: benefits
+application: Accredited Representative Portal
+tier: '1'
+lifecycle: pre-production
+contacts:
+  - name: benefits-representation-engineering
+    type: slack
+    contact: https://dsva.slack.com/archives/C06ABHUNBRS
+description: "For details, visit:
+  https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/pro\
+  ducts/accredited-representative-facing"
+links:
+  - name: ARF Engineering
+    type: doc
+    provider: GitHub
+    url: https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/accredited-representative-facing/engineering
+  - name: ARP Engine in vets-api
+    type: repo
+    provider: github
+    url: https://github.com/department-of-veterans-affairs/vets-api/tree/35e2ebe672b7d2d92c16473e336b99c3a372afda/modules/accredited_representative_portal
+  - name: ARP Frontend
+    type: repo
+    provider: github
+    url: https://github.com/department-of-veterans-affairs/vets-website/tree/5224ca7500fd9292b8fe29d967bcb4ab55f93df3/src/applications/accredited-representative-portal
+  - name: ARP Layout
+    type: repo
+    provider: github
+    url: https://github.com/department-of-veterans-affairs/content-build/blob/6c82218da1661c090d2883b26f40cf18e173ff98/src/site/layouts/representative.html
+tags:
+  - accredited-representative-portal
+type: web
+languages:
+  - ruby
+  - javascript
+integrations: {}
+---
+schema-version: v2.2
 dd-service: dependent-change
 team: benefits
 application: 686c/674

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
@@ -4,11 +4,7 @@ module AccreditedRepresentativePortal
   class ApplicationController < SignIn::ApplicationController
     include SignIn::AudienceValidator
     include Authenticable
-    # TODO: Add ARP to Datadog Service Catalog #77004
-    #   https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/77004
-    # It will be the dd-service property for your application here:
-    #   https://github.com/department-of-veterans-affairs/vets-api/tree/master/datadog-service-catalog
-    service_tag 'accredited-representative-portal'
+    service_tag 'accredited-representative-portal' # ARP DataDog monitoring: https://bit.ly/arp-datadog-monitoring
     validates_access_token_audience Settings.sign_in.arp_client_id
 
     before_action :verify_pilot_enabled_for_user


### PR DESCRIPTION
## Summary
Updates comment to add ARP to the DataDog service catalog with a link to the relevant entry.

- *This work is behind a feature toggle (flipper): YES*

## Related issue(s)
https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/77004

See screenshot of [ARP working in datadog in `env: eks-staging`](https://vagov.ddog-gov.com/apm/services/accredited-representative-portal/operations/rack.request/resources?query=env%3Aeks-prod%20operation_name%3Arack.request%20service%3Aaccredited-representative-portal&dependencyMap=qson%3A%28data%3A%28telemetrySelection%3Aall_sources%29%2Cversion%3A%210%29&deployments=qson%3A%28data%3A%28hits%3A%28selected%3Aversion_count%29%2Cerrors%3A%28selected%3Aversion_count%29%2Clatency%3A%2195%2CtopN%3A%215%29%2Cversion%3A%210%29&env=eks-staging&errors=qson%3A%28data%3A%28issueSort%3ATOTAL_COUNT%29%2Cversion%3A%210%29&fromUser=false&groupMapByOperation=null&logs=qson%3A%28data%3A%28indexes%3A%5B%5D%29%2Cversion%3A%210%29&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&query_translation_version=v0&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap95%29%2CtopN%3A%215%29%2Cversion%3A%211%29&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%2ClagMetrics%3A%28selectedMetric%3A%21s%2CselectedGroupBy%3A%21s%29%29%2Cversion%3A%211%29&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&view=spans&start=1724365070184&end=1724368670184&paused=false#resources):
![image](https://github.com/user-attachments/assets/122a4dbd-0d76-4575-b8e4-f9614310ae46)


