### PR TITLE
replace mhv notification toggles with new ones

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -964,9 +964,18 @@ features:
   profile_user_claims:
     actor_type: user
     description: When enabled, /v0/user will return user profile claims for accessing service endpoints.
-  profile_show_mhv_notification_settings:
+  profile_show_mhv_notification_settings_email_appointment_reminders:
     actor_type: user
-    description: Display MHV notification settings - RX refill shipment, appointment, secure messaging, and medical images/reports
+    description: Show/Hide the email channel for Health appointment reminders notifications
+  profile_show_mhv_notification_settings_email_rx_shipment:
+    actor_type: user
+    description: Show/Hide the email channel for Prescription shipping notifications
+  profile_show_mhv_notification_settings_new_secure_messaging:
+    actor_type: user
+    description: Display MHV notification settings - New secure message notifications
+  profile_show_mhv_notification_settings_medical_images:
+    actor_type: user
+    description: Display MHV notification settings - Medical images/reports notifications
   profile_show_military_academy_attendance:
     actor_type: user
     description: When enabled, profile service history will include military academy attendance.
@@ -990,9 +999,6 @@ features:
   profile_show_direct_deposit_single_form_edu_downtime:
     actor_type: user
     description: Show/hide the edu direct deposit form and instead display a downtime message in its place
-  profile_show_email_notification_settings:
-    actor_type: user
-    description: Show/Hide the email channel based notification settings in profile
   profile_show_payments_notification_setting:
     actor_type: user
     description: Show/Hide the payments section of notifications in profile


### PR DESCRIPTION
## Summary

- **Added new toggles:**
  - `profile_show_mhv_notification_settings_email_appointment_reminders`
  - `profile_show_mhv_notification_settings_new_secure_messaging`
  - `profile_show_mhv_notification_settings_email_rx_shipment`
  - `profile_show_mhv_notification_settings_medical_images`
  
- **Removed toggles:**
  - `profile_show_email_notification_settings`
  - `profile_show_mhv_notification_settings`

#### Details:

- The old toggle `profile_show_email_notification_settings` was responsible for displaying the email notification checkbox options for:
  - Appointment reminders
  - Prescription shipment and tracking updates
  - RX refill shipment notifications
  - VA Appointment reminders
  - Secure messaging alerts
  - Medical images and reports available settings

- The old toggle `profile_show_mhv_notification_settings` was responsible for displaying all the above fields except Appointment reminders.

- The new toggles have the following responsibilities:
  - `profile_show_mhv_notification_settings_email_appointment_reminders`: Controls only the Appointment reminder's EMAIL field.
  - `profile_show_mhv_notification_settings_new_secure_messaging`: Controls the entire Secure messaging alert field.
  - `profile_show_mhv_notification_settings_email_rx_shipment`: Controls the Prescription shipment and tracking updates field.
  - `profile_show_mhv_notification_settings_medical_images`: Controls the Medical images field.

**Timeframe for toggle**
- Depends on when MHV migrates

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89528

## Testing done

Test locally

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Toggle added
- [x]  No error nor warning in the console.
