### PR TITLE
add Sentry logging to narrow down failure mode

### DIFF
--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -19,33 +19,27 @@ module FormAttachmentCreate
   end
 
   def validate_file_upload_class!
-    begin
-      # is it either ActionDispatch::Http::UploadedFile or Rack::Test::UploadedFile
-      unless filtered_params[:file_data].class.name.include? 'UploadedFile'
-        raise Common::Exceptions::InvalidFieldValue.new('file_data', filtered_params[:file_data].class.name)
-      end
-    rescue => e
-      log_exception_to_sentry(e, { context: 'FAC_validate', class: filtered_params[:file_data].class.name })
-      raise e
+    # is it either ActionDispatch::Http::UploadedFile or Rack::Test::UploadedFile
+    unless filtered_params[:file_data].class.name.include? 'UploadedFile'
+      raise Common::Exceptions::InvalidFieldValue.new('file_data', filtered_params[:file_data].class.name)
     end
+  rescue => e
+    log_exception_to_sentry(e, { context: 'FAC_validate', class: filtered_params[:file_data].class.name })
+    raise e
   end
 
   def save_attachment_to_cloud!
-    begin
-      form_attachment.set_file_data!(filtered_params[:file_data], filtered_params[:password])
-    rescue => e
-      log_exception_to_sentry(e, { context: 'FAC_cloud' })
-      raise e
-    end
+    form_attachment.set_file_data!(filtered_params[:file_data], filtered_params[:password])
+  rescue => e
+    log_exception_to_sentry(e, { context: 'FAC_cloud' })
+    raise e
   end
 
   def save_attachment_to_db!
-    begin
-      form_attachment.save!
-    rescue => e
-      log_exception_to_sentry(e, { context: 'FAC_db', errors: form_attachment.errors })
-      raise e
-    end
+    form_attachment.save!
+  rescue => e
+    log_exception_to_sentry(e, { context: 'FAC_db', errors: form_attachment.errors })
+    raise e
   end
 
   def form_attachment


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO*
- Add exception-catching blocks around each of the steps of this action, logging any errors to Sentry
- It's not clear why these 403 errors are coming up, and I hope a more specific understanding of their origin will help.
- Health Enrollment 10-10EZ/CG team

## Related issue(s)

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/92139

## Testing done

I ran the app locally and confirmed that the upload process works; since this is a logging change only, there's no testing to add.

## What areas of the site does it impact?
- This only affects Sentry logging for File Upload failures

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
