### PR TITLE
multistamp fix

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -100,7 +100,7 @@ module IvcChampva
 
       stamps << { coords: [520, 470], text: first_applicant_country, page: 0 }
       stamps << { coords: [520, 590], text: veteran_country, page: 0 } unless sponsor_is_deceased
-
+      stamps << { coords: [420, 45], text: veteran_country, page: 0 } if @data['certifier_role'] == 'sponsor'
       stamps
     end
 


### PR DESCRIPTION
## Summary

There was a bug on the stamper for the country code stamp in 1010D. If the veteran or sponsor passes away, the stamp's multi stamp verification wasn't working properly. 
In the certifier section, the country code will now stamp only if this condition is met. 




## Screenshots

[df1585d6-64d2-459e-a6ea-993421ee7133_vha_10_10d-tmp.pdf](https://github.com/user-attachments/files/16853322/df1585d6-64d2-459e-a6ea-993421ee7133_vha_10_10d-tmp.pdf)

[6dbef983-1f49-4382-b575-ceb9285fce0c_vha_10_10d-tmp.pdf](https://github.com/user-attachments/files/16853332/6dbef983-1f49-4382-b575-ceb9285fce0c_vha_10_10d-tmp.pdf)




