### PR TITLE
Add feature flag for HCA insurance section

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -72,6 +72,10 @@ features:
   hca_enrollment_status_override_enabled:
     actor_type: user
     description: Enables override of enrollment status for a user, to allow multiple submissions with same user.
+  hca_insurance_v2_enabled:
+    actor_type: user
+    description: Enables the the upgraded insurance section of the Health Care Application
+    enable_in_development: true
   hca_performance_alert_enabled:
     actor_type: user
     description: Enables alert notifying users of a potential issue with application performance.


### PR DESCRIPTION
## Summary

This PR adds a new feature flag that will be utilized in an upcoming initiative on the Health Care Application for the 1010 team. The initiative is linked below.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#88810

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs