### PR TITLE
Add error_message_ciphertext and response_ciphertext to form_submission_attempts table

### DIFF
--- a/db/migrate/20240904184430_add_ciphertext_fields_to_form_submission_attempts.rb
+++ b/db/migrate/20240904184430_add_ciphertext_fields_to_form_submission_attempts.rb
@@ -1,0 +1,6 @@
+class AddCiphertextFieldsToFormSubmissionAttempts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :form_submission_attempts, :error_message_ciphertext, :text
+    add_column :form_submission_attempts, :response_ciphertext, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_03_124855) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_04_184430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -736,6 +736,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_03_124855) do
     t.datetime "updated_at", null: false
     t.uuid "benefits_intake_uuid"
     t.datetime "lighthouse_updated_at"
+    t.text "error_message_ciphertext"
+    t.jsonb "response_ciphertext"
     t.index ["form_submission_id"], name: "index_form_submission_attempts_on_form_submission_id"
   end
 


### PR DESCRIPTION
## Summary
This PR (partially) fixes an error I made previously when creating the `form_submission_attempts` table. I didn't append `_ciphertext` to these two fields that are encrypted. Therefore, they don't currently work. I say this only partially fixes the error because I am NOT deleting the `error_message` and `response` fields (which are currently unused and unusable). I've learned that deleting fields is tricky and, strictly speaking, unnecessary right now for me.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1613
