### PR TITLE
Sa 96116 toe notification email trigger

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -643,7 +643,11 @@ features:
     enable_in_development: true
   form1990meb_confirmation_email:
     actor_type: user
-    description: Enables form 1990meb email submission confirmation (VaNotify)
+    description: Enables form 1990 MEB email submission confirmation (VaNotify)
+    enable_in_development: true
+  form1990emeb_confirmation_email:
+    actor_type: user
+    description: Enables form 1990e MEB email submission confirmation (VaNotify)
     enable_in_development: true
   form5490_confirmation_email:
     actor_type: user

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1291,6 +1291,9 @@ vanotify:
         form1990meb_approved_confirmation_email: form1990meb_approved_confirmation_email_template_id
         form1990meb_offramp_confirmation_email: form1990meb_offramp_confirmation_email_template_id
         form1990meb_denied_confirmation_email: form1990meb_denied_confirmation_email_template_id
+        form1990emeb_approved_confirmation_email: form1990emeb_approved_confirmation_email_template_id
+        form1990emeb_offramp_confirmation_email: form1990emeb_offramp_confirmation_email_template_id
+        form1990emeb_denied_confirmation_email: form1990emeb_denied_confirmation_email_template_id
         form1995_confirmation_email: form1995_confirmation_email_template_id
         form21_0966_confirmation_email: form21_0966_confirmation_email_template_id
         form21_0972_confirmation_email: form21_0972_confirmation_email_template_id

--- a/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
@@ -150,10 +150,6 @@ module MebApi
         MebApi::DGI::Automation::Service.new(@current_user)
       end
 
-      def payment_service
-        BGS::Service.new(@current_user)
-      end
-
       def submission_service
         MebApi::DGI::Submission::Service.new(@current_user)
       end

--- a/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
@@ -76,13 +76,13 @@ module MebApi
       end
 
       def send_confirmation_email
-        return unless Flipper.enabled?(:form1990meb_confirmation_email)
+        return head :no_content unless Flipper.enabled?(:form1990emeb_confirmation_email)
 
         status = params[:claim_status]
         email = params[:email] || @current_user.email
         first_name = params[:first_name]&.upcase || @current_user.first_name&.upcase
 
-        MebApi::V0::Submit1990emebFormConfirmation.perform_async(status, email, first_name) if email.present?
+        MebApi::V0::Submit1990emebFormConfirmation.perform_async(status, email, first_name)
       end
 
       private

--- a/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
@@ -102,7 +102,6 @@ module MebApi
       def submission_service
         MebApi::DGI::Forms::Submission::Service.new(@current_user)
       end
-
     end
   end
 end

--- a/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
@@ -75,6 +75,16 @@ module MebApi
         }
       end
 
+      def send_confirmation_email
+        return unless Flipper.enabled?(:form1990meb_confirmation_email)
+
+        status = params[:claim_status]
+        email = params[:email] || @current_user.email
+        first_name = params[:first_name]&.upcase || @current_user.first_name&.upcase
+
+        MebApi::V0::Submit1990emebFormConfirmation.perform_async(status, email, first_name) if email.present?
+      end
+
       private
 
       def claimant_service
@@ -93,9 +103,6 @@ module MebApi
         MebApi::DGI::Forms::Submission::Service.new(@current_user)
       end
 
-      def payment_service
-        BGS::Service.new(@current_user)
-      end
     end
   end
 end

--- a/modules/meb_api/app/workers/meb_api/v0/submit_1990emeb_form_confirmation.rb
+++ b/modules/meb_api/app/workers/meb_api/v0/submit_1990emeb_form_confirmation.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module MebApi
+  module V0
+    class Submit1990emebFormConfirmation
+      include Sidekiq::Worker
+      include SentryLogging
+      sidekiq_options retry: 14
+
+      def perform(claim_status, email, first_name)
+        @claim_status = claim_status
+
+        VANotify::EmailJob.perform_async(
+          email,
+          confirmation_email_template_id,
+          {
+            'first_name' => first_name,
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y')
+          }
+        )
+      end
+
+      private
+
+      def confirmation_email_template_id
+        case @claim_status
+        when 'ELIGIBLE'
+          Settings.vanotify.services.va_gov.template_id.form1990emeb_approved_confirmation_email
+        when 'DENIED'
+          Settings.vanotify.services.va_gov.template_id.form1990emeb_denied_confirmation_email
+        else
+          Settings.vanotify.services.va_gov.template_id.form1990emeb_offramp_confirmation_email
+        end
+      end
+    end
+  end
+end

--- a/modules/meb_api/config/routes.rb
+++ b/modules/meb_api/config/routes.rb
@@ -19,7 +19,7 @@ MebApi::Engine.routes.draw do
     post 'forms_claim_letter', to: 'forms#claim_letter'
     post 'forms_sponsors', to: 'forms#sponsors'
     post 'forms_submit_claim', to: 'forms#submit_claim'
-    post 'send_confirmation_email', to: 'forms#send_confirmation_email'
+    post 'forms_send_confirmation_email', to: 'forms#send_confirmation_email'
     get 'forms_claimant_info', to: 'forms#claimant_info'
     get 'forms_claim_status', to: 'forms#claim_status'
 

--- a/modules/meb_api/config/routes.rb
+++ b/modules/meb_api/config/routes.rb
@@ -23,7 +23,6 @@ MebApi::Engine.routes.draw do
     get 'forms_claimant_info', to: 'forms#claimant_info'
     get 'forms_claim_status', to: 'forms#claim_status'
 
-
     get 'apidocs', to: 'apidocs#index'
   end
 end

--- a/modules/meb_api/config/routes.rb
+++ b/modules/meb_api/config/routes.rb
@@ -19,8 +19,10 @@ MebApi::Engine.routes.draw do
     post 'forms_claim_letter', to: 'forms#claim_letter'
     post 'forms_sponsors', to: 'forms#sponsors'
     post 'forms_submit_claim', to: 'forms#submit_claim'
+    post 'send_confirmation_email', to: 'forms#send_confirmation_email'
     get 'forms_claimant_info', to: 'forms#claimant_info'
     get 'forms_claim_status', to: 'forms#claim_status'
+
 
     get 'apidocs', to: 'apidocs#index'
   end

--- a/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
+RSpec.describe MebApi::V0::EducationBenefitsController, type: :request do
   include SchemaMatchers
   include ActiveSupport::Testing::TimeHelpers
 
@@ -10,200 +10,224 @@ Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
     config.filter_sensitive_data('removed') do |interaction|
       if interaction.request.headers['Authorization']
         token = interaction.request.headers['Authorization'].first
-
         if (match = token.match(/^Bearer.+/) || token.match(/^token.+/))
           match[0]
         end
       end
     end
+  end
 
-    let(:user_details) do
+  let(:user_details) do
+    {
+      first_name: 'Herbert',
+      last_name: 'Hoover',
+      middle_name: '',
+      birth_date: '1970-01-01',
+      ssn: '796121200'
+    }
+  end
+
+  let(:claimant_id) { 1 }
+  let(:user) { build(:user, :loa3, user_details) }
+  let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
+  let(:faraday_response) { double('faraday_connection') }
+
+  before do
+    allow(faraday_response).to receive(:env)
+    sign_in_as(user)
+  end
+
+  describe 'GET /meb_api/v0/claimant_info' do
+    context 'Looks up veteran in LTS' do
+      it 'returns a 200 with claimant info' do
+        VCR.use_cassette('dgi/post_claimant_info') do
+          get '/meb_api/v0/claimant_info'
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('dgi/claimant_info_response', { strict: false })
+        end
+      end
+    end
+  end
+
+  describe 'GET /meb_api/v0/eligibility' do
+    context 'Veteran who has benefit eligibility' do
+      it 'returns a 200 with eligibility data' do
+        VCR.use_cassette('dgi/get_eligibility') do
+          travel_to Time.zone.local(2022, 2, 9, 12) do
+            get '/meb_api/v0/eligibility'
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_response_schema('dgi/eligibility_response', { strict: false })
+          end
+        end
+      end
+    end
+  end
+
+  describe 'GET /meb_api/v0/claim_letter' do
+    context 'Retrieves a veterans claim letter' do
+      it 'returns a 200 status when given claimant id as parameter' do
+        VCR.use_cassette('dgi/get_claim_letter') do
+          get '/meb_api/v0/claim_letter'
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'GET /meb_api/v0/claim_status' do
+    context 'Retrieves a veterans claim status' do
+      it 'returns a 200 status when given claimant id as parameter and claimant is returned' do
+        VCR.use_cassette('dgi/get_claim_status') do
+          get '/meb_api/v0/claim_status'
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('dgi/claim_status_response', { strict: false })
+        end
+      end
+
+      it 'returns a 200 status when given claimant id as parameter and no claimant is returned' do
+        VCR.use_cassette('dgi/get_claim_status_no_claimant') do
+          get '/meb_api/v0/claim_status'
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'GET /meb_api/v0/enrollment' do
+    context 'Retrieves a veterans enrollments' do
+      it 'returns a 200 status' do
+        VCR.use_cassette('dgi/enrollment') do
+          get '/meb_api/v0/enrollment', params: { claimant_id: 1 }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'POST /meb_api/v0/submit_enrollment_verification' do
+    context 'Creates a veterans enrollments' do
+      it 'returns a 200 status' do
+        VCR.use_cassette('dgi/submit_enrollment_verification') do
+          post '/meb_api/v0/submit_enrollment_verification',
+               params: {
+                 "education_benefit": {
+                   enrollment_verifications: {
+                     enrollment_certify_requests: [{
+                       'certified_period_begin_date': '2022-08-01',
+                       'certified_period_end_date': '2022-08-31',
+                       'certified_through_date': '2022-08-31',
+                       'certification_method': 'MEB',
+                       'app_communication': { 'response_type': 'Y' }
+                     }]
+                   }
+                 }
+               }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'POST /meb_api/v0/duplicate_contact_info' do
+    context 'retrieves data contact info' do
+      it 'returns a 200 status' do
+        VCR.use_cassette('dgi/post_contact_info') do
+          post '/meb_api/v0/duplicate_contact_info',
+               params: { "emails": [], "phones": [] }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'GET /meb_api/v0/exclusion_periods' do
+    context 'retrieves exclusion periods' do
+      it 'returns a 200 status' do
+        VCR.use_cassette('dgi/get_exclusion_period_controller') do
+          get '/meb_api/v0/exclusion_periods'
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'POST /meb_api/v0/submit_claim' do
+    let(:claimant_params) do
       {
-        first_name: 'Herbert',
-        last_name: 'Hoover',
-        middle_name: '',
-        birth_date: '1970-01-01',
-        ssn: '796121200'
+        form_id: 1,
+        education_benefit: {
+          claimant: {
+            first_name: 'Herbert',
+            middle_name: 'Hoover',
+            last_name: 'Hoover',
+            date_of_birth: '1980-03-11',
+            contact_info: {
+              address_line1: '503 upper park',
+              address_line2: '',
+              city: 'falls church',
+              zipcode: '22046',
+              email_address: 'hhover@test.com',
+              address_type: 'DOMESTIC',
+              mobile_phone_number: '4409938894',
+              country_code: 'US',
+              state_code: 'VA'
+            },
+            notification_method: 'EMAIL'
+          }
+        },
+        relinquished_benefit: {
+          eff_relinquish_date: '2021-10-15',
+          relinquished_benefit: 'Chapter30'
+        },
+        additional_considerations: {
+          active_duty_kicker: 'N/A',
+          academy_rotc_scholarship: 'YES',
+          reserve_kicker: 'N/A',
+          senior_rotc_scholarship: 'YES',
+          active_duty_dod_repay_loan: 'YES'
+        },
+        comments: {
+          disagree_with_service_period: false
+        },
+        direct_deposit: {
+          account_number: '********3123',
+          account_type: 'savings',
+          routing_number: '*******3123'
+        }
       }
     end
 
-    let(:claimant_id) { 1 }
-    let(:user) { build(:user, :loa3, user_details) }
-    let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
-    let(:faraday_response) { double('faraday_connection') }
-
-    before do
-      allow(faraday_response).to receive(:env)
-      sign_in_as(user)
-    end
-
-    describe 'GET /meb_api/v0/claimant_info' do
-      context 'Looks up veteran in LTS ' do
-        it 'returns a 200 with claimant info' do
-          VCR.use_cassette('dgi/post_claimant_info') do
-            get '/meb_api/v0/claimant_info'
-            expect(response).to have_http_status(:ok)
-            expect(response).to match_response_schema('dgi/claimant_info_response', { strict: false })
-          end
+    context 'direct deposit' do
+      it 'successfully submits with new lighthouse api' do
+        VCR.use_cassette('dgi/submit_claim_lighthouse') do
+          Settings.mobile_lighthouse.rsa_key = OpenSSL::PKey::RSA.generate(2048).to_s
+          Settings.lighthouse.direct_deposit.use_mocks = true
+          post '/meb_api/v0/submit_claim', params: claimant_params
+          expect(response).to have_http_status(:ok)
         end
       end
     end
+  end
 
-    describe 'GET /meb_api/v0/eligibility' do
-      context 'Veteran who has benefit eligibility' do
-        it 'returns a 200 with eligibility data' do
-          VCR.use_cassette('dgi/get_eligibility') do
-            travel_to Time.zone.local(2022, 2, 9, 12) do
-              get '/meb_api/v0/eligibility'
-              expect(response).to have_http_status(:ok)
-              expect(response).to match_response_schema('dgi/eligibility_response', { strict: false })
-            end
-          end
-        end
-      end
-    end
-
-    describe 'GET /meb_api/v0/claim_letter' do
-      context 'Retrieves a veterans claim letter' do
-        it 'returns a 200 status when given claimant id as parameter' do
-          VCR.use_cassette('dgi/get_claim_letter') do
-            get '/meb_api/v0/claim_letter'
-            expect(response).to have_http_status(:ok)
-          end
-        end
-      end
-    end
-
-    describe 'GET /meb_api/v0/claim_status' do
-      context 'Retrieves a veterans claim status' do
-        it 'returns a 200 status when given claimant id as parameter and claimant is returned' do
-          VCR.use_cassette('dgi/get_claim_status') do
-            get '/meb_api/v0/claim_status'
-            expect(response).to have_http_status(:ok)
-            expect(response).to match_response_schema('dgi/claim_status_response', { strict: false })
-          end
-        end
-
-        it 'returns a 200 status when given claimant id as parameter and no claimant is returned' do
-          VCR.use_cassette('dgi/get_claim_status_no_claimant') do
-            get '/meb_api/v0/claim_status'
-            expect(response).to have_http_status(:ok)
-          end
-        end
-      end
-    end
-
-    describe 'GET /meb_api/v0/enrollment' do
-      context 'Retrieves a veterans enrollments' do
-        it 'returns a 200 status when it' do
-          VCR.use_cassette('dgi/enrollment') do
-            get '/meb_api/v0/enrollment', params: { claimant_id: 1 }
-            expect(response).to have_http_status(:ok)
-          end
-        end
-      end
-    end
-
-    describe 'POST /meb_api/v0/submit_enrollment_verification' do
-      context 'Creates a veterans enrollments' do
-        it 'returns a 200 status when it' do
-          VCR.use_cassette('dgi/submit_enrollment_verification') do
-            post '/meb_api/v0/submit_enrollment_verification',
-                 params: { "education_benefit":
-                  { enrollment_verifications: {
-                    enrollment_certify_requests: [{
-                      'certified_period_begin_date': '2022-08-01',
-                      'certified_period_end_date': '2022-08-31',
-                      'certified_through_date': '2022-08-31',
-                      'certification_method': 'MEB',
-                      'app_communication': { 'response_type': 'Y' }
-                    }]
-                  } } }
-            expect(response).to have_http_status(:ok)
-          end
-        end
-      end
-    end
-
-    describe 'POST /meb_api/v0/duplicate_contact_info' do
-      context 'retrieves data contact info ' do
-        it 'returns a 200 status when it' do
-          VCR.use_cassette('dgi/post_contact_info') do
-            post '/meb_api/v0/duplicate_contact_info',
-                 params: { "emails": [], "phones": [] }
-            expect(response).to have_http_status(:ok)
-          end
-        end
-      end
-    end
-
-    describe 'GET /meb_api/v0/exclusion_periods' do
-      context 'retrieves data contact info ' do
-        it 'returns a 200 status when it' do
-          VCR.use_cassette('dgi/get_exclusion_period_controller') do
-            get '/meb_api/v0/exclusion_periods'
-            expect(response).to have_http_status(:ok)
-          end
-        end
-      end
-    end
-
-    describe 'POST /meb_api/v0/submit_claim' do
-      let(:claimant_params) do
-        {
-          form_id: 1,
-          education_benefit: {
-            claimant: {
-              first_name: 'Herbert',
-              middle_name: 'Hoover',
-              last_name: 'Hoover',
-              date_of_birth: '1980-03-11',
-              contact_info: {
-                address_line1: '503 upper park',
-                address_line2: '',
-                city: 'falls church',
-                zipcode: '22046',
-                email_address: 'hhover@test.com',
-                address_type: 'DOMESTIC',
-                mobile_phone_number: '4409938894',
-                country_code: 'US',
-                state_code: 'VA'
-              },
-              notification_method: 'EMAIL'
-            }
-          },
-          relinquished_benefit: {
-            eff_relinquish_date: '2021-10-15',
-            relinquished_benefit: 'Chapter30'
-          },
-          additional_considerations: {
-            active_duty_kicker: 'N/A',
-            academy_rotc_scholarship: 'YES',
-            reserve_kicker: 'N/A',
-            senior_rotc_scholarship: 'YES',
-            active_duty_dod_repay_loan: 'YES'
-          },
-          comments: {
-            disagree_with_service_period: false
-          },
-          direct_deposit: {
-            account_number: '********3123',
-            account_type: 'savings',
-            routing_number: '*******3123'
-          }
+  describe 'POST /meb_api/v0/send_confirmation_email' do
+    context 'when the feature flag is enabled' do
+      it 'sends the confirmation email with provided name and email params' do
+        allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+        post '/meb_api/v0/send_confirmation_email', params: {
+          claim_status: 'ELIGIBLE', email: 'test@test.com', first_name: 'test'
         }
+        expect(MebApi::V0::Submit1990mebFormConfirmation).to have_received(:perform_async)
+          .with('ELIGIBLE', 'test@test.com', 'TEST')
       end
+    end
 
-      context 'direct deposit' do
-        it 'successfully submits with new lighthouse api' do
-          VCR.use_cassette('dgi/submit_claim_lighthouse') do
-            Settings.mobile_lighthouse.rsa_key = OpenSSL::PKey::RSA.generate(2048).to_s
-            Settings.lighthouse.direct_deposit.use_mocks = true
-            post '/meb_api/v0/submit_claim', params: claimant_params
-
-            expect(response).to have_http_status(:ok)
-          end
-        end
+    context 'when the feature flag is disabled' do
+      it 'does not send the confirmation email' do
+        allow(MebApi::V0::Submit1990mebFormConfirmation).to receive(:perform_async)
+        Flipper.disable(:form1990meb_confirmation_email)
+        post '/meb_api/v0/send_confirmation_email', params: {}
+        expect(MebApi::V0::Submit1990mebFormConfirmation).not_to have_received(:perform_async)
+        Flipper.enable(:form1990meb_confirmation_email)
       end
     end
   end

--- a/modules/meb_api/spec/requests/meb_api/v0/forms_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/forms_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-Rspec.describe MebApi::V0::FormsController, type: :request do
+RSpec.describe MebApi::V0::FormsController, type: :request do
   include SchemaMatchers
   include ActiveSupport::Testing::TimeHelpers
 
@@ -16,58 +16,80 @@ Rspec.describe MebApi::V0::FormsController, type: :request do
         end
       end
     end
+  end
 
-    let(:user_details) do
-      {
-        first_name: 'Herbert',
-        last_name: 'Hoover',
-        middle_name: '',
-        birth_date: '1970-01-01',
-        ssn: '796121200'
-      }
-    end
+  let(:user_details) do
+    {
+      first_name: 'Herbert',
+      last_name: 'Hoover',
+      middle_name: '',
+      birth_date: '1970-01-01',
+      ssn: '796121200'
+    }
+  end
 
-    let(:claimant_id) { 1 }
-    let(:user) { build(:user, :loa3, user_details) }
-    let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
-    let(:faraday_response) { double('faraday_connection') }
+  let(:claimant_id) { 1 }
+  let(:user) { build(:user, :loa3, user_details) }
+  let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
 
-    before do
-      allow(faraday_response).to receive(:env)
-      sign_in_as(user)
-    end
+  before do
+    sign_in_as(user)
+  end
 
-    describe 'POST form_sponsors' do
-      context 'Retrieves sponsors for Toes' do
-        it 'returns a 200 status when it' do
-          VCR.use_cassette('dgi/forms/sponsor_toes') do
-            post '/meb_api/v0/forms_sponsors'
-            expect(response).to have_http_status(:ok)
-          end
+  describe 'POST /meb_api/v0/forms_sponsors' do
+    context 'Retrieves sponsors for Toes' do
+      it 'returns a 200 status' do
+        VCR.use_cassette('dgi/forms/sponsor_toes') do
+          post '/meb_api/v0/forms_sponsors'
+          expect(response).to have_http_status(:ok)
         end
       end
-
-      # @NOTE: This is commentted out as we've removed the form_type param from the controller.
-      # Once that is added back this test is valid.
-      # context 'Retrieves sponsors for FryDea' do
-      #   it 'returns a 200 status when it' do
-      #     VCR.use_cassette('dgi/forms/sponsor_fry_dea') do
-      #       post '/meb_api/v0/forms_sponsors', params: { "form_type": 'FryDea' }
-      #       expect(response).to have_http_status(:ok)
-      #     end
-      #   end
-      # end
     end
 
-    describe 'GET /meb_api/v0/toe/claimant_info' do
-      context 'Looks up veteran in LTS ' do
-        it 'returns a 200 with toe claimant info' do
-          VCR.use_cassette('dgi/post_toe_claimant_info') do
-            get '/meb_api/v0/forms_claimant_info'
-            expect(response).to have_http_status(:ok)
-            expect(response).to match_response_schema('dgi/toe_claimant_info_response', { strict: false })
-          end
+    # @NOTE: This is commented out as we've removed the form_type param from the controller.
+    # Once that is added back this test is valid.
+    # context 'Retrieves sponsors for FryDea' do
+    #   it 'returns a 200 status' do
+    #     VCR.use_cassette('dgi/forms/sponsor_fry_dea') do
+    #       post '/meb_api/v0/forms_sponsors', params: { "form_type": 'FryDea' }
+    #       expect(response).to have_http_status(:ok)
+    #     end
+    #   end
+    # end
+  end
+
+  describe 'GET /meb_api/v0/forms_claimant_info' do
+    context 'Looks up veteran in LTS' do
+      it 'returns a 200 status with toe claimant info' do
+        VCR.use_cassette('dgi/post_toe_claimant_info') do
+          get '/meb_api/v0/forms_claimant_info'
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('dgi/toe_claimant_info_response', { strict: false })
         end
+      end
+    end
+  end
+
+  describe 'POST /meb_api/v0/forms_send_confirmation_email' do
+    context 'when the feature flag is enabled' do
+      it 'sends the confirmation email with provided name and email params' do
+        allow(MebApi::V0::Submit1990emebFormConfirmation).to receive(:perform_async)
+        post '/meb_api/v0/forms_send_confirmation_email', params: {
+          claim_status: 'ELIGIBLE', email: 'test@test.com', first_name: 'test'
+        }
+        expect(MebApi::V0::Submit1990emebFormConfirmation).to have_received(:perform_async)
+          .with('ELIGIBLE', 'test@test.com', 'TEST')
+      end
+    end
+
+    context 'when the feature flag is disabled' do
+      it 'does not send the confirmation email' do
+        allow(MebApi::V0::Submit1990emebFormConfirmation).to receive(:perform_async)
+        Flipper.disable(:form1990emeb_confirmation_email)
+        post('/meb_api/v0/forms_send_confirmation_email', params: {}, headers:)
+        expect(MebApi::V0::Submit1990emebFormConfirmation).not_to have_received(:perform_async)
+        expect(response).to have_http_status(:no_content)
+        Flipper.enable(:form1990emeb_confirmation_email)
       end
     end
   end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
- Adds template id settings for form 1990emeb confirmation email templates
- Adds trigger for calling new sidekiq 1990emeb confirmation email job
- Adds sidekiq job for for sending 1990emeb confirmation email based on the status of the claim
- forms_spec and education_benefits_spec are updated with tests ensuring the endpoint properly delegates to the - Submit1990emebFormConfirmation  and Submit1990mebFormConfirmation sidekiq job s
- Tests cover flipper feature being enabled and disabled

## Related issue(s)
<img width="737" alt="Screenshot 2024-08-27 at 5 59 24 PM" src="https://github.com/user-attachments/assets/de357952-ad62-469e-bce9-0f9bdadd617c">


## Testing done

- [X ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
Yes
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
  UAT testing in staging ENV  to confirm scenarios and then once each scenario has passed..

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [X]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

