### PR TITLE
API-39674-update-toxic-exp-regex

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -1722,22 +1722,22 @@
         }
       }
     },
-    "/veterans/{veteranId}/claims": {
-      "get": {
-        "summary": "Find all benefits claims for a Veteran.",
+    "/veterans/{veteranId}/claims/{id}/5103": {
+      "post": {
+        "summary": "Submit Evidence Waiver 5103",
         "tags": [
-          "Claims"
+          "5103 Waiver"
         ],
-        "operationId": "findClaims",
+        "operationId": "submitEvidenceWaiver5103",
         "security": [
           {
             "productionOauth": [
-              "system/claim.read"
+              "system/claim.write"
             ]
           },
           {
             "sandboxOauth": [
-              "system/claim.read"
+              "system/claim.write"
             ]
           },
           {
@@ -1746,282 +1746,7 @@
             ]
           }
         ],
-        "parameters": [
-          {
-            "name": "veteranId",
-            "in": "path",
-            "required": true,
-            "example": "1012667145V762142",
-            "description": "ID of Veteran",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "claim response",
-            "content": {
-              "application/json": {
-                "example": {
-                  "data": [
-                    {
-                      "id": "555555555",
-                      "type": "claim",
-                      "attributes": {
-                        "baseEndProductCode": "400",
-                        "claimDate": "2017-05-02",
-                        "claimPhaseDates": {
-                          "phaseChangeDate": "2017-10-18",
-                          "phaseType": "COMPLETE"
-                        },
-                        "claimType": "Compensation",
-                        "claimTypeCode": "400PREDSCHRG",
-                        "closeDate": "2017-10-18",
-                        "decisionLetterSent": false,
-                        "developmentLetterSent": false,
-                        "documentsNeeded": false,
-                        "endProductCode": "404",
-                        "evidenceWaiverSubmitted5103": false,
-                        "lighthouseId": null,
-                        "status": "COMPLETE"
-                      }
-                    }
-                  ]
-                },
-                "schema": {
-                  "$schema": "http://json-schema.org/draft-04/schema#",
-                  "type": "object",
-                  "required": [
-                    "data"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "required": [
-                          "id",
-                          "type",
-                          "attributes"
-                        ],
-                        "additionalProperties": false,
-                        "description": "Claim details",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
-                            "example": "600131328"
-                          },
-                          "type": {
-                            "type": "string",
-                            "example": "claim"
-                          },
-                          "attributes": {
-                            "type": "object",
-                            "required": [
-                              "baseEndProductCode",
-                              "claimType",
-                              "claimDate",
-                              "claimPhaseDates",
-                              "closeDate",
-                              "developmentLetterSent",
-                              "decisionLetterSent",
-                              "documentsNeeded",
-                              "endProductCode",
-                              "evidenceWaiverSubmitted5103",
-                              "lighthouseId",
-                              "status"
-                            ],
-                            "properties": {
-                              "baseEndProductCode": {
-                                "type": "string",
-                                "description": "Base end product code for claim",
-                                "example": "400"
-                              },
-                              "claimType": {
-                                "type": "string",
-                                "description": "Name of claim type",
-                                "example": "Compensation"
-                              },
-                              "claimDate": {
-                                "format": "date",
-                                "type": "string",
-                                "description": "Date the claim was first filed. In YYYY-MM-DD format.",
-                                "example": "2018-06-04"
-                              },
-                              "claimPhaseDates": {
-                                "type": "object",
-                                "properties": {
-                                  "phaseChangeDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "description": "The date that the claim changed to its current phase",
-                                    "example": "2017-10-18"
-                                  },
-                                  "phaseType": {
-                                    "type": "string",
-                                    "enum": [
-                                      "CLAIM_RECEIVED",
-                                      "UNDER_REVIEW",
-                                      "GATHERING_OF_EVIDENCE",
-                                      "REVIEW_OF_EVIDENCE",
-                                      "PREPARATION_FOR_DECISION",
-                                      "PENDING_DECISION_APPROVAL",
-                                      "PREPARATION_FOR_NOTIFICATION",
-                                      "COMPLETE"
-                                    ],
-                                    "description": "The most current phase for the claim",
-                                    "example": "UNDER_REVIEW"
-                                  }
-                                }
-                              },
-                              "closeDate": {
-                                "format": "date",
-                                "type": "string",
-                                "description": "Date claim was closed",
-                                "example": "2019-09-04"
-                              },
-                              "developmentLetterSent": {
-                                "type": "boolean",
-                                "description": "If true, a development letter has been sent to the claimant regarding a benefit claim",
-                                "example": "false"
-                              },
-                              "decisionLetterSent": {
-                                "type": "boolean",
-                                "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim",
-                                "example": "false"
-                              },
-                              "documentsNeeded": {
-                                "type": "boolean",
-                                "description": "If true, the claim requires additional documents to be submitted",
-                                "example": "false"
-                              },
-                              "endProductCode": {
-                                "type": "string",
-                                "description": "End product code of claim"
-                              },
-                              "evidenceWaiverSubmitted5103": {
-                                "type": "boolean",
-                                "nullable": true,
-                                "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
-                                "example": "false"
-                              },
-                              "lighthouseId": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "Claim ID in Lighthouse",
-                                "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "Status of claim",
-                                "enum": [
-                                  "PENDING",
-                                  "CLAIM_RECEIVED",
-                                  "INITIAL_REVIEW",
-                                  "EVIDENCE_GATHERING_REVIEW_DECISION",
-                                  "PREPARATION_FOR_NOTIFICATION",
-                                  "COMPLETE",
-                                  "ERRORED",
-                                  "CANCELED"
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "Not authorized",
-                      "detail": "Not authorized"
-                    }
-                  ]
-                },
-                "schema": {
-                  "required": [
-                    "errors"
-                  ],
-                  "properties": {
-                    "errors": {
-                      "type": "array",
-                      "items": {
-                        "additionalProperties": false,
-                        "required": [
-                          "title",
-                          "detail"
-                        ],
-                        "properties": {
-                          "title": {
-                            "type": "string",
-                            "description": "HTTP error title"
-                          },
-                          "detail": {
-                            "type": "string",
-                            "description": "HTTP error detail"
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "HTTP error status code"
-                          },
-                          "source": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "Source of error",
-                            "properties": {
-                              "pointer": {
-                                "type": "string",
-                                "description": "Pointer to source of error"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/veterans/{veteranId}/claims/{id}": {
-      "get": {
-        "summary": "Find claim by ID.",
-        "tags": [
-          "Claims"
-        ],
-        "operationId": "findClaimById",
-        "security": [
-          {
-            "productionOauth": [
-              "system/claim.read"
-            ]
-          },
-          {
-            "sandboxOauth": [
-              "system/claim.read"
-            ]
-          },
-          {
-            "bearer_token": [
-
-            ]
-          }
-        ],
-        "description": "Retrieves a specific claim for a Veteran",
+        "description": "Submit Evidence Waiver 5103 for Veteran.",
         "parameters": [
           {
             "name": "id",
@@ -2045,510 +1770,20 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "claim response",
+          "202": {
+            "description": "Successful response",
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "id": "555555555",
-                    "type": "claim",
-                    "attributes": {
-                      "claimTypeCode": "400PREDSCHRG",
-                      "claimDate": "2017-05-02",
-                      "claimPhaseDates": {
-                        "phaseChangeDate": "2017-10-18",
-                        "currentPhaseBack": false,
-                        "latestPhaseType": "COMPLETE",
-                        "previousPhases": {
-                          "phase7CompleteDate": "2017-10-18"
-                        }
-                      },
-                      "claimType": "Compensation",
-                      "closeDate": "2017-10-18",
-                      "contentions": [
-                        {
-                          "name": "abnormal heart (New)"
-                        },
-                        {
-                          "name": "abscess kidney (New)"
-                        },
-                        {
-                          "name": "encephalitis lethargica residuals (New)"
-                        },
-                        {
-                          "name": "dracunculiasis (New)"
-                        },
-                        {
-                          "name": "gingivitis (New)"
-                        },
-                        {
-                          "name": "abnormal weight loss (New)"
-                        },
-                        {
-                          "name": "groin condition (New)"
-                        },
-                        {
-                          "name": "metritis (New)"
-                        }
-                      ],
-                      "decisionLetterSent": false,
-                      "developmentLetterSent": false,
-                      "documentsNeeded": false,
-                      "endProductCode": "404",
-                      "evidenceWaiverSubmitted5103": false,
-                      "errors": [
-
-                      ],
-                      "jurisdiction": "National Work Queue",
-                      "lighthouseId": null,
-                      "maxEstClaimDate": null,
-                      "minEstClaimDate": null,
-                      "status": "CANCELED",
-                      "submitterApplicationCode": "EBN",
-                      "submitterRoleCode": "VET",
-                      "supportingDocuments": [
-                        {
-                          "documentId": "{54EF0C16-A9E7-4C3F-B876-B2C7BEC1F834}",
-                          "documentTypeLabel": "Medical",
-                          "originalFileName": null,
-                          "trackedItemId": null,
-                          "uploadDate": null
-                        }
-                      ],
-                      "tempJurisdiction": null,
-                      "trackedItems": [
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "21-4142a",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293440,
-                          "uploadsAllowed": false
-                        },
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "Employment info needed",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293443,
-                          "uploadsAllowed": false
-                        },
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "Accidental injury - 21-4176 needed",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293444,
-                          "uploadsAllowed": false
-                        },
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "Buddy mentioned - No complete address",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293446,
-                          "uploadsAllowed": false
-                        }
-                      ]
-                    }
-                  }
+                  "success": true
                 },
                 "schema": {
-                  "$schema": "http://json-schema.org/draft-04/schema#",
                   "type": "object",
-                  "required": [
-                    "data"
-                  ],
+                  "additionalProperties": true,
                   "properties": {
-                    "data": {
-                      "type": "object",
-                      "required": [
-                        "id",
-                        "type",
-                        "attributes"
-                      ],
-                      "additionalProperties": false,
-                      "description": "Claim details",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
-                          "example": "600131328"
-                        },
-                        "type": {
-                          "type": "string",
-                          "example": "evss_claims"
-                        },
-                        "attributes": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "required": [
-                            "claimTypeCode",
-                            "claimDate",
-                            "claimPhaseDates",
-                            "claimType",
-                            "closeDate",
-                            "contentions",
-                            "decisionLetterSent",
-                            "developmentLetterSent",
-                            "documentsNeeded",
-                            "endProductCode",
-                            "evidenceWaiverSubmitted5103",
-                            "errors",
-                            "jurisdiction",
-                            "lighthouseId",
-                            "maxEstClaimDate",
-                            "minEstClaimDate",
-                            "status",
-                            "submitterApplicationCode",
-                            "submitterRoleCode",
-                            "supportingDocuments",
-                            "tempJurisdiction",
-                            "trackedItems"
-                          ],
-                          "properties": {
-                            "claimTypeCode": {
-                              "type": "string",
-                              "description": "Type code of benefit claim",
-                              "example": "400PREDSCHRG"
-                            },
-                            "claimType": {
-                              "type": "string",
-                              "description": "Name of claim type",
-                              "example": "Compensation"
-                            },
-                            "contentions": {
-                              "type": "array",
-                              "description": "The contentions being submitted with a claim",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "name": {
-                                    "type": "string",
-                                    "example": "abscess kidney (New)"
-                                  }
-                                }
-                              }
-                            },
-                            "claimDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "The date a claim was filed",
-                              "example": "2017-10-18"
-                            },
-                            "claimPhaseDates": {
-                              "type": "object",
-                              "properties": {
-                                "currentPhaseBack": {
-                                  "type": "boolean",
-                                  "description": "Indicates whether the current phase is moving backward."
-                                },
-                                "latestPhaseType": {
-                                  "type": "string",
-                                  "enum": [
-                                    "CLAIM_RECEIVED",
-                                    "UNDER_REVIEW",
-                                    "GATHERING_OF_EVIDENCE",
-                                    "REVIEW_OF_EVIDENCE",
-                                    "PREPARATION_FOR_DECISION",
-                                    "PENDING_DECISION_APPROVAL",
-                                    "PREPARATION_FOR_NOTIFICATION",
-                                    "COMPLETE"
-                                  ],
-                                  "nullable": true,
-                                  "description": "The most current phase for the claim"
-                                },
-                                "phaseChangeDate": {
-                                  "format": "date",
-                                  "type": "string",
-                                  "nullable": true,
-                                  "description": "The date that the claim changed to its current phase",
-                                  "example": "2017-10-18"
-                                },
-                                "previousPhases": {
-                                  "type": "object",
-                                  "properties": {
-                                    "phase1CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the claim received phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase2CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the initial review phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase3CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the gathering of evidence phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase4CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the reviewing of evidence phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase5CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the preparation for decision phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase6CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the pending decision approval phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase7CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the preparation for notification phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase8CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the completed phase.",
-                                      "example": "2017-10-18"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "closeDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Date claim was closed",
-                              "example": "2019-09-04"
-                            },
-                            "decisionLetterSent": {
-                              "type": "boolean",
-                              "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim"
-                            },
-                            "developmentLetterSent": {
-                              "type": "boolean",
-                              "description": "If true, a development letter has been sent to the claimant regarding a benefit claim"
-                            },
-                            "documentsNeeded": {
-                              "type": "boolean",
-                              "description": "If true, the claim requires additional documents to be submitted"
-                            },
-                            "endProductCode": {
-                              "type": "string",
-                              "description": "End product code of claim",
-                              "example": "930"
-                            },
-                            "evidenceWaiverSubmitted5103": {
-                              "type": "boolean",
-                              "nullable": true,
-                              "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
-                              "example": "false"
-                            },
-                            "errors": {
-                              "type": "array",
-                              "description": "Error details if claim is in an errored state.",
-                              "items": {
-                                "properties": {
-                                  "detail": {
-                                    "type": "string",
-                                    "example": "Something happened"
-                                  },
-                                  "source": {
-                                    "type": "string",
-                                    "example": "some/error/path"
-                                  }
-                                }
-                              }
-                            },
-                            "jurisdiction": {
-                              "type": "string",
-                              "description": "Regional office to which the claim is currently assigned."
-                            },
-                            "lighthouseId": {
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Claim ID in Lighthouse",
-                              "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
-                            },
-                            "minEstClaimDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Minimum estimated claim completion date",
-                              "example": "2019-06-04"
-                            },
-                            "maxEstClaimDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Maximum estimated claim completion date",
-                              "example": "2019-09-04"
-                            },
-                            "status": {
-                              "type": "string",
-                              "description": "Status of claim",
-                              "enum": [
-                                "PENDING",
-                                "CLAIM_RECEIVED",
-                                "INITIAL_REVIEW",
-                                "EVIDENCE_GATHERING_REVIEW_DECISION",
-                                "PREPARATION_FOR_NOTIFICATION",
-                                "COMPLETE",
-                                "ERRORED",
-                                "CANCELED"
-                              ]
-                            },
-                            "submitterApplicationCode": {
-                              "type": "string",
-                              "description": "Application code of benefit claim submitter",
-                              "example": "EBN"
-                            },
-                            "submitterRoleCode": {
-                              "type": "string",
-                              "description": "Role code of benefit claim submitter",
-                              "example": "VET"
-                            },
-                            "supportingDocuments": {
-                              "type": "array",
-                              "description": "Information regarding any supported documents attached to a claim",
-                              "items": {
-                                "properties": {
-                                  "documentId": {
-                                    "type": "string",
-                                    "description": "Unique identifier of document"
-                                  },
-                                  "documentTypeLabel": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "originalFileName": {
-                                    "type": "string",
-                                    "description": "Name of document",
-                                    "nullable": true
-                                  },
-                                  "trackedItemId": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "uploadDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "description": "Date and time document was uploaded",
-                                    "nullable": true
-                                  }
-                                }
-                              }
-                            },
-                            "tempJurisdiction": {
-                              "type": "string",
-                              "description": "Temporary jurisdiction of claim"
-                            },
-                            "trackedItems": {
-                              "type": "array",
-                              "description": "",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                  "closedDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Date the tracked item was closed",
-                                    "example": "2017-10-18"
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Description of the tracked item",
-                                    "example": "You may also submit statements from individuals having knowledge of your claimed condition."
-                                  },
-                                  "requestedDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Date the tracked item was requested",
-                                    "example": "2017-10-18"
-                                  },
-                                  "id": {
-                                    "type": "integer",
-                                    "description": "ID of the tracked item",
-                                    "example": 293454
-                                  },
-                                  "displayName": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Description of the tracked item",
-                                    "example": "Submit buddy statement(s)"
-                                  },
-                                  "receivedDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Date the tracked item was received",
-                                    "example": "2017-10-18"
-                                  },
-                                  "overdue": {
-                                    "type": "boolean",
-                                    "nullable": true,
-                                    "description": "True if the item is overdue",
-                                    "example": true
-                                  },
-                                  "status": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Enum with the status of the tracked item",
-                                    "example": "NO_LONGER_REQUIRED",
-                                    "enum": [
-                                      "ACCEPTED",
-                                      "INITIAL_REVIEW_COMPLETE",
-                                      "NEEDED_FROM_YOU",
-                                      "NEEDED_FROM_OTHERS",
-                                      "NO_LONGER_REQUIRED",
-                                      "SUBMITTED_AWAITING_REVIEW"
-                                    ]
-                                  },
-                                  "suspenseDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "example": "2017-10-18"
-                                  },
-                                  "uploadsAllowed": {
-                                    "type": "boolean",
-                                    "example": true
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
+                    "success": {
+                      "type": "boolean",
+                      "example": "true"
                     }
                   }
                 }
@@ -2563,6 +1798,7 @@
                   "errors": [
                     {
                       "title": "Not authorized",
+                      "status": "401",
                       "detail": "Not authorized"
                     }
                   ]
@@ -2613,12 +1849,13 @@
             }
           },
           "404": {
-            "description": "Resource not found",
+            "description": "NotFound",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
+                      "status": "404",
                       "title": "Resource not found",
                       "detail": "Claim not found"
                     }
@@ -2663,6 +1900,50 @@
                           }
                         }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "attributes": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "description": "Claims API 5103 Schema",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "trackedItemIds": {
+                            "description": "Array of tracked items ids.",
+                            "type": "array",
+                            "nullable": true,
+                            "uniqueItems": true,
+                            "items": {
+                              "type": "integer",
+                              "additionalProperties": false
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "type": "form/5103",
+                    "attributes": {
+                      "trackedItemIds": [
+                        1234
+                      ]
                     }
                   }
                 }
@@ -3155,7 +2436,7 @@
                                     "otherLocationsServed": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Other location(s) where Veteran served."
                                     },
@@ -3209,7 +2490,7 @@
                                     "specifyOtherExposures": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
@@ -3255,7 +2536,7 @@
                                       "exposureLocation": {
                                         "type": "string",
                                         "nullable": true,
-                                        "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                        "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
@@ -4535,7 +3816,7 @@
                                   "otherLocationsServed": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
@@ -4589,7 +3870,7 @@
                                   "specifyOtherExposures": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
@@ -4635,7 +3916,7 @@
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
@@ -5788,7 +5069,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "2d5c4ffa-38db-4639-ad95-ff8cefc31b33",
+                        "id": "925698c0-acd8-4155-80ba-6aed534825da",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -5973,7 +5254,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2024-08-30"
+                              "anticipatedSeparationDate": "2024-08-31"
                             },
                             "confinements": [
                               {
@@ -6019,7 +5300,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "69bc0078-632f-4234-ad22-e2e06f780c60",
+                        "id": "285b02b0-6a6b-4a57-ba90-77a7cfc01e0c",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -6690,7 +5971,7 @@
                                     "otherLocationsServed": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Other location(s) where Veteran served."
                                     },
@@ -6744,7 +6025,7 @@
                                     "specifyOtherExposures": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
@@ -6790,7 +6071,7 @@
                                       "exposureLocation": {
                                         "type": "string",
                                         "nullable": true,
-                                        "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                        "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
@@ -8070,7 +7351,7 @@
                                   "otherLocationsServed": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
@@ -8124,7 +7405,7 @@
                                   "specifyOtherExposures": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
@@ -8170,7 +7451,7 @@
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
@@ -10227,7 +9508,7 @@
                                   "otherLocationsServed": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
@@ -10281,7 +9562,7 @@
                                   "specifyOtherExposures": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
@@ -10327,7 +9608,7 @@
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
@@ -11225,7 +10506,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "24e893dc-7e15-45ee-8eb5-1ce7f7a8aaf3",
+                    "id": "4e010a53-2107-486a-b006-5e98b8394c15",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -13644,22 +12925,22 @@
         }
       }
     },
-    "/veterans/{veteranId}/claims/{id}/5103": {
-      "post": {
-        "summary": "Submit Evidence Waiver 5103",
+    "/veterans/{veteranId}/claims": {
+      "get": {
+        "summary": "Find all benefits claims for a Veteran.",
         "tags": [
-          "5103 Waiver"
+          "Claims"
         ],
-        "operationId": "submitEvidenceWaiver5103",
+        "operationId": "findClaims",
         "security": [
           {
             "productionOauth": [
-              "system/claim.write"
+              "system/claim.read"
             ]
           },
           {
             "sandboxOauth": [
-              "system/claim.write"
+              "system/claim.read"
             ]
           },
           {
@@ -13668,7 +12949,282 @@
             ]
           }
         ],
-        "description": "Submit Evidence Waiver 5103 for Veteran.",
+        "parameters": [
+          {
+            "name": "veteranId",
+            "in": "path",
+            "required": true,
+            "example": "1012667145V762142",
+            "description": "ID of Veteran",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "claim response",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "id": "555555555",
+                      "type": "claim",
+                      "attributes": {
+                        "baseEndProductCode": "400",
+                        "claimDate": "2017-05-02",
+                        "claimPhaseDates": {
+                          "phaseChangeDate": "2017-10-18",
+                          "phaseType": "COMPLETE"
+                        },
+                        "claimType": "Compensation",
+                        "claimTypeCode": "400PREDSCHRG",
+                        "closeDate": "2017-10-18",
+                        "decisionLetterSent": false,
+                        "developmentLetterSent": false,
+                        "documentsNeeded": false,
+                        "endProductCode": "404",
+                        "evidenceWaiverSubmitted5103": false,
+                        "lighthouseId": null,
+                        "status": "COMPLETE"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "required": [
+                          "id",
+                          "type",
+                          "attributes"
+                        ],
+                        "additionalProperties": false,
+                        "description": "Claim details",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
+                            "example": "600131328"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "claim"
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "required": [
+                              "baseEndProductCode",
+                              "claimType",
+                              "claimDate",
+                              "claimPhaseDates",
+                              "closeDate",
+                              "developmentLetterSent",
+                              "decisionLetterSent",
+                              "documentsNeeded",
+                              "endProductCode",
+                              "evidenceWaiverSubmitted5103",
+                              "lighthouseId",
+                              "status"
+                            ],
+                            "properties": {
+                              "baseEndProductCode": {
+                                "type": "string",
+                                "description": "Base end product code for claim",
+                                "example": "400"
+                              },
+                              "claimType": {
+                                "type": "string",
+                                "description": "Name of claim type",
+                                "example": "Compensation"
+                              },
+                              "claimDate": {
+                                "format": "date",
+                                "type": "string",
+                                "description": "Date the claim was first filed. In YYYY-MM-DD format.",
+                                "example": "2018-06-04"
+                              },
+                              "claimPhaseDates": {
+                                "type": "object",
+                                "properties": {
+                                  "phaseChangeDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "description": "The date that the claim changed to its current phase",
+                                    "example": "2017-10-18"
+                                  },
+                                  "phaseType": {
+                                    "type": "string",
+                                    "enum": [
+                                      "CLAIM_RECEIVED",
+                                      "UNDER_REVIEW",
+                                      "GATHERING_OF_EVIDENCE",
+                                      "REVIEW_OF_EVIDENCE",
+                                      "PREPARATION_FOR_DECISION",
+                                      "PENDING_DECISION_APPROVAL",
+                                      "PREPARATION_FOR_NOTIFICATION",
+                                      "COMPLETE"
+                                    ],
+                                    "description": "The most current phase for the claim",
+                                    "example": "UNDER_REVIEW"
+                                  }
+                                }
+                              },
+                              "closeDate": {
+                                "format": "date",
+                                "type": "string",
+                                "description": "Date claim was closed",
+                                "example": "2019-09-04"
+                              },
+                              "developmentLetterSent": {
+                                "type": "boolean",
+                                "description": "If true, a development letter has been sent to the claimant regarding a benefit claim",
+                                "example": "false"
+                              },
+                              "decisionLetterSent": {
+                                "type": "boolean",
+                                "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim",
+                                "example": "false"
+                              },
+                              "documentsNeeded": {
+                                "type": "boolean",
+                                "description": "If true, the claim requires additional documents to be submitted",
+                                "example": "false"
+                              },
+                              "endProductCode": {
+                                "type": "string",
+                                "description": "End product code of claim"
+                              },
+                              "evidenceWaiverSubmitted5103": {
+                                "type": "boolean",
+                                "nullable": true,
+                                "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
+                                "example": "false"
+                              },
+                              "lighthouseId": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Claim ID in Lighthouse",
+                                "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
+                              },
+                              "status": {
+                                "type": "string",
+                                "description": "Status of claim",
+                                "enum": [
+                                  "PENDING",
+                                  "CLAIM_RECEIVED",
+                                  "INITIAL_REVIEW",
+                                  "EVIDENCE_GATHERING_REVIEW_DECISION",
+                                  "PREPARATION_FOR_NOTIFICATION",
+                                  "COMPLETE",
+                                  "ERRORED",
+                                  "CANCELED"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Not authorized",
+                      "detail": "Not authorized"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/veterans/{veteranId}/claims/{id}": {
+      "get": {
+        "summary": "Find claim by ID.",
+        "tags": [
+          "Claims"
+        ],
+        "operationId": "findClaimById",
+        "security": [
+          {
+            "productionOauth": [
+              "system/claim.read"
+            ]
+          },
+          {
+            "sandboxOauth": [
+              "system/claim.read"
+            ]
+          },
+          {
+            "bearer_token": [
+
+            ]
+          }
+        ],
+        "description": "Retrieves a specific claim for a Veteran",
         "parameters": [
           {
             "name": "id",
@@ -13692,20 +13248,510 @@
           }
         ],
         "responses": {
-          "202": {
-            "description": "Successful response",
+          "200": {
+            "description": "claim response",
             "content": {
               "application/json": {
                 "example": {
-                  "success": true
+                  "data": {
+                    "id": "555555555",
+                    "type": "claim",
+                    "attributes": {
+                      "claimTypeCode": "400PREDSCHRG",
+                      "claimDate": "2017-05-02",
+                      "claimPhaseDates": {
+                        "phaseChangeDate": "2017-10-18",
+                        "currentPhaseBack": false,
+                        "latestPhaseType": "COMPLETE",
+                        "previousPhases": {
+                          "phase7CompleteDate": "2017-10-18"
+                        }
+                      },
+                      "claimType": "Compensation",
+                      "closeDate": "2017-10-18",
+                      "contentions": [
+                        {
+                          "name": "abnormal heart (New)"
+                        },
+                        {
+                          "name": "abscess kidney (New)"
+                        },
+                        {
+                          "name": "encephalitis lethargica residuals (New)"
+                        },
+                        {
+                          "name": "dracunculiasis (New)"
+                        },
+                        {
+                          "name": "gingivitis (New)"
+                        },
+                        {
+                          "name": "abnormal weight loss (New)"
+                        },
+                        {
+                          "name": "groin condition (New)"
+                        },
+                        {
+                          "name": "metritis (New)"
+                        }
+                      ],
+                      "decisionLetterSent": false,
+                      "developmentLetterSent": false,
+                      "documentsNeeded": false,
+                      "endProductCode": "404",
+                      "evidenceWaiverSubmitted5103": false,
+                      "errors": [
+
+                      ],
+                      "jurisdiction": "National Work Queue",
+                      "lighthouseId": null,
+                      "maxEstClaimDate": null,
+                      "minEstClaimDate": null,
+                      "status": "CANCELED",
+                      "submitterApplicationCode": "EBN",
+                      "submitterRoleCode": "VET",
+                      "supportingDocuments": [
+                        {
+                          "documentId": "{54EF0C16-A9E7-4C3F-B876-B2C7BEC1F834}",
+                          "documentTypeLabel": "Medical",
+                          "originalFileName": null,
+                          "trackedItemId": null,
+                          "uploadDate": null
+                        }
+                      ],
+                      "tempJurisdiction": null,
+                      "trackedItems": [
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "21-4142a",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293440,
+                          "uploadsAllowed": false
+                        },
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "Employment info needed",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293443,
+                          "uploadsAllowed": false
+                        },
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "Accidental injury - 21-4176 needed",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293444,
+                          "uploadsAllowed": false
+                        },
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "Buddy mentioned - No complete address",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293446,
+                          "uploadsAllowed": false
+                        }
+                      ]
+                    }
+                  }
                 },
                 "schema": {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
                   "type": "object",
-                  "additionalProperties": true,
+                  "required": [
+                    "data"
+                  ],
                   "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": "true"
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
+                      "additionalProperties": false,
+                      "description": "Claim details",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
+                          "example": "600131328"
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "evss_claims"
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "claimTypeCode",
+                            "claimDate",
+                            "claimPhaseDates",
+                            "claimType",
+                            "closeDate",
+                            "contentions",
+                            "decisionLetterSent",
+                            "developmentLetterSent",
+                            "documentsNeeded",
+                            "endProductCode",
+                            "evidenceWaiverSubmitted5103",
+                            "errors",
+                            "jurisdiction",
+                            "lighthouseId",
+                            "maxEstClaimDate",
+                            "minEstClaimDate",
+                            "status",
+                            "submitterApplicationCode",
+                            "submitterRoleCode",
+                            "supportingDocuments",
+                            "tempJurisdiction",
+                            "trackedItems"
+                          ],
+                          "properties": {
+                            "claimTypeCode": {
+                              "type": "string",
+                              "description": "Type code of benefit claim",
+                              "example": "400PREDSCHRG"
+                            },
+                            "claimType": {
+                              "type": "string",
+                              "description": "Name of claim type",
+                              "example": "Compensation"
+                            },
+                            "contentions": {
+                              "type": "array",
+                              "description": "The contentions being submitted with a claim",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "example": "abscess kidney (New)"
+                                  }
+                                }
+                              }
+                            },
+                            "claimDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "The date a claim was filed",
+                              "example": "2017-10-18"
+                            },
+                            "claimPhaseDates": {
+                              "type": "object",
+                              "properties": {
+                                "currentPhaseBack": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the current phase is moving backward."
+                                },
+                                "latestPhaseType": {
+                                  "type": "string",
+                                  "enum": [
+                                    "CLAIM_RECEIVED",
+                                    "UNDER_REVIEW",
+                                    "GATHERING_OF_EVIDENCE",
+                                    "REVIEW_OF_EVIDENCE",
+                                    "PREPARATION_FOR_DECISION",
+                                    "PENDING_DECISION_APPROVAL",
+                                    "PREPARATION_FOR_NOTIFICATION",
+                                    "COMPLETE"
+                                  ],
+                                  "nullable": true,
+                                  "description": "The most current phase for the claim"
+                                },
+                                "phaseChangeDate": {
+                                  "format": "date",
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "The date that the claim changed to its current phase",
+                                  "example": "2017-10-18"
+                                },
+                                "previousPhases": {
+                                  "type": "object",
+                                  "properties": {
+                                    "phase1CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the claim received phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase2CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the initial review phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase3CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the gathering of evidence phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase4CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the reviewing of evidence phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase5CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the preparation for decision phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase6CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the pending decision approval phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase7CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the preparation for notification phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase8CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the completed phase.",
+                                      "example": "2017-10-18"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "closeDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Date claim was closed",
+                              "example": "2019-09-04"
+                            },
+                            "decisionLetterSent": {
+                              "type": "boolean",
+                              "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim"
+                            },
+                            "developmentLetterSent": {
+                              "type": "boolean",
+                              "description": "If true, a development letter has been sent to the claimant regarding a benefit claim"
+                            },
+                            "documentsNeeded": {
+                              "type": "boolean",
+                              "description": "If true, the claim requires additional documents to be submitted"
+                            },
+                            "endProductCode": {
+                              "type": "string",
+                              "description": "End product code of claim",
+                              "example": "930"
+                            },
+                            "evidenceWaiverSubmitted5103": {
+                              "type": "boolean",
+                              "nullable": true,
+                              "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
+                              "example": "false"
+                            },
+                            "errors": {
+                              "type": "array",
+                              "description": "Error details if claim is in an errored state.",
+                              "items": {
+                                "properties": {
+                                  "detail": {
+                                    "type": "string",
+                                    "example": "Something happened"
+                                  },
+                                  "source": {
+                                    "type": "string",
+                                    "example": "some/error/path"
+                                  }
+                                }
+                              }
+                            },
+                            "jurisdiction": {
+                              "type": "string",
+                              "description": "Regional office to which the claim is currently assigned."
+                            },
+                            "lighthouseId": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Claim ID in Lighthouse",
+                              "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
+                            },
+                            "minEstClaimDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Minimum estimated claim completion date",
+                              "example": "2019-06-04"
+                            },
+                            "maxEstClaimDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Maximum estimated claim completion date",
+                              "example": "2019-09-04"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Status of claim",
+                              "enum": [
+                                "PENDING",
+                                "CLAIM_RECEIVED",
+                                "INITIAL_REVIEW",
+                                "EVIDENCE_GATHERING_REVIEW_DECISION",
+                                "PREPARATION_FOR_NOTIFICATION",
+                                "COMPLETE",
+                                "ERRORED",
+                                "CANCELED"
+                              ]
+                            },
+                            "submitterApplicationCode": {
+                              "type": "string",
+                              "description": "Application code of benefit claim submitter",
+                              "example": "EBN"
+                            },
+                            "submitterRoleCode": {
+                              "type": "string",
+                              "description": "Role code of benefit claim submitter",
+                              "example": "VET"
+                            },
+                            "supportingDocuments": {
+                              "type": "array",
+                              "description": "Information regarding any supported documents attached to a claim",
+                              "items": {
+                                "properties": {
+                                  "documentId": {
+                                    "type": "string",
+                                    "description": "Unique identifier of document"
+                                  },
+                                  "documentTypeLabel": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "originalFileName": {
+                                    "type": "string",
+                                    "description": "Name of document",
+                                    "nullable": true
+                                  },
+                                  "trackedItemId": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "uploadDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "description": "Date and time document was uploaded",
+                                    "nullable": true
+                                  }
+                                }
+                              }
+                            },
+                            "tempJurisdiction": {
+                              "type": "string",
+                              "description": "Temporary jurisdiction of claim"
+                            },
+                            "trackedItems": {
+                              "type": "array",
+                              "description": "",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                  "closedDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Date the tracked item was closed",
+                                    "example": "2017-10-18"
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Description of the tracked item",
+                                    "example": "You may also submit statements from individuals having knowledge of your claimed condition."
+                                  },
+                                  "requestedDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Date the tracked item was requested",
+                                    "example": "2017-10-18"
+                                  },
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "ID of the tracked item",
+                                    "example": 293454
+                                  },
+                                  "displayName": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Description of the tracked item",
+                                    "example": "Submit buddy statement(s)"
+                                  },
+                                  "receivedDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Date the tracked item was received",
+                                    "example": "2017-10-18"
+                                  },
+                                  "overdue": {
+                                    "type": "boolean",
+                                    "nullable": true,
+                                    "description": "True if the item is overdue",
+                                    "example": true
+                                  },
+                                  "status": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Enum with the status of the tracked item",
+                                    "example": "NO_LONGER_REQUIRED",
+                                    "enum": [
+                                      "ACCEPTED",
+                                      "INITIAL_REVIEW_COMPLETE",
+                                      "NEEDED_FROM_YOU",
+                                      "NEEDED_FROM_OTHERS",
+                                      "NO_LONGER_REQUIRED",
+                                      "SUBMITTED_AWAITING_REVIEW"
+                                    ]
+                                  },
+                                  "suspenseDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "example": "2017-10-18"
+                                  },
+                                  "uploadsAllowed": {
+                                    "type": "boolean",
+                                    "example": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -13720,7 +13766,6 @@
                   "errors": [
                     {
                       "title": "Not authorized",
-                      "status": "401",
                       "detail": "Not authorized"
                     }
                   ]
@@ -13771,13 +13816,12 @@
             }
           },
           "404": {
-            "description": "NotFound",
+            "description": "Resource not found",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
-                      "status": "404",
                       "title": "Resource not found",
                       "detail": "Claim not found"
                     }
@@ -13822,50 +13866,6 @@
                           }
                         }
                       }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "data": {
-                    "type": "object",
-                    "properties": {
-                      "attributes": {
-                        "$schema": "http://json-schema.org/draft-07/schema#",
-                        "description": "Claims API 5103 Schema",
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                          "trackedItemIds": {
-                            "description": "Array of tracked items ids.",
-                            "type": "array",
-                            "nullable": true,
-                            "uniqueItems": true,
-                            "items": {
-                              "type": "integer",
-                              "additionalProperties": false
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "example": {
-                  "data": {
-                    "type": "form/5103",
-                    "attributes": {
-                      "trackedItemIds": [
-                        1234
-                      ]
                     }
                   }
                 }
@@ -14166,8 +14166,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-08-28",
-                      "expirationDate": "2025-08-28",
+                      "creationDate": "2024-08-29",
+                      "expirationDate": "2025-08-29",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -15063,7 +15063,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "828e8e98-4918-4eb8-af90-d449d5440c24",
+                    "id": "fb3346c4-25c3-45fb-bb7c-99edeb99c5f5",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -15756,7 +15756,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "022ab4a1-b598-4822-8b2d-6c70af2c950f",
+                    "id": "14b7e4ed-1537-479c-ab98-fb65eb97ef18",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -17707,10 +17707,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "c90cd8bb-b48b-4d13-be89-ab4caa95f3ff",
+                    "id": "7ab0c254-3162-45fd-87dd-dc44d14cb2f9",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "dateRequestAccepted": "2024-08-28",
+                      "dateRequestAccepted": "2024-08-29",
                       "previousPoa": null,
                       "representative": {
                         "serviceOrganization": {

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -335,22 +335,22 @@
         }
       }
     },
-    "/veterans/{veteranId}/claims": {
-      "get": {
-        "summary": "Find all benefits claims for a Veteran.",
+    "/veterans/{veteranId}/claims/{id}/5103": {
+      "post": {
+        "summary": "Submit Evidence Waiver 5103",
         "tags": [
-          "Claims"
+          "5103 Waiver"
         ],
-        "operationId": "findClaims",
+        "operationId": "submitEvidenceWaiver5103",
         "security": [
           {
             "productionOauth": [
-              "system/claim.read"
+              "system/claim.write"
             ]
           },
           {
             "sandboxOauth": [
-              "system/claim.read"
+              "system/claim.write"
             ]
           },
           {
@@ -359,282 +359,7 @@
             ]
           }
         ],
-        "parameters": [
-          {
-            "name": "veteranId",
-            "in": "path",
-            "required": true,
-            "example": "1012667145V762142",
-            "description": "ID of Veteran",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "claim response",
-            "content": {
-              "application/json": {
-                "example": {
-                  "data": [
-                    {
-                      "id": "555555555",
-                      "type": "claim",
-                      "attributes": {
-                        "baseEndProductCode": "400",
-                        "claimDate": "2017-05-02",
-                        "claimPhaseDates": {
-                          "phaseChangeDate": "2017-10-18",
-                          "phaseType": "COMPLETE"
-                        },
-                        "claimType": "Compensation",
-                        "claimTypeCode": "400PREDSCHRG",
-                        "closeDate": "2017-10-18",
-                        "decisionLetterSent": false,
-                        "developmentLetterSent": false,
-                        "documentsNeeded": false,
-                        "endProductCode": "404",
-                        "evidenceWaiverSubmitted5103": false,
-                        "lighthouseId": null,
-                        "status": "COMPLETE"
-                      }
-                    }
-                  ]
-                },
-                "schema": {
-                  "$schema": "http://json-schema.org/draft-04/schema#",
-                  "type": "object",
-                  "required": [
-                    "data"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "required": [
-                          "id",
-                          "type",
-                          "attributes"
-                        ],
-                        "additionalProperties": false,
-                        "description": "Claim details",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
-                            "example": "600131328"
-                          },
-                          "type": {
-                            "type": "string",
-                            "example": "claim"
-                          },
-                          "attributes": {
-                            "type": "object",
-                            "required": [
-                              "baseEndProductCode",
-                              "claimType",
-                              "claimDate",
-                              "claimPhaseDates",
-                              "closeDate",
-                              "developmentLetterSent",
-                              "decisionLetterSent",
-                              "documentsNeeded",
-                              "endProductCode",
-                              "evidenceWaiverSubmitted5103",
-                              "lighthouseId",
-                              "status"
-                            ],
-                            "properties": {
-                              "baseEndProductCode": {
-                                "type": "string",
-                                "description": "Base end product code for claim",
-                                "example": "400"
-                              },
-                              "claimType": {
-                                "type": "string",
-                                "description": "Name of claim type",
-                                "example": "Compensation"
-                              },
-                              "claimDate": {
-                                "format": "date",
-                                "type": "string",
-                                "description": "Date the claim was first filed. In YYYY-MM-DD format.",
-                                "example": "2018-06-04"
-                              },
-                              "claimPhaseDates": {
-                                "type": "object",
-                                "properties": {
-                                  "phaseChangeDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "description": "The date that the claim changed to its current phase",
-                                    "example": "2017-10-18"
-                                  },
-                                  "phaseType": {
-                                    "type": "string",
-                                    "enum": [
-                                      "CLAIM_RECEIVED",
-                                      "UNDER_REVIEW",
-                                      "GATHERING_OF_EVIDENCE",
-                                      "REVIEW_OF_EVIDENCE",
-                                      "PREPARATION_FOR_DECISION",
-                                      "PENDING_DECISION_APPROVAL",
-                                      "PREPARATION_FOR_NOTIFICATION",
-                                      "COMPLETE"
-                                    ],
-                                    "description": "The most current phase for the claim",
-                                    "example": "UNDER_REVIEW"
-                                  }
-                                }
-                              },
-                              "closeDate": {
-                                "format": "date",
-                                "type": "string",
-                                "description": "Date claim was closed",
-                                "example": "2019-09-04"
-                              },
-                              "developmentLetterSent": {
-                                "type": "boolean",
-                                "description": "If true, a development letter has been sent to the claimant regarding a benefit claim",
-                                "example": "false"
-                              },
-                              "decisionLetterSent": {
-                                "type": "boolean",
-                                "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim",
-                                "example": "false"
-                              },
-                              "documentsNeeded": {
-                                "type": "boolean",
-                                "description": "If true, the claim requires additional documents to be submitted",
-                                "example": "false"
-                              },
-                              "endProductCode": {
-                                "type": "string",
-                                "description": "End product code of claim"
-                              },
-                              "evidenceWaiverSubmitted5103": {
-                                "type": "boolean",
-                                "nullable": true,
-                                "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
-                                "example": "false"
-                              },
-                              "lighthouseId": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "Claim ID in Lighthouse",
-                                "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "Status of claim",
-                                "enum": [
-                                  "PENDING",
-                                  "CLAIM_RECEIVED",
-                                  "INITIAL_REVIEW",
-                                  "EVIDENCE_GATHERING_REVIEW_DECISION",
-                                  "PREPARATION_FOR_NOTIFICATION",
-                                  "COMPLETE",
-                                  "ERRORED",
-                                  "CANCELED"
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "Not authorized",
-                      "detail": "Not authorized"
-                    }
-                  ]
-                },
-                "schema": {
-                  "required": [
-                    "errors"
-                  ],
-                  "properties": {
-                    "errors": {
-                      "type": "array",
-                      "items": {
-                        "additionalProperties": false,
-                        "required": [
-                          "title",
-                          "detail"
-                        ],
-                        "properties": {
-                          "title": {
-                            "type": "string",
-                            "description": "HTTP error title"
-                          },
-                          "detail": {
-                            "type": "string",
-                            "description": "HTTP error detail"
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "HTTP error status code"
-                          },
-                          "source": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "Source of error",
-                            "properties": {
-                              "pointer": {
-                                "type": "string",
-                                "description": "Pointer to source of error"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/veterans/{veteranId}/claims/{id}": {
-      "get": {
-        "summary": "Find claim by ID.",
-        "tags": [
-          "Claims"
-        ],
-        "operationId": "findClaimById",
-        "security": [
-          {
-            "productionOauth": [
-              "system/claim.read"
-            ]
-          },
-          {
-            "sandboxOauth": [
-              "system/claim.read"
-            ]
-          },
-          {
-            "bearer_token": [
-
-            ]
-          }
-        ],
-        "description": "Retrieves a specific claim for a Veteran",
+        "description": "Submit Evidence Waiver 5103 for Veteran.",
         "parameters": [
           {
             "name": "id",
@@ -658,510 +383,20 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "claim response",
+          "202": {
+            "description": "Successful response",
             "content": {
               "application/json": {
                 "example": {
-                  "data": {
-                    "id": "555555555",
-                    "type": "claim",
-                    "attributes": {
-                      "claimTypeCode": "400PREDSCHRG",
-                      "claimDate": "2017-05-02",
-                      "claimPhaseDates": {
-                        "phaseChangeDate": "2017-10-18",
-                        "currentPhaseBack": false,
-                        "latestPhaseType": "COMPLETE",
-                        "previousPhases": {
-                          "phase7CompleteDate": "2017-10-18"
-                        }
-                      },
-                      "claimType": "Compensation",
-                      "closeDate": "2017-10-18",
-                      "contentions": [
-                        {
-                          "name": "abnormal heart (New)"
-                        },
-                        {
-                          "name": "abscess kidney (New)"
-                        },
-                        {
-                          "name": "encephalitis lethargica residuals (New)"
-                        },
-                        {
-                          "name": "dracunculiasis (New)"
-                        },
-                        {
-                          "name": "gingivitis (New)"
-                        },
-                        {
-                          "name": "abnormal weight loss (New)"
-                        },
-                        {
-                          "name": "groin condition (New)"
-                        },
-                        {
-                          "name": "metritis (New)"
-                        }
-                      ],
-                      "decisionLetterSent": false,
-                      "developmentLetterSent": false,
-                      "documentsNeeded": false,
-                      "endProductCode": "404",
-                      "evidenceWaiverSubmitted5103": false,
-                      "errors": [
-
-                      ],
-                      "jurisdiction": "National Work Queue",
-                      "lighthouseId": null,
-                      "maxEstClaimDate": null,
-                      "minEstClaimDate": null,
-                      "status": "CANCELED",
-                      "submitterApplicationCode": "EBN",
-                      "submitterRoleCode": "VET",
-                      "supportingDocuments": [
-                        {
-                          "documentId": "{54EF0C16-A9E7-4C3F-B876-B2C7BEC1F834}",
-                          "documentTypeLabel": "Medical",
-                          "originalFileName": null,
-                          "trackedItemId": null,
-                          "uploadDate": null
-                        }
-                      ],
-                      "tempJurisdiction": null,
-                      "trackedItems": [
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "21-4142a",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293440,
-                          "uploadsAllowed": false
-                        },
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "Employment info needed",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293443,
-                          "uploadsAllowed": false
-                        },
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "Accidental injury - 21-4176 needed",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293444,
-                          "uploadsAllowed": false
-                        },
-                        {
-                          "closedDate": "2021-06-04",
-                          "description": null,
-                          "displayName": "Buddy mentioned - No complete address",
-                          "overdue": false,
-                          "receivedDate": null,
-                          "requestedDate": "2021-05-05",
-                          "status": "NO_LONGER_REQUIRED",
-                          "suspenseDate": "2021-06-04",
-                          "id": 293446,
-                          "uploadsAllowed": false
-                        }
-                      ]
-                    }
-                  }
+                  "success": true
                 },
                 "schema": {
-                  "$schema": "http://json-schema.org/draft-04/schema#",
                   "type": "object",
-                  "required": [
-                    "data"
-                  ],
+                  "additionalProperties": true,
                   "properties": {
-                    "data": {
-                      "type": "object",
-                      "required": [
-                        "id",
-                        "type",
-                        "attributes"
-                      ],
-                      "additionalProperties": false,
-                      "description": "Claim details",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
-                          "example": "600131328"
-                        },
-                        "type": {
-                          "type": "string",
-                          "example": "evss_claims"
-                        },
-                        "attributes": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "required": [
-                            "claimTypeCode",
-                            "claimDate",
-                            "claimPhaseDates",
-                            "claimType",
-                            "closeDate",
-                            "contentions",
-                            "decisionLetterSent",
-                            "developmentLetterSent",
-                            "documentsNeeded",
-                            "endProductCode",
-                            "evidenceWaiverSubmitted5103",
-                            "errors",
-                            "jurisdiction",
-                            "lighthouseId",
-                            "maxEstClaimDate",
-                            "minEstClaimDate",
-                            "status",
-                            "submitterApplicationCode",
-                            "submitterRoleCode",
-                            "supportingDocuments",
-                            "tempJurisdiction",
-                            "trackedItems"
-                          ],
-                          "properties": {
-                            "claimTypeCode": {
-                              "type": "string",
-                              "description": "Type code of benefit claim",
-                              "example": "400PREDSCHRG"
-                            },
-                            "claimType": {
-                              "type": "string",
-                              "description": "Name of claim type",
-                              "example": "Compensation"
-                            },
-                            "contentions": {
-                              "type": "array",
-                              "description": "The contentions being submitted with a claim",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "name": {
-                                    "type": "string",
-                                    "example": "abscess kidney (New)"
-                                  }
-                                }
-                              }
-                            },
-                            "claimDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "The date a claim was filed",
-                              "example": "2017-10-18"
-                            },
-                            "claimPhaseDates": {
-                              "type": "object",
-                              "properties": {
-                                "currentPhaseBack": {
-                                  "type": "boolean",
-                                  "description": "Indicates whether the current phase is moving backward."
-                                },
-                                "latestPhaseType": {
-                                  "type": "string",
-                                  "enum": [
-                                    "CLAIM_RECEIVED",
-                                    "UNDER_REVIEW",
-                                    "GATHERING_OF_EVIDENCE",
-                                    "REVIEW_OF_EVIDENCE",
-                                    "PREPARATION_FOR_DECISION",
-                                    "PENDING_DECISION_APPROVAL",
-                                    "PREPARATION_FOR_NOTIFICATION",
-                                    "COMPLETE"
-                                  ],
-                                  "nullable": true,
-                                  "description": "The most current phase for the claim"
-                                },
-                                "phaseChangeDate": {
-                                  "format": "date",
-                                  "type": "string",
-                                  "nullable": true,
-                                  "description": "The date that the claim changed to its current phase",
-                                  "example": "2017-10-18"
-                                },
-                                "previousPhases": {
-                                  "type": "object",
-                                  "properties": {
-                                    "phase1CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the claim received phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase2CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the initial review phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase3CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the gathering of evidence phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase4CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the reviewing of evidence phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase5CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the preparation for decision phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase6CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the pending decision approval phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase7CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the preparation for notification phase.",
-                                      "example": "2017-10-18"
-                                    },
-                                    "phase8CompleteDate": {
-                                      "format": "date",
-                                      "type": "string",
-                                      "description": "Completed date of the completed phase.",
-                                      "example": "2017-10-18"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "closeDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Date claim was closed",
-                              "example": "2019-09-04"
-                            },
-                            "decisionLetterSent": {
-                              "type": "boolean",
-                              "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim"
-                            },
-                            "developmentLetterSent": {
-                              "type": "boolean",
-                              "description": "If true, a development letter has been sent to the claimant regarding a benefit claim"
-                            },
-                            "documentsNeeded": {
-                              "type": "boolean",
-                              "description": "If true, the claim requires additional documents to be submitted"
-                            },
-                            "endProductCode": {
-                              "type": "string",
-                              "description": "End product code of claim",
-                              "example": "930"
-                            },
-                            "evidenceWaiverSubmitted5103": {
-                              "type": "boolean",
-                              "nullable": true,
-                              "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
-                              "example": "false"
-                            },
-                            "errors": {
-                              "type": "array",
-                              "description": "Error details if claim is in an errored state.",
-                              "items": {
-                                "properties": {
-                                  "detail": {
-                                    "type": "string",
-                                    "example": "Something happened"
-                                  },
-                                  "source": {
-                                    "type": "string",
-                                    "example": "some/error/path"
-                                  }
-                                }
-                              }
-                            },
-                            "jurisdiction": {
-                              "type": "string",
-                              "description": "Regional office to which the claim is currently assigned."
-                            },
-                            "lighthouseId": {
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Claim ID in Lighthouse",
-                              "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
-                            },
-                            "minEstClaimDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Minimum estimated claim completion date",
-                              "example": "2019-06-04"
-                            },
-                            "maxEstClaimDate": {
-                              "format": "date",
-                              "type": "string",
-                              "nullable": true,
-                              "description": "Maximum estimated claim completion date",
-                              "example": "2019-09-04"
-                            },
-                            "status": {
-                              "type": "string",
-                              "description": "Status of claim",
-                              "enum": [
-                                "PENDING",
-                                "CLAIM_RECEIVED",
-                                "INITIAL_REVIEW",
-                                "EVIDENCE_GATHERING_REVIEW_DECISION",
-                                "PREPARATION_FOR_NOTIFICATION",
-                                "COMPLETE",
-                                "ERRORED",
-                                "CANCELED"
-                              ]
-                            },
-                            "submitterApplicationCode": {
-                              "type": "string",
-                              "description": "Application code of benefit claim submitter",
-                              "example": "EBN"
-                            },
-                            "submitterRoleCode": {
-                              "type": "string",
-                              "description": "Role code of benefit claim submitter",
-                              "example": "VET"
-                            },
-                            "supportingDocuments": {
-                              "type": "array",
-                              "description": "Information regarding any supported documents attached to a claim",
-                              "items": {
-                                "properties": {
-                                  "documentId": {
-                                    "type": "string",
-                                    "description": "Unique identifier of document"
-                                  },
-                                  "documentTypeLabel": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "originalFileName": {
-                                    "type": "string",
-                                    "description": "Name of document",
-                                    "nullable": true
-                                  },
-                                  "trackedItemId": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "uploadDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "description": "Date and time document was uploaded",
-                                    "nullable": true
-                                  }
-                                }
-                              }
-                            },
-                            "tempJurisdiction": {
-                              "type": "string",
-                              "description": "Temporary jurisdiction of claim"
-                            },
-                            "trackedItems": {
-                              "type": "array",
-                              "description": "",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                  "closedDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Date the tracked item was closed",
-                                    "example": "2017-10-18"
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Description of the tracked item",
-                                    "example": "You may also submit statements from individuals having knowledge of your claimed condition."
-                                  },
-                                  "requestedDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Date the tracked item was requested",
-                                    "example": "2017-10-18"
-                                  },
-                                  "id": {
-                                    "type": "integer",
-                                    "description": "ID of the tracked item",
-                                    "example": 293454
-                                  },
-                                  "displayName": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Description of the tracked item",
-                                    "example": "Submit buddy statement(s)"
-                                  },
-                                  "receivedDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Date the tracked item was received",
-                                    "example": "2017-10-18"
-                                  },
-                                  "overdue": {
-                                    "type": "boolean",
-                                    "nullable": true,
-                                    "description": "True if the item is overdue",
-                                    "example": true
-                                  },
-                                  "status": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Enum with the status of the tracked item",
-                                    "example": "NO_LONGER_REQUIRED",
-                                    "enum": [
-                                      "ACCEPTED",
-                                      "INITIAL_REVIEW_COMPLETE",
-                                      "NEEDED_FROM_YOU",
-                                      "NEEDED_FROM_OTHERS",
-                                      "NO_LONGER_REQUIRED",
-                                      "SUBMITTED_AWAITING_REVIEW"
-                                    ]
-                                  },
-                                  "suspenseDate": {
-                                    "format": "date",
-                                    "type": "string",
-                                    "nullable": true,
-                                    "example": "2017-10-18"
-                                  },
-                                  "uploadsAllowed": {
-                                    "type": "boolean",
-                                    "example": true
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
+                    "success": {
+                      "type": "boolean",
+                      "example": "true"
                     }
                   }
                 }
@@ -1176,6 +411,7 @@
                   "errors": [
                     {
                       "title": "Not authorized",
+                      "status": "401",
                       "detail": "Not authorized"
                     }
                   ]
@@ -1226,12 +462,13 @@
             }
           },
           "404": {
-            "description": "Resource not found",
+            "description": "NotFound",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
+                      "status": "404",
                       "title": "Resource not found",
                       "detail": "Claim not found"
                     }
@@ -1276,6 +513,50 @@
                           }
                         }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "attributes": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "description": "Claims API 5103 Schema",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "trackedItemIds": {
+                            "description": "Array of tracked items ids.",
+                            "type": "array",
+                            "nullable": true,
+                            "uniqueItems": true,
+                            "items": {
+                              "type": "integer",
+                              "additionalProperties": false
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "type": "form/5103",
+                    "attributes": {
+                      "trackedItemIds": [
+                        1234
+                      ]
                     }
                   }
                 }
@@ -1768,7 +1049,7 @@
                                     "otherLocationsServed": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Other location(s) where Veteran served."
                                     },
@@ -1822,7 +1103,7 @@
                                     "specifyOtherExposures": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
@@ -1868,7 +1149,7 @@
                                       "exposureLocation": {
                                         "type": "string",
                                         "nullable": true,
-                                        "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                        "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
@@ -3148,7 +2429,7 @@
                                   "otherLocationsServed": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
@@ -3202,7 +2483,7 @@
                                   "specifyOtherExposures": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
@@ -3248,7 +2529,7 @@
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
@@ -4401,7 +3682,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "fd7cb618-ed63-464c-83f9-8ad7a5cb6483",
+                        "id": "0db55941-4811-4fd9-80cd-f743761a64ea",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -4586,7 +3867,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2024-08-30"
+                              "anticipatedSeparationDate": "2024-08-31"
                             },
                             "confinements": [
                               {
@@ -4632,7 +3913,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "bbdf1d40-84d4-4b3e-96bc-48d52c9bb126",
+                        "id": "01a05245-ad48-47c0-b044-60bd1a1cf4d5",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -5303,7 +4584,7 @@
                                     "otherLocationsServed": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Other location(s) where Veteran served."
                                     },
@@ -5357,7 +4638,7 @@
                                     "specifyOtherExposures": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 5000,
                                       "description": "Exposure to asbestos."
                                     },
@@ -5403,7 +4684,7 @@
                                       "exposureLocation": {
                                         "type": "string",
                                         "nullable": true,
-                                        "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                        "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                         "maxLength": 1000,
                                         "description": "Location where the exposure happened."
                                       },
@@ -6683,7 +5964,7 @@
                                   "otherLocationsServed": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
@@ -6737,7 +6018,7 @@
                                   "specifyOtherExposures": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
@@ -6783,7 +6064,7 @@
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
@@ -8840,7 +8121,7 @@
                                   "otherLocationsServed": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Other location(s) where Veteran served."
                                   },
@@ -8894,7 +8175,7 @@
                                   "specifyOtherExposures": {
                                     "type": "string",
                                     "nullable": true,
-                                    "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                    "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                     "maxLength": 5000,
                                     "description": "Exposure to asbestos."
                                   },
@@ -8940,7 +8221,7 @@
                                     "exposureLocation": {
                                       "type": "string",
                                       "nullable": true,
-                                      "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                                      "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                                       "maxLength": 1000,
                                       "description": "Location where the exposure happened."
                                     },
@@ -9838,7 +9119,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "ccbebd29-093b-4bf4-b423-0f34a327fd9f",
+                    "id": "746039f5-8aa5-49b5-abea-5ed07ac16b35",
                     "type": "forms/526",
                     "attributes": {
                       "claimProcessType": "STANDARD_CLAIM_PROCESS",
@@ -12257,22 +11538,22 @@
         }
       }
     },
-    "/veterans/{veteranId}/claims/{id}/5103": {
-      "post": {
-        "summary": "Submit Evidence Waiver 5103",
+    "/veterans/{veteranId}/claims": {
+      "get": {
+        "summary": "Find all benefits claims for a Veteran.",
         "tags": [
-          "5103 Waiver"
+          "Claims"
         ],
-        "operationId": "submitEvidenceWaiver5103",
+        "operationId": "findClaims",
         "security": [
           {
             "productionOauth": [
-              "system/claim.write"
+              "system/claim.read"
             ]
           },
           {
             "sandboxOauth": [
-              "system/claim.write"
+              "system/claim.read"
             ]
           },
           {
@@ -12281,7 +11562,282 @@
             ]
           }
         ],
-        "description": "Submit Evidence Waiver 5103 for Veteran.",
+        "parameters": [
+          {
+            "name": "veteranId",
+            "in": "path",
+            "required": true,
+            "example": "1012667145V762142",
+            "description": "ID of Veteran",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "claim response",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "id": "555555555",
+                      "type": "claim",
+                      "attributes": {
+                        "baseEndProductCode": "400",
+                        "claimDate": "2017-05-02",
+                        "claimPhaseDates": {
+                          "phaseChangeDate": "2017-10-18",
+                          "phaseType": "COMPLETE"
+                        },
+                        "claimType": "Compensation",
+                        "claimTypeCode": "400PREDSCHRG",
+                        "closeDate": "2017-10-18",
+                        "decisionLetterSent": false,
+                        "developmentLetterSent": false,
+                        "documentsNeeded": false,
+                        "endProductCode": "404",
+                        "evidenceWaiverSubmitted5103": false,
+                        "lighthouseId": null,
+                        "status": "COMPLETE"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "required": [
+                          "id",
+                          "type",
+                          "attributes"
+                        ],
+                        "additionalProperties": false,
+                        "description": "Claim details",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
+                            "example": "600131328"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "claim"
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "required": [
+                              "baseEndProductCode",
+                              "claimType",
+                              "claimDate",
+                              "claimPhaseDates",
+                              "closeDate",
+                              "developmentLetterSent",
+                              "decisionLetterSent",
+                              "documentsNeeded",
+                              "endProductCode",
+                              "evidenceWaiverSubmitted5103",
+                              "lighthouseId",
+                              "status"
+                            ],
+                            "properties": {
+                              "baseEndProductCode": {
+                                "type": "string",
+                                "description": "Base end product code for claim",
+                                "example": "400"
+                              },
+                              "claimType": {
+                                "type": "string",
+                                "description": "Name of claim type",
+                                "example": "Compensation"
+                              },
+                              "claimDate": {
+                                "format": "date",
+                                "type": "string",
+                                "description": "Date the claim was first filed. In YYYY-MM-DD format.",
+                                "example": "2018-06-04"
+                              },
+                              "claimPhaseDates": {
+                                "type": "object",
+                                "properties": {
+                                  "phaseChangeDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "description": "The date that the claim changed to its current phase",
+                                    "example": "2017-10-18"
+                                  },
+                                  "phaseType": {
+                                    "type": "string",
+                                    "enum": [
+                                      "CLAIM_RECEIVED",
+                                      "UNDER_REVIEW",
+                                      "GATHERING_OF_EVIDENCE",
+                                      "REVIEW_OF_EVIDENCE",
+                                      "PREPARATION_FOR_DECISION",
+                                      "PENDING_DECISION_APPROVAL",
+                                      "PREPARATION_FOR_NOTIFICATION",
+                                      "COMPLETE"
+                                    ],
+                                    "description": "The most current phase for the claim",
+                                    "example": "UNDER_REVIEW"
+                                  }
+                                }
+                              },
+                              "closeDate": {
+                                "format": "date",
+                                "type": "string",
+                                "description": "Date claim was closed",
+                                "example": "2019-09-04"
+                              },
+                              "developmentLetterSent": {
+                                "type": "boolean",
+                                "description": "If true, a development letter has been sent to the claimant regarding a benefit claim",
+                                "example": "false"
+                              },
+                              "decisionLetterSent": {
+                                "type": "boolean",
+                                "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim",
+                                "example": "false"
+                              },
+                              "documentsNeeded": {
+                                "type": "boolean",
+                                "description": "If true, the claim requires additional documents to be submitted",
+                                "example": "false"
+                              },
+                              "endProductCode": {
+                                "type": "string",
+                                "description": "End product code of claim"
+                              },
+                              "evidenceWaiverSubmitted5103": {
+                                "type": "boolean",
+                                "nullable": true,
+                                "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
+                                "example": "false"
+                              },
+                              "lighthouseId": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Claim ID in Lighthouse",
+                                "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
+                              },
+                              "status": {
+                                "type": "string",
+                                "description": "Status of claim",
+                                "enum": [
+                                  "PENDING",
+                                  "CLAIM_RECEIVED",
+                                  "INITIAL_REVIEW",
+                                  "EVIDENCE_GATHERING_REVIEW_DECISION",
+                                  "PREPARATION_FOR_NOTIFICATION",
+                                  "COMPLETE",
+                                  "ERRORED",
+                                  "CANCELED"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Not authorized",
+                      "detail": "Not authorized"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/veterans/{veteranId}/claims/{id}": {
+      "get": {
+        "summary": "Find claim by ID.",
+        "tags": [
+          "Claims"
+        ],
+        "operationId": "findClaimById",
+        "security": [
+          {
+            "productionOauth": [
+              "system/claim.read"
+            ]
+          },
+          {
+            "sandboxOauth": [
+              "system/claim.read"
+            ]
+          },
+          {
+            "bearer_token": [
+
+            ]
+          }
+        ],
+        "description": "Retrieves a specific claim for a Veteran",
         "parameters": [
           {
             "name": "id",
@@ -12305,20 +11861,510 @@
           }
         ],
         "responses": {
-          "202": {
-            "description": "Successful response",
+          "200": {
+            "description": "claim response",
             "content": {
               "application/json": {
                 "example": {
-                  "success": true
+                  "data": {
+                    "id": "555555555",
+                    "type": "claim",
+                    "attributes": {
+                      "claimTypeCode": "400PREDSCHRG",
+                      "claimDate": "2017-05-02",
+                      "claimPhaseDates": {
+                        "phaseChangeDate": "2017-10-18",
+                        "currentPhaseBack": false,
+                        "latestPhaseType": "COMPLETE",
+                        "previousPhases": {
+                          "phase7CompleteDate": "2017-10-18"
+                        }
+                      },
+                      "claimType": "Compensation",
+                      "closeDate": "2017-10-18",
+                      "contentions": [
+                        {
+                          "name": "abnormal heart (New)"
+                        },
+                        {
+                          "name": "abscess kidney (New)"
+                        },
+                        {
+                          "name": "encephalitis lethargica residuals (New)"
+                        },
+                        {
+                          "name": "dracunculiasis (New)"
+                        },
+                        {
+                          "name": "gingivitis (New)"
+                        },
+                        {
+                          "name": "abnormal weight loss (New)"
+                        },
+                        {
+                          "name": "groin condition (New)"
+                        },
+                        {
+                          "name": "metritis (New)"
+                        }
+                      ],
+                      "decisionLetterSent": false,
+                      "developmentLetterSent": false,
+                      "documentsNeeded": false,
+                      "endProductCode": "404",
+                      "evidenceWaiverSubmitted5103": false,
+                      "errors": [
+
+                      ],
+                      "jurisdiction": "National Work Queue",
+                      "lighthouseId": null,
+                      "maxEstClaimDate": null,
+                      "minEstClaimDate": null,
+                      "status": "CANCELED",
+                      "submitterApplicationCode": "EBN",
+                      "submitterRoleCode": "VET",
+                      "supportingDocuments": [
+                        {
+                          "documentId": "{54EF0C16-A9E7-4C3F-B876-B2C7BEC1F834}",
+                          "documentTypeLabel": "Medical",
+                          "originalFileName": null,
+                          "trackedItemId": null,
+                          "uploadDate": null
+                        }
+                      ],
+                      "tempJurisdiction": null,
+                      "trackedItems": [
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "21-4142a",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293440,
+                          "uploadsAllowed": false
+                        },
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "Employment info needed",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293443,
+                          "uploadsAllowed": false
+                        },
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "Accidental injury - 21-4176 needed",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293444,
+                          "uploadsAllowed": false
+                        },
+                        {
+                          "closedDate": "2021-06-04",
+                          "description": null,
+                          "displayName": "Buddy mentioned - No complete address",
+                          "overdue": false,
+                          "receivedDate": null,
+                          "requestedDate": "2021-05-05",
+                          "status": "NO_LONGER_REQUIRED",
+                          "suspenseDate": "2021-06-04",
+                          "id": 293446,
+                          "uploadsAllowed": false
+                        }
+                      ]
+                    }
+                  }
                 },
                 "schema": {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
                   "type": "object",
-                  "additionalProperties": true,
+                  "required": [
+                    "data"
+                  ],
                   "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": "true"
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
+                      "additionalProperties": false,
+                      "description": "Claim details",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Claim ID in VBMS. If a claim was submitted with Lighthouse and not successfully established upstream, it could have a null claimId.",
+                          "example": "600131328"
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "evss_claims"
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "claimTypeCode",
+                            "claimDate",
+                            "claimPhaseDates",
+                            "claimType",
+                            "closeDate",
+                            "contentions",
+                            "decisionLetterSent",
+                            "developmentLetterSent",
+                            "documentsNeeded",
+                            "endProductCode",
+                            "evidenceWaiverSubmitted5103",
+                            "errors",
+                            "jurisdiction",
+                            "lighthouseId",
+                            "maxEstClaimDate",
+                            "minEstClaimDate",
+                            "status",
+                            "submitterApplicationCode",
+                            "submitterRoleCode",
+                            "supportingDocuments",
+                            "tempJurisdiction",
+                            "trackedItems"
+                          ],
+                          "properties": {
+                            "claimTypeCode": {
+                              "type": "string",
+                              "description": "Type code of benefit claim",
+                              "example": "400PREDSCHRG"
+                            },
+                            "claimType": {
+                              "type": "string",
+                              "description": "Name of claim type",
+                              "example": "Compensation"
+                            },
+                            "contentions": {
+                              "type": "array",
+                              "description": "The contentions being submitted with a claim",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "example": "abscess kidney (New)"
+                                  }
+                                }
+                              }
+                            },
+                            "claimDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "The date a claim was filed",
+                              "example": "2017-10-18"
+                            },
+                            "claimPhaseDates": {
+                              "type": "object",
+                              "properties": {
+                                "currentPhaseBack": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the current phase is moving backward."
+                                },
+                                "latestPhaseType": {
+                                  "type": "string",
+                                  "enum": [
+                                    "CLAIM_RECEIVED",
+                                    "UNDER_REVIEW",
+                                    "GATHERING_OF_EVIDENCE",
+                                    "REVIEW_OF_EVIDENCE",
+                                    "PREPARATION_FOR_DECISION",
+                                    "PENDING_DECISION_APPROVAL",
+                                    "PREPARATION_FOR_NOTIFICATION",
+                                    "COMPLETE"
+                                  ],
+                                  "nullable": true,
+                                  "description": "The most current phase for the claim"
+                                },
+                                "phaseChangeDate": {
+                                  "format": "date",
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "The date that the claim changed to its current phase",
+                                  "example": "2017-10-18"
+                                },
+                                "previousPhases": {
+                                  "type": "object",
+                                  "properties": {
+                                    "phase1CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the claim received phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase2CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the initial review phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase3CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the gathering of evidence phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase4CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the reviewing of evidence phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase5CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the preparation for decision phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase6CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the pending decision approval phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase7CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the preparation for notification phase.",
+                                      "example": "2017-10-18"
+                                    },
+                                    "phase8CompleteDate": {
+                                      "format": "date",
+                                      "type": "string",
+                                      "description": "Completed date of the completed phase.",
+                                      "example": "2017-10-18"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "closeDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Date claim was closed",
+                              "example": "2019-09-04"
+                            },
+                            "decisionLetterSent": {
+                              "type": "boolean",
+                              "description": "If true, a decision letter has been sent to the claimant regarding a benefit claim"
+                            },
+                            "developmentLetterSent": {
+                              "type": "boolean",
+                              "description": "If true, a development letter has been sent to the claimant regarding a benefit claim"
+                            },
+                            "documentsNeeded": {
+                              "type": "boolean",
+                              "description": "If true, the claim requires additional documents to be submitted"
+                            },
+                            "endProductCode": {
+                              "type": "string",
+                              "description": "End product code of claim",
+                              "example": "930"
+                            },
+                            "evidenceWaiverSubmitted5103": {
+                              "type": "boolean",
+                              "nullable": true,
+                              "description": "If true, indicates a decision has been requested and/or a Waiver 5103 has been submitted",
+                              "example": "false"
+                            },
+                            "errors": {
+                              "type": "array",
+                              "description": "Error details if claim is in an errored state.",
+                              "items": {
+                                "properties": {
+                                  "detail": {
+                                    "type": "string",
+                                    "example": "Something happened"
+                                  },
+                                  "source": {
+                                    "type": "string",
+                                    "example": "some/error/path"
+                                  }
+                                }
+                              }
+                            },
+                            "jurisdiction": {
+                              "type": "string",
+                              "description": "Regional office to which the claim is currently assigned."
+                            },
+                            "lighthouseId": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Claim ID in Lighthouse",
+                              "example": "0BAEFC26-1CE4-4046-9B3C-3071055603DB"
+                            },
+                            "minEstClaimDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Minimum estimated claim completion date",
+                              "example": "2019-06-04"
+                            },
+                            "maxEstClaimDate": {
+                              "format": "date",
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Maximum estimated claim completion date",
+                              "example": "2019-09-04"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Status of claim",
+                              "enum": [
+                                "PENDING",
+                                "CLAIM_RECEIVED",
+                                "INITIAL_REVIEW",
+                                "EVIDENCE_GATHERING_REVIEW_DECISION",
+                                "PREPARATION_FOR_NOTIFICATION",
+                                "COMPLETE",
+                                "ERRORED",
+                                "CANCELED"
+                              ]
+                            },
+                            "submitterApplicationCode": {
+                              "type": "string",
+                              "description": "Application code of benefit claim submitter",
+                              "example": "EBN"
+                            },
+                            "submitterRoleCode": {
+                              "type": "string",
+                              "description": "Role code of benefit claim submitter",
+                              "example": "VET"
+                            },
+                            "supportingDocuments": {
+                              "type": "array",
+                              "description": "Information regarding any supported documents attached to a claim",
+                              "items": {
+                                "properties": {
+                                  "documentId": {
+                                    "type": "string",
+                                    "description": "Unique identifier of document"
+                                  },
+                                  "documentTypeLabel": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "originalFileName": {
+                                    "type": "string",
+                                    "description": "Name of document",
+                                    "nullable": true
+                                  },
+                                  "trackedItemId": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "uploadDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "description": "Date and time document was uploaded",
+                                    "nullable": true
+                                  }
+                                }
+                              }
+                            },
+                            "tempJurisdiction": {
+                              "type": "string",
+                              "description": "Temporary jurisdiction of claim"
+                            },
+                            "trackedItems": {
+                              "type": "array",
+                              "description": "",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                  "closedDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Date the tracked item was closed",
+                                    "example": "2017-10-18"
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Description of the tracked item",
+                                    "example": "You may also submit statements from individuals having knowledge of your claimed condition."
+                                  },
+                                  "requestedDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Date the tracked item was requested",
+                                    "example": "2017-10-18"
+                                  },
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "ID of the tracked item",
+                                    "example": 293454
+                                  },
+                                  "displayName": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Description of the tracked item",
+                                    "example": "Submit buddy statement(s)"
+                                  },
+                                  "receivedDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Date the tracked item was received",
+                                    "example": "2017-10-18"
+                                  },
+                                  "overdue": {
+                                    "type": "boolean",
+                                    "nullable": true,
+                                    "description": "True if the item is overdue",
+                                    "example": true
+                                  },
+                                  "status": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Enum with the status of the tracked item",
+                                    "example": "NO_LONGER_REQUIRED",
+                                    "enum": [
+                                      "ACCEPTED",
+                                      "INITIAL_REVIEW_COMPLETE",
+                                      "NEEDED_FROM_YOU",
+                                      "NEEDED_FROM_OTHERS",
+                                      "NO_LONGER_REQUIRED",
+                                      "SUBMITTED_AWAITING_REVIEW"
+                                    ]
+                                  },
+                                  "suspenseDate": {
+                                    "format": "date",
+                                    "type": "string",
+                                    "nullable": true,
+                                    "example": "2017-10-18"
+                                  },
+                                  "uploadsAllowed": {
+                                    "type": "boolean",
+                                    "example": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -12333,7 +12379,6 @@
                   "errors": [
                     {
                       "title": "Not authorized",
-                      "status": "401",
                       "detail": "Not authorized"
                     }
                   ]
@@ -12384,13 +12429,12 @@
             }
           },
           "404": {
-            "description": "NotFound",
+            "description": "Resource not found",
             "content": {
               "application/json": {
                 "example": {
                   "errors": [
                     {
-                      "status": "404",
                       "title": "Resource not found",
                       "detail": "Claim not found"
                     }
@@ -12435,50 +12479,6 @@
                           }
                         }
                       }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "data": {
-                    "type": "object",
-                    "properties": {
-                      "attributes": {
-                        "$schema": "http://json-schema.org/draft-07/schema#",
-                        "description": "Claims API 5103 Schema",
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                          "trackedItemIds": {
-                            "description": "Array of tracked items ids.",
-                            "type": "array",
-                            "nullable": true,
-                            "uniqueItems": true,
-                            "items": {
-                              "type": "integer",
-                              "additionalProperties": false
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "example": {
-                  "data": {
-                    "type": "form/5103",
-                    "attributes": {
-                      "trackedItemIds": [
-                        1234
-                      ]
                     }
                   }
                 }
@@ -12779,8 +12779,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2024-08-28",
-                      "expirationDate": "2025-08-28",
+                      "creationDate": "2024-08-29",
+                      "expirationDate": "2025-08-29",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -13676,7 +13676,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "79f52c9f-c573-4765-9ddf-458ddbc0c19e",
+                    "id": "69b82793-223a-4d60-ab61-eb67ddb77fc6",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -14369,7 +14369,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "b9872c12-3dce-41f2-9fae-6cb5795567f1",
+                    "id": "5cfd4d55-d0c5-4476-87c1-a1956c8dc02b",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -16320,10 +16320,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "7fa8fc2f-160b-4792-969c-29ba45feff3a",
+                    "id": "22563f3d-74c4-44b8-b2a0-0da7bfe639a4",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "dateRequestAccepted": "2024-08-28",
+                      "dateRequestAccepted": "2024-08-29",
                       "previousPoa": null,
                       "representative": {
                         "serviceOrganization": {

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -402,7 +402,7 @@
             "otherLocationsServed": {
               "type": ["string", "null"],
               "nullable": true,
-              "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+              "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
               "maxLength": 5000,
               "description": "Other location(s) where Veteran served."
             },
@@ -457,7 +457,7 @@
             "specifyOtherExposures": {
               "type": ["string", "null"],
               "nullable": true,
-              "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+              "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
               "maxLength": 5000,
               "description": "Exposure to asbestos."
             },
@@ -503,7 +503,7 @@
               "exposureLocation": {
                 "type": ["string", "null"],
                 "nullable": true,
-                "pattern": "^([-a-zA-Z0-9'.,&# ])+$",
+                "pattern": "^$|([a-zA-Z0-9\"\\/&\\(\\)\\-'.,#\\[\\] ]([a-zA-Z0-9(\\)\\-'.,#\\[\\] ])?)+$",
                 "maxLength": 1000,
                 "description": "Location where the exposure happened."
               },

--- a/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
@@ -1031,14 +1031,14 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
         context 'when the other_locations_served does not match the regex' do
           let(:other_locations_served) { 'some !@#@#$#%$^%$#&$^%&&(*978078)' }
 
-          it 'responds with a 422' do
+          it 'responds with a 202' do
             mock_ccg(scopes) do |auth_header|
               json = JSON.parse(data)
               json['data']['attributes']['toxicExposure']['herbicideHazardService']['otherLocationsServed'] =
                 other_locations_served
               data = json.to_json
               post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response).to have_http_status(:accepted)
             end
           end
         end
@@ -1061,14 +1061,14 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
         context 'when the specify_other_exposures does not match the regex' do
           let(:specify_other_exposures) { 'some !@#@#$#%$^%$#&$^%&&(*978078)' }
 
-          it 'responds with a bad request' do
+          it 'responds with a accepted' do
             mock_ccg(scopes) do |auth_header|
               json = JSON.parse(data)
               json['data']['attributes']['toxicExposure']['additionalHazardExposures']['specifyOtherExposures'] =
                 specify_other_exposures
               data = json.to_json
               post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response).to have_http_status(:accepted)
             end
           end
         end
@@ -1076,14 +1076,14 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
         context 'when the exposure_location does not match the regex' do
           let(:exposure_location) { 'some !@#@#$#%$^%$#&$^%&&(*978078)' }
 
-          it 'responds with a bad request' do
+          it 'responds with a accepted' do
             mock_ccg(scopes) do |auth_header|
               json = JSON.parse(data)
               json['data']['attributes']['toxicExposure']['multipleExposures'][0]['exposureLocation'] =
                 exposure_location
               data = json.to_json
               post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response).to have_http_status(:accepted)
             end
           end
         end


### PR DESCRIPTION
## Summary

- Softens restrictions/regex pattern for toxicExposure.herbicideHazardService.otherLocationsServed, toxicExposure.additionalHazardExposures.specifyOtherExposures, 
toxicExposure.multipleExposures.exposureLocation. 
- Updates v2/dev/swagger.json & v2/production/swagger.json. 
- Updates tests.

## Related issue(s)

- [API-39674](https://jira.devops.va.gov/browse/API-39674)

## Testing done

- [ ] *New code is covered by unit tests*
- Postman v2 526 sync


## Screenshots
<img width="1218" alt="Screenshot 2024-08-29 at 11 43 26 AM" src="https://github.com/user-attachments/assets/bf8bef7d-0720-4a3f-8a45-1a34b6850571">


## What areas of the site does it impact?
	modified:   modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
	modified:   modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
	modified:   modules/claims_api/config/schemas/v2/526.json
	modified:   modules/claims_api/spec/requests/v2/veterans/526_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

Regex suggestions
