### PR TITLE
Re-record Form1010_ezr cassettes

### DIFF
--- a/config/health_care_application/wsdl/voa.wsdl
+++ b/config/health_care_application/wsdl/voa.wsdl
@@ -3,7 +3,6 @@
 -->
 <definitions
     xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-    xmlns:tns="http://va.gov/service/esr/voa/v1"
     xmlns:ns1="http://va.gov/schema/esr/voa/v1"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://va.gov/service/esr/voa/v1" name="voaService">

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -303,8 +303,8 @@ RSpec.describe Form1010Ezr::Service do
           expect(submission_response).to eq(
             {
               success: true,
-              formSubmissionId: 432_775_981,
-              timestamp: '2023-11-21T14:42:44.858-06:00'
+              formSubmissionId: 436_462_561,
+              timestamp: '2024-08-23T13:00:11.005-05:00'
             }
           )
         end
@@ -342,8 +342,8 @@ RSpec.describe Form1010Ezr::Service do
             expect(service.submit_sync(overridden_form)).to eq(
               {
                 success: true,
-                formSubmissionId: 432_777_930,
-                timestamp: '2023-11-21T16:29:52.432-06:00'
+                formSubmissionId: 436_460_791,
+                timestamp: '2024-08-23T11:49:44.562-05:00'
               }
             )
           end
@@ -365,8 +365,8 @@ RSpec.describe Form1010Ezr::Service do
             expect(service.submit_sync(form)).to eq(
               {
                 success: true,
-                formSubmissionId: 432_861_975,
-                timestamp: '2023-11-30T09:52:37.290-06:00'
+                formSubmissionId: 436_462_887,
+                timestamp: '2024-08-23T13:22:29.157-05:00'
               }
             )
           end
@@ -386,8 +386,8 @@ RSpec.describe Form1010Ezr::Service do
             expect(service.submit_sync(form)).to eq(
               {
                 success: true,
-                formSubmissionId: 433_956_488,
-                timestamp: '2024-03-13T13:14:50.252-05:00'
+                formSubmissionId: 436_462_892,
+                timestamp: '2024-08-23T13:22:59.196-05:00'
               }
             )
           end
@@ -406,8 +406,8 @@ RSpec.describe Form1010Ezr::Service do
               expect(service.submit_sync(ezr_form_with_attachments)).to eq(
                 {
                   success: true,
-                  formSubmissionId: 435_845_348,
-                  timestamp: '2024-07-17T13:17:32.384-05:00'
+                  formSubmissionId: 436_462_804,
+                  timestamp: '2024-08-23T13:20:06.967-05:00'
                 }
               )
               expect(Rails.logger).to have_received(:info).with(
@@ -443,8 +443,8 @@ RSpec.describe Form1010Ezr::Service do
               expect(service.submit_sync(form_with_non_pdf_attachment)).to eq(
                 {
                   success: true,
-                  formSubmissionId: 435_845_365,
-                  timestamp: '2024-07-17T13:17:35.167-05:00'
+                  formSubmissionId: 436_462_905,
+                  timestamp: '2024-08-23T13:23:53.956-05:00'
                 }
               )
               expect(Rails.logger).to have_received(:info).with(

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit.yml
@@ -42,7 +42,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 21 Nov 2023 20:42:44 GMT
+      - Fri, 23 Aug 2024 18:00:10 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -50,13 +50,13 @@ http_interactions:
       Content-Security-Policy:
       - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
       Content-Length:
-      - '10838'
+      - '17028'
       Accept:
       - text/xml
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - bddca6b8-059e-431a-8624-33eec916e5e2-00005d8e
+      - 1457e295-3ad6-49d6-ab54-4373104dff9c-00b60586
       Soapaction:
       - '""'
       X-Oneagent-Js-Injection:
@@ -70,7 +70,7 @@ http_interactions:
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1405277406"
+      - dtSInfo;desc="0", dtRpid;desc="1173062715"
       Content-Type:
       - text/xml; charset=UTF-8
       Strict-Transport-Security:
@@ -78,47 +78,84 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
+        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>Part
+        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
+        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
         Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
         IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance><insurance><groupName>Part
-        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
-        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
+        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Pre-Certification
+        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
         ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
-        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-21T14:30:05.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
+        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
         CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
-        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility><eligibility><type>SERVICE
-        ACT</type><indicator>S</indicator><eligibilityReportDate>2023-11-21T14:30:05.000-06:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
+        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
         for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
+        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
+        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
+        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
         Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
         condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2023-11-21T14:41:53.000-06:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-21T14:30:05.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
+        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2024-08-23T11:49:44.000-05:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Primary
+        Next of Kin</contactType><givenName>FIRSTNOKA</givenName><middleName>MIDDLENOKA</middleName><familyName>LASTNOKA</familyName><relationship>SON</relationship><address><line1>476
+        TEST AVE</line1><city>DULLES</city><state>VA</state><zipCode>20101</zipCode><zipPlus4>0101</zipPlus4><country>USA</country></address><primaryPhone>1239131234</primaryPhone><lastUpdateDate>2024-08-20T18:54:12.000-05:00</lastUpdateDate><alternatePhone>7254551234</alternatePhone></association><association><contactType>Emergency
+        Contact</contactType><givenName>FIRSTECA</givenName><middleName>MIDDLEECA</middleName><familyName>LASTECA</familyName><relationship>BROTHER</relationship><address><line1>28
+        NW 78TH ST</line1><city>DULLES</city><state>VA</state><zipCode>20101</zipCode><zipPlus4>0101</zipPlus4><country>USA</country></address><primaryPhone>7452743546</primaryPhone><lastUpdateDate>2024-08-20T18:54:12.000-05:00</lastUpdateDate><alternatePhone>2699352134</alternatePhone></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
         - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-21T14:30:05.000-06:00</addressChangeDateTime><addressChangeSource>Health
+        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>7321
+        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>MEX</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2024-08-23T11:49:44.000-05:00</addressChangeDateTime><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address><address><line1>123 M ST</line1><city>CO
-        SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
+        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2024-08-23T11:49:53.000-05:00</contactMethodReportDate></address><address><line1>123
+        M ST</line1><city>CO SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>7321
-        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2023-11-21T14:41:53.000-06:00</addressChangeDateTime><addressChangeSource>Health
+        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>123
+        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>MEX</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2024-08-23T11:49:44.000-05:00</addressChangeDateTime><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2023-11-21T14:41:53.000-06:00</contactMethodReportDate></address></addresses><phones><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2023-11-21T14:41:53.000-06:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
+        CENTER</addressChangeSite></address></addresses><phones><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2024-08-23T11:49:44.000-05:00</phoneNumberReportDate></phone><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
         - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate><preferredLanguage>eng
+        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2024-08-23T11:49:46.000-05:00</assignmentDate><preferredLanguage>eng
         - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:32:19.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:17:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
         - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-17T13:17:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
         - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2023-11-21T14:42:44</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T15:34:19.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-03-13T12:31:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:10.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:53:47.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T12:12:19.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:54:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T13:36:06.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T19:28:05.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:51:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:18:28.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:08:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:55:07.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T11:01:56.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:54:13.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:55:38.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T15:44:34.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-21T17:48:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:42:11.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:53:17.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-03-13T13:14:55.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T11:49:46.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-08-23T13:00:10</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
   recorded_at: Tue, 21 Nov 2023 20:42:44 GMT
 - request:
     method: post
@@ -155,7 +192,7 @@ http_interactions:
       Date:
       - Tue, 21 Nov 2023 20:42:44 GMT
       Content-Length:
-      - '12415'
+      - '12416'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -164,7 +201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 21 Nov 2023 20:42:44 GMT
+      - Fri, 23 Aug 2024 18:00:10 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -174,7 +211,7 @@ http_interactions:
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - 666a9a68-12e6-47b1-8338-7f0ead38eb6b-0001ce15
+      - c2c62aca-191c-42ad-bad8-dbbd9c5271ad-001eeb55
       X-Oneagent-Js-Injection:
       - 'true'
       Ssl-Env:
@@ -186,7 +223,7 @@ http_interactions:
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1471439173"
+      - dtSInfo;desc="0", dtRpid;desc="1548009941"
       Transfer-Encoding:
       - chunked
       Content-Type:
@@ -196,7 +233,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><submitFormResponse
-        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>432775981</formSubmissionId><message><type>Form
-        successfully received for EE processing</type></message><timeStamp>2023-11-21T14:42:44.858-06:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
+        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>436462561</formSubmissionId><message><type>Form
+        successfully received for EE processing</type></message><timeStamp>2024-08-23T13:00:11.005-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
   recorded_at: Tue, 21 Nov 2023 20:42:44 GMT
-recorded_with: VCR 6.2.0
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_async.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_async.yml
@@ -31,7 +31,7 @@ http_interactions:
       User-Agent:
       - Vets.gov Agent
       Date:
-      - Thu, 01 Feb 2024 20:53:43 GMT
+      - Fri, 23 Aug 2024 18:30:18 GMT
       Content-Length:
       - '975'
       Accept-Encoding:
@@ -42,7 +42,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Feb 2024 20:53:43 GMT
+      - Fri, 23 Aug 2024 18:30:19 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -50,13 +50,13 @@ http_interactions:
       Content-Security-Policy:
       - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
       Content-Length:
-      - '12607'
+      - '17828'
       Accept:
       - text/xml
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - 1a6a995c-aa91-4eca-b07c-bf0e9271cc9c-0007a256
+      - 1457e295-3ad6-49d6-ab54-4373104dff9c-00b6295e
       Soapaction:
       - '""'
       X-Oneagent-Js-Injection:
@@ -70,7 +70,7 @@ http_interactions:
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="-522265326"
+      - dtSInfo;desc="0", dtRpid;desc="946632237"
       Content-Type:
       - text/xml; charset=UTF-8
       Strict-Transport-Security:
@@ -78,56 +78,88 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
-        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>Part
+        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>Part
         A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
         FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
         Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
         IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
+        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Pre-Certification
+        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
+        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
         1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
         CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
         Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
         for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
+        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
+        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
+        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
         Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
         condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2023-12-22T11:23:42.000-06:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>988
-        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
+        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2024-08-23T13:23:53.000-05:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Primary
+        Next of Kin</contactType><givenName>FIRSTNOKA</givenName><middleName>MIDDLENOKA</middleName><familyName>LASTNOKA</familyName><relationship>SON</relationship><address><line1>476
+        TEST AVE</line1><city>DULLES</city><state>VA</state><zipCode>20101</zipCode><zipPlus4>0101</zipPlus4><country>USA</country></address><primaryPhone>1239131234</primaryPhone><lastUpdateDate>2024-08-23T13:22:29.000-05:00</lastUpdateDate><alternatePhone>7254551234</alternatePhone></association><association><contactType>Emergency
+        Contact</contactType><givenName>FIRSTECA</givenName><middleName>MIDDLEECA</middleName><familyName>LASTECA</familyName><relationship>BROTHER</relationship><address><line1>28
+        NW 78TH ST</line1><city>DULLES</city><state>VA</state><zipCode>20101</zipCode><zipPlus4>0101</zipPlus4><country>USA</country></address><primaryPhone>7452743546</primaryPhone><lastUpdateDate>2024-08-23T13:22:29.000-05:00</lastUpdateDate><alternatePhone>2699352134</alternatePhone></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
+        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>742
+        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>7321
+        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2024-08-23T13:23:53.000-05:00</addressChangeDateTime><addressChangeSource>Health
+        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
+        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2024-08-23T13:23:53.000-05:00</contactMethodReportDate></address><address><line1>123
         M ST</line1><city>CO SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
         CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-27T12:59:14.000-06:00</addressChangeDateTime><addressChangeSource>Health
+        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2024-08-23T13:00:11.000-05:00</addressChangeDateTime><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address><address><line1>7321 SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2023-12-22T11:23:42.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2023-12-22T11:23:42.000-06:00</contactMethodReportDate></address></addresses><phones><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2023-12-22T11:23:42.000-06:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
+        CENTER</addressChangeSite></address></addresses><phones><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2024-08-23T13:23:53.000-05:00</phoneNumberReportDate></phone><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
         - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate><preferredLanguage>eng
+        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2024-08-23T13:23:55.000-05:00</assignmentDate><preferredLanguage>eng
         - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
         - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:32:19.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:17:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
         - DAYT20</preferredFacility><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-17T13:17:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T15:34:19.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-03-13T12:31:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:10.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:53:47.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T12:12:19.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:54:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T13:36:06.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T19:28:05.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:23:00.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:51:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:18:28.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:08:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:55:07.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
         - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-02-01T14:53:43</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
-  recorded_at: Thu, 01 Feb 2024 20:53:43 GMT
-recorded_with: VCR 6.2.0
+        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T11:01:56.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:54:13.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:22:30.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:55:38.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T15:44:34.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-21T17:48:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:42:11.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:00:12.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:23:55.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:53:17.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:20:08.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-03-13T13:14:55.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T11:49:46.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-08-23T13:30:19</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
+  recorded_at: Fri, 23 Aug 2024 18:30:19 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_attachments.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_attachments.yml
@@ -2,139 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: <%= Settings.hca.ee.endpoint %>
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0"?>
-        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sch="http://jaxws.webservices.esr.med.va.gov/schemas">
-          <SOAP-ENV:Header>
-            <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustUnderstand="1">
-              <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="XWSSGID-1281117217796-43574433">
-                <wsse:Username>HCASvcUsr</wsse:Username>
-                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"><EE_PASS></wsse:Password>
-              </wsse:UsernameToken>
-            </wsse:Security>
-          </SOAP-ENV:Header>
-          <SOAP-ENV:Body>
-            <sch:getEESummaryRequest>
-              <sch:key>1013032368V065534</sch:key>
-              <sch:requestName>HCAData</sch:requestName>
-            </sch:getEESummaryRequest>
-          </SOAP-ENV:Body>
-        </SOAP-ENV:Envelope>
-    headers:
-      Accept:
-      - text/xml;charset=UTF-8
-      Content-Type:
-      - text/xml;charset=UTF-8
-      User-Agent:
-      - Vets.gov Agent
-      Date:
-      - Wed, 17 Jul 2024 18:17:30 GMT
-      Content-Length:
-      - '975'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Jul 2024 18:17:31 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '14207'
-      Accept:
-      - text/xml
-      X-Oracle-Dms-Rid:
-      - '0'
-      X-Oracle-Dms-Ecid:
-      - 82cbcd40-702c-4bea-bcb9-6d580a97a368-000c5553
-      Soapaction:
-      - '""'
-      X-Oneagent-Js-Injection:
-      - 'true'
-      Ssl-Env:
-      - 'On'
-      Cache-Control:
-      - max-age=0, no-store
-      Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="-44608336"
-      Content-Type:
-      - text/xml; charset=UTF-8
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: UTF-8
-      string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>Part
-        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
-        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
-        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
-        Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
-        IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
-        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
-        CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
-        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
-        for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
-        Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
-        condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2024-07-16T14:36:35.000-05:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>988
-        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-27T12:59:14.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address><address><line1>123 M ST</line1><city>CO
-        SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>7321
-        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2024-07-16T14:36:35.000-05:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2024-07-16T14:36:35.000-05:00</contactMethodReportDate></address></addresses><phones><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2024-07-16T14:36:35.000-05:00</phoneNumberReportDate></phone><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
-        - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2024-07-16T14:36:36.000-05:00</assignmentDate><preferredLanguage>eng
-        - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:08:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:18:28.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:55:07.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-03-13T13:14:55.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:42:11.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:10.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-03-13T12:31:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:17:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-07-16T13:36:06.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:32:19.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-07-17T13:17:31</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
-  recorded_at: Wed, 17 Jul 2024 18:17:31 GMT
-- request:
-    method: post
     uri: <%= Settings.hca.endpoint %>
     body:
       encoding: UTF-8
@@ -166,7 +33,7 @@ http_interactions:
       User-Agent:
       - Vets.gov Agent
       Date:
-      - Wed, 17 Jul 2024 18:17:31 GMT
+      - Wed, 17 Jul 2024 18:17:30 GMT
       Content-Length:
       - '370784'
       Accept-Encoding:
@@ -177,21 +44,29 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Jul 2024 18:17:32 GMT
+      - Fri, 23 Aug 2024 18:20:06 GMT
       Server:
       - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - 0f3c7236-7702-4cda-b906-122f47406d27-0006e0bb
+      - c2c62aca-191c-42ad-bad8-dbbd9c5271ad-001ef1eb
       X-Oneagent-Js-Injection:
       - 'true'
       Ssl-Env:
       - 'On'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="-1733665142"
+      - dtSInfo;desc="0", dtRpid;desc="1540721108"
       Transfer-Encoding:
       - chunked
       Content-Type:
@@ -201,7 +76,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><submitFormResponse
-        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>435845348</formSubmissionId><message><type>Form
-        successfully received for EE processing</type></message><timeStamp>2024-07-17T13:17:32.384-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
-  recorded_at: Wed, 17 Jul 2024 18:17:32 GMT
-recorded_with: VCR 6.2.0
+        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>436462804</formSubmissionId><message><type>Form
+        successfully received for EE processing</type></message><timeStamp>2024-08-23T13:20:06.967-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
+  recorded_at: Wed, 17 Jul 2024 18:17:30 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_es_dev_uri.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_es_dev_uri.yml
@@ -42,7 +42,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 21 Nov 2023 20:42:44 GMT
+      - Fri, 23 Aug 2024 18:28:06 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -50,13 +50,13 @@ http_interactions:
       Content-Security-Policy:
       - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
       Content-Length:
-      - '10838'
+      - '17828'
       Accept:
       - text/xml
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - bddca6b8-059e-431a-8624-33eec916e5e2-00005d8e
+      - 1457e295-3ad6-49d6-ab54-4373104dff9c-00b626bc
       Soapaction:
       - '""'
       X-Oneagent-Js-Injection:
@@ -70,7 +70,7 @@ http_interactions:
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1405277406"
+      - dtSInfo;desc="0", dtRpid;desc="1513080260"
       Content-Type:
       - text/xml; charset=UTF-8
       Strict-Transport-Security:
@@ -78,125 +78,88 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
+        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>Part
+        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
+        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
         Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
         IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance><insurance><groupName>Part
-        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
-        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
+        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Pre-Certification
+        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
         ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
-        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-21T14:30:05.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
+        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
         CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
-        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility><eligibility><type>SERVICE
-        ACT</type><indicator>S</indicator><eligibilityReportDate>2023-11-21T14:30:05.000-06:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
+        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
         for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
+        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
+        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
+        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
         Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
         condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2023-11-21T14:41:53.000-06:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-21T14:30:05.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
+        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2024-08-23T13:23:53.000-05:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Primary
+        Next of Kin</contactType><givenName>FIRSTNOKA</givenName><middleName>MIDDLENOKA</middleName><familyName>LASTNOKA</familyName><relationship>SON</relationship><address><line1>476
+        TEST AVE</line1><city>DULLES</city><state>VA</state><zipCode>20101</zipCode><zipPlus4>0101</zipPlus4><country>USA</country></address><primaryPhone>1239131234</primaryPhone><lastUpdateDate>2024-08-23T13:22:29.000-05:00</lastUpdateDate><alternatePhone>7254551234</alternatePhone></association><association><contactType>Emergency
+        Contact</contactType><givenName>FIRSTECA</givenName><middleName>MIDDLEECA</middleName><familyName>LASTECA</familyName><relationship>BROTHER</relationship><address><line1>28
+        NW 78TH ST</line1><city>DULLES</city><state>VA</state><zipCode>20101</zipCode><zipPlus4>0101</zipPlus4><country>USA</country></address><primaryPhone>7452743546</primaryPhone><lastUpdateDate>2024-08-23T13:22:29.000-05:00</lastUpdateDate><alternatePhone>2699352134</alternatePhone></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
         - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-21T14:30:05.000-06:00</addressChangeDateTime><addressChangeSource>Health
+        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>7321
+        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2024-08-23T13:23:53.000-05:00</addressChangeDateTime><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address><address><line1>123 M ST</line1><city>CO
-        SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
+        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2024-08-23T13:23:53.000-05:00</contactMethodReportDate></address><address><line1>123
+        M ST</line1><city>CO SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>7321
-        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2023-11-21T14:41:53.000-06:00</addressChangeDateTime><addressChangeSource>Health
+        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>123
+        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2024-08-23T13:00:11.000-05:00</addressChangeDateTime><addressChangeSource>Health
         Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2023-11-21T14:41:53.000-06:00</contactMethodReportDate></address></addresses><phones><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2023-11-21T14:41:53.000-06:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
+        CENTER</addressChangeSite></address></addresses><phones><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2024-08-23T13:23:53.000-05:00</phoneNumberReportDate></phone><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
         - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate><preferredLanguage>eng
+        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2024-08-23T13:23:55.000-05:00</assignmentDate><preferredLanguage>eng
         - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:32:19.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:17:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
         - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-17T13:17:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
         - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2023-11-21T14:42:44</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T15:34:19.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-03-13T12:31:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:10.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:53:47.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T12:12:19.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:54:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-16T13:36:06.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T19:28:05.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:23:00.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:51:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:18:28.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:08:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:55:07.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T11:01:56.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:54:13.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:22:30.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:55:38.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-07-24T15:44:34.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-21T17:48:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:42:11.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:00:12.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:23:55.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-20T18:53:17.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T13:20:08.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-03-13T13:14:55.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2024-08-23T11:49:46.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
+        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-08-23T13:28:06</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
   recorded_at: Tue, 21 Nov 2023 20:42:44 GMT
-- request:
-    method: post
-    uri: https://es-dev/voa/voaSvc?wsdl
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns1="http://va.gov/schema/esr/voa/v1"
-        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://va.gov/service/esr/voa/v1"><soap:Body><ns1:submitFormRequest><va:form
-        xmlns:va="http://va.gov/schema/esr/voa/v1"><va:formIdentifier><va:type>101</va:type><va:value>1010EZR</va:value><va:version>2986360436</va:version></va:formIdentifier><va:summary><eeSummary:associations
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:association><eeSummary:contactType>11</eeSummary:contactType><eeSummary:relationship>Stepson</eeSummary:relationship><eeSummary:givenName>FIRSTCHILDA</eeSummary:givenName><eeSummary:middleName>MIDDLECHILDA</eeSummary:middleName><eeSummary:familyName>LASTCHILDA</eeSummary:familyName><eeSummary:suffix>JR.</eeSummary:suffix></eeSummary:association><eeSummary:association><eeSummary:contactType>11</eeSummary:contactType><eeSummary:relationship>Stepdaughter</eeSummary:relationship><eeSummary:givenName>FIRSTCHILDB</eeSummary:givenName><eeSummary:middleName>MIDDLECHILDB</eeSummary:middleName><eeSummary:familyName>LASTCHILDB</eeSummary:familyName><eeSummary:suffix>SR.</eeSummary:suffix></eeSummary:association><eeSummary:association><eeSummary:address><eeSummary:city>Dulles</eeSummary:city><eeSummary:country>USA</eeSummary:country><eeSummary:line1>123
-        NW 8th St</eeSummary:line1><eeSummary:state>VA</eeSummary:state><eeSummary:zipCode>20101</eeSummary:zipCode><eeSummary:zipPlus4>0101</eeSummary:zipPlus4></eeSummary:address><eeSummary:contactType>10</eeSummary:contactType><eeSummary:relationship>SPOUSE</eeSummary:relationship><eeSummary:givenName>FIRSTSPOUSE</eeSummary:givenName><eeSummary:middleName>MIDDLESPOUSE</eeSummary:middleName><eeSummary:familyName>LASTSPOUSE</eeSummary:familyName><eeSummary:suffix>SR.</eeSummary:suffix></eeSummary:association></eeSummary:associations><eeSummary:demographics
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:appointmentRequestResponse>false</eeSummary:appointmentRequestResponse><eeSummary:contactInfo><eeSummary:addresses><eeSummary:address><eeSummary:city>Ontario</eeSummary:city><eeSummary:country>CAN</eeSummary:country><eeSummary:line1>7321
-        SW 7th St</eeSummary:line1><eeSummary:provinceCode>ON</eeSummary:provinceCode><eeSummary:postalCode>21534</eeSummary:postalCode><eeSummary:addressTypeCode>P</eeSummary:addressTypeCode></eeSummary:address><eeSummary:address><eeSummary:city>Ontario</eeSummary:city><eeSummary:country>CAN</eeSummary:country><eeSummary:line1>123
-        NW 5th St</eeSummary:line1><eeSummary:provinceCode>ON</eeSummary:provinceCode><eeSummary:postalCode>21231</eeSummary:postalCode><eeSummary:addressTypeCode>R</eeSummary:addressTypeCode></eeSummary:address></eeSummary:addresses><eeSummary:emails><eeSummary:email><eeSummary:address>foo@example.com</eeSummary:address><eeSummary:type>1</eeSummary:type></eeSummary:email></eeSummary:emails><eeSummary:phones><eeSummary:phone><eeSummary:phoneNumber>1231241234</eeSummary:phoneNumber><eeSummary:type>1</eeSummary:type></eeSummary:phone><eeSummary:phone><eeSummary:phoneNumber>1235551234</eeSummary:phoneNumber><eeSummary:type>4</eeSummary:type></eeSummary:phone></eeSummary:phones></eeSummary:contactInfo><eeSummary:maritalStatus>M</eeSummary:maritalStatus><eeSummary:preferredFacility>988</eeSummary:preferredFacility><eeSummary:acaIndicator>false</eeSummary:acaIndicator></eeSummary:demographics><eeSummary:enrollmentDeterminationInfo
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:eligibleForMedicaid>true</eeSummary:eligibleForMedicaid><eeSummary:noseThroatRadiumInfo><eeSummary:receivingTreatment>false</eeSummary:receivingTreatment></eeSummary:noseThroatRadiumInfo><eeSummary:serviceConnectionAward><eeSummary:serviceConnectedIndicator>false</eeSummary:serviceConnectedIndicator></eeSummary:serviceConnectionAward><eeSummary:specialFactors><eeSummary:agentOrangeInd>false</eeSummary:agentOrangeInd><eeSummary:envContaminantsInd>false</eeSummary:envContaminantsInd><eeSummary:campLejeuneInd>false</eeSummary:campLejeuneInd><eeSummary:radiationExposureInd>false</eeSummary:radiationExposureInd></eeSummary:specialFactors></eeSummary:enrollmentDeterminationInfo><eeSummary:financialsInfo
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:incomeTest><eeSummary:discloseFinancialInformation>true</eeSummary:discloseFinancialInformation></eeSummary:incomeTest><eeSummary:financialStatement><eeSummary:expenses><eeSummary:expense><eeSummary:amount>77.77</eeSummary:amount><eeSummary:expenseType>3</eeSummary:expenseType></eeSummary:expense><eeSummary:expense><eeSummary:amount>44.44</eeSummary:amount><eeSummary:expenseType>19</eeSummary:expenseType></eeSummary:expense><eeSummary:expense><eeSummary:amount>33.3</eeSummary:amount><eeSummary:expenseType>18</eeSummary:expenseType></eeSummary:expense></eeSummary:expenses><eeSummary:incomes><eeSummary:income><eeSummary:amount>123.33</eeSummary:amount><eeSummary:type>7</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>90.11</eeSummary:amount><eeSummary:type>13</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>10.1</eeSummary:amount><eeSummary:type>10</eeSummary:type></eeSummary:income></eeSummary:incomes><eeSummary:spouseFinancialsList><eeSummary:spouseFinancials><eeSummary:incomes><eeSummary:income><eeSummary:amount>64.1</eeSummary:amount><eeSummary:type>7</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>35.1</eeSummary:amount><eeSummary:type>13</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>12.3</eeSummary:amount><eeSummary:type>10</eeSummary:type></eeSummary:income></eeSummary:incomes><eeSummary:spouse><eeSummary:dob>04/06/1990</eeSummary:dob><eeSummary:relationship>2</eeSummary:relationship><eeSummary:startDate>05/10/2003</eeSummary:startDate><eeSummary:ssns><eeSummary:ssn><eeSummary:ssnText>111221234</eeSummary:ssnText></eeSummary:ssn></eeSummary:ssns><eeSummary:address><eeSummary:city>Dulles</eeSummary:city><eeSummary:country>USA</eeSummary:country><eeSummary:line1>123
-        NW 8th St</eeSummary:line1><eeSummary:state>VA</eeSummary:state><eeSummary:zipCode>20101</eeSummary:zipCode><eeSummary:zipPlus4>0101</eeSummary:zipPlus4></eeSummary:address><eeSummary:givenName>FIRSTSPOUSE</eeSummary:givenName><eeSummary:middleName>MIDDLESPOUSE</eeSummary:middleName><eeSummary:familyName>LASTSPOUSE</eeSummary:familyName><eeSummary:suffix>SR.</eeSummary:suffix></eeSummary:spouse><eeSummary:contributedToSpousalSupport>false</eeSummary:contributedToSpousalSupport><eeSummary:livedWithPatient>false</eeSummary:livedWithPatient></eeSummary:spouseFinancials></eeSummary:spouseFinancialsList><eeSummary:marriedLastCalendarYear>true</eeSummary:marriedLastCalendarYear><eeSummary:dependentFinancialsList><eeSummary:dependentFinancials><eeSummary:incomes><eeSummary:income><eeSummary:amount>991.9</eeSummary:amount><eeSummary:type>7</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>981.2</eeSummary:amount><eeSummary:type>13</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>91.9</eeSummary:amount><eeSummary:type>10</eeSummary:type></eeSummary:income></eeSummary:incomes><eeSummary:expenses><eeSummary:expense><eeSummary:amount>45.2</eeSummary:amount><eeSummary:expenseType>16</eeSummary:expenseType></eeSummary:expense></eeSummary:expenses><eeSummary:dependentInfo><eeSummary:dob>05/05/1982</eeSummary:dob><eeSummary:relationship>5</eeSummary:relationship><eeSummary:ssns><eeSummary:ssn><eeSummary:ssnText>111229876</eeSummary:ssnText></eeSummary:ssn></eeSummary:ssns><eeSummary:startDate>04/07/1992</eeSummary:startDate><eeSummary:givenName>FIRSTCHILDA</eeSummary:givenName><eeSummary:middleName>MIDDLECHILDA</eeSummary:middleName><eeSummary:familyName>LASTCHILDA</eeSummary:familyName><eeSummary:suffix>JR.</eeSummary:suffix></eeSummary:dependentInfo><eeSummary:livedWithPatient>false</eeSummary:livedWithPatient><eeSummary:incapableOfSelfSupport>true</eeSummary:incapableOfSelfSupport><eeSummary:attendedSchool>true</eeSummary:attendedSchool><eeSummary:contributedToSupport>false</eeSummary:contributedToSupport></eeSummary:dependentFinancials><eeSummary:dependentFinancials><eeSummary:incomes><eeSummary:income><eeSummary:amount>791.9</eeSummary:amount><eeSummary:type>7</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>781.2</eeSummary:amount><eeSummary:type>13</eeSummary:type></eeSummary:income><eeSummary:income><eeSummary:amount>71.9</eeSummary:amount><eeSummary:type>10</eeSummary:type></eeSummary:income></eeSummary:incomes><eeSummary:expenses><eeSummary:expense><eeSummary:amount>1198.11</eeSummary:amount><eeSummary:expenseType>16</eeSummary:expenseType></eeSummary:expense></eeSummary:expenses><eeSummary:dependentInfo><eeSummary:dob>03/07/1996</eeSummary:dob><eeSummary:relationship>6</eeSummary:relationship><eeSummary:ssns><eeSummary:ssn><eeSummary:ssnText>222111234</eeSummary:ssnText></eeSummary:ssn></eeSummary:ssns><eeSummary:startDate>04/07/2003</eeSummary:startDate><eeSummary:givenName>FIRSTCHILDB</eeSummary:givenName><eeSummary:middleName>MIDDLECHILDB</eeSummary:middleName><eeSummary:familyName>LASTCHILDB</eeSummary:familyName><eeSummary:suffix>SR.</eeSummary:suffix></eeSummary:dependentInfo><eeSummary:livedWithPatient>false</eeSummary:livedWithPatient><eeSummary:incapableOfSelfSupport>false</eeSummary:incapableOfSelfSupport><eeSummary:attendedSchool>true</eeSummary:attendedSchool><eeSummary:contributedToSupport>false</eeSummary:contributedToSupport></eeSummary:dependentFinancials></eeSummary:dependentFinancialsList><eeSummary:numberOfDependentChildren>2</eeSummary:numberOfDependentChildren></eeSummary:financialStatement></eeSummary:financialsInfo><eeSummary:insuranceList
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:insurance><eeSummary:companyName>MyInsurance</eeSummary:companyName><eeSummary:policyHolderName>FirstName
-        ZZTEST</eeSummary:policyHolderName><eeSummary:policyNumber>P1234</eeSummary:policyNumber><eeSummary:groupNumber>G1234</eeSummary:groupNumber><eeSummary:insuranceMappingTypeName>PI</eeSummary:insuranceMappingTypeName></eeSummary:insurance><eeSummary:insurance><eeSummary:companyName>Medicare</eeSummary:companyName><eeSummary:enrolledInPartA>true</eeSummary:enrolledInPartA><eeSummary:insuranceMappingTypeName>MDCR</eeSummary:insuranceMappingTypeName><eeSummary:policyNumber>873462432</eeSummary:policyNumber><eeSummary:partAEffectiveDate>10/16/1999</eeSummary:partAEffectiveDate></eeSummary:insurance></eeSummary:insuranceList><eeSummary:militaryServiceInfo
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:dischargeDueToDisability>false</eeSummary:dischargeDueToDisability><eeSummary:militaryServiceSiteRecords><eeSummary:militaryServiceSiteRecord><eeSummary:site>988</eeSummary:site></eeSummary:militaryServiceSiteRecord></eeSummary:militaryServiceSiteRecords></eeSummary:militaryServiceInfo><eeSummary:prisonerOfWarInfo
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:powIndicator>false</eeSummary:powIndicator></eeSummary:prisonerOfWarInfo><eeSummary:purpleHeart
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:indicator>false</eeSummary:indicator></eeSummary:purpleHeart><eeSummary:personInfo
-        xmlns:eeSummary="http://jaxws.webservices.esr.med.va.gov/schemas"><eeSummary:firstName>FIRSTNAME</eeSummary:firstName><eeSummary:middleName>MIDDLENAME</eeSummary:middleName><eeSummary:lastName>ZZTEST</eeSummary:lastName><eeSummary:suffix>JR.</eeSummary:suffix><eeSummary:gender>F</eeSummary:gender><eeSummary:dob>01/02/1986</eeSummary:dob><eeSummary:ssnText>111111234</eeSummary:ssnText></eeSummary:personInfo></va:summary><va:applications><va:applicationInfo><va:appDate>2023-11-21</va:appDate><va:appMethod>1</va:appMethod></va:applicationInfo></va:applications></va:form><va:identity
-        xmlns:va="http://va.gov/schema/esr/voa/v1"><va:authenticationLevel><va:type>102</va:type><va:value>Assurance
-        Level 2</va:value></va:authenticationLevel><va:veteranIdentifier><va:type>1</va:type><va:value>1013032368V065534</va:value></va:veteranIdentifier></va:identity></ns1:submitFormRequest></soap:Body></soap:Envelope>
-    headers:
-      Accept:
-      - text/xml;charset=UTF-8
-      Content-Type:
-      - text/xml;charset=UTF-8
-      User-Agent:
-      - Vets.gov Agent
-      Date:
-      - Tue, 21 Nov 2023 20:42:44 GMT
-      Content-Length:
-      - '12415'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 21 Nov 2023 20:42:44 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Security-Policy:
-      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
-      X-Oracle-Dms-Rid:
-      - '0'
-      X-Oracle-Dms-Ecid:
-      - 666a9a68-12e6-47b1-8338-7f0ead38eb6b-0001ce15
-      X-Oneagent-Js-Injection:
-      - 'true'
-      Ssl-Env:
-      - 'On'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Cache-Control:
-      - max-age=0, no-store
-      Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1471439173"
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - text/xml; charset=utf-8
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: UTF-8
-      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><submitFormResponse
-        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>432775981</formSubmissionId><message><type>Form
-        successfully received for EE processing</type></message><timeStamp>2023-11-21T14:42:44.858-06:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
-  recorded_at: Tue, 21 Nov 2023 20:42:44 GMT
-recorded_with: VCR 6.2.0
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_mexican_province.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_mexican_province.yml
@@ -2,127 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: <%= Settings.hca.ee.endpoint %>
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0"?>
-        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sch="http://jaxws.webservices.esr.med.va.gov/schemas">
-          <SOAP-ENV:Header>
-            <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustUnderstand="1">
-              <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="XWSSGID-1281117217796-43574433">
-                <wsse:Username>HCASvcUsr</wsse:Username>
-                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"><EE_PASS></wsse:Password>
-              </wsse:UsernameToken>
-            </wsse:Security>
-          </SOAP-ENV:Header>
-          <SOAP-ENV:Body>
-            <sch:getEESummaryRequest>
-              <sch:key>1013032368V065534</sch:key>
-              <sch:requestName>HCAData</sch:requestName>
-            </sch:getEESummaryRequest>
-          </SOAP-ENV:Body>
-        </SOAP-ENV:Envelope>
-    headers:
-      Accept:
-      - text/xml;charset=UTF-8
-      Content-Type:
-      - text/xml;charset=UTF-8
-      User-Agent:
-      - Vets.gov Agent
-      Date:
-      - Tue, 21 Nov 2023 22:29:51 GMT
-      Content-Length:
-      - '975'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 21 Nov 2023 22:29:51 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Security-Policy:
-      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
-      Content-Length:
-      - '10998'
-      Accept:
-      - text/xml
-      X-Oracle-Dms-Rid:
-      - '0'
-      X-Oracle-Dms-Ecid:
-      - bddca6b8-059e-431a-8624-33eec916e5e2-00008453
-      Soapaction:
-      - '""'
-      X-Oneagent-Js-Injection:
-      - 'true'
-      Ssl-Env:
-      - 'On'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Cache-Control:
-      - max-age=0, no-store
-      Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="-13872712"
-      Content-Type:
-      - text/xml; charset=UTF-8
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: UTF-8
-      string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
-        Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
-        IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance><insurance><groupName>Part
-        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
-        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
-        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
-        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-21T14:30:05.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
-        CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
-        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility><eligibility><type>SERVICE
-        ACT</type><indicator>S</indicator><eligibilityReportDate>2023-11-21T14:30:05.000-06:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
-        for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
-        Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
-        condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2023-11-21T14:42:44.000-06:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-21T14:30:05.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
-        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-21T14:30:05.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address><address><line1>123 M ST</line1><city>CO
-        SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>7321
-        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2023-11-21T14:42:44.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2023-11-21T14:42:44.000-06:00</contactMethodReportDate></address></addresses><phones><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2023-11-21T14:42:44.000-06:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
-        - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate><preferredLanguage>eng
-        - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2023-11-21T16:29:52</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
-  recorded_at: Tue, 21 Nov 2023 22:29:52 GMT
-- request:
-    method: post
     uri: <%= Settings.hca.endpoint %>
     body:
       encoding: UTF-8
@@ -156,7 +35,7 @@ http_interactions:
       Date:
       - Tue, 21 Nov 2023 22:29:52 GMT
       Content-Length:
-      - '8810'
+      - '8811'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -165,7 +44,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 21 Nov 2023 22:29:52 GMT
+      - Fri, 23 Aug 2024 16:49:44 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -175,7 +54,7 @@ http_interactions:
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - 666a9a68-12e6-47b1-8338-7f0ead38eb6b-0002628e
+      - c2c62aca-191c-42ad-bad8-dbbd9c5271ad-001e9392
       X-Oneagent-Js-Injection:
       - 'true'
       Ssl-Env:
@@ -187,7 +66,7 @@ http_interactions:
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1759274849"
+      - dtSInfo;desc="0", dtRpid;desc="-384101255"
       Transfer-Encoding:
       - chunked
       Content-Type:
@@ -197,7 +76,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><submitFormResponse
-        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>432777930</formSubmissionId><message><type>Form
-        successfully received for EE processing</type></message><timeStamp>2023-11-21T16:29:52.432-06:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
+        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>436460791</formSubmissionId><message><type>Form
+        successfully received for EE processing</type></message><timeStamp>2024-08-23T11:49:44.562-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
   recorded_at: Tue, 21 Nov 2023 22:29:52 GMT
-recorded_with: VCR 6.2.0
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_next_of_kin_and_emergency_contact.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_next_of_kin_and_emergency_contact.yml
@@ -2,130 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: <%= Settings.hca.ee.endpoint %>
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0"?>
-        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sch="http://jaxws.webservices.esr.med.va.gov/schemas">
-          <SOAP-ENV:Header>
-            <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustUnderstand="1">
-              <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="XWSSGID-1281117217796-43574433">
-                <wsse:Username>HCASvcUsr</wsse:Username>
-                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"><EE_PASS></wsse:Password>
-              </wsse:UsernameToken>
-            </wsse:Security>
-          </SOAP-ENV:Header>
-          <SOAP-ENV:Body>
-            <sch:getEESummaryRequest>
-              <sch:key>1013032368V065534</sch:key>
-              <sch:requestName>HCAData</sch:requestName>
-            </sch:getEESummaryRequest>
-          </SOAP-ENV:Body>
-        </SOAP-ENV:Envelope>
-    headers:
-      Accept:
-      - text/xml;charset=UTF-8
-      Content-Type:
-      - text/xml;charset=UTF-8
-      User-Agent:
-      - Vets.gov Agent
-      Date:
-      - Thu, 30 Nov 2023 15:52:36 GMT
-      Content-Length:
-      - '975'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 Nov 2023 15:52:36 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Security-Policy:
-      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
-      Content-Length:
-      - '11487'
-      Accept:
-      - text/xml
-      X-Oracle-Dms-Rid:
-      - '0'
-      X-Oracle-Dms-Ecid:
-      - 0a77b57d-6f7f-45c8-9130-265505c0491a-0008b781
-      Soapaction:
-      - '""'
-      X-Oneagent-Js-Injection:
-      - 'true'
-      Ssl-Env:
-      - 'On'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Cache-Control:
-      - max-age=0, no-store
-      Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="840768977"
-      Content-Type:
-      - text/xml; charset=UTF-8
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: UTF-8
-      string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>Part
-        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
-        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
-        Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
-        IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
-        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
-        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
-        CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
-        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
-        for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
-        Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
-        condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2023-11-27T13:15:14.000-06:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
-        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
-        M ST</line1><city>CO SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>7321
-        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2023-11-27T13:15:14.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2023-11-27T13:15:14.000-06:00</contactMethodReportDate></address><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-27T12:59:14.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address></addresses><phones><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2023-11-27T13:15:14.000-06:00</phoneNumberReportDate></phone><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
-        - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate><preferredLanguage>eng
-        - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2023-11-30T09:52:36</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
-  recorded_at: Thu, 30 Nov 2023 15:52:36 GMT
-- request:
-    method: post
     uri: <%= Settings.hca.endpoint %>
     body:
       encoding: UTF-8
@@ -164,7 +40,7 @@ http_interactions:
       Date:
       - Thu, 30 Nov 2023 15:52:36 GMT
       Content-Length:
-      - '15298'
+      - '15299'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -173,7 +49,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 Nov 2023 15:52:37 GMT
+      - Fri, 23 Aug 2024 18:22:29 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -183,7 +59,7 @@ http_interactions:
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - ba102866-1ebb-4bf7-9640-c9ae9f34de74-000a988d
+      - c2c62aca-191c-42ad-bad8-dbbd9c5271ad-001ef44c
       X-Oneagent-Js-Injection:
       - 'true'
       Ssl-Env:
@@ -195,7 +71,7 @@ http_interactions:
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1186747307"
+      - dtSInfo;desc="0", dtRpid;desc="275687922"
       Transfer-Encoding:
       - chunked
       Content-Type:
@@ -205,7 +81,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><submitFormResponse
-        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>432861975</formSubmissionId><message><type>Form
-        successfully received for EE processing</type></message><timeStamp>2023-11-30T09:52:37.290-06:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
-  recorded_at: Thu, 30 Nov 2023 15:52:37 GMT
-recorded_with: VCR 6.2.0
+        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>436462887</formSubmissionId><message><type>Form
+        successfully received for EE processing</type></message><timeStamp>2024-08-23T13:22:29.157-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
+  recorded_at: Thu, 30 Nov 2023 15:52:36 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_non_pdf_attachment.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_non_pdf_attachment.yml
@@ -2,139 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: <%= Settings.hca.ee.endpoint %>
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0"?>
-        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sch="http://jaxws.webservices.esr.med.va.gov/schemas">
-          <SOAP-ENV:Header>
-            <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustUnderstand="1">
-              <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="XWSSGID-1281117217796-43574433">
-                <wsse:Username>HCASvcUsr</wsse:Username>
-                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"><EE_PASS></wsse:Password>
-              </wsse:UsernameToken>
-            </wsse:Security>
-          </SOAP-ENV:Header>
-          <SOAP-ENV:Body>
-            <sch:getEESummaryRequest>
-              <sch:key>1013032368V065534</sch:key>
-              <sch:requestName>HCAData</sch:requestName>
-            </sch:getEESummaryRequest>
-          </SOAP-ENV:Body>
-        </SOAP-ENV:Envelope>
-    headers:
-      Accept:
-      - text/xml;charset=UTF-8
-      Content-Type:
-      - text/xml;charset=UTF-8
-      User-Agent:
-      - Vets.gov Agent
-      Date:
-      - Wed, 17 Jul 2024 18:17:34 GMT
-      Content-Length:
-      - '975'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Jul 2024 18:17:34 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '14207'
-      Accept:
-      - text/xml
-      X-Oracle-Dms-Rid:
-      - '0'
-      X-Oracle-Dms-Ecid:
-      - 82cbcd40-702c-4bea-bcb9-6d580a97a368-000c5561
-      Soapaction:
-      - '""'
-      X-Oneagent-Js-Injection:
-      - 'true'
-      Ssl-Env:
-      - 'On'
-      Cache-Control:
-      - max-age=0, no-store
-      Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1803026492"
-      Content-Type:
-      - text/xml; charset=UTF-8
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: UTF-8
-      string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>Part
-        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
-        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
-        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
-        Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
-        IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
-        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
-        CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
-        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
-        for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
-        Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
-        condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2024-07-16T14:36:35.000-05:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>988
-        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-27T12:59:14.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address><address><line1>123 M ST</line1><city>CO
-        SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address><address><line1>7321
-        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2024-07-16T14:36:35.000-05:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2024-07-16T14:36:35.000-05:00</contactMethodReportDate></address></addresses><phones><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2024-07-16T14:36:35.000-05:00</phoneNumberReportDate></phone><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
-        - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2024-07-16T14:36:36.000-05:00</assignmentDate><preferredLanguage>eng
-        - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:08:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:18:28.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T12:55:07.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-03-13T13:14:55.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:42:11.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:10.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-03-13T12:31:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-06-18T13:17:45.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-07-16T14:36:36.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-07-16T13:36:06.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:32:19.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-07-17T13:17:34</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
-  recorded_at: Wed, 17 Jul 2024 18:17:34 GMT
-- request:
-    method: post
     uri: <%= Settings.hca.endpoint %>
     body:
       encoding: UTF-8
@@ -177,21 +44,29 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Jul 2024 18:17:35 GMT
+      - Fri, 23 Aug 2024 18:23:53 GMT
       Server:
       - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - 0f3c7236-7702-4cda-b906-122f47406d27-0006e0bd
+      - c2c62aca-191c-42ad-bad8-dbbd9c5271ad-001ef4cd
       X-Oneagent-Js-Injection:
       - 'true'
       Ssl-Env:
       - 'On'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="625697898"
+      - dtSInfo;desc="0", dtRpid;desc="1135155923"
       Transfer-Encoding:
       - chunked
       Content-Type:
@@ -201,7 +76,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><submitFormResponse
-        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>435845365</formSubmissionId><message><type>Form
-        successfully received for EE processing</type></message><timeStamp>2024-07-17T13:17:35.167-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
-  recorded_at: Wed, 17 Jul 2024 18:17:35 GMT
-recorded_with: VCR 6.2.0
+        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>436462905</formSubmissionId><message><type>Form
+        successfully received for EE processing</type></message><timeStamp>2024-08-23T13:23:53.956-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
+  recorded_at: Wed, 17 Jul 2024 18:17:34 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_tera.yml
+++ b/spec/support/vcr_cassettes/form1010_ezr/authorized_submit_with_tera.yml
@@ -2,138 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: <%= Settings.hca.ee.endpoint %>
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0"?>
-        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sch="http://jaxws.webservices.esr.med.va.gov/schemas">
-          <SOAP-ENV:Header>
-            <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustUnderstand="1">
-              <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="XWSSGID-1281117217796-43574433">
-                <wsse:Username>HCASvcUsr</wsse:Username>
-                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"><EE_PASS></wsse:Password>
-              </wsse:UsernameToken>
-            </wsse:Security>
-          </SOAP-ENV:Header>
-          <SOAP-ENV:Body>
-            <sch:getEESummaryRequest>
-              <sch:key>1013032368V065534</sch:key>
-              <sch:requestName>HCAData</sch:requestName>
-            </sch:getEESummaryRequest>
-          </SOAP-ENV:Body>
-        </SOAP-ENV:Envelope>
-    headers:
-      Accept:
-      - text/xml;charset=UTF-8
-      Content-Type:
-      - text/xml;charset=UTF-8
-      User-Agent:
-      - Vets.gov Agent
-      Date:
-      - Wed, 13 Mar 2024 18:14:49 GMT
-      Content-Length:
-      - '975'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Mar 2024 18:14:49 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Security-Policy:
-      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
-      Content-Length:
-      - '12767'
-      Accept:
-      - text/xml
-      X-Oracle-Dms-Rid:
-      - '0'
-      X-Oracle-Dms-Ecid:
-      - 9fc2a4bd-5736-4ba1-92cf-66405ac698ca-000183a4
-      Soapaction:
-      - '""'
-      X-Oneagent-Js-Injection:
-      - 'true'
-      Ssl-Env:
-      - 'On'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Cache-Control:
-      - max-age=0, no-store
-      Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="2092125871"
-      Content-Type:
-      - text/xml; charset=UTF-8
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: UTF-8
-      string: <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><getEESummaryResponse
-        xmlns="http://jaxws.webservices.esr.med.va.gov/schemas"><eesVersion>5.12.0.05003</eesVersion><summary><insuranceList><insurance><groupName>Part
-        A</groupName><groupNumber>Part A</groupNumber><companyName>Medicare</companyName><policyHolderName>ZZTEST,
-        FIRSTNAME</policyHolderName><policyNumber>873462432</policyNumber><enrolledInPartA>true</enrolledInPartA><partAEffectiveDate>19991016</partAEffectiveDate><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupNumber>G1234</groupNumber><companyName>MyInsurance</companyName><policyHolderName>FirstName
-        ZZTEST</policyHolderName><policyNumber>P1234</policyNumber><lastEditedDate>2023-10-23T18:12:24.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship></insurance><insurance><groupName>123456</groupName><groupNumber>123456</groupNumber><planType>Dental
-        Insurance</planType><companyName>Aetna</companyName><policyEffectiveDate>20180101</policyEffectiveDate><policyExpirationDate>20250101</policyExpirationDate><policyHolderName>Four
-        IVMTEST</policyHolderName><policyNumber>123456</policyNumber><lastEditedDate>2020-04-13T13:07:34.000-05:00</lastEditedDate><insuredRelationship>Veteran</insuredRelationship><preadmitCertification>false</preadmitCertification><insAddress><line1>457
-        H ST</line1><city>SAN ANTONIO</city><county>BEXAR</county><state>TX</state><zipCode>78259</zipCode><addressTypeCode>Firm/Business</addressTypeCode></insAddress><insurancePhones><phone><type>Pre-Certification
-        Phone</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Business</type><phoneNumber>(123)456-7890</phoneNumber></phone><phone><type>Fax</type><phoneNumber>(123)456-7890</phoneNumber></phone></insurancePhones></insurance></insuranceList><eligibilityVerificationInfo><eligibilityStatus>VERIFIED</eligibilityStatus><eligibilityStatusDate>20200319</eligibilityStatusDate><verificationMethod>dd214</verificationMethod></eligibilityVerificationInfo><purpleHeart><indicator>false</indicator><status>Rejected</status></purpleHeart><enrollmentDeterminationInfo><priorityGroup>Group
-        1</priorityGroup><calculationSource>HEC</calculationSource><enrollmentStatus>Verified</enrollmentStatus><enrollmentDate>2019-08-09T16:13:43.000-05:00</enrollmentDate><effectiveDate>2023-11-27T12:59:14.000-06:00</effectiveDate><eligibleForMedicaid>true</eligibleForMedicaid><applicationDate>2021-01-01T23:00:06.000-06:00</applicationDate><veteran>true</veteran><primaryEligibility><type>SERVICE
-        CONNECTED 50% to 100%</type><indicator>P</indicator><eligibilityReportDate>2020-08-04T12:42:32.000-05:00</eligibilityReportDate></primaryEligibility><secondaryEligibilities><eligibility><type>Clinical
-        Evaluation</type><indicator>S</indicator><eligibilityReportDate>2023-07-11T11:29:24.000-05:00</eligibilityReportDate></eligibility></secondaryEligibilities><otherEligibilities><eligibility><type>Eligible
-        for Medicaid</type><indicator>O</indicator><eligibilityReportDate>2023-10-23T18:12:24.000-05:00</eligibilityReportDate></eligibility></otherEligibilities><monetaryBenefitAwardInfo><monetaryBenefits><monetaryBenefit><type>VA
-        Pension</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Aid
-        And Attendance</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Housebound</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit><monetaryBenefit><type>Disability
-        Compensation</type><monetaryBenefitIndicator>false</monetaryBenefitIndicator><monetaryBenefitReportDate>2019-11-19T16:56:24.000-06:00</monetaryBenefitReportDate></monetaryBenefit></monetaryBenefits></monetaryBenefitAwardInfo><militarySexualTraumaInfo><status>Unknown,
-        Not Screened</status></militarySexualTraumaInfo><specialFactors><agentOrangeInd>false</agentOrangeInd><radiationExposureInd>false</radiationExposureInd><envContaminantsInd>false</envContaminantsInd></specialFactors><cancelDeclineInfo><cancelDeclineIndicator>false</cancelDeclineIndicator></cancelDeclineInfo><serviceConnectionAward><serviceConnectedPercentage>60</serviceConnectedPercentage><serviceConnectedIndicator>true</serviceConnectedIndicator><combinedServiceConnectedPercentageEffectiveDate>20181105</combinedServiceConnectedPercentageEffectiveDate><unemployable>false</unemployable><permanentAndTotal>false</permanentAndTotal><ratedDisabilities><ratedDisability><disability>6711-Lung
-        condition</disability><percentage>60</percentage><diagnosticExtremity>Both
-        Lower Extremities</diagnosticExtremity><recordModifiedDate>2020-08-04T12:42:32.000-05:00</recordModifiedDate><disabilityCode>6711</disabilityCode></ratedDisability></ratedDisabilities><scReportDate>2020-08-04T12:42:32.000-05:00</scReportDate></serviceConnectionAward><medicaidLastModifiedDate>2024-03-13T12:31:33.000-05:00</medicaidLastModifiedDate><recordCreatedDate>2018-02-02T18:08:22.000-06:00</recordCreatedDate><recordModifiedDate>2023-11-27T12:59:14.000-06:00</recordModifiedDate><enrollmentCategoryName>Enrolled</enrollmentCategoryName></enrollmentDeterminationInfo><associations><association><contactType>Emergency
-        Contact</contactType><givenName>EMERG</givenName><familyName>IVM</familyName><relationship>FATHER</relationship><address><line1>877
-        MAIN STREET</line1><city>NEWTOWN</city><state>CO</state><zipCode>99999</zipCode><zipPlus4>3530</zipPlus4><country>USA</country></address><primaryPhone>(555)457-2514</primaryPhone><lastUpdateDate>2022-02-16T21:43:32.000-06:00</lastUpdateDate></association></associations><militaryServiceInfo><militaryServiceSiteRecords><militaryServiceSiteRecord><site>988
-        - DAYT20</site><servicePeriod>OTHER OR NONE</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord><militaryServiceSiteRecord><site>742
-        - HEALTH ELIGIBILITY CENTER</site><servicePeriod>VIETNAM ERA</servicePeriod><militaryServiceEpisodes><militaryServiceEpisode><serviceBranch>ARMY</serviceBranch><dischargeType>HONORABLE</dischargeType><serviceNumber>379852146</serviceNumber><startDate>19540101</startDate><endDate>19640101</endDate></militaryServiceEpisode></militaryServiceEpisodes></militaryServiceSiteRecord></militaryServiceSiteRecords></militaryServiceInfo><prisonerOfWarInfo><powIndicator>No</powIndicator></prisonerOfWarInfo><demographics><contactInfo><addresses><address><line1>7321
-        SW 7TH ST</line1><city>ONTARIO</city><postalCode>21534</postalCode><country>CAN</country><addressTypeCode>Permanent</addressTypeCode><addressChangeDateTime>2024-03-13T12:31:33.000-05:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2024-03-13T12:31:33.000-05:00</contactMethodReportDate></address><address><line1>123
-        NW 5TH ST</line1><city>ONTARIO</city><postalCode>21231</postalCode><country>CAN</country><addressTypeCode>Residential</addressTypeCode><addressChangeDateTime>2023-11-27T12:59:14.000-06:00</addressChangeDateTime><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite></address><address><line1>123 M ST</line1><city>CO
-        SPGS</city><county>EL PASO</county><state>CO</state><zipCode>80922</zipCode><country>USA</country><addressTypeCode>Temporary</addressTypeCode><addressChangeDateTime>2018-04-04T21:41:20.000-05:00</addressChangeDateTime><addressChangeEffectiveDate>20180403</addressChangeEffectiveDate><addressChangeSource>Health
-        Eligibility Center</addressChangeSource><addressChangeSite>742 - HEALTH ELIGIBILITY
-        CENTER</addressChangeSite><contactMethodType>08</contactMethodType><contactMethodReportDate>2019-11-19T16:56:24.000-06:00</contactMethodReportDate></address></addresses><phones><phone><type>Mobile</type><phoneNumber>(123)555-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Home</type><phoneNumber>(123)124-1234</phoneNumber><phoneNumberReportDate>2023-10-23T18:12:24.000-05:00</phoneNumberReportDate></phone><phone><type>Business</type><phoneNumber>(801)444-8888</phoneNumber><phoneNumberReportDate>2024-03-13T12:31:33.000-05:00</phoneNumberReportDate></phone></phones><emails><email><type>Personal</type><address>foo@example.com</address><siteOfChange>742
-        - HEALTH ELIGIBILITY CENTER</siteOfChange><sourceOfChange>HEC</sourceOfChange></email></emails></contactInfo><maritalStatus>Married</maritalStatus><preferredFacility>988
-        - DAYT20</preferredFacility><appointmentRequestResponse>false</appointmentRequestResponse><assignmentDate>2024-03-13T12:31:39.000-05:00</assignmentDate><preferredLanguage>eng
-        - English</preferredLanguage><preferredLanguageEntryDate>2018-08-28T00:00:00.000-05:00</preferredLanguageEntryDate><preferredFacilities><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:50:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2024-03-13T12:31:39.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:24.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2018-02-02T18:08:28.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:15:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:30:13.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-22T11:23:44.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:12:26.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-10-23T18:42:54.000-05:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:32:19.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:41:55.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T11:18:39.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T13:12:06.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-12-13T17:36:15.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-27T12:59:16.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:58:25.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T14:42:45.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-21T16:29:59.000-06:00</assignmentDate></preferredFacilityInfo><preferredFacilityInfo><preferredFacility>988
-        - DAYT20</preferredFacility><assignmentDate>2023-11-30T09:52:39.000-06:00</assignmentDate></preferredFacilityInfo></preferredFacilities></demographics><deathRecond><deathReportDate>2023-10-23T18:12:27.000-05:00</deathReportDate></deathRecond></summary><invocationDate>2024-03-13T13:14:49</invocationDate></getEESummaryResponse></env:Body></env:Envelope>
-  recorded_at: Wed, 13 Mar 2024 18:14:49 GMT
-- request:
-    method: post
     uri: <%= Settings.hca.endpoint %>
     body:
       encoding: UTF-8
@@ -180,7 +48,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Mar 2024 18:14:50 GMT
+      - Fri, 23 Aug 2024 18:22:59 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -190,7 +58,7 @@ http_interactions:
       X-Oracle-Dms-Rid:
       - '0'
       X-Oracle-Dms-Ecid:
-      - 59a8ab0c-028f-428f-8a34-300981c02cdd-00006967
+      - c2c62aca-191c-42ad-bad8-dbbd9c5271ad-001ef4c5
       X-Oneagent-Js-Injection:
       - 'true'
       Ssl-Env:
@@ -202,7 +70,7 @@ http_interactions:
       Cache-Control:
       - max-age=0, no-store
       Server-Timing:
-      - dtSInfo;desc="0", dtRpid;desc="1139800737"
+      - dtSInfo;desc="0", dtRpid;desc="121504022"
       Transfer-Encoding:
       - chunked
       Content-Type:
@@ -212,7 +80,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><submitFormResponse
-        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>433956488</formSubmissionId><message><type>Form
-        successfully received for EE processing</type></message><timeStamp>2024-03-13T13:14:50.252-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
-  recorded_at: Wed, 13 Mar 2024 18:14:50 GMT
-recorded_with: VCR 6.2.0
+        xmlns="http://va.gov/schema/esr/voa/v1" xmlns:ns0="http://jaxws.webservices.esr.med.va.gov/schemas"><status>100</status><formSubmissionId>436462892</formSubmissionId><message><type>Form
+        successfully received for EE processing</type></message><timeStamp>2024-08-23T13:22:59.196-05:00</timeStamp></submitFormResponse></S:Body></S:Envelope>
+  recorded_at: Wed, 13 Mar 2024 18:14:49 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary

- Cassettes need to be re-recorded with the updated version of savon (15.1) to confirm SOAP requests are being generated in the same way
- This will ultimately be merged into the branch in [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18051), which bumps `savon`, and a few other gems that must be bumped at the same time because of dependencies (`httpi`, `connect_vbms`, and `bgs_ext`).
- When [recording in a Review Instance](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/tutorials/record_vcr.md), I would receive the following error message when sending a request with the newly generated payload:
  - `Couldn't create SOAP message due to exception: XML reader error: Duplicate declaration for namespace prefix 'tns'` 
  - Sure enough, The new request, compared against the original request in the cassette, had duplicate `tns` namespaces (`xmlns:tns="http://va.gov/service/esr/voa/v1"`) in the `soap:Envelope` element. 
  - I found that the corresponding `.wsdl` file, had both a `tns` header AND a `TargetNamespace` header. While a search determined they are not exactly the same thing, **REMOVING THE `tns` HEADER FROM THE `definition` ELEMENT** did indeed remove the duplicate namespace in the generated cassettes.
- This PR handles the cassettes for the following failing specs
  - `./spec/lib/form1010_ezr/service_spec.rb:160 # Form1010Ezr::Service#submit_form submits the ezr with a background job`
  - `./spec/lib/form1010_ezr/service_spec.rb:313 # Form1010Ezr::Service#submit_sync when successful logs the submission id, payload size, and individual attachment sizes in descending order (if applicable)`
  - `./spec/lib/form1010_ezr/service_spec.rb:294 # Form1010Ezr::Service#submit_sync when successful returns an object that includes 'success', 'formSubmissionId', and 'timestamp'`
  - `./spec/lib/form1010_ezr/service_spec.rb:401 # Form1010Ezr::Service#submit_sync when successful submitting with attachments with pdf attachments returns a success object`
  - `./spec/lib/form1010_ezr/service_spec.rb:421 # Form1010Ezr::Service#submit_sync when successful submitting with attachments with a non-pdf attachment returns a success object`
  - `./spec/lib/form1010_ezr/service_spec.rb:335 # Form1010Ezr::Service#submit_sync when successful when the form includes a Mexican province returns a success object`
  - `./spec/lib/form1010_ezr/service_spec.rb:360 # Form1010Ezr::Service#submit_sync when successful when the form includes next of kin and/or emergency contact info returns a success object`
  - `./spec/lib/form1010_ezr/service_spec.rb:381 # Form1010Ezr::Service#submit_sync when successful when the form includes TERA info returns a success object`

## Related issue(s)

- Original ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/74461
- In progress ticket recording cassettes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/74433

## Testing done

- [x] *New code is covered by unit tests*
- Cassettes were [re-recorded in a review instance](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/tutorials/record_vcr.md)
- Cassettes, while having minor changes, had successful responses from the upstream service
- A couple specs had to modified to match the IDs/timestamps returned in the cassettes, but that seems to be ok
