### PR TITLE
91327: Fix metric tag for DR SavedClaim status updater jobs

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -33,7 +33,7 @@ module DecisionReview
           StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         else
-          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: [status])
+          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])
         end
 
         hlr.update(params)

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -33,7 +33,7 @@ module DecisionReview
           StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         else
-          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: [status])
+          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])
         end
 
         nod.update(params)

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -33,7 +33,7 @@ module DecisionReview
           StatsD.increment("#{STATSD_KEY_PREFIX}.delete_date_update")
           Rails.logger.info("#{self.class.name} updated delete_date", guid:)
         else
-          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: [status])
+          StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])
         end
 
         sc.update(params)

--- a/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_hlr_status_updater_job_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe DecisionReview::SavedClaimHlrStatusUpdaterJob, type: :job do
             expect(StatsD).to have_received(:increment)
               .with('worker.decision_review.saved_claim_hlr_status_updater.delete_date_update').exactly(1).time
             expect(StatsD).to have_received(:increment)
-              .with('worker.decision_review.saved_claim_hlr_status_updater.status', tags: ['pending']).exactly(1).time
+              .with('worker.decision_review.saved_claim_hlr_status_updater.status', tags: ['status:pending'])
+              .exactly(1).time
           end
         end
 

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.saved_claim_nod_status_updater.delete_date_update').exactly(1).time
           expect(StatsD).to have_received(:increment)
-            .with('worker.decision_review.saved_claim_nod_status_updater.status', tags: ['pending']).exactly(1).time
+            .with('worker.decision_review.saved_claim_nod_status_updater.status', tags: ['status:pending'])
+            .exactly(1).time
         end
 
         it 'handles request errors and increments the statsd metric' do

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.saved_claim_sc_status_updater.delete_date_update').exactly(1).time
           expect(StatsD).to have_received(:increment)
-            .with('worker.decision_review.saved_claim_sc_status_updater.status', tags: ['pending']).exactly(1).time
+            .with('worker.decision_review.saved_claim_sc_status_updater.status', tags: ['status:pending'])
+            .exactly(1).time
         end
 
         it 'handles request errors and increments the statsd metric' do


### PR DESCRIPTION

## Summary
Fixes missing tag keys for the new status metrics that were added for #18177. 

## Related issue(s)

#18177
https://github.com/department-of-veterans-affairs/va.gov-team/issues/90103
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91327

## Testing done
Local run + spec tests
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
This impacts StatsD and the SavedClaim status updater jobs.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
