### PR TITLE
Disable `FormReloader` job in VSP `sandbox` ENV

### DIFF
--- a/modules/va_forms/app/sidekiq/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_reloader.rb
@@ -54,6 +54,10 @@ module VAForms
     end
 
     def perform
+      # Temporarily disable FormReloader job in sandbox to support data migration
+      # https://jira.devops.va.gov/browse/API-37197
+      return if Settings.vsp_environment.downcase == 'sandbox'
+
       return unless enabled?
 
       all_forms_data.each { |form| VAForms::FormBuilder.perform_async(form) }


### PR DESCRIPTION
![disable-digital-distortion-gif-by-nico-roxe](https://github.com/user-attachments/assets/213d782a-84dd-4550-9139-92c9295a592d)

## Summary
As part of bringing our VSP and LHDI sandbox datasets into parity, this PR and [it's sibling](https://github.com/department-of-veterans-affairs/lighthouse-vets-api/pull/345) disable the `FormReloader` job *only* in the `sandbox` environments.

## Related issue(s)
- [🎟️ API-37197 - Migrate VSP Sandbox Form Data to LHDI Sandbox Environment](https://jira.devops.va.gov/browse/API-37197)

## What areas of the site does it impact?
Only the `FormReloader` job is impacted and only in the `sandbox` VSP ENV.

## Acceptance criteria
- [ ] `FormReloader` job does not run overnight
