### PR TITLE
#91156 [10-10EZR]: Update submission failure notifications and add user initials to successful submissions

### DIFF
--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -8,13 +8,14 @@ module HCA
     include Sidekiq::Job
     include SentryLogging
     VALIDATION_ERROR = HCA::SOAPParser::ValidationError
+    STATSD_KEY_PREFIX = 'api.1010ezr'
 
     sidekiq_options retry: 14
 
     sidekiq_retries_exhausted do |msg, _e|
       parsed_form = decrypt_form(msg['args'][0])
 
-      StatsD.increment("#{Form1010Ezr::Service::STATSD_KEY_PREFIX}.failed_wont_retry")
+      StatsD.increment("#{STATSD_KEY_PREFIX}.failed_wont_retry")
 
       if parsed_form.present?
         PersonalInformationLog.create!(
@@ -44,7 +45,7 @@ module HCA
       Form1010Ezr::Service.new(nil).log_submission_failure(parsed_form)
       log_exception_to_sentry(e)
     rescue
-      StatsD.increment("#{Form1010Ezr::Service::STATSD_KEY_PREFIX}.async.retries")
+      StatsD.increment("#{STATSD_KEY_PREFIX}.async.retries")
       raise
     end
   end

--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -12,9 +12,8 @@ module HCA
     sidekiq_options retry: 14
 
     sidekiq_retries_exhausted do |msg, _e|
-      Form1010Ezr::Service.new(nil).log_submission_failure(
-        decrypt_form(msg['args'][0]),
-        retries_exhausted: true
+      Form1010Ezr::Service.new(nil).log_exhausted_submission_failure(
+        decrypt_form(msg['args'][0])
       )
     end
 

--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -7,7 +7,6 @@ module HCA
   class EzrSubmissionJob
     include Sidekiq::Job
     include SentryLogging
-    include Common::Client::Concerns::Monitoring
     VALIDATION_ERROR = HCA::SOAPParser::ValidationError
 
     sidekiq_options retry: 14

--- a/lib/form1010_ezr/service.rb
+++ b/lib/form1010_ezr/service.rb
@@ -73,8 +73,6 @@ module Form1010Ezr
           error_class: 'Form1010Ezr Failed'
         )
 
-        failure_message = '1010EZR failure'
-
         log_message_to_sentry(
           '1010EZR failure',
           :error,

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe Form1010Ezr::Service do
 
   describe '#post_fill_required_fields' do
     it 'Adds required fields in the Enrollment System API to the form object',
-      run_at: 'Fri, 08 Feb 2019 02:50:45 GMT' do
+       run_at: 'Fri, 08 Feb 2019 02:50:45 GMT' do
       VCR.use_cassette(
         'hca/ee/lookup_user',
         VCR::MATCH_EVERYTHING.merge(erb: true)
       ) do
-        expect(form.keys).to_not include('isEssentialAcaCoverage', 'vaMedicalFacility')
+        expect(form.keys).not_to include('isEssentialAcaCoverage', 'vaMedicalFacility')
 
         service.send(:post_fill_required_fields, form)
 
@@ -375,7 +375,7 @@ RSpec.describe Form1010Ezr::Service do
         end
       end
 
-      it "logs the submission id, user's initials, payload size, and individual attachment sizes in descending "\
+      it "logs the submission id, user's initials, payload size, and individual attachment sizes in descending " \
          'order (if applicable)',
          run_at: 'Wed, 17 Jul 2024 18:17:30 GMT' do
         VCR.use_cassette(

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -196,39 +196,6 @@ RSpec.describe Form1010Ezr::Service do
     end
   end
 
-  describe '#log_exhausted_submission_failure' do
-    context "when 'parsed_form' is not present" do
-      it 'only increments StatsD' do
-        allow(StatsD).to receive(:increment)
-        expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
-
-        described_class.new(nil).log_exhausted_submission_failure(nil)
-      end
-    end
-
-    context "when 'parsed_form' is present" do
-      it "increments StatsD, creates a 'PersonalInformationLog' record, and logs a failure message to sentry" do
-        allow(StatsD).to receive(:increment)
-
-        expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
-        expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-          '1010EZR total failure',
-          :error,
-          {
-            first_initial: 'F',
-            middle_initial: 'M',
-            last_initial: 'Z'
-          },
-          ezr: :total_failure
-        )
-
-        described_class.new(nil).log_exhausted_submission_failure(form)
-
-        expect_personal_info_log('Form1010Ezr FailedWontRetry')
-      end
-    end
-  end
-
   describe '#submit_form' do
     it 'submits the ezr with a background job', run_at: 'Tue, 21 Nov 2023 20:42:44 GMT' do
       VCR.use_cassette(

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -165,6 +165,15 @@ RSpec.describe Form1010Ezr::Service do
   end
 
   describe '#log_submission_failure' do
+    context "when 'parsed_form' is not present" do
+      it 'only increments StatsD' do
+        allow(StatsD).to receive(:increment)
+        expect(StatsD).to receive(:increment).with('api.1010ezr.failed')
+
+        described_class.new(nil).log_submission_failure(nil)
+      end
+    end
+
     context "when 'parsed_form' is present" do
       context "when 'retries_exhausted' is false" do
         it "increments StatsD, creates a 'PersonalInformationLog' record, and logs a failure message to sentry" do
@@ -316,7 +325,7 @@ RSpec.describe Form1010Ezr::Service do
         it 'increments StatsD as well as logs and raises the error' do
           allow(StatsD).to receive(:increment)
 
-          expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
+          expect(StatsD).to receive(:increment).with('api.1010ezr.failed')
           expect { submit_form(form) }.to raise_error(
             StandardError, 'Uh oh. Some bad error occurred.'
           )

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe Form1010Ezr::Service do
     )
   end
 
+  def expect_personal_info_log(message)
+    pii_log = PersonalInformationLog.last
+
+    expect(pii_log.error_class).to eq(message)
+    expect(pii_log.data).to eq(form)
+  end
+
   describe '#add_financial_flag' do
     context 'when the form has veteran gross income' do
       let(:parsed_form) do
@@ -86,17 +93,18 @@ RSpec.describe Form1010Ezr::Service do
 
   describe '#post_fill_required_fields' do
     it 'Adds required fields in the Enrollment System API to the form object',
-       run_at: 'Fri, 08 Feb 2019 02:50:45 GMT' do
+      run_at: 'Fri, 08 Feb 2019 02:50:45 GMT' do
       VCR.use_cassette(
         'hca/ee/lookup_user',
         VCR::MATCH_EVERYTHING.merge(erb: true)
       ) do
-        expect(form['isEssentialAcaCoverage']).to eq(nil)
-        expect(form['vaMedicalFacility']).to eq(nil)
+        expect(form.keys).to_not include('isEssentialAcaCoverage', 'vaMedicalFacility')
 
         service.send(:post_fill_required_fields, form)
 
         expect(form.keys).to include('isEssentialAcaCoverage', 'vaMedicalFacility')
+        expect(form['isEssentialAcaCoverage']).to eq(false)
+        expect(form['vaMedicalFacility']).to eq('988')
       end
     end
   end
@@ -151,6 +159,54 @@ RSpec.describe Form1010Ezr::Service do
 
         required_user_fields.each do |key, value|
           expect(parsed_form[key]).to eq(value)
+        end
+      end
+    end
+  end
+
+  describe '#log_submission_failure' do
+    context "when 'parsed_form' is present" do
+      context "when 'retries_exhausted' is false" do
+        it "increments StatsD, creates a 'PersonalInformationLog' record, and logs a failure message to sentry" do
+          # The names for these errors will not include 'total' or 'wont_retry' as they are not for total failures
+          allow(StatsD).to receive(:increment)
+          expect(StatsD).to receive(:increment).with('api.1010ezr.failed')
+          expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+            '1010EZR failure',
+            :error,
+            {
+              first_initial: 'F',
+              middle_initial: 'M',
+              last_initial: 'Z'
+            },
+            ezr: :failure
+          )
+
+          described_class.new(nil).log_submission_failure(form)
+
+          expect_personal_info_log('Form1010Ezr Failed')
+        end
+      end
+
+      context "when 'retries_exhausted' is true" do
+        it "increments StatsD, creates a 'PersonalInformationLog' record, and logs a TOTAL failure message to sentry" do
+          allow(StatsD).to receive(:increment)
+
+          expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
+          expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+            '1010EZR total failure',
+            :error,
+            {
+              first_initial: 'F',
+              middle_initial: 'M',
+              last_initial: 'Z'
+            },
+            ezr: :total_failure
+          )
+
+          described_class.new(nil).log_submission_failure(form, retries_exhausted: true)
+
+          expect_personal_info_log('Form1010Ezr FailedWontRetry')
         end
       end
     end
@@ -310,7 +366,8 @@ RSpec.describe Form1010Ezr::Service do
         end
       end
 
-      it 'logs the submission id, payload size, and individual attachment sizes in descending order (if applicable)',
+      it "logs the submission id, user's initials, payload size, and individual attachment sizes in descending "\
+         'order (if applicable)',
          run_at: 'Wed, 17 Jul 2024 18:17:30 GMT' do
         VCR.use_cassette(
           'form1010_ezr/authorized_submit_with_attachments',
@@ -318,7 +375,15 @@ RSpec.describe Form1010Ezr::Service do
         ) do
           submission_response = service.submit_sync(ezr_form_with_attachments)
 
-          expect(Rails.logger).to have_received(:info).with("SubmissionID=#{submission_response[:formSubmissionId]}")
+          expect(Rails.logger).to have_received(:info).with(
+            '1010EZR successfully submitted',
+            submission_id: submission_response[:formSubmissionId],
+            veteran_initials: {
+              first_initial: 'F',
+              middle_initial: 'M',
+              last_initial: 'Z'
+            }
+          )
           expect(Rails.logger).to have_received(:info).with('Payload for submitted 1010EZR: ' \
                                                             'Body size of 362 KB with 2 attachment(s)')
           expect(Rails.logger).to have_received(:info).with(

--- a/spec/sidekiq/hca/ezr_submission_job_spec.rb
+++ b/spec/sidekiq/hca/ezr_submission_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
 
         described_class.within_sidekiq_retries_exhausted_block(msg) do
           expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
-          expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+          expect(described_class).to receive(:log_message_to_sentry).with(
             '1010EZR total failure',
             :error,
             {
@@ -73,7 +73,7 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
           # of the 'Form1010Ezr::Service', we need to stub out a new instance of the service
           allow(Form1010Ezr::Service).to receive(:new).with(nil).once.and_return(ezr_service)
 
-          expect_any_instance_of(HCA::EzrSubmissionJob).to receive(:log_exception_to_sentry).with(error)
+          expect(HCA::EzrSubmissionJob).to receive(:log_exception_to_sentry).with(error)
           expect(ezr_service).to receive(:log_submission_failure).with(
             form
           )

--- a/spec/sidekiq/hca/ezr_submission_job_spec.rb
+++ b/spec/sidekiq/hca/ezr_submission_job_spec.rb
@@ -13,30 +13,43 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
   let(:ezr_service) { double }
 
   describe 'when retries are exhausted' do
-    let(:msg) do
-      {
-        'args' => [encrypted_form, nil]
-      }
+    context 'when the parsed form is not present' do
+      it 'only increments StatsD' do
+        msg = {
+          'args' => [HealthCareApplication::LOCKBOX.encrypt({}.to_json), nil]
+        }
+
+        described_class.within_sidekiq_retries_exhausted_block(msg) do
+          allow(StatsD).to receive(:increment)
+          expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
+        end
+      end
     end
 
-    it "increments StatsD, creates a 'PersonalInformationLog' record, and logs a failure message to sentry" do
-      described_class.within_sidekiq_retries_exhausted_block(msg) do
-        expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
-        expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-          '1010EZR total failure',
-          :error,
-          {
-            first_initial: 'F',
-            middle_initial: 'M',
-            last_initial: 'Z'
-          },
-          ezr: :total_failure
-        )
-      end
+    context 'when the parsed form is present' do
+      it "increments StatsD, creates a 'PersonalInformationLog' record, and logs a failure message to sentry" do
+        msg = {
+          'args' => [encrypted_form, nil]
+        }
 
-      pii_log = PersonalInformationLog.last
-      expect(pii_log.error_class).to eq('Form1010Ezr FailedWontRetry')
-      expect(pii_log.data).to eq(form)
+        described_class.within_sidekiq_retries_exhausted_block(msg) do
+          expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
+          expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+            '1010EZR total failure',
+            :error,
+            {
+              first_initial: 'F',
+              middle_initial: 'M',
+              last_initial: 'Z'
+            },
+            ezr: :total_failure
+          )
+        end
+
+        pii_log = PersonalInformationLog.last
+        expect(pii_log.error_class).to eq('Form1010Ezr FailedWontRetry')
+        expect(pii_log.data).to eq(form)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This PR adds code that allows the 10-10 team to differentiate between failures that are still retrying and exhausted failures. It also adds user initials to successful submissions in order to more easily discern when failure retries have finally succeeded.
- I work for the 10-10 health apps team

## Related issue(s)

- https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/91156

## Testing done

- [X] *New code is covered by unit tests*
- Prior to the change, all submission failures were considered exhausted failures. This code separates failures that are still retrying and exhausted failures.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10EZR form

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
