### PR TITLE
Refactor Document Upload Api Provider for better flexibility

### DIFF
--- a/lib/disability_compensation/factories/api_provider_factory.rb
+++ b/lib/disability_compensation/factories/api_provider_factory.rb
@@ -56,7 +56,7 @@ class ApiProviderFactory
   FEATURE_TOGGLE_BRD = 'disability_compensation_lighthouse_brd'
   FEATURE_TOGGLE_GENERATE_PDF = 'disability_compensation_lighthouse_generate_pdf'
 
-  FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS = 'disability_compensation_lighthouse_upload_bdd_instructions'
+  FEATURE_TOGGLE_UPLOAD_SUPPLEMENTAL_DOCUMENT = 'disability_compensation_lighthouse_upload_supplemental_document'
 
   attr_reader :type
 

--- a/lib/disability_compensation/factories/api_provider_factory.rb
+++ b/lib/disability_compensation/factories/api_provider_factory.rb
@@ -56,7 +56,7 @@ class ApiProviderFactory
   FEATURE_TOGGLE_BRD = 'disability_compensation_lighthouse_brd'
   FEATURE_TOGGLE_GENERATE_PDF = 'disability_compensation_lighthouse_generate_pdf'
 
-  FEATURE_TOGGLE_UPLOAD_SUPPLEMENTAL_DOCUMENT = 'disability_compensation_lighthouse_upload_supplemental_document'
+  FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS = 'disability_compensation_lighthouse_upload_bdd_instructions'
 
   attr_reader :type
 
@@ -189,9 +189,9 @@ class ApiProviderFactory
   def supplemental_document_upload_service_provider
     case api_provider
     when API_PROVIDER[:evss]
-      EVSSSupplementalDocumentUploadProvider.new(@options[:form526_submission], @options[:file_body])
+      EVSSSupplementalDocumentUploadProvider.new(@options[:form526_submission])
     when API_PROVIDER[:lighthouse]
-      LighthouseSupplementalDocumentUploadProvider.new(@options[:form526_submission], @options[:file_body])
+      LighthouseSupplementalDocumentUploadProvider.new(@options[:form526_submission])
     else
       raise NotImplementedError, 'No known Supplemental Document Upload Api Provider type provided'
     end

--- a/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
@@ -8,10 +8,8 @@ class EVSSSupplementalDocumentUploadProvider
   STATSD_PROVIDER_METRIC = 'evss_supplemental_document_upload_provider'
 
   # @param form526_submission [Form526Submission]
-  # @param file_body [String]
-  def initialize(form526_submission, file_body)
+  def initialize(form526_submission)
     @form526_submission = form526_submission
-    @file_body = file_body
   end
 
   # Uploads to EVSS via the EVSS::DocumentsService require both the file body and an instance
@@ -45,29 +43,27 @@ class EVSSSupplementalDocumentUploadProvider
   # Initializes and uploads via our EVSS Document Service API wrapper
   #
   # @param evss_claim_document
+  # @param file_body [String]
+  #
   # @return [Faraday::Response] The EVSS::DocumentsService API calls are implemented with Faraday
-  def submit_upload_document(evss_claim_document)
+  def submit_upload_document(evss_claim_document, file_body)
     client = EVSS::DocumentsService.new(@form526_submission.auth_headers)
-    client.upload(@file_body, evss_claim_document)
+    client.upload(file_body, evss_claim_document)
   end
 
   def log_upload_success(uploading_class_prefix)
     StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
   end
 
-  def log_upload_error_retry(uploading_class_prefix)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_RETRIED_METRIC}")
-  end
-
-  def log_upload_failure(uploading_class_prefix, error)
+  def log_upload_failure(uploading_class_prefix, error_class, error_message)
     StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
 
     Rails.logger.error(
       'EVSSSupplementalDocumentUploadProvider upload failure',
       {
         class: 'EVSSSupplementalDocumentUploadProvider',
-        error_class: error.class,
-        error_message: error.message
+        error_class:,
+        error_message:
       }
     )
   end

--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -9,10 +9,8 @@ class LighthouseSupplementalDocumentUploadProvider
   STATSD_PROVIDER_METRIC = 'lighthouse_supplemental_document_upload_provider'
 
   # @param form526_submission [Form526Submission]
-  # @param file_body [String]
-  def initialize(form526_submission, file_body)
+  def initialize(form526_submission)
     @form526_submission = form526_submission
-    @file_body = file_body
   end
 
   # Uploads to Lighthouse require both the file body and an instance
@@ -46,29 +44,27 @@ class LighthouseSupplementalDocumentUploadProvider
   # Uploads the supplied file to the Lighthouse Benefits Documents API
   #
   # @param lighthouse_document [LighthouseDocument]
+  # @param file_body [String]
+  #
   # return [Faraday::Response] BenefitsDocuments::WorkerService makes http
   # calls with the Faraday gem under the hood
-  def submit_upload_document(lighthouse_document)
-    BenefitsDocuments::Form526::UploadSupplementalDocumentService.call(@file_body, lighthouse_document)
+  def submit_upload_document(lighthouse_document, file_body)
+    BenefitsDocuments::Form526::UploadSupplementalDocumentService.call(file_body, lighthouse_document)
   end
 
   def log_upload_success(uploading_class_prefix)
     StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
   end
 
-  def log_upload_error_retry(uploading_class_prefix)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_RETRIED_METRIC}")
-  end
-
-  def log_upload_failure(uploading_class_prefix, error)
+  def log_upload_failure(uploading_class_prefix, error_class, error_message)
     StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
 
     Rails.logger.error(
       'LighthouseSupplementalDocumentUploadProvider upload failure',
       {
         class: 'LighthouseSupplementalDocumentUploadProvider',
-        error_class: error.class,
-        error_message: error.message
+        error_class:,
+        error_message:
       }
     )
   end

--- a/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider.rb
@@ -13,11 +13,11 @@ module SupplementalDocumentUploadProvider
     raise_not_implemented_error
   end
 
-  def self.validate_upload_document(_lighthouse_document)
+  def self.validate_upload_document(_document)
     raise_not_implemented_error
   end
 
-  def self.submit_upload_document(_lighthouse_document)
+  def self.submit_upload_document(_document, _file_body)
     raise_not_implemented_error
   end
 
@@ -25,11 +25,7 @@ module SupplementalDocumentUploadProvider
     raise_not_implemented_error
   end
 
-  def self.log_upload_error_retry(_uploading_class_prefix)
-    raise_not_implemented_error
-  end
-
-  def self.log_upload_failure(_uploading_class_prefix, _error)
+  def self.log_upload_failure(_uploading_class_prefix, _error_class, _error_message)
     raise_not_implemented_error
   end
 end

--- a/spec/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe SupplementalDocumentUploadProvider do
 
   it 'raises an error if the submit_upload_document method is not implemented' do
     expect do
-      subject.submit_upload_document(LighthouseDocument.new)
+      file_body = double
+      subject.submit_upload_document(LighthouseDocument.new, file_body)
     end.to raise_error NotImplementedError
   end
 
@@ -28,15 +29,9 @@ RSpec.describe SupplementalDocumentUploadProvider do
     end.to raise_error NotImplementedError
   end
 
-  it 'raises an error if the log_upload_error_retry method is not implemented' do
-    expect do
-      subject.log_upload_error_retry('my_upload_job_prefix')
-    end.to raise_error NotImplementedError
-  end
-
   it 'raises an error if the log_upload_failure method is not implemented' do
     expect do
-      subject.log_upload_failure('my_upload_job_prefix', StandardError.new)
+      subject.log_upload_failure('my_upload_job_prefix', 'StandardError', 'Something broke')
     end.to raise_error NotImplementedError
   end
 end

--- a/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
+++ b/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
@@ -3,10 +3,9 @@
 require 'rails_helper'
 
 shared_examples 'supplemental document upload provider' do
-  subject { described_class.new(submission, file_body) }
+  subject { described_class.new(submission) }
 
   let(:submission) { create(:form526_submission) }
-  let(:file_body) { File.read(fixture_file_upload('doctors-note.pdf', 'application/pdf')) }
 
   it { is_expected.to respond_to(:generate_upload_document) }
   it { is_expected.to respond_to(:validate_upload_document) }


### PR DESCRIPTION
Makes some changes to the new `Api Provider` infrastructure for Form 526 document uploads to make it easier to work with in the jobs we will be migrating from EVSS uploads to Lighthouse uploads. Also updates the Api Provider to have a feature toggle for the BDD instructions job instead of a generic feature toggle, since all of the jobs will be migrated and tested separately.

TLDR (probably not important to reviewer) decoupling the provider constructor from the document file body allows us to use the logging I built in the `sidekiq_retries_exhausted` block for these jobs, where we don't have access to the file body as we do in the job instance itself. Also tweaks the error logging since we don't have access to an error object in that block, just the error class and message




## Summary

- *This work is behind a feature toggle (flipper): YES it will be it is not currently in use in the jobs yet


## Related issue(s)

- N/A this is a follow on to work done in https://github.com/department-of-veterans-affairs/vets-api/pull/17903. But I had to tweak it once I started going in and trying to use it in a job.
## Testing done
Unit tests, integration tests N/A this is shared functionality which isn't used anywhere yet


## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- X ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution N/A
- [ ]  Documentation has been updated (link to documentation) N/A
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [ ]  I added a screenshot of the developed feature N/A

## Requested Feedback

N/A
