### PR TITLE
VA-90998: Add caching and metrics to VBS copayments

### DIFF
--- a/app/models/concerns/redis_caching.rb
+++ b/app/models/concerns/redis_caching.rb
@@ -30,5 +30,12 @@ module RedisCaching
     def clear_cache(key)
       @redis.del(key)
     end
+
+    def time_until_5am_utc
+      now = Time.now.utc
+      five_am_utc = Time.utc(now.year, now.month, now.day, 5)
+      five_am_utc += 1.day if now >= five_am_utc
+      five_am_utc - now
+    end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -317,6 +317,9 @@ features:
   debts_cache_dmc_empty_response:
     actor_type: user
     description: Enables caching of empty DMC response
+  debts_cache_vbs_copays_empty_response:
+    actor_type: user
+    description: Enables caching of empty VBS medical copay response
   decision_review_hlr_email:
     actor_type: user
     description: Send email notification for successful HLR submission

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -6,6 +6,7 @@ require 'debt_management_center/responses/debts_response'
 
 module DebtManagementCenter
   class DebtsService < DebtManagementCenter::BaseService
+    include RedisCaching
     attr_reader :file_number
 
     class DebtNotFound < StandardError; end
@@ -98,7 +99,7 @@ module DebtManagementCenter
 
         if response.is_a?(Array) && response.empty?
           # DMC refreshes DB at 5am every morning
-          Rails.cache.write(cache_key, response, expires_in: time_until_5am_utc)
+          Rails.cache.write(cache_key, response, expires_in: self.class.time_until_5am_utc)
           StatsD.increment("#{STATSD_KEY_PREFIX}.init_cached_debts.empty_response_cached")
         end
 
@@ -115,13 +116,6 @@ module DebtManagementCenter
 
     def sort_by_date(debt_history)
       debt_history.sort_by { |d| Date.strptime(d['date'], '%m/%d/%Y') }.reverse
-    end
-
-    def time_until_5am_utc
-      now = Time.now.utc
-      five_am_utc = Time.utc(now.year, now.month, now.day, 5)
-      five_am_utc += 1.day if now >= five_am_utc
-      five_am_utc - now
     end
   end
 end


### PR DESCRIPTION
## Summary

This adds caching for empty requests for the VBA copay endpoints to lighten some of their load. It also adds DataDog tracking to monitor how often it is used. This functionality is hidden behind the `debts_cache_vbs_copays_empty_response` feature flag.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90998

## Testing done

- [x] *New code is covered by unit tests*

New tests check that the proper functions are called when expected for the caching and that the correct DataDog metrics are tracked.

## What areas of the site does it impact?

* VBS Medical Copays

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
