### PR TITLE
add hasover65

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -34,7 +34,8 @@ module IvcChampva
         'businessLine' => 'CMP',
         'ssn_or_tin' => @data.dig('veteran', 'ssn_or_tin'),
         'uuid' => @uuid,
-        'primaryContactInfo' => @data['primary_contact_info']
+        'primaryContactInfo' => @data['primary_contact_info'],
+        'hasApplicantOver65' => @data['has_applicant_over65'].to_s
       }
     end
 

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe IvcChampva::VHA1010d do
         'address' => { 'country' => 'USA', 'postal_code' => '12345' }
       },
       'form_number' => 'VHA1010d',
+      'has_applicant_over65' => false,
       'veteran_supporting_documents' => [
         { 'confirmation_code' => 'abc123' },
         { 'confirmation_code' => 'def456' }
@@ -54,6 +55,7 @@ RSpec.describe IvcChampva::VHA1010d do
         'source' => 'VA Platform Digital Forms',
         'docType' => 'VHA1010d',
         'businessLine' => 'CMP',
+        'hasApplicantOver65' => 'false',
         'primaryContactInfo' => {
           'name' => {
             'first' => 'Veteran',


### PR DESCRIPTION
Related to frontend: https://app.zenhub.com/workspaces/ivc-forms-652da2d3f0ae4c0016bfb109/issues/gh/department-of-veterans-affairs/va.gov-team/91216

As a Pega Backend analyst, I need to determine if any applicants in the form are over 65, we can introduce a boolean flag named hasApplicantOver65. This flag will be initialized to false and updated to true if an applicant with an age greater than or equal to 65 is found.

Acceptance Criteria:
The boolean flag will be set to true if one or more applicants in the list loop are 65 years old or older.
This metadata will be added to all 10-10d submissions

![Uploading Screenshot 2024-08-28 at 1.00.16 PM.png…]()
