### PR TITLE
skip soap call if participant id is nil

### DIFF
--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -15,6 +15,8 @@ module BGS
     end
 
     def read_diaries
+      return { dependency_decs: nil, diaries: [] } if participant_id.blank?
+      
       diaries = service.diaries.read_diaries(
         {
           beneficiary_id: participant_id,

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -17,7 +17,7 @@ module BGS
 
     def read_diaries
       if participant_id.blank?
-        Rails.logger.warn("read_diaries: participant_id is blank", { icn:, user_uuid: })
+        Rails.logger.warn('read_diaries: participant_id is blank', { icn:, user_uuid: })
         return { dependency_decs: nil, diaries: [] }
       end
 

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -4,7 +4,7 @@ module BGS
   class DependencyVerificationService
     include SentryLogging
 
-    attr_reader :participant_id, :ssn, :common_name, :email, :icn
+    attr_reader :participant_id, :ssn, :common_name, :email, :icn, :user_uuid
 
     def initialize(user)
       @participant_id = user.participant_id
@@ -12,10 +12,14 @@ module BGS
       @common_name = user.common_name
       @email = user.email
       @icn = user.icn
+      @user_uuid = user.uuid
     end
 
     def read_diaries
-      return { dependency_decs: nil, diaries: [] } if participant_id.blank?
+      if participant_id.blank?
+        Rails.logger.warn("read_diaries: participant_id is blank", { icn:, user_uuid: })
+        return { dependency_decs: nil, diaries: [] }
+      end
 
       diaries = service.diaries.read_diaries(
         {

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -16,7 +16,7 @@ module BGS
 
     def read_diaries
       return { dependency_decs: nil, diaries: [] } if participant_id.blank?
-      
+
       diaries = service.diaries.read_diaries(
         {
           beneficiary_id: participant_id,

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
+    it 'retuns an empty response if participant id is nil' do
+      VCR.use_cassette('bgs/diaries_service/read_diaries') do
+        allow(user).to receive(:participant_id).and_return(nil)
+        service = BGS::DependencyVerificationService.new(user)
+        diaries = service.read_diaries
+
+        expect(diaries).to eq({ dependency_decs: nil, diaries: [] })
+      end
+    end
+
     it 'does not include any dependency decisions that are in the future' do
       VCR.use_cassette('bgs/diaries_service/read_diaries') do
         allow(user).to receive(:participant_id).and_return('13014883')


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO*
- Changed the call to read_diaries to return a hash with empty values before making the SOAP call if participant_id is nil.
- To reproduce on staging, use user: vets.gov.user+243@gmail.com	 and navigate to https://staging.va.gov/view-change-dependents/view The issue will be confirmed in datadog. The bug was that the sentry error generated from the SOAP attempt returned true, which broke in a previous issue when iterating over diaries.
- The solution is to return a hash with nil/empty values for dependency_decs/diaries (respectively). The previous bug fix will read the nil and move on. Confirmation of the fix can be seen when the logger message stating that diaries is not a hash is no longer present.
- VA Benefits and Claims
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

[- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/90970)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/90901
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
