### PR TITLE
API-37520: Add 403s to List of Non-Retryable Error Codes for `VAForms::FormBuilder`

### DIFF
--- a/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
@@ -11,6 +11,8 @@ module VAForms
 
     STATSD_KEY_PREFIX = 'api.va_forms.form_builder'
 
+    NON_RETRYABLE_ERROR_CODES = [403, 404].freeze
+
     sidekiq_options retry: 7
 
     sidekiq_retries_exhausted do |msg, _ex|
@@ -89,7 +91,7 @@ module VAForms
     # and sends Slack notifications; if response is unsuccessful, raises an error
     def check_form_validity(form, attrs, url)
       response = fetch_form(url)
-      if response.success? || response.status == 404 # 404s are non-recoverable and should not be retried
+      if response.success? || NON_RETRYABLE_ERROR_CODES.include?(response.status)
         attrs[:valid_pdf] = response.success?
         attrs[:sha256] = response.success? ? Digest::SHA256.hexdigest(response.body) : nil
         attrs[:url] = url

--- a/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
@@ -11,7 +11,7 @@ module VAForms
 
     STATSD_KEY_PREFIX = 'api.va_forms.form_builder'
 
-    NON_RETRYABLE_ERROR_CODES = [403, 404].freeze # No need to retry because not likely to recover
+    NON_RETRYABLE_ERROR_CODES = [403, 404].freeze # No need to retry because unlikely to recover
 
     sidekiq_options retry: 7
 

--- a/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
+++ b/modules/va_forms/app/sidekiq/va_forms/form_builder.rb
@@ -11,7 +11,7 @@ module VAForms
 
     STATSD_KEY_PREFIX = 'api.va_forms.form_builder'
 
-    NON_RETRYABLE_ERROR_CODES = [403, 404].freeze
+    NON_RETRYABLE_ERROR_CODES = [403, 404].freeze # No need to retry because not likely to recover
 
     sidekiq_options retry: 7
 


### PR DESCRIPTION
## Summary
This work is NOT behind a feature toggle.

This PR updates the `VAForms::FormBuilder` nightly forms refresh job to change how it handles form URLs that return 403s (Forbidden). It expands upon the work from #18287, which updated the handling for 404s.

All form URLs served up by the VA Forms API need to be publicly available. Therefore, a form URL returning a 403 response (we have one example in Production today) should automatically be marked invalid and does not need to be retried.

A `VAForms::FormBuilder` job is kicked off nightly for each data entry in the forms source database. Therefore, if a form URL is later modified by a form administrator and changed to a publicly available form, it will have a chance to be marked valid again.

My team (Lighthouse Banana Peels) owns the `va_forms` module.

## Related issue(s)
- [API-37520](https://jira.devops.va.gov/browse/API-37520)

## Testing done
- [x] New code is covered by unit tests – We already have specs for 404 responses, which should cover both scenarios (403 and 404)

I tested the behavior outlined in the PR summary above using local data and a lower environment forms database.

## Screenshots
N/A

## What areas of the site does it impact?
This PR impacts the `va_forms` module only, and within that module, only the `VAForms::FormBuilder` job and its specs.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.