### PR TITLE
Extract request preferred dates from requested periods

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -180,15 +180,16 @@ module VAOS
       def extract_appointment_fields(appointment)
         reason_code_service.extract_reason_code_fields(appointment)
 
-        # Fallback to extracting preferred dates from requested periods if not available from reason code fields
-        extract_preferred_dates(appointment) if appointment[:preferred_dates].blank?
+        # Fallback to extracting preferred dates from requested periods
+        extract_preferred_dates(appointment)
       end
 
-      # Extract preferred date from the requested periods if possible.
+      # Extract preferred date from the requested periods if necessary.
       #
       # @param @param appointment [Hash] the appointment to modify
       def extract_preferred_dates(appointment)
-        if appointment[:requested_periods].present?
+        # Do not overwrite preferred dates if they are already present
+        if appointment[:preferred_dates].blank? && appointment[:requested_periods].present?
           dates = []
 
           appointment[:requested_periods].each do |period|

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -20,6 +20,11 @@ module VAOS
       APPOINTMENTS_USE_VPG = :va_online_scheduling_use_vpg
       APPOINTMENTS_ENABLE_OH_REQUESTS = :va_online_scheduling_enable_OH_requests
 
+      # Output format for preferred dates
+      # Example: "Thu, July 18, 2024 in the ..."
+      OUTPUT_FORMAT_AM = '%a, %B %-d, %Y in the morning'
+      OUTPUT_FORMAT_PM = '%a, %B %-d, %Y in the afternoon'
+
       # rubocop:disable Metrics/MethodLength
       def get_appointments(start_date, end_date, statuses = nil, pagination_params = {}, include = {})
         params = date_params(start_date, end_date).merge(page_params(pagination_params))
@@ -39,7 +44,7 @@ module VAOS
           appointments = response.body[:data]
           appointments.each do |appt|
             prepare_appointment(appt)
-            reason_code_service.extract_reason_code_fields(appt)
+            extract_appointment_fields(appt)
             merge_clinic(appt) if include[:clinics]
             merge_facility(appt) if include[:facilities]
             cnp_count += 1 if cnp?(appt)
@@ -67,7 +72,7 @@ module VAOS
           response = perform(:get, get_appointment_base_path(appointment_id), params, headers)
           appointment = response.body[:data]
           prepare_appointment(appointment)
-          reason_code_service.extract_reason_code_fields(appointment)
+          extract_appointment_fields(appointment)
           OpenStruct.new(appointment)
         end
       end
@@ -95,7 +100,7 @@ module VAOS
           new_appointment = response.body
           convert_appointment_time(new_appointment)
           find_and_merge_provider_name(new_appointment) if cc?(new_appointment)
-          reason_code_service.extract_reason_code_fields(new_appointment)
+          extract_appointment_fields(new_appointment)
           OpenStruct.new(new_appointment)
         rescue Common::Exceptions::BackendServiceException => e
           log_direct_schedule_submission_errors(e) if booked?(params)
@@ -113,7 +118,7 @@ module VAOS
           else
             response = update_appointment_vaos(appt_id, status)
             convert_appointment_time(response.body)
-            reason_code_service.extract_reason_code_fields(response.body)
+            extract_appointment_fields(response.body)
             OpenStruct.new(response.body)
           end
         end
@@ -166,6 +171,38 @@ module VAOS
       memoize :get_facility_timezone_memoized
 
       private
+
+      # Modifies the appointment, extracting individual fields from the appointment. This currently includes:
+      # 1. Reason code fields
+      # 2. Preferred dates for requests (if not available from reason code fields)
+      #
+      # @param appointment [Hash] the appointment to modify
+      def extract_appointment_fields(appointment)
+        reason_code_service.extract_reason_code_fields(appointment)
+
+        # Fallback to extracting preferred dates from requested periods if not available from reason code fields
+        extract_preferred_dates(appointment) if appointment[:preferred_dates].blank?
+      end
+
+      # Extract preferred date from the requested periods if possible.
+      #
+      # @param @param appointment [Hash] the appointment to modify
+      def extract_preferred_dates(appointment)
+        if appointment[:requested_periods].present?
+          dates = []
+
+          appointment[:requested_periods].each do |period|
+            datetime = DateTime.parse(period[:start])
+            if datetime.strftime('%p') == 'AM'
+              dates.push(datetime.strftime(OUTPUT_FORMAT_AM))
+            else
+              dates.push(datetime.strftime(OUTPUT_FORMAT_PM))
+            end
+          end
+
+          appointment[:preferred_dates] = dates unless dates.nil?
+        end
+      end
 
       # Modifies params so that the facility timezone offset is included in the desired date.
       # The desired date is sent in this format: 2019-12-31T00:00:00-00:00

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -91,6 +91,29 @@ FactoryBot.define do
       end
     end
 
+    trait :community_cares_multiple_request_dates do
+      community_cares
+      requested_periods do
+        [
+          {
+            'start': '2024-08-28T06:00:00Z',
+            'end': '2024-08-28T17:59:00Z'
+          },
+          {
+            'start': '2024-08-28T18:00:00Z',
+            'end': '2024-08-29T05:59:00Z'
+          }
+        ]
+      end
+    end
+
+    trait :community_cares_no_request_dates do
+      community_cares
+      requested_periods do
+        []
+      end
+    end
+
     trait :community_cares2 do
       kind { 'cc' }
       status { 'proposed' }
@@ -211,10 +234,12 @@ FactoryBot.define do
       service_type { 'audiology' }
       comment { 'Follow-up/Routine: testing' }
       requested_periods do
-        {
-          'end': '2022-01-04T11:59:00Z',
-          'start': '2022-01-04T00:00:00Z'
-        }
+        [
+          {
+            'end': '2022-01-04T11:59:00Z',
+            'start': '2022-01-04T00:00:00Z'
+          }
+        ]
       end
     end
 
@@ -264,10 +289,12 @@ FactoryBot.define do
         }
       end
       requested_periods do
-        {
-          'end': '2022-01-04T11:59:00Z',
-          'start': '2022-01-04T00:00:00Z'
-        }
+        [
+          {
+            'end': '2022-01-04T11:59:00Z',
+            'start': '2022-01-04T00:00:00Z'
+          }
+        ]
       end
     end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1384,4 +1384,29 @@ describe VAOS::V2::AppointmentsService do
       end
     end
   end
+
+  describe '#extract_appointment_fields' do
+    it 'do not overwrite existing preferred dates' do
+      # Note that the va_proposed appointment here contains both a reason code text and
+      # requested periods which will not occur in a real scenario. However the example
+      # demonstrates that the preferred dates from reason code text are not overwritten.
+      appt = FactoryBot.build(:appointment_form_v2, :va_proposed_valid_reason_code_text, user:).attributes
+      subject.send(:extract_appointment_fields, appt)
+      expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
+                                            'Wed, June 26, 2024 in the afternoon'])
+    end
+
+    it 'extracts preferred dates if possible' do
+      appt = FactoryBot.build(:appointment_form_v2, :community_cares_multiple_request_dates, user:).attributes
+      subject.send(:extract_appointment_fields, appt)
+      expect(appt[:preferred_dates]).to eq(['Wed, August 28, 2024 in the morning',
+                                            'Wed, August 28, 2024 in the afternoon'])
+    end
+
+    it 'do not extract preferred dates if no requested periods' do
+      appt = FactoryBot.build(:appointment_form_v2, :community_cares_no_request_dates, user:).attributes
+      subject.send(:extract_appointment_fields, appt)
+      expect(appt[:preferred_dates]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Currently we only extract preferred dates from the reason text for VA appointment requests which comes from the reason code text. This PR adds a fallback for non-VA requests (cc and cerner) which extracts this information from the requested periods field.
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90831

## Testing done

- [x] *New code is covered by unit tests* 

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
