### PR TITLE
Check for icn when submitting 26-4555

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -188,8 +188,7 @@ module SimpleFormsApi
       end
 
       def form_is264555_and_should_use_lgy_api
-        # TODO: Remove comment octothorpe and ALWAYS require icn
-        params[:form_number] == '26-4555' # && icn
+        params[:form_number] == '26-4555' && icn
       end
 
       def icn


### PR DESCRIPTION
## Summary
This PR removes a commented-out bit of code such that we will now require an `icn` before submitting the 26-4555 through the LGY API.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/89316
