### PR TITLE
[DBX-88683] update 526 state logger with StatsD

### DIFF
--- a/spec/sidekiq/form526_state_logging_job_spec.rb
+++ b/spec/sidekiq/form526_state_logging_job_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Form526StateLoggingJob, type: :worker do
         ].sort
       }
 
-      expect(described_class.new.state_log).to eq(expected_log)
+      expect(described_class.new.base_state).to eq(expected_log)
     end
 
     it 'converts the logs to counts where prefered' do
@@ -302,6 +302,21 @@ RSpec.describe Form526StateLoggingJob, type: :worker do
         expect(label).to eq('Form 526 State Data')
         expect(log).to eq(expected_log)
       end
+      described_class.new.perform
+    end
+
+    it 'writes counts as Stats D gauges' do
+      prefix = described_class::STATSD_PREFIX
+
+      expect(StatsD).to receive(:gauge).with("#{prefix}.timeboxed_count", 17)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.timeboxed_primary_successes_count", 4)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.timeboxed_exhausted_primary_job_count", 8)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.timeboxed_exhausted_backup_job_count", 3)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.timeboxed_incomplete_type_count", 5)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.total_awaiting_backup_status_count", 1)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.total_incomplete_type_count", 5)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.total_failure_type_count", 10)
+
       described_class.new.perform
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Update the state logger to also use `StatsD` gauges. this will unblock the desired state visualization. 
- For now we are leaving the logs in place as well for full context, if needed.

## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=71313591)
- [Datadog docs](https://www.rubydoc.info/github/DataDog/dogstatsd-ruby/Datadog%2FStatsd:gauge)

## Testing done

- [x] *New code is covered by unit tests*
- Previously this just wrote logs, but Datadog mapping of a changing payload value is better handled with Gauges

## What areas of the site does it impact?
526 state logging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution (comming soon)
- [ ]  Documentation has been updated (see above)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature (n/a)
