### PR TITLE
[CST] [Backend] Removed cst_use_claim_details_v2 from features.yml

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -218,10 +218,6 @@ features:
     actor_type: user
     description: When enabled, the Download Decision Letters feature includes 5103 letters
     enable_in_development: true
-  cst_use_claim_details_v2:
-    actor_type: user
-    description: When enabled, claims status tool uses the new claim details design
-    enable_in_development: true
   cst_use_dd_rum:
     actor_type: user
     description: When enabled, claims status tool uses DataDog's Real User Monitoring logging


### PR DESCRIPTION
## Summary

- Removed `cst_use_claim_details_v2` feature toggle from `features.yml`

## Related issue(s)

- [[CST] [ENG] Remove the feature flag cst_use_claim_details_v2 from vets-api](https://github.com/department-of-veterans-affairs/va.gov-team/issues/87712)
