### PR TITLE
Remove two EP 400 Merge eligibility feature toggles

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -120,14 +120,6 @@ module Form526ClaimFastTrackingConcern
     disabilities.pluck('diagnosticCode')
   end
 
-  def eligible_for_ep_merge?
-    user = User.find(user_uuid)
-    return true if Flipper.enabled?(:disability_526_ep_merge_multi_contention, user)
-    return false unless disabilities.count == 1
-
-    Flipper.enabled?(:disability_526_ep_merge_new_claims, user) ? increase_or_new? : increase_only?
-  end
-
   def prepare_for_evss!
     begin
       is_claim_fully_classified = update_classification!
@@ -136,7 +128,7 @@ module Form526ClaimFastTrackingConcern
       Rails.logger.error e.backtrace.join('\n')
     end
 
-    prepare_for_ep_merge! if eligible_for_ep_merge? && is_claim_fully_classified
+    prepare_for_ep_merge! if is_claim_fully_classified
 
     return if pending_eps? || disabilities_not_service_connected?
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -424,12 +424,6 @@ features:
   disability_526_ep_merge_api:
     actor_type: user
     description: enables sending 526 claims with a pending EP to VRO EP Merge API for automated merging.
-  disability_526_ep_merge_new_claims:
-    actor_type: user
-    description: enables EP Merge for single-contention 526 claims for a new condition
-  disability_526_ep_merge_multi_contention:
-    actor_type: user
-    description: enables EP Merge for multi-contention 526 claims
   disability_526_toxic_exposure:
     actor_type: user
     description: enables new pages, processing, and submission of toxic exposure claims

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1398,44 +1398,6 @@ RSpec.describe Form526Submission do
     end
   end
 
-  describe '#eligible_for_ep_merge?' do
-    subject { Form526Submission.create(form_json: File.read(path)).eligible_for_ep_merge? }
-
-    before { Flipper.disable(:disability_526_ep_merge_multi_contention) }
-
-    context 'when there are multiple contentions' do
-      let(:path) { 'spec/support/disability_compensation_form/submissions/only_526_mixed_action_disabilities.json' }
-
-      context 'when multi-contention claims are not eligible' do
-        it { is_expected.to be_falsey }
-      end
-
-      context 'when multi-contention claims are eligible' do
-        before { Flipper.enable(:disability_526_ep_merge_multi_contention) }
-
-        it { is_expected.to be_truthy }
-      end
-    end
-
-    context 'when there is a single new contention' do
-      let(:path) { 'spec/support/disability_compensation_form/submissions/only_526_new_disability.json' }
-
-      context 'when new claims are eligible' do
-        before { Flipper.enable(:disability_526_ep_merge_new_claims) }
-        after { Flipper.disable(:disability_526_ep_merge_new_claims) }
-
-        it { is_expected.to be_truthy }
-      end
-
-      context 'when new claims are not eligible' do
-        before { Flipper.disable(:disability_526_ep_merge_new_claims) }
-        after { Flipper.enable(:disability_526_ep_merge_new_claims) }
-
-        it { is_expected.to be_falsey }
-      end
-    end
-  end
-
   describe '#remediated?' do
     context 'when there are no form526_submission_remediations' do
       it 'returns false' do


### PR DESCRIPTION
## Summary

- This PR removes two feature toggles used for gradually rolling out EP400 Merge eligibility to single-contention new claims, and then to multi-contention claims. Both rollouts were successful, and monitoring since hitting 100% has been uneventful.
- I'm on the Employee Experience team; we work with the Disability Experience team which maintains Form 526.

## Related issue(s)
- Ticket: department-of-veterans-affairs/abd-vro#3396
- Feature toggles originally added in:
  - #17034
  - #17440

## Testing done
- [ ] ~New code is covered by unit tests~ There is no new code

## What areas of the site does it impact?
No impact.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
