### PR TITLE
Remove va_online_scheduling_appointment_details_redesign feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1345,10 +1345,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for routing appointment requests to the VetsAPI Gateway Service(VPG) instead of vaos-service.
-  va_online_scheduling_appointment_details_redesign:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for redesigning the appointment details page.
   va_online_scheduling_recent_locations_filter:
     actor_type: user
     enable_in_development: true
@@ -1663,7 +1659,7 @@ features:
     description: >-
       A frontend-focused switch that toggles visibility of and access to the Travel Pay claim details page and entry point (features toggled together).
       Enabled - Entry point link and claim details page are viewable.
-      Disabled - Entry point link and claim details page are not viewable. 
+      Disabled - Entry point link and claim details page are not viewable.
   travel_pay_submit_mileage_expense:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Removing obsolete feature toggle since the feature has been fully released.
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89375

## Testing done

- Ensured existing test suites pass

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
