### PR TITLE
[DBX-18193] remove passed arg logging from logging wrapper

### DIFF
--- a/lib/logging/third_party_transaction.rb
+++ b/lib/logging/third_party_transaction.rb
@@ -27,11 +27,10 @@ module Logging
           method_names.each do |method_name|
             # define patchable method(s) with the same name inside of a proxy module.
             define_method(method_name) do |*args, &block|
-              str_args = args.to_s
-              log_3pi_begin(method_name, additional_class_logs, additional_instance_logs, str_args)
+              log_3pi_begin(method_name, additional_class_logs, additional_instance_logs)
               # delegate to the original behavior
               result = super(*args, &block)
-              log_3pi_complete(method_name, additional_class_logs, additional_instance_logs, str_args)
+              log_3pi_complete(method_name, additional_class_logs, additional_instance_logs)
               result
             end
           end
@@ -45,13 +44,12 @@ module Logging
     # these will be included after instance instantiation, making them available
     # to the instance and retaining their scope.
     module ScopedInstanceMethods
-      def log_3pi_begin(method_name, additional_class_logs, additional_instance_logs, args)
+      def log_3pi_begin(method_name, additional_class_logs, additional_instance_logs)
         @start_time = Time.current
 
         log = {
           start_time: @start_time.to_s,
-          wrapped_method: "#{self.class}##{method_name}",
-          passed_args: args.to_s
+          wrapped_method: "#{self.class}##{method_name}"
         }
 
         log.merge!(default_logs)
@@ -63,14 +61,13 @@ module Logging
         Rails.logger.error(e)
       end
 
-      def log_3pi_complete(method_name, additional_class_logs, additional_instance_logs, args)
+      def log_3pi_complete(method_name, additional_class_logs, additional_instance_logs)
         now = Time.current
 
         log = {
           upload_duration: (now - @start_time).to_f,
           wrapped_method: "#{self.class}##{method_name}",
-          end_time: now.to_s,
-          passed_args: args.to_s
+          end_time: now.to_s
         }
 
         log.merge!(default_logs)


### PR DESCRIPTION
## Summary

**HIGH PRIORITY** this stops the bleeding on a PII leak

- *This work is behind a feature toggle (flipper): NO*

## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=76472380)

## Testing done

- [ ] *New code is covered by unit tests*
- Logging of passed args has been leaking PII. an incident has been created, this changes stops the bleeding

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature