### PR TITLE
90381 add Parent attribute to facility

### DIFF
--- a/lib/lighthouse/facilities/facility.rb
+++ b/lib/lighthouse/facilities/facility.rb
@@ -30,6 +30,7 @@ module Lighthouse
       attribute :unique_id, String
       attribute :visn, String
       attribute :website, String
+      attribute :parent, Object
 
       def initialize(fac)
         super(fac)

--- a/spec/lib/lighthouse/facilities/client_spec.rb
+++ b/spec/lib/lighthouse/facilities/client_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Lighthouse::Facilities::Client, team: :facilities, vcr: vcr_optio
 
   let(:vha_358_attributes) do
     {
-      id: 'vha_358',
+      id: 'vha_358AB',
       type: 'va_facilities',
       name: 'Manila VA Clinic',
       facility_type: 'va_health_facility',
@@ -86,7 +86,8 @@ RSpec.describe Lighthouse::Facilities::Client, team: :facilities, vcr: vcr_optio
       operating_status: { 'code' => 'NORMAL' },
       operational_hours_special_instructions: nil,
       facility_type_prefix: 'vha',
-      unique_id: '358'
+      unique_id: '358AB',
+      parent: { 'id' => 'vha_358' }
     }
   end
 

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -246,6 +246,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                                               'name' => "Baxter Springs City Soldiers' Lot",
                                               'operating_status' => { 'code' => 'NORMAL' },
                                               'operational_hours_special_instructions' => nil,
+                                              'parent' => nil,
                                               'phone' => { 'fax' => '9137584136', 'main' => '9137584105' },
                                               'services' => nil,
                                               'type' => 'va_facilities',

--- a/spec/support/vcr_cassettes/lighthouse/facilities.yml
+++ b/spec/support/vcr_cassettes/lighthouse/facilities.yml
@@ -114,8 +114,8 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"data":{"id":"vha_358","type":"va_facilities","attributes":{"name":"Manila
-        VA Clinic","facility_type":"va_health_facility","classification":"Other Outpatient
+      string: '{"data":{"id":"vha_358AB","type":"va_facilities","attributes":{"name":"Manila
+        VA Clinic","parent":{"id":"vha_358"},"facility_type":"va_health_facility","classification":"Other Outpatient
         Services (OOS)","website":null,"lat":14.54408,"long":120.99139,"address":{"mailing":{},"physical":{"zip":"01302","city":"Pasay
         City","state":"PH","address_1":"1501 Roxas Boulevard","address_2":"NOX3 Seafront
         Compound","address_3":null}},"phone":{"fax":"632-310-5962","main":"632-550-3888","pharmacy":"632-550-3888
@@ -1872,8 +1872,8 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"vha_358","type":"va_facilities","attributes":{"name":"Manila
-        VA Clinic","facility_type":"va_health_facility","classification":"Other Outpatient
+      string: '{"data":[{"id":"vha_358AB","type":"va_facilities","attributes":{"name":"Manila
+        VA Clinic","parent":{"id":"vha_358"},"facility_type":"va_health_facility","classification":"Other Outpatient
         Services (OOS)","website":null,"lat":14.54408,"long":120.99139,"address":{"mailing":{},"physical":{"zip":"01302","city":"Pasay
         City","state":"PH","address_1":"1501 Roxas Boulevard","address_2":"NOX3 Seafront
         Compound","address_3":null}},"phone":{"fax":"632-310-5962","main":"632-550-3888","pharmacy":"632-550-3888
@@ -1967,8 +1967,8 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"vha_358","type":"va_facilities","attributes":{"name":"Manila
-        VA Clinic","facility_type":"va_health_facility","classification":"Other Outpatient
+      string: '{"data":[{"id":"vha_358AB","type":"va_facilities","attributes":{"name":"Manila
+        VA Clinic","parent":{"id":"vha_358"},"facility_type":"va_health_facility","classification":"Other Outpatient
         Services (OOS)","website":null,"lat":14.54408,"long":120.99139,"address":{"mailing":{},"physical":{"zip":"01302","city":"Pasay
         City","state":"PH","address_1":"1501 Roxas Boulevard","address_2":"NOX3 Seafront
         Compound","address_3":null}},"phone":{"fax":"632-310-5962","main":"632-550-3888","pharmacy":"632-550-3888


### PR DESCRIPTION
## Summary
- *This work is behind a feature toggle (flipper):* NO
- Adds a `parent` attribute to the Facilities retrieved from Lighthouse.
- This matches the new v1 return value structure, since v0 didn't have the attribute
- We will use this value in the Caregiver signup process to make sure that if a Veteran's main medical facility doesn't have the Caregiver Support service, we assign the Caregiver to a facility that does.
- 10-10EZ/CG Health Enrollment team
- No Flipper is necessary since this is purely additive - we're not taking away or changing anything anyone could rely on.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90381

## Testing done

- [x] *New code is covered by unit tests*
- Previously the model ignored the `parent` attribute, even though Lighthouse started sending it in v1.
- Now the model extracts the `parent` value from its response attributes.
- To reproduce, launch a local rails console with `bundle exec rails c`, then run:
```
require 'lighthouse/facilities/v1/client'
lighthouse_facilities_service ||= Lighthouse::Facilities::V1::Client.new
lighthouse_facilities_service.get_facilities(state: 'VT').map{|a| [a.id, a.unique_id, a.parent]}
```
- ... or the equivalent for another state. Confirm that the model gets the `parent` value for any facilities that have one, equal to the facility's ID without any trailing letters after the station number, e.g.,
- `["vha_405GA", "405GA", {"id"=>"vha_405", "link"=>"https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_405"}],`
- note that a parent facility will list itself as its own parent, e.g., `["vha_405", "405", {"id"=>"vha_405", "link"=>"https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_405"}],`
- non-health facilities may have none, e.g., `["nca_061", "061", nil],`
- *What is the testing plan for rolling out the feature?*
    - This will be tested through the frontend once that's built.

## What areas of the site does it impact?
None for now. CG signup when the frontend work is done.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
