### PR TITLE
[API-39196] Add `transaction_id` to 526 synchronous logs

### DIFF
--- a/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
@@ -10,21 +10,21 @@ module ClaimsApi
       LOG_TAG = '526_v2_Docker_Container_service'
 
       def upload(claim_id)
-        log_job_progress(claim_id,
-                         'Docker container service started')
-
         auto_claim = get_claim(claim_id)
+
+        log_job_progress(claim_id, 'Docker container service started', auto_claim.transaction_id)
+
         update_auth_headers(auto_claim) if auto_claim.transaction_id.present?
 
         evss_data = get_evss_data(auto_claim)
 
-        log_job_progress(claim_id,
-                         'Submitting mapped data to Docker container')
+        log_job_progress(claim_id, 'Submitting mapped data to Docker container', auto_claim.transaction_id)
 
         evss_res = evss_service.submit(auto_claim, evss_data, false)
 
-        log_job_progress(claim_id,
-                         "Successfully submitted to Docker container with response: #{evss_res}")
+        log_job_progress(claim_id, "Successfully submitted to Docker container with response: #{evss_res}",
+                         auto_claim.transaction_id)
+
         # update with the evss_id returned
         auto_claim.update!(evss_id: evss_res[:claimId])
       rescue => e

--- a/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
@@ -12,20 +12,19 @@ module ClaimsApi
       def generate(claim_id, middle_initial) # rubocop:disable Metrics/MethodLength
         auto_claim = get_claim(claim_id)
 
-        log_job_progress(auto_claim.id,
-                         "526EZ PDF generator started for claim #{auto_claim.id}")
+        log_job_progress(auto_claim.id, "526EZ PDF generator started for claim #{auto_claim.id}",
+                         auto_claim.transaction_id)
 
         mapped_claim = generate_mapped_claim(auto_claim, middle_initial)
         pdf_string = generate_526_pdf(mapped_claim)
 
         if pdf_string.empty?
-          log_job_progress(auto_claim.id,
-                           '526EZ PDF generator failed to return PDF string for claim')
+          log_job_progress(auto_claim.id, '526EZ PDF generator failed to return PDF string for claim',
+                           auto_claim.transaction_id)
 
           set_errored_state_on_claim(auto_claim)
         elsif pdf_string
-          log_job_progress(auto_claim.id,
-                           '526EZ PDF generator PDF string returned')
+          log_job_progress(auto_claim.id, '526EZ PDF generator PDF string returned', auto_claim.transaction_id)
 
           file_name = "#{SecureRandom.hex}.pdf"
           path = ::Common::FileHelpers.generate_temp_file(pdf_string, file_name)
@@ -35,8 +34,8 @@ module ClaimsApi
                                                             tempfile: File.open(path)
                                                           })
 
-          log_job_progress(auto_claim.id,
-                           "526EZ PDF generator Uploaded 526EZ PDF #{file_name} to S3")
+          log_job_progress(auto_claim.id, "526EZ PDF generator Uploaded 526EZ PDF #{file_name} to S3",
+                           auto_claim.transaction_id)
 
           auto_claim.set_file_data!(upload, EVSS_DOCUMENT_TYPE)
           auto_claim.save!
@@ -44,8 +43,7 @@ module ClaimsApi
           ::Common::FileHelpers.delete_file_if_exists(path)
         end
 
-        log_job_progress(auto_claim.id,
-                         '526EZ PDF generator job finished')
+        log_job_progress(auto_claim.id, '526EZ PDF generator job finished', auto_claim.transaction_id)
 
         auto_claim.id
       end

--- a/modules/claims_api/app/sidekiq/claims_api/service_base.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/service_base.rb
@@ -162,10 +162,10 @@ module ClaimsApi
       ClaimsApi::AutoEstablishedClaim::ERRORED
     end
 
-    def log_job_progress(claim_id, detail)
-      ClaimsApi::Logger.log(self.class::LOG_TAG,
-                            claim_id:,
-                            detail:)
+    def log_job_progress(claim_id, detail, transaction_id = nil)
+      log_data = { claim_id:, detail:, transaction_id: }
+      log_data.compact!
+      ClaimsApi::Logger.log(self.class::LOG_TAG, **log_data)
     end
 
     def error_responds_to_original_body?(error)

--- a/modules/claims_api/lib/evss_service/base.rb
+++ b/modules/claims_api/lib/evss_service/base.rb
@@ -90,8 +90,8 @@ module ClaimsApi
       end
 
       def log_outcome_for_claims_api(action, status, response, claim)
-        ClaimsApi::Logger.log('526_docker_container',
-                              detail: "EVSS DOCKER CONTAINER #{action} #{status}: #{response}", claim: claim&.id)
+        ClaimsApi::Logger.log('526_docker_container', detail: "EVSS DOCKER CONTAINER #{action} #{status}: #{response}",
+                                                      claim: claim&.id, transaction_id: claim&.transaction_id)
       end
 
       def error_handler(error, detail, async = true) # rubocop:disable Style/OptionalBooleanParameter

--- a/modules/claims_api/spec/services/disability_compensation/docker_container_service_spec.rb
+++ b/modules/claims_api/spec/services/disability_compensation/docker_container_service_spec.rb
@@ -57,6 +57,13 @@ describe ClaimsApi::DisabilityCompensation::DockerContainerService do
       end
     end
 
+    it 'logs the transaction_id' do
+      VCR.use_cassette('/claims_api/evss/submit') do
+        expect(Rails.logger).to receive(:info).with(/#{claim_with_transaction_id.transaction_id}/).at_least(:once)
+        docker_container_service.send(:upload, claim_with_transaction_id.id)
+      end
+    end
+
     context 'the error is saved on the claim in the evss_response attribute' do
       errors = {
         messages: [

--- a/modules/claims_api/spec/sidekiq/service_base_spec.rb
+++ b/modules/claims_api/spec/sidekiq/service_base_spec.rb
@@ -128,5 +128,13 @@ RSpec.describe ClaimsApi::ServiceBase do
 
       @service.send(:log_job_progress, claim.id, detail)
     end
+
+    it 'logs job progress with transaction_id when provided' do
+      transaction_id = '00000000-0000-0000-000000000000'
+      expect(ClaimsApi::Logger).to receive(:log).with('claims_api_sidekiq_service_base', claim_id: claim.id, detail:,
+                                                                                         transaction_id:)
+
+      @service.send(:log_job_progress, claim.id, detail, transaction_id)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Add `transaction_id` to:
* Docker container service logs
* PDF generation service logs
* EVSS service logs

## Related issue(s)

[API-39196](https://jira.devops.va.gov/browse/API-39196)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

526 synchronous endpoint, including:
* Docker container service
* PDF generation service
* EVSS service

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A