### PR TITLE
Fix Error Message Printout in Dependents Jobs

### DIFF
--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -36,7 +36,6 @@ module BGS
 
       Rails.logger.warn('BGS::SubmitForm674Job received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
-      log_message_to_sentry(e.message, :warning, {}, { team: 'vfs-ebenefits' })
       raise
     end
 

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -36,7 +36,7 @@ module BGS
 
       Rails.logger.warn('BGS::SubmitForm674Job received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
-      log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
+      log_message_to_sentry(e.message, :warning, {}, { team: 'vfs-ebenefits' })
       raise
     end
 

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -36,7 +36,7 @@ module BGS
 
       Rails.logger.warn('BGS::SubmitForm686cJob received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
-      log_message_to_sentry(e, :warning, {}, { team: 'vfs-ebenefits' })
+      log_message_to_sentry(e.message, :warning, {}, { team: 'vfs-ebenefits' })
       raise
     end
 

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -36,7 +36,6 @@ module BGS
 
       Rails.logger.warn('BGS::SubmitForm686cJob received error, retrying...',
                         { user_uuid:, saved_claim_id:, icn:, error: e.message, nested_error: e.cause&.message })
-      log_message_to_sentry(e.message, :warning, {}, { team: 'vfs-ebenefits' })
       raise
     end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): *NO*
- This fixes the issue we have been seeing in datadog where the error is wrapped in an additional "argument expected to be a string, got (ErrorObject).

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done
- Verified that this error was occurring and is fixed when updating the sentry logging lines

## What areas of the site does it impact?
This only impacts logging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
