### PR TITLE
[API-39419] Add `find_dependents_by_ptcpnt_id` to local bgs

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -201,6 +201,15 @@ module ClaimsApi
             path: 'PersonWebService'
           )
 
+        module FindDependentsByPtcpntId
+          DEFINITION =
+            Action.new(
+              service: PersonWebService::DEFINITION,
+              name: 'findDependentsByPtcpntId',
+              key: 'DependentDTO'
+            )
+        end
+
         module FindPersonBySSN
           DEFINITION =
             Action.new(

--- a/modules/claims_api/lib/bgs_service/local_bgs.rb
+++ b/modules/claims_api/lib/bgs_service/local_bgs.rb
@@ -18,6 +18,7 @@ module ClaimsApi
       ClaimantServiceBean/ClaimantWebService
       OrgWebServiceBean/OrgWebService
       IntentToFileWebServiceBean/IntentToFileWebService
+      PersonWebServiceBean/PersonWebService
       StandardDataWebServiceBean/StandardDataWebService
       VDC/VeteranRepresentativeService
       VdcBean/ManageRepresentativeService

--- a/modules/claims_api/lib/bgs_service/person_web_service.rb
+++ b/modules/claims_api/lib/bgs_service/person_web_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  class PersonWebService < ClaimsApi::LocalBGS
+    def bean_name
+      'PersonWebServiceBean/PersonWebService'
+    end
+
+    def find_dependents_by_ptcpnt_id(id)
+      body = Nokogiri::XML::DocumentFragment.parse <<~EOXML
+        <ptcpntId />
+      EOXML
+
+      { ptcpntId: id }.each do |k, v|
+        body.xpath("./*[local-name()='#{k}']").first.content = v
+      end
+
+      make_request(endpoint: bean_name, action: 'findDependentsByPtcpntId', body:, key: 'DependentDTO')
+    end
+  end
+end

--- a/modules/claims_api/spec/lib/claims_api/person_web_service_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/person_web_service_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'bgs_service/person_web_service'
+
+describe ClaimsApi::PersonWebService do
+  subject { described_class.new external_uid: 'xUid', external_key: 'xKey' }
+
+  describe '#find_dependents_by_ptcpnt_id' do
+    it 'responds as expected' do
+      VCR.use_cassette('claims_api/bgs/claimant_web_service/find_dependents_by_ptcpnt_id') do
+        # rubocop:disable Style/NumericLiterals
+        result = subject.find_dependents_by_ptcpnt_id(600052699)
+        # rubocop:enable Style/NumericLiterals
+        expect(result).to be_a Hash
+        expect(result[:dependent][:first_nm]).to eq 'MARGIE'
+      end
+    end
+  end
+end

--- a/spec/support/vcr_cassettes/claims_api/bgs/claimant_web_service/find_dependents_by_ptcpnt_id.yml
+++ b/spec/support/vcr_cassettes/claims_api/bgs/claimant_web_service/find_dependents_by_ptcpnt_id.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<BGS_BASE_URL>/PersonWebServiceBean/PersonWebService"
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+          <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://person.services.vetsnet.vba.va.gov/" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+          <env:Header>
+          <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+            <wsse:UsernameToken>
+              <wsse:Username>VAgovAPI</wsse:Username>
+            </wsse:UsernameToken>
+            <vaws:VaServiceHeaders xmlns:vaws="http://vbawebservices.vba.va.gov/vawss">
+              <vaws:CLIENT_MACHINE>127.0.0.1</vaws:CLIENT_MACHINE>
+              <vaws:STN_ID>281</vaws:STN_ID>
+              <vaws:applicationName>VAgovAPI</vaws:applicationName>
+              <vaws:ExternalUid>xUid</vaws:ExternalUid>
+              <vaws:ExternalKey>xKey</vaws:ExternalKey>
+            </vaws:VaServiceHeaders>
+          </wsse:Security>
+        </env:Header>
+
+          <env:Body>
+            <tns:findDependentsByPtcpntId><ptcpntId>600052699</ptcpntId>
+        </tns:findDependentsByPtcpntId>
+          </env:Body>
+          </env:Envelope>
+    headers:
+      User-Agent:
+      - "<FARADAY_VERSION>"
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Host:
+      - ".vba.va.gov"
+      Soapaction:
+      - '"findDependentsByPtcpntId"'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Sep 2024 17:07:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><env:Header><work:WorkContext
+        xmlns:work="http://oracle.com/weblogic/soap/workarea/">rO0ABXdUAB13ZWJsb2dpYy5hcHAuQ29ycG9yYXRlRGF0YUVBUgAAANYAAAAjd2VibG9naWMud29ya2FyZWEuU3RyaW5nV29ya0NvbnRleHQABjMuMy40MgAA</work:WorkContext></env:Header><S:Body><ns0:findDependentsByPtcpntIdResponse
+        xmlns:ns0="http://person.services.vetsnet.vba.va.gov/"><DependentDTO><dependent><awardInd>N</awardInd><beginDt>2013-03-21T06:33:24-05:00</beginDt><blockCaddInd>U</blockCaddInd><brthdyDt>1953-02-11T00:00:00-06:00</brthdyDt><deathDt>2022-08-29T00:00:00-05:00</deathDt><emailAddrsTxt></emailAddrsTxt><fileNbr>796163672</fileNbr><firstNm>MARGIE</firstNm><genderCd>F</genderCd><lastNm>CURTIS</lastNm><mailingAddress><addrsOneTxt>TOKYO
+        TOWER</addrsOneTxt><addrsThreeTxt>SHIBAKOEN</addrsThreeTxt><addrsTwoTxt>4
+        CHOME-2-8</addrsTwoTxt><cityNm>TOKYO</cityNm><cntryNm>Afghanistan</cntryNm><efctvDt>2024-08-13T15:12:55-05:00</efctvDt><ptcpntAddrsTypeNm>Mailing</ptcpntAddrsTypeNm><zipPrefixNbr>932</zipPrefixNbr></mailingAddress><personDeathCauseTypeNm>Unknown</personDeathCauseTypeNm><phone><areaNbr>703</areaNbr><cntryNbr>1</cntryNbr><efctvDt>2022-09-22T14:36:01-05:00</efctvDt><phoneNbr>3397136</phoneNbr><phoneTypeNm>Daytime</phoneTypeNm></phone><phone><areaNbr>571</areaNbr><cntryNbr>1</cntryNbr><efctvDt>2022-09-22T14:36:01-05:00</efctvDt><phoneNbr>5276860</phoneNbr><phoneTypeNm>Nighttime</phoneTypeNm></phone><proofDepncyInd>N</proofDepncyInd><ptcpntId>600052700</ptcpntId><ptcpntRlnshpTypeNm>Spouse</ptcpntRlnshpTypeNm><ssnNbr>796163672</ssnNbr><ssnVrfctnStatusTypeCd>0</ssnVrfctnStatusTypeCd><vetInd>Y</vetInd></dependent><numberOfRecords>1</numberOfRecords></DependentDTO></ns0:findDependentsByPtcpntIdResponse></S:Body></S:Envelope>
+  recorded_at: Tue, 03 Sep 2024 17:07:06 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
_⚠️ Please do not merge until after https://github.com/department-of-veterans-affairs/vets-api/pull/18195._

## Summary

* Create PersonWebService class
* Move `find_by_ssn` to new PersonWebService class
* Add `FindDependentsByPtcpntId` to BGSClient Definitions for WSDL caching
* Add test and cassette

## Related issue(s)

[API-39419](https://jira.devops.va.gov/browse/API-39419)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

Local BGS service

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A