### PR TITLE
ClamAV New File Location

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -867,6 +867,7 @@ lib/common/file_helpers.rb @department-of-veterans-affairs/va-api-engineers @dep
 lib/common/pdf_helpers.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 lib/common/models @department-of-veterans-affairs/backend-review-group
 lib/common/virus_scan.rb @department-of-veterans-affairs/backend-review-group
+lib/common @department-of-veterans-affairs/backend-review-group
 lib/debt_management_center @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/decision_review @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/decision_review_v1 @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1477,6 +1478,7 @@ spec/lib/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-v
 spec/lib/rx @department-of-veterans-affairs/vfs-mhv-medications
 spec/lib/rx/client_request_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/mobile-api-team
 spec/lib/saml @department-of-veterans-affairs/octo-identity
+app/models/saved_claim @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/saved_claims_spec_helper.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/search @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/search_click_tracking @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/saved_claim/coe_claim.rb
+++ b/app/models/saved_claim/coe_claim.rb
@@ -176,7 +176,7 @@ class SavedClaim::CoeClaim < SavedClaim
         { 'attachmentType' => '', 'attachmentDescription' => '' }
 
       if %w[.jpg .jpeg .png .pdf].include? file_extension.downcase
-        file_path = Common::FileHelpers.generate_temp_file(attachment.file.read)
+        file_path = Common::FileHelpers.generate_clamav_temp_file(attachment.file.read)
 
         File.rename(file_path, "#{file_path}#{file_extension}")
         file_path = "#{file_path}#{file_extension}"

--- a/app/sidekiq/vbms/submit_dependents_pdf_job.rb
+++ b/app/sidekiq/vbms/submit_dependents_pdf_job.rb
@@ -41,7 +41,7 @@ module VBMS
 
         file_extension = File.extname(URI.parse(attachment.file.url).path)
         if %w[.jpg .jpeg .png .pdf].include? file_extension.downcase
-          file_path = Common::FileHelpers.generate_temp_file(attachment.file.read)
+          file_path = Common::FileHelpers.generate_clamav_temp_file(attachment.file.read)
 
           File.rename(file_path, "#{file_path}#{file_extension}")
           file_path = "#{file_path}#{file_extension}"

--- a/lib/benefits_intake_service/service.rb
+++ b/lib/benefits_intake_service/service.rb
@@ -104,7 +104,7 @@ module BenefitsIntakeService
     end
 
     def generate_tmp_metadata_file(metadata)
-      Common::FileHelpers.generate_temp_file(metadata.to_s, "#{SecureRandom.hex}.benefits_intake.metadata.json")
+      Common::FileHelpers.generate_clamav_temp_file(metadata.to_s, "#{SecureRandom.hex}.benefits_intake.metadata.json")
     end
 
     # Instantiates a new location and uuid via lighthouse

--- a/lib/common/convert_to_pdf.rb
+++ b/lib/common/convert_to_pdf.rb
@@ -9,7 +9,7 @@ module Common
     end
 
     def run
-      in_file = Common::FileHelpers.generate_temp_file(@file.read)
+      in_file = Common::FileHelpers.generate_clamav_temp_file(@file.read)
       return in_file if @file.content_type == Mime[:pdf].to_s
 
       unless @file.content_type.starts_with?('image/')

--- a/lib/common/file_helpers.rb
+++ b/lib/common/file_helpers.rb
@@ -12,17 +12,6 @@ module Common
       "tmp/#{SecureRandom.hex}"
     end
 
-    def generate_temp_file(file_body, file_name = nil)
-      file_name = SecureRandom.hex if file_name.nil?
-      file_path = "tmp/#{file_name}"
-
-      File.open(file_path, 'wb') do |file|
-        file.write(file_body)
-      end
-
-      file_path
-    end
-
     def generate_clamav_temp_file(file_body, file_name = nil)
       file_name = SecureRandom.hex if file_name.nil?
       clamav_directory = Rails.root.join('clamav_tmp')

--- a/lib/lighthouse/benefits_intake/service.rb
+++ b/lib/lighthouse/benefits_intake/service.rb
@@ -47,7 +47,7 @@ module BenefitsIntake
       upload_url, _uuid = request_upload unless upload_url
 
       metadata = JSON.parse(metadata)
-      meta_tmp = Common::FileHelpers.generate_temp_file(metadata.to_json, "#{STATSD_KEY_PREFIX}.#{@uuid}.metadata.json")
+      meta_tmp = Common::FileHelpers.generate_clamav_temp_file(metadata.to_json, "#{STATSD_KEY_PREFIX}.#{@uuid}.metadata.json")
 
       params = {}
       params[:metadata] = Faraday::UploadIO.new(meta_tmp, Mime[:json].to_s, 'metadata.json')

--- a/lib/lighthouse/benefits_intake/service.rb
+++ b/lib/lighthouse/benefits_intake/service.rb
@@ -47,7 +47,8 @@ module BenefitsIntake
       upload_url, _uuid = request_upload unless upload_url
 
       metadata = JSON.parse(metadata)
-      meta_tmp = Common::FileHelpers.generate_clamav_temp_file(metadata.to_json, "#{STATSD_KEY_PREFIX}.#{@uuid}.metadata.json")
+      meta_tmp = Common::FileHelpers.generate_clamav_temp_file(metadata.to_json,
+                                                               "#{STATSD_KEY_PREFIX}.#{@uuid}.metadata.json")
 
       params = {}
       params[:metadata] = Faraday::UploadIO.new(meta_tmp, Mime[:json].to_s, 'metadata.json')

--- a/lib/simple_forms_api_submission/service.rb
+++ b/lib/simple_forms_api_submission/service.rb
@@ -24,7 +24,7 @@ module SimpleFormsApiSubmission
     end
 
     def generate_tmp_metadata(metadata)
-      Common::FileHelpers.generate_temp_file(metadata.to_s, "#{SecureRandom.hex}.SimpleFormsApi.metadata.json")
+      Common::FileHelpers.generate_clamav_temp_file(metadata.to_s, "#{SecureRandom.hex}.SimpleFormsApi.metadata.json")
     end
 
     def get_upload_docs(file:, metadata:)

--- a/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
@@ -28,7 +28,7 @@ module ClaimsApi
                            '526EZ PDF generator PDF string returned')
 
           file_name = "#{SecureRandom.hex}.pdf"
-          path = ::Common::FileHelpers.generate_temp_file(pdf_string, file_name)
+          path = ::Common::FileHelpers.generate_clamav_temp_file(pdf_string, file_name)
           upload = ActionDispatch::Http::UploadedFile.new({
                                                             filename: file_name,
                                                             type: 'application/pdf',

--- a/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
@@ -38,7 +38,7 @@ module ClaimsApi
                            '526EZ PDF generator PDF string returned')
 
           file_name = "#{SecureRandom.hex}.pdf"
-          path = ::Common::FileHelpers.generate_temp_file(pdf_string, file_name)
+          path = ::Common::FileHelpers.generate_clamav_temp_file(pdf_string, file_name)
           upload = ActionDispatch::Http::UploadedFile.new({
                                                             filename: file_name,
                                                             type: 'application/pdf',

--- a/modules/simple_forms_api/spec/requests/v1/scanned_form_uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/scanned_form_uploads_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Scanned forms uploader', type: :request do
       VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
       VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
       allow(Common::FileHelpers).to receive(:random_file_path).and_return(file_seed)
-      allow(Common::FileHelpers).to receive(:generate_temp_file).and_wrap_original do |original_method, *args|
+      allow(Common::FileHelpers).to receive(:generate_clamav_temp_file).and_wrap_original do |original_method, *args|
         original_method.call(args[0], random_string)
       end
     end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Forms uploader', type: :request do
         VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
         VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
         allow(Common::FileHelpers).to receive(:random_file_path).and_return(file_seed)
-        allow(Common::FileHelpers).to receive(:generate_temp_file).and_wrap_original do |original_method, *args|
+        allow(Common::FileHelpers).to receive(:generate_clamav_temp_file).and_wrap_original do |original_method, *args|
           original_method.call(args[0], random_string)
         end
         Flipper.disable(:simple_forms_email_confirmations)

--- a/spec/lib/lighthouse/benefits_intake/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_intake/service_spec.rb
@@ -63,14 +63,14 @@ RSpec.describe BenefitsIntake::Service do
       service.instance_variable_set(:@location, 'location')
       service.instance_variable_set(:@uuid, 'uuid')
 
-      allow(Common::FileHelpers).to receive(:generate_temp_file).and_return 'a-temp-file'
+      allow(Common::FileHelpers).to receive(:generate_clamav_temp_file).and_return 'a-temp-file'
     end
 
     it 'performs the upload' do
       allow(Faraday::UploadIO).to receive(:new).and_return 'a-file-io-object'
 
       expect(Common::FileHelpers).to(
-        receive(:generate_temp_file).once.with(metadata.to_json, 'api.benefits_intake.uuid.metadata.json')
+        receive(:generate_clamav_temp_file).once.with(metadata.to_json, 'api.benefits_intake.uuid.metadata.json')
       )
 
       expect(Faraday::UploadIO).to receive(:new).once.with('a-temp-file', mime_json, 'metadata.json')
@@ -94,7 +94,7 @@ RSpec.describe BenefitsIntake::Service do
     it 'errors on invalid JSON metadata' do
       args[:metadata] = 'not a json string'
 
-      expect(Common::FileHelpers).not_to receive(:generate_temp_file)
+      expect(Common::FileHelpers).not_to receive(:generate_clamav_temp_file)
       expect(service).not_to receive(:perform)
       expect { service.perform_upload(**args) }.to raise_error JSON::ParserError
     end

--- a/spec/lib/simple_forms_api_submission/service_spec.rb
+++ b/spec/lib/simple_forms_api_submission/service_spec.rb
@@ -29,7 +29,7 @@ describe SimpleFormsApiSubmission::Service do
 
     it 'generates a json file from the metadata' do
       simple_forms_service.generate_tmp_metadata(mock_metadata)
-      expect(Dir['tmp/*.SimpleFormsApi.metadata.json'].any?).to equal(true)
+      expect(Dir['clamav_tmp/*.SimpleFormsApi.metadata.json'].any?).to equal(true)
     ensure
       Common::FileHelpers.delete_file_if_exists(mock_file_path_metadata)
     end

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -435,7 +435,7 @@ RSpec.describe Form1010cg::Service do
     end
 
     context 'with claim pdf' do
-      let(:claim_pdf_path) { Common::FileHelpers.generate_temp_file('foo', 'claim.pdf') }
+      let(:claim_pdf_path) { Common::FileHelpers.generate_clamav_temp_file('foo', 'claim.pdf') }
 
       after do
         File.delete(claim_pdf_path)
@@ -453,7 +453,7 @@ RSpec.describe Form1010cg::Service do
       end
 
       context 'with poa pdf' do
-        let(:poa_pdf_path) { Common::FileHelpers.generate_temp_file('foo', 'poa.pdf') }
+        let(:poa_pdf_path) { Common::FileHelpers.generate_clamav_temp_file('foo', 'poa.pdf') }
 
         after do
           File.delete(poa_pdf_path)


### PR DESCRIPTION
## Summary

The [generate_clamav_temp_file](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/generate_clamav_temp_file) method replaces generate_temp_file when an attachment is being uploaded to vets-api. Generating a temp clamav file creates a temp file in the /clamav_tmp directory. 

This ticket ensures the generate_temp_file/generate_clamav_temp_file is being properly used throughout vets-api.

## Related issue(s)

[Zenhub Ticket](https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/90773)

## Testing done

- [x]  All specs are passing.
- [x]  Common::VirusScan is being ran when needed.

