### PR TITLE
API-39890 - Updates typeOfAddress, addressLine1, city, country, sate and zipFirstFive validations

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -62,10 +62,16 @@ module ClaimsApi
       def validate_form_526_change_of_address_required_fields
         change_of_address = form_attributes['changeOfAddress']
         coa_begin_date = change_of_address&.dig('dates', 'beginDate') # we can have a valid form without an endDate
+        type_of_address_change = change_of_address&.dig('typeOfAddressChange')
+        address_line_one = change_of_address&.dig('addressLine1')
+        country = change_of_address&.dig('country')
 
         form_object_desc = '/changeOfAddress'
 
         collect_error_if_value_not_present('begin date', form_object_desc) if coa_begin_date.blank?
+        collect_error_if_value_not_present('addressLine1', form_object_desc) if address_line_one.blank?
+        collect_error_if_value_not_present('country', form_object_desc) if country.blank?
+        collect_error_if_value_not_present('typeOfAddressChange', form_object_desc) if type_of_address_change.blank?
       end
 
       def validate_form_526_change_of_address_beginning_date

--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -65,11 +65,13 @@ module ClaimsApi
         type_of_address_change = change_of_address&.dig('typeOfAddressChange')
         address_line_one = change_of_address&.dig('addressLine1')
         country = change_of_address&.dig('country')
+        city = change_of_address&.dig('city')
 
         form_object_desc = '/changeOfAddress'
 
         collect_error_if_value_not_present('begin date', form_object_desc) if coa_begin_date.blank?
         collect_error_if_value_not_present('addressLine1', form_object_desc) if address_line_one.blank?
+        collect_error_if_value_not_present('city', form_object_desc) if city.blank?
         collect_error_if_value_not_present('country', form_object_desc) if country.blank?
         collect_error_if_value_not_present('typeOfAddressChange', form_object_desc) if type_of_address_change.blank?
       end
@@ -116,7 +118,7 @@ module ClaimsApi
 
         collect_error_messages(
           source: '/changeOfAddress/country',
-          detail: 'The country provided is not a valid.'
+          detail: 'The country provided is not valid.'
         )
       end
 

--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -134,20 +134,42 @@ module ClaimsApi
 
       def validate_form_526_change_of_address_zip
         address = form_attributes['changeOfAddress'] || {}
-        if address['country'] == 'USA' && address['zipFirstFive'].blank?
+
+        if address['country'] == 'USA'
+          validate_form_526_usa_zip_code(address)
+        else
+          validate_form_526_international_zip_code(address)
+        end
+      end
+
+      def validate_form_526_usa_zip_code(address)
+        if address['zipFirstFive'].blank?
           collect_error_messages(
             source: '/changeOfAddress/zipFirstFive',
             detail: 'The zipFirstFive is required if the country is USA.'
           )
-        elsif address['country'] != 'USA' && address['internationalPostalCode'].blank?
+        end
+
+        if address['internationalPostalCode'].present?
+          collect_error_messages(
+            source: '/changeOfAddress/internationalPostalCode',
+            detail: 'The internationalPostalCode should not be provided if the country is USA.'
+          )
+        end
+      end
+
+      def validate_form_526_international_zip_code(address)
+        if address['internationalPostalCode'].blank?
           collect_error_messages(
             source: '/changeOfAddress/internationalPostalCode',
             detail: 'The internationalPostalCode is required if the country is not USA.'
           )
-        elsif address['country'] == 'USA' && address['internationalPostalCode'].present?
+        end
+
+        if address['zipFirstFive'].present?
           collect_error_messages(
-            source: '/changeOfAddress/internationalPostalCode',
-            detail: 'The internationalPostalCode should not be provided if the country is USA.'
+            source: '/changeOfAddress/zipFirstFive',
+            detail: 'The zipFirstFive is prohibited if the country is USA.'
           )
         end
       end

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -152,7 +152,7 @@
       }
     },
     "changeOfAddress": {
-      "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'addressLine1', 'city', 'country'.",
+      "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'addressLine1', 'city', 'country'7.",
       "type": ["object", "null"],
       "nullable": true,
       "additionalProperties": false,

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -152,7 +152,7 @@
       }
     },
     "changeOfAddress": {
-      "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'dates.beginDate', 'addressLine1', 'city', 'state', 'country', 'zipFirstFive'.",
+      "description": "If 'changeOfAddress' is included, the following attributes are required: 'typeOfAddressChange', 'addressLine1', 'city', 'country'.",
       "type": ["object", "null"],
       "nullable": true,
       "additionalProperties": false,

--- a/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
@@ -259,30 +259,30 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
         end
       end
 
-      describe 'validation of claimant change of address elements' do
-        context "when any values present, 'dates','typeOfAddressChange','numberAndStreet','country' are required" do
-          context 'with the required values present' do
-            let(:valid_change_of_address) do
-              {
-                dates: {
-                  beginDate: '2012-11-30'
-                },
-                typeOfAddressChange: 'PERMANENT',
-                addressLine1: '10 Peach St',
-                addressLine2: 'Unit 4',
-                addressLine3: 'Room 1',
-                city: 'Atlanta',
-                zipFirstFive: '42220',
-                zipLastFour: '',
-                state: 'OH',
-                country: 'USA'
-              }
-            end
+      describe 'validation of changeOfAddress' do
+        let(:change_of_address_values) do
+          {
+            dates: {
+              beginDate: '2012-11-30'
+            },
+            typeOfAddressChange: 'PERMANENT',
+            addressLine1: '10 Peach St',
+            addressLine2: 'Unit 4',
+            addressLine3: 'Room 1',
+            city: 'Atlanta',
+            zipFirstFive: '42220',
+            zipLastFour: '',
+            state: 'OH',
+            country: 'USA'
+          }
+        end
 
+        context "'typeOfAddressChange','addressLine1','city' and 'country' are conditionally required" do
+          context 'with the required values present' do
             it 'responds with a 202' do
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
-                json['data']['attributes']['changeOfAddress'] = valid_change_of_address
+                json['data']['attributes']['changeOfAddress'] = change_of_address_values
                 data = json.to_json
                 post submit_path, params: data, headers: auth_header
                 expect(response).to have_http_status(:accepted)
@@ -290,26 +290,10 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
             end
           end
 
-          context 'without the required numberAndStreet value present' do
-            let(:invalid_change_of_address) do
-              {
-                dates: {
-                  beginDate: '2012-11-30',
-                  endDate: '2013-11-12'
-                },
-                typeOfAddressChange: 'PERMANENT',
-                addressLine1: '',
-                addressLine2: 'Unit 4',
-                addressLine3: 'Room 1',
-                city: '',
-                zipFirstFive: '42220',
-                zipLastFour: '',
-                state: '',
-                country: 'USA'
-              }
-            end
-
+          context 'when addressLine1 is an empty string' do
             it 'responds with a 422' do
+              invalid_change_of_address = change_of_address_values.merge(addressLine1: '')
+
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
                 json['data']['attributes']['changeOfAddress'] = invalid_change_of_address
@@ -318,32 +302,16 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
                 expect(response).to have_http_status(:unprocessable_entity)
                 response_body = JSON.parse(response.body)
                 expect(response_body['errors'][0]['detail']).to eq(
-                  'Change of address endDate cannot be included when typeOfAddressChange is PERMANENT'
+                  'The addressLine1 is required for /changeOfAddress.'
                 )
               end
             end
           end
 
           context 'without the required country value present' do
-            let(:invalid_change_of_address) do
-              {
-                dates: {
-                  beginDate: '2012-11-31',
-                  endDate: '2013-11-31'
-                },
-                typeOfAddressChange: 'PERMANENT',
-                addressLine1: '10 Peach St',
-                addressLine2: '',
-                addressLine3: '',
-                city: '',
-                zipFirstFive: '42220',
-                zipLastFour: '',
-                state: '',
-                country: ''
-              }
-            end
-
             it 'responds with a 422' do
+              invalid_change_of_address = change_of_address_values.merge(country: '')
+
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
                 json['data']['attributes']['changeOfAddress'] = invalid_change_of_address
@@ -351,32 +319,17 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
                 post submit_path, params: data, headers: auth_header
                 expect(response).to have_http_status(:unprocessable_entity)
                 response_body = JSON.parse(response.body)
-                expect(response_body['errors'][0]['detail']).to include(
-                  'is not a valid'
+                expect(response_body['errors'][0]['detail']).to eq(
+                  'The country is required for /changeOfAddress.'
                 )
               end
             end
           end
 
           context 'without the required dates values present' do
-            let(:invalid_change_of_address) do
-              {
-                dates: {
-                  endDate: '2013-11-30'
-                },
-                typeOfAddressChange: 'PERMANENT',
-                addressLine1: '10 Peach St',
-                addressLine2: '22',
-                addressLine3: '',
-                city: 'Atlanta',
-                zipFirstFive: '42220',
-                zipLastFour: '',
-                state: 'GA',
-                country: 'USA'
-              }
-            end
-
             it 'responds with a 422' do
+              invalid_change_of_address = change_of_address_values.merge(dates: { beginDate: nil })
+
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
                 json['data']['attributes']['changeOfAddress'] = invalid_change_of_address
@@ -391,32 +344,20 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
             end
           end
 
-          context 'without the required typeOfAddressChange values present' do
-            let(:invalid_change_of_address) do
-              {
-                dates: {
-                  beginDate: '2012-11-31',
-                  endDate: ''
-                },
-                typeOfAddressChange: '',
-                addressLine1: '10 Peach St',
-                addressLine2: '22',
-                addressLine3: '',
-                city: 'Atlanta',
-                zipFirstFive: '42220',
-                zipLastFour: '',
-                state: 'GA',
-                country: 'USA'
-              }
-            end
-
+          context 'when typeOfAddressChange is an empty string' do
             it 'responds with a 422' do
+              invalid_change_of_address = change_of_address_values.merge(typeOfAddressChange: '')
+
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
                 json['data']['attributes']['changeOfAddress'] = invalid_change_of_address
                 data = json.to_json
                 post submit_path, params: data, headers: auth_header
                 expect(response).to have_http_status(:unprocessable_entity)
+                response_body = JSON.parse(response.body)
+                expect(response_body['errors'][0]['detail']).to eq(
+                  'The typeOfAddressChange is required for /changeOfAddress.'
+                )
               end
             end
           end

--- a/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
@@ -281,46 +281,23 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
           context 'with the required values present' do
             it 'responds with a 202' do
               mock_ccg(scopes) do |auth_header|
-                json = JSON.parse(data)
-                json['data']['attributes']['changeOfAddress'] = change_of_address_values
-                data = json.to_json
                 post submit_path, params: data, headers: auth_header
                 expect(response).to have_http_status(:accepted)
               end
             end
           end
 
-          context 'when addressLine1 is an empty string' do
+          context 'without the condtionally required addressLine1' do
             it 'responds with a 422' do
-              invalid_change_of_address = change_of_address_values.merge(addressLine1: '')
-
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
-                json['data']['attributes']['changeOfAddress'] = invalid_change_of_address
+                json['data']['attributes']['changeOfAddress']['addressLine1'] = ''
                 data = json.to_json
                 post submit_path, params: data, headers: auth_header
                 expect(response).to have_http_status(:unprocessable_entity)
                 response_body = JSON.parse(response.body)
                 expect(response_body['errors'][0]['detail']).to eq(
                   'The addressLine1 is required for /changeOfAddress.'
-                )
-              end
-            end
-          end
-
-          context 'without the required country value present' do
-            it 'responds with a 422' do
-              invalid_change_of_address = change_of_address_values.merge(country: '')
-
-              mock_ccg(scopes) do |auth_header|
-                json = JSON.parse(data)
-                json['data']['attributes']['changeOfAddress'] = invalid_change_of_address
-                data = json.to_json
-                post submit_path, params: data, headers: auth_header
-                expect(response).to have_http_status(:unprocessable_entity)
-                response_body = JSON.parse(response.body)
-                expect(response_body['errors'][0]['detail']).to eq(
-                  'The country is required for /changeOfAddress.'
                 )
               end
             end
@@ -344,13 +321,11 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
             end
           end
 
-          context 'when typeOfAddressChange is an empty string' do
+          context 'without the condtionally required typeOfAddressChange' do
             it 'responds with a 422' do
-              invalid_change_of_address = change_of_address_values.merge(typeOfAddressChange: '')
-
               mock_ccg(scopes) do |auth_header|
                 json = JSON.parse(data)
-                json['data']['attributes']['changeOfAddress'] = invalid_change_of_address
+                json['data']['attributes']['changeOfAddress']['typeOfAddressChange'] = ''
                 data = json.to_json
                 post submit_path, params: data, headers: auth_header
                 expect(response).to have_http_status(:unprocessable_entity)
@@ -361,58 +336,82 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
               end
             end
           end
-        end
 
-        context 'when the country is valid' do
-          let(:country) { 'USA' }
-
-          it 'responds with a 202' do
-            mock_ccg(scopes) do |auth_header|
-              json = JSON.parse(data)
-              json['data']['attributes']['changeOfAddress']['country'] = country
-              data = json.to_json
-              post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:accepted)
+          context 'without the condtionally required country value present' do
+            it 'responds with a 422' do
+              mock_ccg(scopes) do |auth_header|
+                json = JSON.parse(data)
+                json['data']['attributes']['changeOfAddress']['country'] = ''
+                data = json.to_json
+                post submit_path, params: data, headers: auth_header
+                expect(response).to have_http_status(:unprocessable_entity)
+                response_body = JSON.parse(response.body)
+                expect(response_body['errors'][0]['detail']).to eq(
+                  'The country is required for /changeOfAddress.'
+                )
+              end
             end
           end
-        end
 
-        context 'when the country is invalid' do
-          let(:country) { 'United States of Nada' }
+          context 'when the country is valid' do
+            let(:country) { 'USA' }
 
-          it 'responds with 422' do
-            mock_ccg(scopes) do |auth_header|
-              json = JSON.parse(data)
-              json['data']['attributes']['changeOfAddress']['country'] = country
-              data = json.to_json
-              post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:unprocessable_entity)
+            it 'responds with a 202' do
+              mock_ccg(scopes) do |auth_header|
+                json = JSON.parse(data)
+                json['data']['attributes']['changeOfAddress']['country'] = country
+                data = json.to_json
+                post submit_path, params: data, headers: auth_header
+                expect(response).to have_http_status(:accepted)
+              end
             end
           end
-        end
 
-        context 'when the city is valid' do
-          let(:city) { '#Base 6' }
+          context 'when the country is invalid' do
+            let(:country) { 'United States of Nada' }
 
-          it 'responds with 202' do
-            mock_ccg(scopes) do |auth_header|
-              json = JSON.parse(data)
-              json['data']['attributes']['changeOfAddress']['city'] = city
-              data = json.to_json
-              post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:accepted)
+            it 'responds with 422' do
+              mock_ccg(scopes) do |auth_header|
+                json = JSON.parse(data)
+                json['data']['attributes']['changeOfAddress']['country'] = country
+                data = json.to_json
+                post submit_path, params: data, headers: auth_header
+                expect(response).to have_http_status(:unprocessable_entity)
+                response_body = JSON.parse(response.body)
+                expect(response_body['errors'][0]['detail']).to eq(
+                  'The country provided is not valid.'
+                )
+              end
             end
           end
-        end
 
-        context 'when the city is invalid' do
-          it 'responds with 422' do
-            mock_ccg(scopes) do |auth_header|
-              json = JSON.parse(data)
-              json['data']['attributes']['changeOfAddress']['city'] = nil
-              data = json.to_json
-              post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:unprocessable_entity)
+          context 'without the condtionally required city value' do
+            it 'responds with a 422' do
+              mock_ccg(scopes) do |auth_header|
+                json = JSON.parse(data)
+                json['data']['attributes']['changeOfAddress']['city'] = ''
+                data = json.to_json
+                post submit_path, params: data, headers: auth_header
+                expect(response).to have_http_status(:unprocessable_entity)
+                response_body = JSON.parse(response.body)
+                expect(response_body['errors'][0]['detail']).to eq(
+                  'The city is required for /changeOfAddress.'
+                )
+              end
+            end
+          end
+
+          context 'when the city is valid' do
+            let(:city) { '#Base 6' }
+
+            it 'responds with 202' do
+              mock_ccg(scopes) do |auth_header|
+                json = JSON.parse(data)
+                json['data']['attributes']['changeOfAddress']['city'] = city
+                data = json.to_json
+                post submit_path, params: data, headers: auth_header
+                expect(response).to have_http_status(:accepted)
+              end
             end
           end
         end


### PR DESCRIPTION
## Summary
* Updates description in 526 json to reflect conditiionally required values
* Updates/adds validation for:
	* typeOfAddressChange
	* addressLine1
	* country
	* city
	*  zipFirstFive
* Refactors zip validation method into usa and international
* Adds/updates related tests

## Related issue(s)
[API-39890](https://jira.devops.va.gov/browse/API-39890)

## Testing done
- [x] *New code is covered by unit tests*


## Screenshots

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
	modified:   modules/claims_api/config/schemas/v2/526.json
	modified:   modules/claims_api/spec/requests/v2/veterans/526_spec.rb

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
