### PR TITLE
91327: Add record status metrics for DR SavedClaim updater jobs

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -23,9 +23,7 @@ module DecisionReview
 
       higher_level_reviews.each do |hlr|
         guid = hlr.guid
-        response = decision_review_service.get_higher_level_review(guid).body
-        status = response.dig('data', 'attributes', 'status')
-        attributes = response.dig('data', 'attributes')
+        status, attributes = get_status_and_attributes(guid)
 
         timestamp = DateTime.now
         params = { metadata: attributes.to_json, metadata_updated_at: timestamp }
@@ -34,6 +32,8 @@ module DecisionReview
           params[:delete_date] = timestamp + RETENTION_PERIOD
           StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
+        else
+          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: [status])
         end
 
         hlr.update(params)
@@ -53,6 +53,14 @@ module DecisionReview
 
     def higher_level_reviews
       @higher_level_reviews ||= ::SavedClaim::HigherLevelReview.where(delete_date: nil).order(created_at: :asc)
+    end
+
+    def get_status_and_attributes(guid)
+      response = decision_review_service.get_higher_level_review(guid).body
+      status = response.dig('data', 'attributes', 'status')
+      attributes = response.dig('data', 'attributes')
+
+      [status, attributes]
     end
 
     def enabled?

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -23,9 +23,7 @@ module DecisionReview
 
       notice_of_disagreements.each do |nod|
         guid = nod.guid
-        response = decision_review_service.get_notice_of_disagreement(guid).body
-        status = response.dig('data', 'attributes', 'status')
-        attributes = response.dig('data', 'attributes')
+        status, attributes = get_status_and_attributes(guid)
 
         timestamp = DateTime.now
         params = { metadata: attributes.to_json, metadata_updated_at: timestamp }
@@ -34,6 +32,8 @@ module DecisionReview
           params[:delete_date] = timestamp + RETENTION_PERIOD
           StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
+        else
+          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: [status])
         end
 
         nod.update(params)
@@ -53,6 +53,14 @@ module DecisionReview
 
     def notice_of_disagreements
       @notice_of_disagreements ||= ::SavedClaim::NoticeOfDisagreement.where(delete_date: nil).order(created_at: :asc)
+    end
+
+    def get_status_and_attributes(guid)
+      response = decision_review_service.get_notice_of_disagreement(guid).body
+      status = response.dig('data', 'attributes', 'status')
+      attributes = response.dig('data', 'attributes')
+
+      [status, attributes]
     end
 
     def enabled?

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -23,9 +23,7 @@ module DecisionReview
 
       supplemental_claims.each do |sc|
         guid = sc.guid
-        response = decision_review_service.get_supplemental_claim(guid).body
-        status = response.dig('data', 'attributes', 'status')
-        attributes = response.dig('data', 'attributes')
+        status, attributes = get_status_and_attributes(guid)
 
         timestamp = DateTime.now
         params = { metadata: attributes.to_json, metadata_updated_at: timestamp }
@@ -34,6 +32,8 @@ module DecisionReview
           params[:delete_date] = timestamp + RETENTION_PERIOD
           StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
+        else
+          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: [status])
         end
 
         sc.update(params)
@@ -53,6 +53,14 @@ module DecisionReview
 
     def supplemental_claims
       @supplemental_claims ||= ::SavedClaim::SupplementalClaim.where(delete_date: nil).order(created_at: :asc)
+    end
+
+    def get_status_and_attributes(guid)
+      response = decision_review_service.get_supplemental_claim(guid).body
+      status = response.dig('data', 'attributes', 'status')
+      attributes = response.dig('data', 'attributes')
+
+      [status, attributes]
     end
 
     def enabled?

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -69,6 +69,8 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
               .with('worker.decision_review.saved_claim_hlr_status_updater.processing_records', 2).exactly(1).time
             expect(StatsD).to have_received(:increment)
               .with('worker.decision_review.saved_claim_hlr_status_updater.delete_date_update').exactly(1).time
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_hlr_status_updater.status', tags: ['pending']).exactly(1).time
           end
         end
 

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
             .with('worker.decision_review.saved_claim_nod_status_updater.processing_records', 2).exactly(1).time
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.saved_claim_nod_status_updater.delete_date_update').exactly(1).time
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_nod_status_updater.status', tags: ['pending']).exactly(1).time
         end
 
         it 'handles request errors and increments the statsd metric' do

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
             .with('worker.decision_review.saved_claim_sc_status_updater.processing_records', 2).exactly(1).time
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.saved_claim_sc_status_updater.delete_date_update').exactly(1).time
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_sc_status_updater.status', tags: ['pending']).exactly(1).time
         end
 
         it 'handles request errors and increments the statsd metric' do


### PR DESCRIPTION
## Summary

This PR adds record status metrics for the SavedClaim Updater jobs for monitoring on our DD dashboard. Dashboard link: https://vagov.ddog-gov.com/dashboard/fps-2wj-ceb

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90103
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91327
- #18103

## Testing done
Local run + spec tests
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
This impacts StatsD and the SavedClaim status updater jobs.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/decision-reviews/engineering/form-submission-storage.md
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
