### PR TITLE
85683: Allow multiple claims to be created in one submission

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -20,8 +20,8 @@ module IvcChampva
           Datadog::Tracing.active_trace&.set_tag('form_id', params[:form_number])
           form_id = get_form_id
           parsed_form_data = JSON.parse(params.to_json)
-          file_paths, metadata, attachment_ids = get_file_paths_and_metadata(parsed_form_data)
-          statuses, error_message = FileUploader.new(form_id, metadata, file_paths, attachment_ids, true).handle_uploads
+          file_paths, metadata = get_file_paths_and_metadata(parsed_form_data)
+          statuses, error_message = FileUploader.new(form_id, metadata, file_paths, true).handle_uploads
           response = build_json(Array(statuses), error_message)
 
           if @current_user && response[:status] == 200
@@ -51,16 +51,15 @@ module IvcChampva
 
       private
 
-      # rubocop:disable Layout/LineLength
       def get_attachment_ids_and_form(parsed_form_data)
         form_id = get_form_id
         form_class = "IvcChampva::#{form_id.titleize.gsub(' ', '')}".constantize
         additional_pdf_count = form_class.const_defined?(:ADDITIONAL_PDF_COUNT) ? form_class::ADDITIONAL_PDF_COUNT : 1
         applicant_key = form_class.const_defined?(:ADDITIONAL_PDF_KEY) ? form_class::ADDITIONAL_PDF_KEY : 'applicants'
 
-        applicants_count = parsed_form_data[applicant_key]&.count || 1
+        applicants_count = parsed_form_data[applicant_key]&.count.to_i
         total_applicants_count = applicants_count.to_f / additional_pdf_count
-        applicant_rounded_number = total_applicants_count.positive? ? total_applicants_count.ceil : total_applicants_count.floor
+        applicant_rounded_number = total_applicants_count.ceil
 
         form = form_class.new(parsed_form_data)
         # DataDog Tracking
@@ -68,20 +67,16 @@ module IvcChampva
         form.track_current_user_loa(@current_user)
         form.track_email_usage
 
-        attachment_ids = generate_attachment_ids(form_id, applicant_rounded_number)
+        attachment_ids = Array.new(applicant_rounded_number) { form_id }
         attachment_ids.concat(supporting_document_ids(parsed_form_data))
         attachment_ids = [form_id] if attachment_ids.empty?
 
-        [attachment_ids, form]
-      end
-      # rubocop:enable Layout/LineLength
-
-      def generate_attachment_ids(form_id, count)
-        count == 1 ? [form_id] : Array.new(count, form_id)
+        [attachment_ids.compact, form]
       end
 
       def supporting_document_ids(parsed_form_data)
-        parsed_form_data['supporting_docs']&.pluck('attachment_id') || []
+        parsed_form_data['supporting_docs']&.pluck('attachment_id')&.compact.presence ||
+          parsed_form_data['supporting_docs']&.pluck('claim_id')&.compact.presence || []
       end
 
       def get_file_paths_and_metadata(parsed_form_data)
@@ -95,16 +90,14 @@ module IvcChampva
         metadata = IvcChampva::MetadataValidator.validate(form.metadata)
         file_paths = form.handle_attachments(file_path)
 
-        [file_paths, metadata, attachment_ids]
+        [file_paths, metadata.merge({ 'attachment_ids' => attachment_ids })]
       end
 
       def get_form_id
         form_number = params[:form_number]
-        raise 'missing form_number in params' unless form_number
+        raise 'Missing/malformed form_number in params' unless form_number
 
-        form_number_without_colon = form_number.sub(':', '')
-
-        FORM_NUMBER_MAP[form_number_without_colon]
+        FORM_NUMBER_MAP[form_number]
       end
 
       def build_json(statuses, error_message)

--- a/modules/ivc_champva/app/form_mappings/vha_10_7959a.json.erb
+++ b/modules/ivc_champva/app/form_mappings/vha_10_7959a.json.erb
@@ -20,10 +20,10 @@
   "form1[0].#subform[0].NameOHI-2[0]":                                        "<%= form.data.dig('policies', 1, 'name') %>",
   "form1[0].#subform[0].OHIPolicyNmbr-2[0]":                                  "<%= form.data.dig('policies', 1, 'policy_num') %>",
   "form1[0].#subform[0].Phone-OHI-2[0]":                                      "<%= form.data.dig('policies', 1, 'provider_phone') %>",
-  "form1[0].#subform[0].#area[2].WorkRelatedTreat[0]":                        "<%= form.data.dig('claim_is_work_related') ? 0 : 1 %>",
-  "form1[0].#subform[0].#area[0].OutsdWrkAccdnt[0]":                          "<%= form.data.dig('claim_is_auto_related') ? 0 : 1 %>",
-  "form1[0].#subform[0].PtntCverage[0]":                                      "<%= form.data.dig('has_ohi') ? 0 : 1 %>",
-  "form1[0].#subform[0].#area[1].RadioButtonList[0]":                         "<%= form.data.dig('policies', 0, 'type') === 'group' ? 1 : 
+  "form1[0].#subform[0].#area[2].WorkRelatedTreat[0]":                        "<%= ['true', true].include?(form.data.dig('claims', 0, 'claim_is_work_related')) ? 0 : 1 %>",
+  "form1[0].#subform[0].#area[0].OutsdWrkAccdnt[0]":                          "<%= ['true', true].include?(form.data.dig('claims', 0, 'claim_is_auto_related')) ? 0 : 1 %>",
+  "form1[0].#subform[0].PtntCverage[0]":                                      "<%= ['true', true].include?(form.data.dig('has_ohi')) ? 0 : 1 %>",
+  "form1[0].#subform[0].#area[1].RadioButtonList[0]":                         "<%= form.data.dig('policies', 0, 'type') === 'group' ? 1 :
                                                                                    form.data.dig('policies', 0, 'type') === 'non_group' ? 2 :
                                                                                    form.data.dig('policies', 0, 'type') === 'medicare' ? 3 :
                                                                                    form.data.dig('policies', 0, 'type') === 'other' ? 4 : 0 %>",

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -2,6 +2,8 @@
 
 module IvcChampva
   class VHA107959a
+    ADDITIONAL_PDF_KEY = 'claims'
+    ADDITIONAL_PDF_COUNT = 1
     STATS_KEY = 'api.ivc_champva_form.10_7959a'
 
     include Virtus.model(nullify_blank: true)

--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -11,12 +11,13 @@ module IvcChampva
       file_paths = [file_path_uuid]
 
       if attachments.count.positive?
-        attachments.each_with_index do |attachment, index|
+        supporting_doc_index = 0
+        attachments.each do |attachment|
           new_file_name =
             if attachment.include?('_additional_')
               "#{uuid}_#{File.basename(attachment, '.*')}.pdf"
             else
-              "#{uuid}_#{form_id}_supporting_doc-#{index + 1}.pdf"
+              "#{uuid}_#{form_id}_supporting_doc-#{supporting_doc_index}.pdf".tap { supporting_doc_index += 1 }
             end
 
           new_file_path = File.join(File.dirname(attachment), new_file_name)

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -2,20 +2,19 @@
 
 module IvcChampva
   class FileUploader
-    def initialize(form_id, metadata, file_paths, attachment_ids, insert_db_row = false) # rubocop:disable Style/OptionalBooleanParameter
+    def initialize(form_id, metadata, file_paths, insert_db_row = false) # rubocop:disable Style/OptionalBooleanParameter
       @form_id = form_id
       @metadata = metadata || {}
       @file_paths = Array(file_paths)
-      @attachment_ids = attachment_ids
       @insert_db_row = insert_db_row
     end
 
     def handle_uploads
-      results = @attachment_ids.zip(@file_paths).map do |attachment_id, file_path|
-        next unless attachment_id != 'Form ID'
+      results = @metadata['attachment_ids'].zip(@file_paths).map do |attachment_id, file_path|
+        next if file_path.blank?
 
         file_name = File.basename(file_path).gsub('-tmp', '')
-        response_status = upload_file(attachment_id, file_name, file_path)
+        response_status = upload(file_name, file_path, metadata_for_s3(attachment_id))
         insert_form(file_name, response_status.to_s) if @insert_db_row
 
         response_status
@@ -31,6 +30,11 @@ module IvcChampva
     end
 
     private
+
+    def metadata_for_s3(attachment_id)
+      key = attachment_id.is_a?(Integer) ? 'claim_id' : 'attachment_id'
+      @metadata.except('primaryContactInfo', 'attachment_ids').merge({ key => attachment_id.to_s })
+    end
 
     def insert_form(file_path, response_status)
       pega_status = response_status.first == 200 ? 'Submitted' : nil
@@ -48,17 +52,11 @@ module IvcChampva
       Rails.logger.error("Database Insertion Error for #{@metadata['uuid']}: #{e.message}")
     end
 
-    def upload_file(attachment_id, file_name, file_path)
-      upload(file_name, file_path, attachment_ids: [attachment_id])
-    end
-
     def generate_and_upload_meta_json
       meta_file_name = "#{@metadata['uuid']}_#{@form_id}_metadata.json"
       meta_file_path = "tmp/#{meta_file_name}"
       File.write(meta_file_path, @metadata.to_json)
-      meta_upload_status, meta_upload_error_message = upload(meta_file_name,
-                                                             meta_file_path,
-                                                             attachment_ids: @attachment_ids)
+      meta_upload_status, meta_upload_error_message = upload(meta_file_name, meta_file_path)
 
       if meta_upload_status == 200
         FileUtils.rm_f(meta_file_path)
@@ -68,8 +66,8 @@ module IvcChampva
       end
     end
 
-    def upload(file_name, file_path, attachment_ids:)
-      case client.put_object(file_name, file_path, @metadata.except('primaryContactInfo'), attachment_ids)
+    def upload(file_name, file_path, metadata = {})
+      case client.put_object(file_name, file_path, metadata)
       in { success: true }
         [200]
       in { success: false, error_message: error_message }

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -11,10 +11,9 @@ module IvcChampva
       @bucket = bucket
     end
 
-    def put_object(key, file, metadata = {}, attachment_ids = {})
+    def put_object(key, file, metadata = {})
       Datadog::Tracing.trace('S3 Put File(s)') do
         metadata&.transform_values! { |value| value || '' }
-        metadata['attachment_ids'] = attachment_ids.empty? ? '' : attachment_ids.join(',')
 
         client.put_object({
                             bucket:,

--- a/modules/ivc_champva/spec/fixtures/form_json/vha_10_10d.json
+++ b/modules/ivc_champva/spec/fixtures/form_json/vha_10_10d.json
@@ -142,6 +142,18 @@
       "vet_relationship": "Relative - Other"
     }
   ],
+  "supporting_docs": [
+      {
+        "name": "file.png",
+        "confirmation_code": "c1f25ef2-e5e3-48b6-927b-a0049a6dcbce",
+        "attachment_id": "Birth certificate",
+        "is_encrypted": false,
+        "applicant_name": {
+            "first": "Applicant",
+            "last": "Jones"
+        }
+    }
+  ],
   "certification": {
     "last_name": "Joe",
     "first_name": "GI",

--- a/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959a.json
+++ b/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959a.json
@@ -1,19 +1,20 @@
 {
   "form_number": "10-7959A",
+  "certifier_role": "applicant",
   "primary_contact_info": {
-    "name": {
-      "first": "GI",
-      "last": "Joe"
-    }
+    "name": { "first": "Beneficiary", "last": "Jones" },
+    "email": false,
+    "phone": "1231231234"
   },
-  "applicant_dob": "11/18/2001",
+  "applicant_dob": "10-25-2000",
   "applicant_phone": "215-355-5555",
   "applicant_address": {
     "country": "USA",
-    "street": "123 Street Road",
-    "city": "Philadelphia",
-    "state": "PA",
-    "postal_code": "19020"
+    "street": "123 Beneficiary Street",
+    "city": "Citytown",
+    "state": "MD",
+    "postal_code": "12345",
+    "street_combined": "123 Beneficiary Street  "
   },
   "applicant_new_address": "",
   "applicant_member_number": "12345678",
@@ -22,25 +23,73 @@
     "last": "Joe"
   },
   "sponsor_name": {
-    "first": "GI",
-    "last": "Joe"
+    "first": "Sponsor",
+    "middle": "Quincy",
+    "last": "Jones",
+    "suffix": "Jr."
   },
   "policies": [
     {
-      "name": "Michael",
-      "provider_phone": "215-355-5555",
-      "policy_num": "12345"
+      "type": "group",
+      "name": "BCBS",
+      "policy_num": "123",
+      "provider_phone": "1231231234"
     },
     {
-      "name": "Jordan",
-      "provider_phone": "215-355-5555",
-      "policy_num": "54321"
+      "type": "nonGroup",
+      "name": "Cigna",
+      "policy_num": "321",
+      "provider_phone": "1231231235"
     }
   ],
-  "claim_is_auto_related": false,
-  "claim_is_work_related": false,
-  "claim_type": "FILTERED",
+  "claim_is_auto_related": true,
+  "claim_is_work_related": true,
+  "claim_type": "medical",
   "has_ohi": false,
+  "claims": [
+    {
+      "medical_upload": {
+        "confirmation_code": "e955735c-d433-4c0f-9060-1499a7b8353d",
+        "is_encrypted": false,
+        "name": "file.png",
+        "size": 3530,
+        "claim_id": 0
+      },
+      "claim_is_auto_related": true,
+      "claim_is_work_related": true,
+      "claim_type": "medical",
+      "claim_id": 0
+    },
+    {
+      "medical_upload": {
+        "confirmation_code": "1b39d28c-5d38-4467-808b-9da252b6e95f",
+        "is_encrypted": false,
+        "name": "caia_widget_copy.png",
+        "size": 224266,
+        "claim_id": 1
+      },
+      "claim_is_auto_related": true,
+      "claim_is_work_related": false,
+      "claim_type": "medical",
+      "claim_id": 1
+    }
+  ],
+  "supporting_docs": [
+    {
+      "confirmation_code": "e955735c-d433-4c0f-9060-1499a7b8353d",
+      "is_encrypted": false,
+      "name": "file.png",
+      "size": 3530,
+      "claim_id": 0
+    },
+    {
+      "confirmation_code": "1b39d28c-5d38-4467-808b-9da252b6e95f",
+      "is_encrypted": false,
+      "name": "caia_widget_copy.png",
+      "size": 224266,
+      "claim_id": 1
+    }
+  ],
   "certifier_relationship": "other",
   "certifier_name": {
     "first": "Veteran",
@@ -55,6 +104,6 @@
       "zip_code": "12345"
     },
     "certifier_phone": "5555555555",
-    "certification_date": "10/31/2000",
+    "certification_date": "08-14-2024",
   "statement_of_truth_signature": "GI Joe"
 }

--- a/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/v1/uploads_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Forms uploader', type: :request do
 
     it 'raises an error for a missing form number' do
       allow(controller).to receive(:params).and_return({})
-      expect { controller.send(:get_form_id) }.to raise_error('missing form_number in params')
+      expect { controller.send(:get_form_id) }.to raise_error('Missing/malformed form_number in params')
     end
   end
 
@@ -143,14 +143,13 @@ RSpec.describe 'Forms uploader', type: :request do
         it 'returns the correct file paths, metadata, and attachment IDs' do
           allow(controller).to receive(:get_attachment_ids_and_form).and_return([%w[doc1 doc2], form_class.new({})])
           allow_any_instance_of(IvcChampva::PdfFiller).to receive(:generate).and_return('file_path')
-          allow(IvcChampva::MetadataValidator).to receive(:validate).and_return('metadata')
+          allow(IvcChampva::MetadataValidator).to receive(:validate).and_return({ 'metadata' => {} })
           allow_any_instance_of(form_class).to receive(:handle_attachments).and_return(['file_path'])
 
-          file_paths, metadata, attachment_ids = controller.send(:get_file_paths_and_metadata, parsed_form_data)
+          file_paths, metadata = controller.send(:get_file_paths_and_metadata, parsed_form_data)
 
           expect(file_paths).to eq(['file_path'])
-          expect(metadata).to eq('metadata')
-          expect(attachment_ids).to eq(%w[doc1 doc2])
+          expect(metadata).to eq({ 'metadata' => {}, 'attachment_ids' => %w[doc1 doc2] })
         end
       end
     end

--- a/modules/ivc_champva/spec/services/attachments_spec.rb
+++ b/modules/ivc_champva/spec/services/attachments_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe IvcChampva::Attachments do
       it 'renames and processes attachments' do
         expect(File).to receive(:rename).with(file_path, "tmp/#{uuid}_#{form_id}-tmp.pdf")
         expect(test_instance).to receive(:get_attachments).and_return(['attachment1.pdf', 'attachment2.png'])
-        expect(File).to receive(:rename).with('attachment1.pdf', "./#{uuid}_#{form_id}_supporting_doc-1.pdf")
-        expect(File).to receive(:rename).with('attachment2.png', "./#{uuid}_#{form_id}_supporting_doc-2.pdf")
+        expect(File).to receive(:rename).with('attachment1.pdf', "./#{uuid}_#{form_id}_supporting_doc-0.pdf")
+        expect(File).to receive(:rename).with('attachment2.png', "./#{uuid}_#{form_id}_supporting_doc-1.pdf")
 
         result = test_instance.handle_attachments(file_path)
-        expect(result).to contain_exactly("tmp/#{uuid}_#{form_id}-tmp.pdf", "./#{uuid}_#{form_id}_supporting_doc-1.pdf",
-                                          "./#{uuid}_#{form_id}_supporting_doc-2.pdf")
+        expect(result).to contain_exactly("tmp/#{uuid}_#{form_id}-tmp.pdf", "./#{uuid}_#{form_id}_supporting_doc-0.pdf",
+                                          "./#{uuid}_#{form_id}_supporting_doc-1.pdf")
       end
     end
 

--- a/modules/ivc_champva/spec/services/file_uploader_spec.rb
+++ b/modules/ivc_champva/spec/services/file_uploader_spec.rb
@@ -4,11 +4,13 @@ require 'rails_helper'
 
 describe IvcChampva::FileUploader do
   let(:form_id) { '123' }
-  let(:metadata) { { 'uuid' => '4171e61a-03b5-49f3-8717-dbf340310473' } }
+  let(:metadata) do
+    { 'uuid' => '4171e61a-03b5-49f3-8717-dbf340310473',
+      'attachment_ids' => ['Social Security card', 'Birth certificate'] }
+  end
   let(:file_paths) { ['tmp/file1.pdf', 'tmp/file2.png'] }
-  let(:attachment_ids) { ['Social Security card', 'Birth certificate'] }
   let(:insert_db_row) { false }
-  let(:uploader) { IvcChampva::FileUploader.new(form_id, metadata, file_paths, attachment_ids, insert_db_row) }
+  let(:uploader) { IvcChampva::FileUploader.new(form_id, metadata, file_paths, insert_db_row) }
 
   describe '#handle_uploads' do
     context 'when all PDF uploads succeed' do
@@ -46,8 +48,7 @@ describe IvcChampva::FileUploader do
       expect(File).to receive(:write).with(meta_file_path, metadata.to_json)
       expect(uploader).to receive(:upload).with(
         "#{metadata['uuid']}_#{form_id}_metadata.json",
-        meta_file_path,
-        attachment_ids:
+        meta_file_path
       ).and_return([200, nil])
       uploader.send(:generate_and_upload_meta_json)
     end
@@ -79,7 +80,7 @@ describe IvcChampva::FileUploader do
 
     it 'uploads the file to S3 and returns the upload status' do
       expect(s3_client).to receive(:put_object).and_return({ success: true })
-      expect(uploader.send(:upload, 'file_name', 'file_path', attachment_ids: 'attachment_ids')).to eq([200])
+      expect(uploader.send(:upload, 'file_name', 'file_path', 'attachment_id')).to eq([200])
     end
 
     context 'when upload fails' do
@@ -88,7 +89,7 @@ describe IvcChampva::FileUploader do
         expect(uploader.send(:upload,
                              'file_name',
                              'file_path',
-                             attachment_ids: 'attachment_ids')).to eq([400, 'Upload failed'])
+                             'attachment_id')).to eq([400, 'Upload failed'])
       end
     end
 


### PR DESCRIPTION
As a 10-7959a applicant I want to include more than 1 claim on the form so that I don't have to keep filling out a separate form for each claim.


## Summary

- Updated and cleaned up controller to move attachment_ids into @metadata
- Added global vars to 10-7959A to allow multiple PDFs to be created
- Updated other files to use @metadata over another argument to keep some areas a bit cleaner
- Updated tests

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85683

## Testing done

- manuel
- rspec

## Screenshots
<img width="564" alt="Screenshot 2024-08-22 at 11 47 29 AM" src="https://github.com/user-attachments/assets/01c5c7fb-d824-406e-bd06-4b65d02c252f">

<img width="910" alt="Screenshot 2024-08-22 at 11 47 44 AM" src="https://github.com/user-attachments/assets/9fcb2b89-8acb-441a-87e6-f754ca92699a">

## What areas of the site does it impact?
Just IVC forms

## Acceptance criteria

- [ ] Given the applicant has multiple claims to submit
- [ ] When they fill out the form with all their claims
- [ ] Then the form should generate separate PDFs for each claim
