### PR TITLE
Remove remaining references to the travel pay `ping` endpoints

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/client.rb
+++ b/modules/travel_pay/app/services/travel_pay/client.rb
@@ -141,29 +141,6 @@ module TravelPay
       }
     end
 
-    def request_ping(veis_token)
-      btsss_url = Settings.travel_pay.base_url
-      api_key = Settings.travel_pay.subscription_key
-
-      connection(server_url: btsss_url).get('api/v1/Sample/ping') do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['Ocp-Apim-Subscription-Key'] = api_key
-        req.headers['X-Correlation-ID'] = SecureRandom.uuid
-      end
-    end
-
-    def request_authorized_ping(veis_token, btsss_token)
-      btsss_url = Settings.travel_pay.base_url
-      api_key = Settings.travel_pay.subscription_key
-
-      connection(server_url: btsss_url).get('api/v1/Sample/authorized-ping') do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['Ocp-Apim-Subscription-Key'] = api_key
-        req.headers['X-Correlation-ID'] = SecureRandom.uuid
-      end
-    end
-
     def request_claims(veis_token, btsss_token)
       btsss_url = Settings.travel_pay.base_url
       correlation_id = SecureRandom.uuid


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*
  - Remove the last few remaining references to the travel pay ping endpoints 
  - (missed a few function defs in the process of removing the endpoints, this is code cleanup)

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira* 
- [#91021](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91021)
- *Link to previous change of the code/bug (if applicable)*
- #18261 

## Testing done

- [x] *New code is covered by unit tests*
  - Tests already removed

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
- Travel Pay Module

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

