### PR TITLE
Fixes syntax on optional param for sidekiq job

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -80,7 +80,7 @@ module ClaimsApi
           @power_of_attorney.reload
 
           # If upload is successful, then the PoaUpater job is also called to update the code in BGS.
-          ClaimsApi::PoaVBMSUploadJob.perform_async(@power_of_attorney.id, action: 'put')
+          ClaimsApi::PoaVBMSUploadJob.perform_async(@power_of_attorney.id, 'put')
 
           render json: ClaimsApi::PowerOfAttorneySerializer.new(@power_of_attorney)
         end

--- a/modules/claims_api/app/sidekiq/claims_api/poa_vbms_upload_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_vbms_upload_job.rb
@@ -12,7 +12,7 @@ module ClaimsApi
     # If successfully uploaded, it queues a job to update the POA code in BGS, as well.
     #
     # @param power_of_attorney_id [String] Unique identifier of the submitted POA
-    def perform(power_of_attorney_id, action: 'post')
+    def perform(power_of_attorney_id, action = 'post')
       power_of_attorney = ClaimsApi::PowerOfAttorney.find(power_of_attorney_id)
       uploader = ClaimsApi::PowerOfAttorneyUploader.new(power_of_attorney_id)
       uploader.retrieve_from_store!(power_of_attorney.file_data['filename'])


### PR DESCRIPTION
## Summary
* Fixes syntax on optional param sent to job

## Related issue(s)
[API-39286](https://jira.devops.va.gov/browse/API-39286)

## Testing done
* Submissions uploaded still reflect the desired file name. All async workflows ran as expected.

## Screenshots
<img width="466" alt="Screenshot 2024-09-06 at 12 40 59 PM" src="https://github.com/user-attachments/assets/56dbee2c-49a0-4473-a058-375e92feb03d">


## What areas of the site does it impact?


## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
