### PR TITLE
Add resubmission rake task

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'lighthouse/benefits_intake/service'
 require 'simple_forms_api_submission/metadata_validator'
 
 module SimpleFormsApi
@@ -21,6 +22,10 @@ module SimpleFormsApi
       end
 
       private
+
+      def lighthouse_service
+        @lighthouse_service ||= BenefitsIntake::Service.new
+      end
 
       def upload_response
         file_path = find_attachment_path(params[:confirmation_code])
@@ -51,7 +56,43 @@ module SimpleFormsApi
       end
 
       def upload_pdf(file_path, metadata)
-        SimpleFormsApi::PdfUploader.new(file_path, metadata, params[:form_number]).upload_to_benefits_intake(params)
+        location, uuid = prepare_for_upload
+        log_upload_details(location, uuid)
+        response = perform_pdf_upload(location, file_path, metadata)
+        [response.status, uuid]
+      end
+
+      def prepare_for_upload
+        location, uuid = lighthouse_service.request_upload
+        create_form_submission_attempt(uuid)
+
+        [location, uuid]
+      end
+
+      def create_form_submission_attempt(uuid)
+        form_submission = create_form_submission(uuid)
+        FormSubmissionAttempt.create(form_submission:)
+      end
+
+      def create_form_submission(uuid)
+        FormSubmission.create(
+          form_type: params[:form_number],
+          benefits_intake_uuid: uuid,
+          user_account: @current_user&.user_account
+        )
+      end
+
+      def log_upload_details(location, uuid)
+        Datadog::Tracing.active_trace&.set_tag('uuid', uuid)
+        Rails.logger.info('Simple forms api - preparing to upload scanned PDF to benefits intake', { location:, uuid: })
+      end
+
+      def perform_pdf_upload(location, file_path, metadata)
+        lighthouse_service.perform_upload(
+          metadata: metadata.to_json,
+          document: file_path,
+          upload_url: location
+        )
       end
     end
   end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -127,7 +127,7 @@ module SimpleFormsApi
           status, confirmation_number = upload_pdf(file_path, metadata, form)
         else
           status, confirmation_number = SimpleFormsApi::PdfUploader.new(file_path, metadata,
-                                                                        form_id).upload_to_benefits_intake(params)
+                                                                        form).upload_to_benefits_intake(params)
         end
 
         form.track_user_identity(confirmation_number)

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -127,7 +127,7 @@ module SimpleFormsApi
           status, confirmation_number = upload_pdf(file_path, metadata, form)
         else
           status, confirmation_number = SimpleFormsApi::PdfUploader.new(file_path, metadata,
-                                                                        form).upload_to_benefits_intake(params)
+                                                                        form_id).upload_to_benefits_intake(params)
         end
 
         form.track_user_identity(confirmation_number)

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -186,7 +186,7 @@ module SimpleFormsApi
 
       def stamp_pdf_with_uuid(form, uuid)
         # Stamp uuid on 40-10007
-        pdf_stamper = SimpleFormsApi::PdfStamper.new('tmp/vba_40_10007-tmp.pdf', form)
+        pdf_stamper = SimpleFormsApi::PdfStamper.new(stamped_template_path: 'tmp/vba_40_10007-tmp.pdf', form:)
         pdf_stamper.stamp_uuid(uuid)
       end
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -40,7 +40,7 @@ module SimpleFormsApi
       []
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp = Time.current)
       [
         {
           coords: [460, 710],
@@ -50,7 +50,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -40,7 +40,7 @@ module SimpleFormsApi
       []
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [460, 710],
@@ -50,7 +50,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -105,7 +105,7 @@ module SimpleFormsApi
       [{ coords:, text: data['statement_of_truth_signature'], page: 4 }]
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [460, 710],
@@ -115,7 +115,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 2,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -105,7 +105,7 @@ module SimpleFormsApi
       [{ coords:, text: data['statement_of_truth_signature'], page: 4 }]
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp = Time.current)
       [
         {
           coords: [460, 710],
@@ -115,7 +115,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 2,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -41,7 +41,7 @@ module SimpleFormsApi
       [{ coords: [50, 240], text: data['statement_of_truth_signature'], page: 2 }]
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp = Time.current)
       [
         {
           coords: [460, 710],
@@ -51,7 +51,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -41,7 +41,7 @@ module SimpleFormsApi
       [{ coords: [50, 240], text: data['statement_of_truth_signature'], page: 2 }]
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [460, 710],
@@ -51,7 +51,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -85,7 +85,7 @@ module SimpleFormsApi
       [{ coords: [50, 415], text: data['statement_of_truth_signature'], page: 1 }]
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp = Time.current)
       [
         {
           coords: [460, 710],
@@ -95,7 +95,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -85,7 +85,7 @@ module SimpleFormsApi
       [{ coords: [50, 415], text: data['statement_of_truth_signature'], page: 1 }]
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [460, 710],
@@ -95,7 +95,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -31,7 +31,7 @@ module SimpleFormsApi
       [{ coords: [50, 465], text: data['statement_of_truth_signature'], page: 2 }]
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp)
       [
         {
           coords: [440, 690],
@@ -41,7 +41,7 @@ module SimpleFormsApi
         },
         {
           coords: [440, 670],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -31,7 +31,7 @@ module SimpleFormsApi
       [{ coords: [50, 465], text: data['statement_of_truth_signature'], page: 2 }]
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [440, 690],
@@ -41,7 +41,7 @@ module SimpleFormsApi
         },
         {
           coords: [440, 670],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -37,7 +37,7 @@ module SimpleFormsApi
       [{ coords: [50, 160], text: data['statement_of_truth_signature'], page: 2 }]
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp = Time.current)
       [
         {
           coords: [460, 710],
@@ -47,7 +47,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -37,7 +37,7 @@ module SimpleFormsApi
       [{ coords: [50, 160], text: data['statement_of_truth_signature'], page: 2 }]
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [460, 710],
@@ -47,7 +47,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
@@ -19,7 +19,7 @@ module SimpleFormsApi
       }]
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [460, 710],
@@ -29,7 +29,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
@@ -19,7 +19,7 @@ module SimpleFormsApi
       }]
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp = Time.current)
       [
         {
           coords: [460, 710],
@@ -29,7 +29,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -36,8 +36,8 @@ module SimpleFormsApi
       [{ coords: [50, 560], text: data['statement_of_truth_signature'], page: 1 }]
     end
 
-    def submission_date_stamps
-      [submission_date_stamps_first_page, submission_date_stamps_fourth_page].flatten
+    def submission_date_stamps(timestamp)
+      [submission_date_stamps_first_page(timestamp), submission_date_stamps_fourth_page(timestamp)].flatten
     end
 
     def track_user_identity(confirmation_number)
@@ -94,7 +94,7 @@ module SimpleFormsApi
       ]
     end
 
-    def submission_date_stamps_first_page(timestamp = nil)
+    def submission_date_stamps_first_page(timestamp)
       [
         {
           coords: [440, 710],
@@ -104,14 +104,14 @@ module SimpleFormsApi
         },
         {
           coords: [440, 690],
-          text: timestamp || Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }
       ]
     end
 
-    def submission_date_stamps_fourth_page(timestamp = nil)
+    def submission_date_stamps_fourth_page(timestamp)
       [
         {
           coords: [440, 710],
@@ -121,7 +121,7 @@ module SimpleFormsApi
         },
         {
           coords: [440, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 3,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -94,7 +94,7 @@ module SimpleFormsApi
       ]
     end
 
-    def submission_date_stamps_first_page
+    def submission_date_stamps_first_page(timestamp = nil)
       [
         {
           coords: [440, 710],
@@ -104,14 +104,14 @@ module SimpleFormsApi
         },
         {
           coords: [440, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp || Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }
       ]
     end
 
-    def submission_date_stamps_fourth_page
+    def submission_date_stamps_fourth_page(timestamp = nil)
       [
         {
           coords: [440, 710],
@@ -121,7 +121,7 @@ module SimpleFormsApi
         },
         {
           coords: [440, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 3,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -35,7 +35,7 @@ module SimpleFormsApi
       [{ coords: [50, 190], text: data['statement_of_truth_signature'], page: 1 }]
     end
 
-    def submission_date_stamps(timestamp = nil)
+    def submission_date_stamps(timestamp = Time.current)
       [
         {
           coords: [460, 710],
@@ -45,7 +45,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -35,7 +35,7 @@ module SimpleFormsApi
       [{ coords: [50, 190], text: data['statement_of_truth_signature'], page: 1 }]
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(timestamp = nil)
       [
         {
           coords: [460, 710],
@@ -45,7 +45,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: Time.current.in_time_zone('UTC').strftime('%H:%M %Z %D'),
+          text: (timestamp || Time.current).in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -57,7 +57,7 @@ module SimpleFormsApi
       end.compact
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(_timestamp)
       []
     end
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -80,7 +80,7 @@ module SimpleFormsApi
       []
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(_timestamp)
       []
     end
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
@@ -337,7 +337,7 @@ module SimpleFormsApi
       Rails.logger.info('Simple forms api - 40-10007 submission user identity', identity:, confirmation_number:)
     end
 
-    def submission_date_stamps
+    def submission_date_stamps(_timestamp)
       []
     end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -17,7 +17,7 @@ module SimpleFormsApi
       @name = name || form_number
     end
 
-    def generate(current_loa = nil)
+    def generate(current_loa = nil, override_timestamp: nil)
       template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
       generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf").to_s
       stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf").to_s
@@ -33,7 +33,7 @@ module SimpleFormsApi
       FileUtils.copy_file(tempfile.path, stamped_template_path)
 
       if File.exist? stamped_template_path
-        stamper = PdfStamper.new(stamped_template_path, form, current_loa)
+        stamper = PdfStamper.new(stamped_template_path, form, current_loa, override_timestamp)
         stamper.stamp_pdf
         pdftk.fill_form(stamped_template_path, generated_form_path, mapped_data, flatten: true)
         Common::FileHelpers.delete_file_if_exists(stamped_template_path)

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -40,15 +40,19 @@ module SimpleFormsApi
     end
 
     def copy_from_tempfile(stamped_template_path)
+      tempfile = create_tempfile
+      FileUtils.touch(tempfile)
+      FileUtils.copy_file(tempfile.path, stamped_template_path)
+    end
+
+    def create_tempfile
       # Tempfile workaround inspired by this:
       #   https://github.com/actions/runner-images/issues/4443#issuecomment-965391736
       template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
-      tempfile = Tempfile.new(['', '.pdf'], Rails.root.join('tmp')).tap do |tmpfile|
+      Tempfile.new(['', '.pdf'], Rails.root.join('tmp')).tap do |tmpfile|
         IO.copy_stream(template_form_path, tmpfile)
         tmpfile.close
       end
-      FileUtils.touch(tempfile)
-      FileUtils.copy_file(tempfile.path, stamped_template_path)
     end
 
     def stamp_pdf(stamped_template_path, current_loa, timestamp)

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -17,33 +17,51 @@ module SimpleFormsApi
       @name = name || form_number
     end
 
-    def generate(current_loa = nil, override_timestamp: nil)
-      template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
-      generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf").to_s
-      stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf").to_s
-      pdftk = PdfForms.new(Settings.binaries.pdftk)
-
-      # Tempfile workaround inspired by this:
-      #   https://github.com/actions/runner-images/issues/4443#issuecomment-965391736
-      tempfile = Tempfile.new(['', '.pdf'], Rails.root.join('tmp')).tap do |tmpfile|
-        IO.copy_stream(template_form_path, tmpfile)
-        tmpfile.close
-      end
-      FileUtils.touch(tempfile)
-      FileUtils.copy_file(tempfile.path, stamped_template_path)
+    def generate(current_loa = nil, timestamp: Time.current)
+      generated_form_path, stamped_template_path = prepare_to_generate_pdf
 
       if File.exist? stamped_template_path
-        stamper = PdfStamper.new(stamped_template_path, form, current_loa, override_timestamp)
-        stamper.stamp_pdf
-        pdftk.fill_form(stamped_template_path, generated_form_path, mapped_data, flatten: true)
-        Common::FileHelpers.delete_file_if_exists(stamped_template_path)
-        generated_form_path
+        stamp_pdf(stamped_template_path, current_loa, timestamp)
+        fill_and_generate_pdf(generated_form_path, stamped_template_path)
       else
         raise "stamped template file does not exist: #{stamped_template_path}"
       end
     end
 
     private
+
+    def prepare_to_generate_pdf
+      generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf").to_s
+      stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf").to_s
+
+      copy_from_tempfile(stamped_template_path)
+
+      [generated_form_path, stamped_template_path]
+    end
+
+    def copy_from_tempfile(stamped_template_path)
+      # Tempfile workaround inspired by this:
+      #   https://github.com/actions/runner-images/issues/4443#issuecomment-965391736
+      template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
+      tempfile = Tempfile.new(['', '.pdf'], Rails.root.join('tmp')).tap do |tmpfile|
+        IO.copy_stream(template_form_path, tmpfile)
+        tmpfile.close
+      end
+      FileUtils.touch(tempfile)
+      FileUtils.copy_file(tempfile.path, stamped_template_path)
+    end
+
+    def stamp_pdf(stamped_template_path, current_loa, timestamp)
+      stamper = PdfStamper.new(stamped_template_path:, form:, current_loa:, timestamp:)
+      stamper.stamp_pdf
+    end
+
+    def fill_and_generate_pdf(generated_form_path, stamped_template_path)
+      pdftk = PdfForms.new(Settings.binaries.pdftk)
+      pdftk.fill_form(stamped_template_path, generated_form_path, mapped_data, flatten: true)
+      Common::FileHelpers.delete_file_if_exists(stamped_template_path)
+      generated_form_path
+    end
 
     def mapped_data
       template = Rails.root.join('modules', 'simple_forms_api', 'app', 'form_mappings', "#{form_number}.json.erb").read

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -8,7 +8,7 @@ module SimpleFormsApi
 
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
 
-    def initialize(stamped_template_path:, form:, current_loa:, timestamp:)
+    def initialize(stamped_template_path:, form:, current_loa: nil, timestamp: nil)
       @stamped_template_path = stamped_template_path
       @form = form
       @loa = current_loa

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -4,15 +4,15 @@ require 'pdf_utilities/datestamp_pdf'
 
 module SimpleFormsApi
   class PdfStamper
-    attr_reader :stamped_template_path, :form, :loa
+    attr_reader :stamped_template_path, :form, :loa, :timestamp
 
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
-    SUBMISSION_DATE_TITLE = 'Application Submitted:'
 
-    def initialize(stamped_template_path, form, loa = nil)
+    def initialize(stamped_template_path, form, loa = nil, override_timestamp = nil)
       @stamped_template_path = stamped_template_path
       @form = form
       @loa = loa
+      @timestamp = override_timestamp
     end
 
     def stamp_pdf
@@ -45,7 +45,7 @@ module SimpleFormsApi
     end
 
     def all_form_stamps
-      form.desired_stamps + form.submission_date_stamps
+      form.desired_stamps + form.submission_date_stamps(timestamp)
     end
 
     def stamp_form(desired_stamp)
@@ -142,7 +142,7 @@ module SimpleFormsApi
       Rails.logger.info('Calling PDFUtilities::DatestampPdf', stamped_template_path:)
       text_only = append_to_stamp ? false : true
       datestamp_instance = PDFUtilities::DatestampPdf.new(stamped_template_path, append_to_stamp:)
-      datestamp_instance.run(text:, x: coords[0], y: coords[1], text_only:, size: 9)
+      datestamp_instance.run(text:, x: coords[0], y: coords[1], text_only:, size: 9, timestamp:)
     end
 
     def get_auth_text_stamp

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -8,11 +8,11 @@ module SimpleFormsApi
 
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
 
-    def initialize(stamped_template_path, form, loa = nil, override_timestamp = nil)
+    def initialize(stamped_template_path:, form:, timestamp:, current_loa:)
       @stamped_template_path = stamped_template_path
       @form = form
-      @loa = loa
-      @timestamp = override_timestamp
+      @loa = current_loa
+      @timestamp = timestamp
     end
 
     def stamp_pdf

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -8,7 +8,7 @@ module SimpleFormsApi
 
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
 
-    def initialize(stamped_template_path:, form:, timestamp:, current_loa:)
+    def initialize(stamped_template_path:, form:, current_loa:, timestamp:)
       @stamped_template_path = stamped_template_path
       @form = form
       @loa = current_loa

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
@@ -44,7 +44,7 @@ module SimpleFormsApi
 
       # Stamp uuid on 40-10007
       uuid = upload_location.dig('data', 'id')
-      SimpleFormsApi::PdfStamper.new('tmp/vba_40_10007-tmp.pdf', form).stamp_uuid(uuid)
+      SimpleFormsApi::PdfStamper.new(stamped_template_path: 'tmp/vba_40_10007-tmp.pdf', form:).stamp_uuid(uuid)
 
       { uuid:, location: upload_location.dig('data', 'attributes', 'location') }
     end

--- a/modules/simple_forms_api/lib/tasks/resubmit_forms_by_uuid.rake
+++ b/modules/simple_forms_api/lib/tasks/resubmit_forms_by_uuid.rake
@@ -38,8 +38,6 @@ namespace :simple_forms_api do
         'Simple forms api - resubmitted PDF to benefits intake',
         { status: response.status, uuid: }
       )
-
-      p uuid
     end
   end
 end

--- a/modules/simple_forms_api/lib/tasks/resubmit_forms_by_uuid.rake
+++ b/modules/simple_forms_api/lib/tasks/resubmit_forms_by_uuid.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'lighthouse/benefits_intake/service'
+require 'simple_forms_api_submission/metadata_validator'
+
+# Invoke this as follows (tested on ZShell):
+#   rails "simple_forms_api:resubmit_forms_by_uuid[abc-123 def-456]"
+namespace :simple_forms_api do
+  task :resubmit_forms_by_uuid, [:benefits_intake_uuids] => :environment do |_, args|
+    benefits_intake_uuids = args[:benefits_intake_uuids].split
+    benefits_intake_uuids.each do |benefits_intake_uuid|
+      # Get the original submission
+      form_submission = FormSubmission.find_by(benefits_intake_uuid:)
+      next unless form_submission
+
+      # Re-generate the form PDF
+      form_id = SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[form_submission.form_type]
+      parsed_form_data = JSON.parse(form_submission.form_data)
+      form = "SimpleFormsApi::#{form_id.titleize.gsub(' ', '')}".constantize.new(parsed_form_data)
+      filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, form:)
+      file_path = filler.generate(override_timestamp: form_submission.created_at)
+      metadata = SimpleFormsApiSubmission::MetadataValidator.validate(form.metadata,
+                                                                      zip_code_is_us_based: form.zip_code_is_us_based)
+      form.handle_attachments(file_path) if %w[vba_40_0247 vba_20_10207 vba_40_10007].include? form_id
+
+      # Attempt to re-submit
+      lighthouse_service = BenefitsIntake::Service.new
+      location, uuid = lighthouse_service.request_upload
+      FormSubmissionAttempt.create(form_submission:, benefits_intake_uuid: uuid)
+      Rails.logger.info(
+        'Simple forms api - preparing to resubmit PDF to benefits intake',
+        { location:, uuid: }
+      )
+      response = lighthouse_service.perform_upload(metadata: metadata.to_json, document: file_path,
+                                                   upload_url: location)
+
+      Rails.logger.info(
+        'Simple forms api - resubmitted PDF to benefits intake',
+        { status: response.status, uuid: }
+      )
+
+      p uuid
+    end
+  end
+end

--- a/modules/simple_forms_api/lib/tasks/resubmit_forms_by_uuid.rake
+++ b/modules/simple_forms_api/lib/tasks/resubmit_forms_by_uuid.rake
@@ -18,7 +18,7 @@ namespace :simple_forms_api do
       parsed_form_data = JSON.parse(form_submission.form_data)
       form = "SimpleFormsApi::#{form_id.titleize.gsub(' ', '')}".constantize.new(parsed_form_data)
       filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, form:)
-      file_path = filler.generate(override_timestamp: form_submission.created_at)
+      file_path = filler.generate(timestamp: form_submission.created_at)
       metadata = SimpleFormsApiSubmission::MetadataValidator.validate(form.metadata,
                                                                       zip_code_is_us_based: form.zip_code_is_us_based)
       form.handle_attachments(file_path) if %w[vba_40_0247 vba_20_10207 vba_40_10007].include? form_id

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -60,19 +60,6 @@ describe SimpleFormsApi::PdfFiller do
           end
         end
       end
-
-      context 'override_timestamp is populated' do
-        it 'passes the timestamp along to the PdfStamper' do
-          timestamp = 'fake-timestamp'
-          allow(SimpleFormsApi::PdfStamper).to receive(:new).with(anything, anything, anything,
-                                                                  timestamp)
-
-          described_class.new(form_number:, form:, name:).generate(override_timestamp: timestamp)
-
-          expect(SimpleFormsApi::PdfStamper).to have_received(:new).with(anything, anything, anything,
-                                                                         timestamp)
-        end
-      end
     end
   end
 

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -60,6 +60,19 @@ describe SimpleFormsApi::PdfFiller do
           end
         end
       end
+
+      context 'override_timestamp is populated' do
+        it 'passes the timestamp along to the PdfStamper' do
+          timestamp = 'fake-timestamp'
+          allow(SimpleFormsApi::PdfStamper).to receive(:new).with(anything, anything, anything,
+                                                                  timestamp)
+
+          described_class.new(form_number:, form:, name:).generate(override_timestamp: timestamp)
+
+          expect(SimpleFormsApi::PdfStamper).to have_received(:new).with(anything, anything, anything,
+                                                                         timestamp)
+        end
+      end
     end
   end
 

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -35,6 +35,17 @@ describe SimpleFormsApi::PdfStamper do
 
           expect(instance).to have_received(:verified_multistamp).with(desired_stamp, page_configuration)
         end
+
+        context 'override_timestamp is passed in' do
+          let(:timestamp) { 'right-timestamp' }
+          let(:instance) { described_class.new(path, form, 3, timestamp) }
+
+          it 'passes the right timestamp when fetching the submission date stamps' do
+            instance.stamp_pdf
+
+            expect(form).to have_received(:submission_date_stamps).with(timestamp)
+          end
+        end
       end
 
       context 'page is not specified' do
@@ -73,8 +84,21 @@ describe SimpleFormsApi::PdfStamper do
         instance.stamp_pdf
 
         expect(datestamp_instance).to have_received(:run).with(text:, x: anything, y: anything, text_only: false,
-                                                               size: 9)
+                                                               size: 9, timestamp: nil)
         expect(File).to have_received(:rename).with(current_file_path, path)
+      end
+
+      context 'override_timestamp is passed in' do
+        let(:timestamp) { 'fake-timestamp' }
+        let(:instance) { described_class.new(path, form, 3, timestamp) }
+
+        it 'calls PDFUtilities::DatestampPdf with the timestamp' do
+          text = /Signed electronically and submitted via VA.gov at /
+          instance.stamp_pdf
+
+          expect(datestamp_instance).to have_received(:run).with(text:, x: anything, y: anything, text_only: false,
+                                                                 size: 9, timestamp:)
+        end
       end
     end
   end

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -7,7 +7,7 @@ describe SimpleFormsApi::PdfStamper do
   let(:data) { JSON.parse(File.read('modules/simple_forms_api/spec/fixtures/form_json/vba_21_0845.json')) }
   let(:form) { SimpleFormsApi::VBA210845.new(data) }
   let(:path) { 'tmp/template.pdf' }
-  let(:instance) { described_class.new(path, form, 3) }
+  let(:instance) { described_class.new(stamped_template_path: path, form:, current_loa: 3, timestamp: nil) }
 
   describe '#stamp_pdf' do
     context 'applying stamps as specified by the form model' do
@@ -36,9 +36,9 @@ describe SimpleFormsApi::PdfStamper do
           expect(instance).to have_received(:verified_multistamp).with(desired_stamp, page_configuration)
         end
 
-        context 'override_timestamp is passed in' do
+        context 'timestamp is passed in' do
           let(:timestamp) { 'right-timestamp' }
-          let(:instance) { described_class.new(path, form, 3, timestamp) }
+          let(:instance) { described_class.new(stamped_template_path: path, form:, current_loa: 3, timestamp:) }
 
           it 'passes the right timestamp when fetching the submission date stamps' do
             instance.stamp_pdf
@@ -84,13 +84,13 @@ describe SimpleFormsApi::PdfStamper do
         instance.stamp_pdf
 
         expect(datestamp_instance).to have_received(:run).with(text:, x: anything, y: anything, text_only: false,
-                                                               size: 9, timestamp: nil)
+                                                               size: 9, timestamp: anything)
         expect(File).to have_received(:rename).with(current_file_path, path)
       end
 
-      context 'override_timestamp is passed in' do
+      context 'timestamp is passed in' do
         let(:timestamp) { 'fake-timestamp' }
-        let(:instance) { described_class.new(path, form, 3, timestamp) }
+        let(:instance) { described_class.new(stamped_template_path: path, form:, current_loa: 3, timestamp:) }
 
         it 'calls PDFUtilities::DatestampPdf with the timestamp' do
           text = /Signed electronically and submitted via VA.gov at /

--- a/modules/simple_forms_api/spec/services/pdf_uploader_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_uploader_spec.rb
@@ -14,6 +14,7 @@ describe SimpleFormsApi::PdfUploader do
       expected_uuid = 'some-uuid'
       lighthouse_service = double
       upload_location = double
+      form = double
       body = { 'data' => { 'id' => expected_uuid } }
       params = { form_number: form_id }
       expected_response = double(status: expected_status)
@@ -21,7 +22,7 @@ describe SimpleFormsApi::PdfUploader do
       allow(lighthouse_service).to receive_messages(get_upload_location: upload_location, upload_doc: expected_response)
       allow(SimpleFormsApiSubmission::Service).to receive(:new).and_return lighthouse_service
 
-      pdf_uploader = SimpleFormsApi::PdfUploader.new(file_path, metadata, form_id)
+      pdf_uploader = SimpleFormsApi::PdfUploader.new(file_path, metadata, form)
 
       expect(pdf_uploader.upload_to_benefits_intake(params)).to eq [expected_status, expected_uuid]
     end


### PR DESCRIPTION
## Summary
This is a successor to #18145 and replaces it. The main point of this PR is in the diff for `modules/simple_forms_api/lib/tasks/resubmit_forms_by_uuid.rake`. This PR also uses the recent refactor I did to supply the task with a timestamp override.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/820

## Testing done
Changes to PdfFiller and PdfStamper are tested.

## Screenshots
These screenshots are from a form I resubmitted to staging on 8/28 BUT the dates display 8/2. Pretty cool, eh? 😎

<img width="1040" alt="Screenshot 2024-08-28 at 12 59 57 PM" src="https://github.com/user-attachments/assets/73c6eb05-e6c0-4986-ab9f-2470c3cebc7b">
<img width="1100" alt="Screenshot 2024-08-28 at 1 00 09 PM" src="https://github.com/user-attachments/assets/2465becb-a0a4-457e-a7c9-9ae0c2a13ab8">
