### PR TITLE
Reorganize Health Quest & Income Limits Request Specs

### DIFF
--- a/modules/health_quest/spec/requests/health_quest/v0/apidocs_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/apidocs_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'health quest appointment requests', type: :request do
+RSpec.describe 'HealthQuest::V0::Apidocs', type: :request do
   describe 'GET /health_quest/v0/apidocs' do
     let(:openapi_version) { %w[openapi 3.0.0] }
 

--- a/modules/health_quest/spec/requests/health_quest/v0/lighthouse_appointments_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/lighthouse_appointments_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'HealthQuest::V0::LighthouseAppointments', type: :request do
         allow_any_instance_of(HealthQuest::Resource::Query).to receive(:search).with(anything).and_return(client_reply)
       end
 
-      it 'returns a FHIR Bundle ' do
+      it 'returns a FHIR Bundle' do
         get '/health_quest/v0/lighthouse_appointments?test=1234'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })

--- a/modules/health_quest/spec/requests/health_quest/v0/lighthouse_appointments_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/lighthouse_appointments_spec.rb
@@ -2,10 +2,54 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Lighthouse locations', type: :request do
+RSpec.describe 'HealthQuest::V0::LighthouseAppointments', type: :request do
   let(:access_denied_message) { 'You do not have access to the health quest service' }
+  let(:questionnaire_responses_id) { '32' }
 
-  describe 'GET locations `index`' do
+  describe 'GET appointment `show`' do
+    context 'loa1 user' do
+      before do
+        sign_in_as(current_user)
+      end
+
+      let(:current_user) { build(:user, :loa1) }
+
+      it 'has forbidden status' do
+        get '/health_quest/v0/lighthouse_appointments/I2-ABC123'
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get '/health_quest/v0/lighthouse_appointments/I2-ABC123'
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+      let(:id) { 'faae134c-9c7b-49d7-8161-10e314da4de1' }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) do
+        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Appointment' } })
+      end
+
+      before do
+        sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:get).with(anything).and_return(client_reply)
+      end
+
+      it 'returns a FHIR type of Appointment' do
+        get '/health_quest/v0/lighthouse_appointments/I2-ABC123'
+
+        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Appointment' })
+      end
+    end
+  end
+
+  describe 'GET appointments `index`' do
     context 'loa1 user' do
       let(:current_user) { build(:user, :loa1) }
 
@@ -14,13 +58,13 @@ RSpec.describe 'Lighthouse locations', type: :request do
       end
 
       it 'has forbidden status' do
-        get '/health_quest/v0/locations?_id=1234'
+        get '/health_quest/v0/lighthouse_appointments?test=1234'
 
         expect(response).to have_http_status(:forbidden)
       end
 
       it 'has access denied message' do
-        get '/health_quest/v0/locations?_id=1234'
+        get '/health_quest/v0/lighthouse_appointments?test=1234'
 
         expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
       end
@@ -38,51 +82,9 @@ RSpec.describe 'Lighthouse locations', type: :request do
       end
 
       it 'returns a FHIR Bundle ' do
-        get '/health_quest/v0/locations?_id=abc123,def456'
+        get '/health_quest/v0/lighthouse_appointments?test=1234'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })
-      end
-    end
-  end
-
-  describe 'GET location `show`' do
-    context 'loa1 user' do
-      before do
-        sign_in_as(current_user)
-      end
-
-      let(:current_user) { build(:user, :loa1) }
-
-      it 'has forbidden status' do
-        get '/health_quest/v0/locations/I2-ABC123'
-
-        expect(response).to have_http_status(:forbidden)
-      end
-
-      it 'has access denied message' do
-        get '/health_quest/v0/locations/I2-ABC123'
-
-        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
-      end
-    end
-
-    context 'health quest user' do
-      let(:current_user) { build(:user, :health_quest) }
-      let(:session_store) { double('SessionStore', token: '123abc') }
-      let(:client_reply) do
-        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Location' } })
-      end
-
-      before do
-        sign_in_as(current_user)
-        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
-        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:get).with(anything).and_return(client_reply)
-      end
-
-      it 'returns a FHIR type of Location' do
-        get '/health_quest/v0/locations/I2-ABC123'
-
-        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Location' })
       end
     end
   end

--- a/modules/health_quest/spec/requests/health_quest/v0/locations_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/locations_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'LHealthQuest::V0::Locations', type: :request do
         allow_any_instance_of(HealthQuest::Resource::Query).to receive(:search).with(anything).and_return(client_reply)
       end
 
-      it 'returns a FHIR Bundle ' do
+      it 'returns a FHIR Bundle' do
         get '/health_quest/v0/locations?_id=abc123,def456'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })

--- a/modules/health_quest/spec/requests/health_quest/v0/organizations_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/organizations_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'HealthQuest::V0::Organizations', type: :request do
         allow_any_instance_of(HealthQuest::Resource::Query).to receive(:search).with(anything).and_return(client_reply)
       end
 
-      it 'returns a FHIR Bundle ' do
+      it 'returns a FHIR Bundle' do
         get '/health_quest/v0/organizations?_id=abc123,def456'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })

--- a/modules/health_quest/spec/requests/health_quest/v0/organizations_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/organizations_spec.rb
@@ -2,54 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe 'health_quest questionnaires', type: :request do
+RSpec.describe 'HealthQuest::V0::Organizations', type: :request do
   let(:access_denied_message) { 'You do not have access to the health quest service' }
-  let(:questionnaires_id) { '32' }
 
-  describe 'GET questionnaire' do
-    context 'loa1 user' do
-      before do
-        sign_in_as(current_user)
-      end
-
-      let(:current_user) { build(:user, :loa1) }
-
-      it 'has forbidden status' do
-        get "/health_quest/v0/questionnaires/#{questionnaires_id}"
-
-        expect(response).to have_http_status(:forbidden)
-      end
-
-      it 'has access denied message' do
-        get "/health_quest/v0/questionnaires/#{questionnaires_id}"
-
-        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
-      end
-    end
-
-    context 'health quest user' do
-      let(:current_user) { build(:user, :health_quest) }
-      let(:id) { 'faae134c-9c7b-49d7-8161-10e314da4de1' }
-      let(:session_store) { double('SessionStore', token: '123abc') }
-      let(:client_reply) do
-        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Questionnaire' } })
-      end
-
-      before do
-        sign_in_as(current_user)
-        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
-        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:get).with(anything).and_return(client_reply)
-      end
-
-      it 'returns a FHIR type of Questionnaire' do
-        get "/health_quest/v0/questionnaires/#{id}"
-
-        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Questionnaire' })
-      end
-    end
-  end
-
-  describe 'GET all questionnaires' do
+  describe 'GET organizations `index`' do
     context 'loa1 user' do
       let(:current_user) { build(:user, :loa1) }
 
@@ -58,13 +14,13 @@ RSpec.describe 'health_quest questionnaires', type: :request do
       end
 
       it 'has forbidden status' do
-        get '/health_quest/v0/questionnaires'
+        get '/health_quest/v0/organizations?_id=1234'
 
         expect(response).to have_http_status(:forbidden)
       end
 
       it 'has access denied message' do
-        get '/health_quest/v0/questionnaires'
+        get '/health_quest/v0/organizations?_id=1234'
 
         expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
       end
@@ -81,10 +37,52 @@ RSpec.describe 'health_quest questionnaires', type: :request do
         allow_any_instance_of(HealthQuest::Resource::Query).to receive(:search).with(anything).and_return(client_reply)
       end
 
-      it 'returns a FHIR bundle' do
-        get '/health_quest/v0/questionnaires?context-type-value=123'
+      it 'returns a FHIR Bundle ' do
+        get '/health_quest/v0/organizations?_id=abc123,def456'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })
+      end
+    end
+  end
+
+  describe 'GET organization `show`' do
+    context 'loa1 user' do
+      before do
+        sign_in_as(current_user)
+      end
+
+      let(:current_user) { build(:user, :loa1) }
+
+      it 'has forbidden status' do
+        get '/health_quest/v0/organizations/I2-ABC123'
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get '/health_quest/v0/organizations/I2-ABC123'
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) do
+        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Location' } })
+      end
+
+      before do
+        sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:get).with(anything).and_return(client_reply)
+      end
+
+      it 'returns a FHIR type of Location' do
+        get '/health_quest/v0/organizations/I2-ABC123'
+
+        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Location' })
       end
     end
   end

--- a/modules/health_quest/spec/requests/health_quest/v0/questionnaire_manager_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/questionnaire_manager_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'health_quest questionnaire_manager', type: :request do
+RSpec.describe 'HealthQuest::V0::QuestionnaireManager', type: :request do
   let(:access_denied_message) { 'You do not have access to the health quest service' }
   let(:questionnaires_id) { '32' }
   let(:default_client_reply) { double('FHIR::ClientReply') }

--- a/modules/health_quest/spec/requests/health_quest/v0/questionnaire_responses_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/questionnaire_responses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'health_quest questionnaire_responses', type: :request do
+RSpec.describe 'HealthQuest::V0::QuestionnaireResponses', type: :request do
   let(:access_denied_message) { 'You do not have access to the health quest service' }
   let(:questionnaire_responses_id) { '32' }
 

--- a/modules/health_quest/spec/requests/health_quest/v0/questionnaires_spec.rb
+++ b/modules/health_quest/spec/requests/health_quest/v0/questionnaires_spec.rb
@@ -2,10 +2,54 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Lighthouse organizations', type: :request do
+RSpec.describe 'HealthQuest::V0::Questionnaires', type: :request do
   let(:access_denied_message) { 'You do not have access to the health quest service' }
+  let(:questionnaires_id) { '32' }
 
-  describe 'GET organizations `index`' do
+  describe 'GET questionnaire' do
+    context 'loa1 user' do
+      before do
+        sign_in_as(current_user)
+      end
+
+      let(:current_user) { build(:user, :loa1) }
+
+      it 'has forbidden status' do
+        get "/health_quest/v0/questionnaires/#{questionnaires_id}"
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get "/health_quest/v0/questionnaires/#{questionnaires_id}"
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+      let(:id) { 'faae134c-9c7b-49d7-8161-10e314da4de1' }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) do
+        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Questionnaire' } })
+      end
+
+      before do
+        sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:get).with(anything).and_return(client_reply)
+      end
+
+      it 'returns a FHIR type of Questionnaire' do
+        get "/health_quest/v0/questionnaires/#{id}"
+
+        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Questionnaire' })
+      end
+    end
+  end
+
+  describe 'GET all questionnaires' do
     context 'loa1 user' do
       let(:current_user) { build(:user, :loa1) }
 
@@ -14,13 +58,13 @@ RSpec.describe 'Lighthouse organizations', type: :request do
       end
 
       it 'has forbidden status' do
-        get '/health_quest/v0/organizations?_id=1234'
+        get '/health_quest/v0/questionnaires'
 
         expect(response).to have_http_status(:forbidden)
       end
 
       it 'has access denied message' do
-        get '/health_quest/v0/organizations?_id=1234'
+        get '/health_quest/v0/questionnaires'
 
         expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
       end
@@ -37,52 +81,10 @@ RSpec.describe 'Lighthouse organizations', type: :request do
         allow_any_instance_of(HealthQuest::Resource::Query).to receive(:search).with(anything).and_return(client_reply)
       end
 
-      it 'returns a FHIR Bundle ' do
-        get '/health_quest/v0/organizations?_id=abc123,def456'
+      it 'returns a FHIR bundle' do
+        get '/health_quest/v0/questionnaires?context-type-value=123'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })
-      end
-    end
-  end
-
-  describe 'GET organization `show`' do
-    context 'loa1 user' do
-      before do
-        sign_in_as(current_user)
-      end
-
-      let(:current_user) { build(:user, :loa1) }
-
-      it 'has forbidden status' do
-        get '/health_quest/v0/organizations/I2-ABC123'
-
-        expect(response).to have_http_status(:forbidden)
-      end
-
-      it 'has access denied message' do
-        get '/health_quest/v0/organizations/I2-ABC123'
-
-        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
-      end
-    end
-
-    context 'health quest user' do
-      let(:current_user) { build(:user, :health_quest) }
-      let(:session_store) { double('SessionStore', token: '123abc') }
-      let(:client_reply) do
-        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Location' } })
-      end
-
-      before do
-        sign_in_as(current_user)
-        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
-        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:get).with(anything).and_return(client_reply)
-      end
-
-      it 'returns a FHIR type of Location' do
-        get '/health_quest/v0/organizations/I2-ABC123'
-
-        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Location' })
       end
     end
   end

--- a/modules/income_limits/spec/requests/income_limits/v1/limits_by_zip_code_spec.rb
+++ b/modules/income_limits/spec/requests/income_limits/v1/limits_by_zip_code_spec.rb
@@ -4,7 +4,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'IncomeLimits::V1::IncomeLimitsController', type: :request do
+RSpec.describe 'IncomeLimits::V1::LimitsByZipCode', type: :request do
   describe 'GET #index' do
     def parse_response(response)
       JSON.parse(response.body)['data']

--- a/modules/income_limits/spec/requests/income_limits/v1/validate_zip_code_spec.rb
+++ b/modules/income_limits/spec/requests/income_limits/v1/validate_zip_code_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'IncomeLimits::V1::IncomeLimitsController', type: :request do
+RSpec.describe 'IncomeLimits::V1::ValidateZipCode', type: :request do
   describe 'GET #validate_zipcode' do
     def parse_response(response)
       JSON.parse(response.body)


### PR DESCRIPTION
## Summary

- Files were renamed to follow convention (detailed at the bottom)
- Top-level example groups were renamed to follow convention
- somes of the changes are from old rubocop disables that have no been resolved

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91125

## Testing done

- [x] No new tests

## Acceptance criteria

- [x] The tests pass
- [x] request specs files are named and organized based on established convention 
- [x] request specs example group names are named based on established convention 