### PR TITLE
[VA-86081] Add extra logging for full backend transform

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/enhanced_expense_calculator.rb
@@ -31,6 +31,9 @@ module DebtsApi
             exclude_expenses_by(@other_expenses, [FOOD]),
             exclude_expenses_by(@expense_records, [RENT, MORTGAGE_PAYMENT])
           )
+
+          update_rent_mortgage_tracking_metrics
+
           @all_expenses ||= get_all_expenses
         end
 
@@ -126,6 +129,13 @@ module DebtsApi
           installment_monthly_due = @installment_contracts.pluck('amountDueMonthly')
           credit_card_monthly_due = @credit_card_bills.pluck('amountDueMonthly')
           safe_sum([installment_monthly_due, credit_card_monthly_due].flatten)
+        end
+
+        def update_rent_mortgage_tracking_metrics
+          return unless @new_rent_mortgage_attr.present? || @old_rent_mortgage_attr.present?
+
+          tracking_label = "#{@new_rent_mortgage_attr.present? ? 'new' : 'old'}_rent_mortgage_attr"
+          StatsD.increment("#{DebtsApi::V0::Form5655Submission::STATS_KEY}.full_transform.expenses.#{tracking_label}")
         end
       end
     end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/gmt_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/gmt_calculator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'debts_api/v0/fsr_form_transform/utils'
+
 module DebtsApi
   module V0
     module FsrFormTransform

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/streamlined_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/streamlined_calculator.rb
@@ -21,6 +21,8 @@ module DebtsApi
         end
 
         def get_streamlined_data
+          update_streamlined_tracking_metrics
+
           {
             'value' => streamlined_short_form? || streamlined_long_form?,
             'type' => if streamlined_short_form?
@@ -81,6 +83,11 @@ module DebtsApi
           debt_below_vha_limit? && total_waiver_and_copay_debts
         end
 
+        def update_streamlined_tracking_metrics
+          tracking_label = "full_transform.#{streamlined? ? 'has' : 'no'}_streamlined_data"
+          StatsD.increment("#{DebtsApi::V0::Form5655Submission::STATS_KEY}.#{tracking_label}")
+        end
+
         def are_liquid_assets_below_gmt_threshold?
           return false if @gmt_data['gmt_threshold'].blank?
 
@@ -114,6 +121,10 @@ module DebtsApi
 
         def debt_below_vha_limit?
           total_debt < VHA_LIMIT
+        end
+
+        def streamlined?
+          streamlined_short_form? || streamlined_long_form?
         end
       end
     end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/streamlined_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/streamlined_calculator_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::StreamlinedCalculator, type: :ser
         allow(GmtThreshold).to receive(:first)
           .and_return(gmt_threshold_data)
 
+        allow(StatsD).to receive(:increment).and_call_original
+
         get_streamlined_data
       end
 
@@ -75,6 +77,7 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::StreamlinedCalculator, type: :ser
         it 'gets streamlined data correct' do
           skip 'The pre_data variable needs to be modified as needed to make this pass'
           expect(expected_post_streamlined_data).to eq(@data)
+          expect(StatsD).to receive(:increment).once.with('api.fsr_submission.full_transform.has_streamlined_data')
         end
       end
 
@@ -93,6 +96,7 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::StreamlinedCalculator, type: :ser
         it 'gets streamlined data correct' do
           skip 'The pre_data variable needs to be modified as needed to make this pass'
           expect(expected_post_streamlined_data).to eq(@data)
+          expect(StatsD).to receive(:increment).once.with('api.fsr_submission.full_transform.has_streamlined_data')
         end
       end
     end


### PR DESCRIPTION
## Summary

This adds additional DataDog tracking for when the full backend transform is released.

* Track whether the expense property with the `financial_status_report_expenses_update` toggle on the front end is used or if it falls back to the old one.
* Track if the form is streamlined (long or short)

## Related issue(s)

- [Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/86081)

## Testing done

- [x] *New code is covered by unit tests*

These tests check that the additional logging is being done properly.

## What areas of the site does it impact?

FSR Forms and the full backend transform.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
