### PR TITLE
Change BankName model to Session

### DIFF
--- a/lib/admin/redis_health_checker.rb
+++ b/lib/admin/redis_health_checker.rb
@@ -8,10 +8,10 @@ module RedisHealthChecker
   def self.app_data_redis_up
     Thread.current[:app_data_redis_up] ||= begin
       # Test 1: Check attribute that uses redis key
-      bank_name = BankName.find_or_build('fake routing number')
-      bank_name.update(bank_name: 'fake bank name')
-      BankName.delete('fake routing number')
-      bank_name.present?
+      session = Session.find_or_build('fake token')
+      session.update(uuid: '1234')
+      Session.delete('fake token')
+      session.present?
     rescue => e
       Rails.logger.error(
         { message: "ARGO CD UPGRADE - REDIS TEST: Failed to access app data Redis. Error: #{e.message}" }


### PR DESCRIPTION
## Summary

- Remove a reference to `BankName` by swapping it with `Session`, another model using a `redis_key` , so that we can delete the `BankName` class

Session behaves properly:
```
irb(main):006> session = Session.find_or_build('fake token')
=> 
#<Session:0x000000015bf33d40
...
irb(main):007> session
=> 
#<Session:0x000000015bf33d40
 @charon_response=nil,
 @created_at=2024-08-27 17:32:53.559099 UTC,
 @launch=nil,
 @persisted=false,
 @profile=nil,
 @ssoe_transactionid=nil,
 @token="fake token",
 @uuid=nil>
irb(main):008> session.update(uuid: '1234')
=> true
irb(main):009> session
=> 
#<Session:0x000000015bf33d40
 @charon_response=nil,
 @created_at=2024-08-27 17:32:53.559099 UTC,
 @errors=#<ActiveModel::Errors []>,
 @launch=nil,
 @persisted=true,
 @profile=nil,
 @ssoe_transactionid=nil,
 @token="fake token",
 @uuid="1234",
 @validation_context=nil>
irb(main):010> Session.delete('fake token')
=> 1
irb(main):011> session.present?
=> true
```

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/18054

## Testing done

- [x] Specs Pass