### PR TITLE
Add vaos relationships endpoint

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/relationships_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/relationships_controller.rb
@@ -9,8 +9,7 @@ module VAOS
           relationships_params[:facility_id]
         )
 
-        serializer = VAOS::V2::VAOSSerializer.new
-        serialized = serializer.serialize(response, 'relationship')
+        serialized = VAOS::V2::VAOSSerializer.new.serialize(response, 'relationship')
         serialized.each { |relationship| relationship.delete(:id) }
 
         render json: { data: serialized }

--- a/modules/vaos/app/controllers/vaos/v2/relationships_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/relationships_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module VAOS
+  module V2
+    class RelationshipsController < VAOS::BaseController
+      def index
+        response = relationships_service.get_patient_relationships(
+          relationships_params[:clinical_service_id],
+          relationships_params[:facility_id]
+        )
+
+        serializer = VAOS::V2::VAOSSerializer.new
+        serialized = serializer.serialize(response, 'relationship')
+        serialized.each { |relationship| relationship.delete(:id) }
+
+        render json: { data: serialized }
+      end
+
+      private
+
+      def relationships_service
+        VAOS::V2::RelationshipsService.new(current_user)
+      end
+
+      def relationships_params
+        params.permit(:clinical_service_id)
+        params.permit(:facility_id)
+        params
+      end
+    end
+  end
+end

--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -1324,7 +1324,7 @@ components:
             clinic:
               $ref: "#/components/schemas/ClinicReference"
             serviceType:
-              $ref: '#/components/schemas/CodeableConcept'
+              $ref: "#/components/schemas/CodeableConcept"
             lastSeen:
               type: string
               description: The date-time (in UTC) when the patient was last seen.

--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -797,6 +797,68 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
         "504":
           $ref: "#/components/responses/GatewayTimeout"
+  "/relationships":
+    parameters:
+      - in: query
+        required: false
+        name: clinical_service_id
+        description: The clinical service (type of care) ID to filter results by. The currently supported/available VAOS clinical service IDs can be discovered from Mobile Facility Service v2.
+        schema:
+          type: string
+      - in: query
+        required: false
+        name: facility_id
+        description: The VHA facility ID to filter results by
+        schema:
+          type: string
+    get:
+      tags:
+        - relationships
+      summary: Search patient relationships
+      operationId: getRelationships
+      security:
+        - bearerAuth: [ ]
+      responses:
+        "200":
+          description: Retrieves all matching relationships for the patient
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      required:
+                        - type
+                        - attributes
+                      properties:
+                        type:
+                          type: string
+                          example: relationships
+                        attributes:
+                          $ref: "#/components/schemas/PatientProviderRelationship"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+        "502":
+          $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: "#/components/responses/GatewayTimeout"
 components:
   securitySchemes:
     bearerAuth:
@@ -1209,7 +1271,6 @@ components:
     PatientEligibilityResponse:
       type: object
       required:
-        - id
         - type
         - attributes
       properties:
@@ -1245,6 +1306,29 @@ components:
               items:
                 $ref: '#/components/schemas/CodeableConcept'
       description: The response for a patient scheduing eligibility request.
+    PatientProviderRelationship:
+      type: object
+      required:
+        - type
+        - attributes
+      properties:
+        type:
+          type: string
+        attributes:
+          type: object
+          properties:
+            provider:
+              $ref: "#/components/schemas/PractitionerReference"
+            location:
+              $ref: "#/components/schemas/LocationReference"
+            clinic:
+              $ref: "#/components/schemas/ClinicReference"
+            serviceType:
+              $ref: '#/components/schemas/CodeableConcept'
+            lastSeen:
+              type: string
+              description: The date-time (in UTC) when the patient was last seen.
+              format: date-time
     PreferredLocation:
       type: object
       properties:
@@ -1295,6 +1379,19 @@ components:
             clinicIen:
               type: string
               example: "32216049"
+    ClinicReference:
+      type: object
+      properties:
+        vistaSite:
+          type: string
+          example: 534
+        ien:
+          type: string
+          example: 6569
+        name:
+          type: string
+          description: The clinic name. The clinic patient friendly name will be used if one is set.
+          example: Zanesville Primary Care
     ContactPoint:
       type: object
       properties:
@@ -1393,6 +1490,16 @@ components:
           pattern: '([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?'
       description: |
         Standard hours of operation. Currently formatted as descriptive text suitable for display, with no guarantee of a standard parsable format. Hours of operation may vary due to holidays or other events.
+    LocationReference:
+      type: object
+      properties:
+        vhaFacilityId:
+          type: string
+          description: The VHA Facility ID.
+        name:
+          type: string
+          description: The name of the location.
+          example: Marion VA Clinic
     OperatingStatus:
       type: object
       description: 'Current status of facility operations.The overall status of the facility which can be Normal Hours and Services, Facility Notice, Limited Hours and/or Services, or Closed. This field replaces active_status.'
@@ -1448,6 +1555,17 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/Identifier"
+    PractitionerReference:
+      type: object
+      properties:
+        cernerId:
+          type: string
+          description: The logical ID of the Cerner Practitioner.
+          example: Practitioner/123456
+        name:
+          type: string
+          description: The name of the practitioner.
+          example: Doe, John D, MD
     PhoneNumbers:
       type: object
       properties:

--- a/modules/vaos/app/services/vaos/v2/relationships_service.rb
+++ b/modules/vaos/app/services/vaos/v2/relationships_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'common/exceptions'
+require 'common/client/errors'
+require 'json'
+
+module VAOS
+  module V2
+    class RelationshipsService < VAOS::SessionService
+      def get_patient_relationships(clinic_service_id, facility_id)
+        with_monitoring do
+          params = {
+            clinicalService: clinic_service_id,
+            location: facility_id
+          }
+
+          response = perform(:get, "/vpg/v1/patients/#{user.icn}/relationships", params, headers)
+
+          response[:body][:data][:relationships].map { |relationship| OpenStruct.new(relationship) }
+        end
+      end
+    end
+  end
+end

--- a/modules/vaos/config/routes.rb
+++ b/modules/vaos/config/routes.rb
@@ -27,6 +27,7 @@ VAOS::Engine.routes.draw do
     get '/scheduling/configurations', to: 'scheduling#configurations'
     get '/facilities', to: 'facilities#index'
     get '/facilities/:facility_id', to: 'facilities#show'
+    get '/relationships', to: 'relationships#index'
     post '/appointments', to: 'appointments#create'
   end
 end

--- a/modules/vaos/spec/request/v2/relationships_request_spec.rb
+++ b/modules/vaos/spec/request/v2/relationships_request_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'relationships', :skip_mvi, type: :request do
+  before do
+    sign_in_as(current_user)
+    allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
+  end
+
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+
+  context 'loa3 user' do
+    let(:current_user) { build(:user, :vaos) }
+
+    describe 'GET relationships' do
+      let(:params) { { clinical_service_id: 'primaryCare', facility_id: '100' } }
+
+      context 'patient relationships' do
+        it 'successfully returns patient relationships' do
+          VCR.use_cassette('vaos/v2/relationships/get_relationships',
+                           match_requests_on: %i[method path query]) do
+            get '/vaos/v2/relationships?clinicalServiceId=primaryCare&facilityId=100', params:,
+                                                                                       headers: inflection_header
+            expect(response).to have_http_status(:ok)
+
+            relationships = JSON.parse(response.body)['data']
+            expect(relationships).not_to be_nil
+            expect(relationships.length).to eq(4)
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/vaos/spec/services/v2/relationships_service_spec.rb
+++ b/modules/vaos/spec/services/v2/relationships_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VAOS::V2::RelationshipsService do
+  subject { described_class.new(user) }
+
+  let(:user) { build(:user, :vaos) }
+
+  before { allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token') }
+
+  context 'when the upstream server returns a 500' do
+    it 'raises a backend exception' do
+      VCR.use_cassette('vaos/v2/relationships/get_relationships_500',
+                       match_requests_on: %i[method path query]) do
+        expect { subject.get_patient_relationships('primaryCare', '100') }.to raise_error(
+          Common::Exceptions::BackendServiceException
+        )
+      end
+    end
+  end
+end

--- a/spec/support/vcr_cassettes/vaos/v2/relationships/get_relationships.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/relationships/get_relationships.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012845331V153043/relationships?clinicalService=primaryCare&location=100
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - stubbed_token
+        X-Request-Id:
+          - 06054f2f-fec7-4ee1-be71-6d9e381f063a
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Fri, 23 Aug 2024 14:46:54 GMT
+        Content-Type:
+          - application/json
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "data": {
+              "patientIcn": "1012781163V209546",
+              "relationships": [
+                {
+                  "provider": {
+                    "cernerId": "Practitioner/1",
+                    "name": "House, Gregory, M.D."
+                  },
+                  "location": {
+                    "vhaFacilityId": "653",
+                    "name": "653 ROS OR VA"
+                  },
+                  "clinic": null,
+                  "serviceType": null,
+                  "lastSeen": "2024-02-22T21:20:52.661Z"
+                },
+                {
+                  "provider": {
+                    "cernerId": "Practitioner/1",
+                    "name": "House, Gregory, M.D."
+                  },
+                  "location": {
+                    "vhaFacilityId": "653",
+                    "name": "653 ROS OR VA"
+                  },
+                  "clinic": null,
+                  "serviceType": {
+                    "coding": {
+                      "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                      "code": "primaryCare",
+                      "display": "Primary Care"
+                    },
+                    "text": "Primary Care"
+                  },
+                  "lastSeen": "2024-08-22T21:20:52.661Z"
+                },
+                {
+                  "provider": {
+                    "cernerId": "Practitioner/1",
+                    "name": "House, Gregory, M.D."
+                  },
+                  "location": {
+                    "vhaFacilityId": "653GB",
+                    "name": "653GB BRK OR VA"
+                  },
+                  "clinic": "null",
+                  "serviceType": {
+                    "coding": {
+                      "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                      "code": "optometry",
+                      "display": "Optometry"
+                    },
+                    "text": "Optometry"
+                  },
+                  "lastSeen": "2023-08-22T21:20:52.661Z"
+                },
+                {
+                  "provider": {
+                    "cernerId": "Practitioner/2",
+                    "name": "Cuddy, Lisa, M.D."
+                  },
+                  "location": {
+                    "vhaFacilityId": "653GA",
+                    "name": "653GA NBD OR VA"
+                  },
+                  "clinic": null,
+                  "serviceType": {
+                    "coding": {
+                      "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                      "code": "audiology",
+                      "display": "Audiology"
+                    },
+                    "text": "Audiology"
+                  },
+                  "lastSeen": "2024-08-22T21:20:52.661Z"
+                }
+              ]
+            }
+          }
+    recorded_at: Fri, 23 Aug 2024 14:46:55 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/vcr_cassettes/vaos/v2/relationships/get_relationships_500.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/relationships/get_relationships_500.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012845331V153043/relationships?clinicalService=primaryCare&location=100
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - stubbed_token
+        X-Request-Id:
+          - 06054f2f-fec7-4ee1-be71-6d9e381f063a
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 500
+        message: Internal Server Error
+      headers:
+        Date:
+          - Fri, 23 Aug 2024 14:46:54 GMT
+        Content-Type:
+          - application/json
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+      body:
+        encoding: UTF-8
+        string: '{"code":500,"status":500,"message":"Failed to fetch relationships","id":"8f82ace3-725b-4ac2-9dd9-af24a08b9511","traceId":"66cca2fc08756a082363af261c74ee40"}'
+    recorded_at: Fri, 23 Aug 2024 14:46:55 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Added a new `/relationships` endpoint to the VAOS module that will be used for future appointment booking work. This uses VPG to pull patient provider relationship information from Oracle Health and VAOS

## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-oracle-health-integration-65a6e99ea522640e4d09393b/issues/gh/department-of-veterans-affairs/va.gov-team/90606

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
This will have no impact on the site.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
