### PR TITLE
Reorganize IvcChampva & MebApi Request Specs

### DIFF
--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Pega callback', type: :request do
+RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
   before do
     allow_any_instance_of(IvcChampva::V1::PegaController).to receive(:authenticate_service_account).and_return(true)
   end

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Forms uploader', type: :request do
+RSpec.describe 'IvcChampva::V1::Forms::Uploads', type: :request do
   # forms_numbers_and_classes is a hash that maps form numbers if they have attachments
   form_numbers_and_classes = {
     '10-10D' => IvcChampva::VHA1010d,

--- a/modules/meb_api/spec/requests/meb_api/v0/apidocs_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/apidocs_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MebApi::V0::ApidocsController, type: :request do
+RSpec.describe 'MebApi::V0::Apidocs', type: :request do
   describe 'GET /meb_api/v0/apidocs' do
     it 'renders the apidocs as json' do
       get '/meb_api/v0/apidocs'

--- a/modules/meb_api/spec/requests/meb_api/v0/authentication_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/authentication_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-RSpec.describe MebApi::V0::BaseController, type: :request do
+RSpec.describe 'MebApi::V0 Authentication', type: :request do
   let(:user_details_loa3) do
     {
       first_name: 'Lara',

--- a/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/education_benefits_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-Rspec.describe MebApi::V0::EducationBenefitsController, type: :request do
+Rspec.describe 'MebApi::V0 EducationBenefits', type: :request do
   include SchemaMatchers
   include ActiveSupport::Testing::TimeHelpers
 

--- a/modules/meb_api/spec/requests/meb_api/v0/forms_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/forms_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-Rspec.describe MebApi::V0::FormsController, type: :request do
+Rspec.describe 'MebApi::V0 Forms', type: :request do
   include SchemaMatchers
   include ActiveSupport::Testing::TimeHelpers
 


### PR DESCRIPTION
## Summary

- Files were renamed to follow convention (detailed at the bottom)
- Top-level example groups were renamed to follow convention

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91126

## Testing done

- [x] No new tests

## Acceptance criteria

- [x] The tests pass
- [x] request specs files are named and organized based on established convention 
- [x] request specs example group names are named based on established convention 