### PR TITLE
Add lighthouse_updated_at to form_submission_attempts table

### DIFF
--- a/db/migrate/20240903124855_add_lighthouse_updated_at_to_form_submission_attempts.rb
+++ b/db/migrate/20240903124855_add_lighthouse_updated_at_to_form_submission_attempts.rb
@@ -1,0 +1,5 @@
+class AddLighthouseUpdatedAtToFormSubmissionAttempts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :form_submission_attempts, :lighthouse_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_21_145040) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_03_124855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -735,6 +735,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_145040) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "benefits_intake_uuid"
+    t.datetime "lighthouse_updated_at"
     t.index ["form_submission_id"], name: "index_form_submission_attempts_on_form_submission_id"
   end
 


### PR DESCRIPTION
## Summary
This PR should help us debug form submissions a bit better. It adds a new timestamp to our form submission attempts table so we can differentiate between the nightly job we run (when `updated_at` gets set) and the timestamp reported from Lighthouse on when it most recently changed state.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1613
