### PR TITLE
Reorganize Mocked Authentication Request Specs 91143

### DIFF
--- a/modules/mocked_authentication/spec/requests/mocked_authentication/credentials_spec.rb
+++ b/modules/mocked_authentication/spec/requests/mocked_authentication/credentials_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Mocked Authentication Mock Credential', type: :request do
+RSpec.describe 'MockedAuthentication::Credentials', type: :request do
   describe 'GET authorize' do
     subject do
       get(authorize_path, params: authorize_params)

--- a/modules/mocked_authentication/spec/requests/mocked_authentication/mpi/mockdata_request_spec.rb
+++ b/modules/mocked_authentication/spec/requests/mocked_authentication/mpi/mockdata_request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mockdata/mpi/find'
 
-RSpec.describe 'Mocked authentication mpi mockdata', type: :request do
+RSpec.describe 'MockedAuthentication::MPI::Mockdata', type: :request do
   let(:icn) { '12345' }
   let(:yml) { 'some-yml-content' }
   let(:api_key) { 'some-api-key' }


### PR DESCRIPTION
## Summary

- Files were renamed to follow convention (detailed at the bottom)
- Top-level example groups were renamed to follow convention

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91143

## Testing done

- [x] No new tests

## Acceptance criteria

- [x] The tests pass
- [x] request specs files are named and organized based on established convention 
- [x] request specs example group names are named based on established convention 