### PR TITLE
add toggles for new debt team notification items

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -964,9 +964,18 @@ features:
   profile_user_claims:
     actor_type: user
     description: When enabled, /v0/user will return user profile claims for accessing service endpoints.
-  profile_show_mhv_notification_settings:
+  profile_show_mhv_notification_settings_email_appointment_reminders:
     actor_type: user
-    description: Display MHV notification settings - RX refill shipment, appointment, secure messaging, and medical images/reports
+    description: Show/Hide the email channel for Health appointment reminders notifications
+  profile_show_mhv_notification_settings_email_rx_shipment:
+    actor_type: user
+    description: Show/Hide the email channel for Prescription shipping notifications
+  profile_show_mhv_notification_settings_new_secure_messaging:
+    actor_type: user
+    description: Display MHV notification settings - New secure message notifications
+  profile_show_mhv_notification_settings_medical_images:
+    actor_type: user
+    description: Display MHV notification settings - Medical images/reports notifications
   profile_show_military_academy_attendance:
     actor_type: user
     description: When enabled, profile service history will include military academy attendance.
@@ -990,9 +999,6 @@ features:
   profile_show_direct_deposit_single_form_edu_downtime:
     actor_type: user
     description: Show/hide the edu direct deposit form and instead display a downtime message in its place
-  profile_show_email_notification_settings:
-    actor_type: user
-    description: Show/Hide the email channel based notification settings in profile
   profile_show_payments_notification_setting:
     actor_type: user
     description: Show/Hide the payments section of notifications in profile

--- a/config/features.yml
+++ b/config/features.yml
@@ -1002,6 +1002,12 @@ features:
   profile_show_payments_notification_setting:
     actor_type: user
     description: Show/Hide the payments section of notifications in profile
+  profile_show_new_benefit_overpayment_debt_notification_setting:
+    actor_type: user
+    description: Show/Hide the Benefit overpayment debt notification item of notifications in profile
+  profile_show_new_health_care_copay_bill_notification_setting:
+    actor_type: user
+    description: Show/Hide the Health care copay bill section of notifications in profile
   profile_show_privacy_policy:
     actor_type: user
     description: Show/Hide the privacy policy section on profile pages


### PR DESCRIPTION
## Summary

- **Added new toggles:**
  - `profile_show_new_benefit_overpayment_debt_notification_setting`
  - `profile_show_new_health_care_copay_bill_notification_setting`

#### Details:

- The `New benefit overpayment debt notification` and `New health care copay bill` items were recently added under the Payment notification group, and these new toggles were introduced to control the visibility of these items.
  - `profile_show_new_benefit_overpayment_debt_notification_setting`: Controls the `New benefit overpayment debt notification` item.
  - `profile_show_new_health_care_copay_bill_notification_setting`: Controls the `New health care copay bill` item.

**Timeframe for toggle**
- Depends on when MHV migrates

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89359

## Testing done

Test locally

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Toggle added
- [x]  No error nor warning in the console.
