### PR TITLE
[SIMPLE_FORMS] feat: update attachment logic to handle form 20-10207

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -216,7 +216,7 @@ module SimpleFormsApi
           metadata: metadata.to_json,
           document: file_path,
           upload_url: location,
-          attachments: form.data[:form_id] == 'vba_20_10207' ? form.get_attachments : nil
+          attachments: get_form_id == 'vba_20_10207' ? form.get_attachments : nil
         }.compact
 
         lighthouse_service.perform_upload(**upload_params)

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -165,12 +165,7 @@ module SimpleFormsApi
         metadata = SimpleFormsApiSubmission::MetadataValidator.validate(form.metadata,
                                                                         zip_code_is_us_based: form.zip_code_is_us_based)
 
-        @attachments = []
-        if form_id == 'vba_20_10207'
-          @attachments = form.get_attachments
-        elsif %w[vba_40_0247 vba_40_10007].include?(form_id)
-          form.handle_attachments(file_path)
-        end
+        form.handle_attachments(file_path) if %w[vba_40_0247 vba_40_10007].include?(form_id)
 
         [file_path, metadata, form]
       end
@@ -178,7 +173,7 @@ module SimpleFormsApi
       def upload_pdf(file_path, metadata, form)
         location, uuid = prepare_for_upload(form, file_path)
         log_upload_details(location, uuid)
-        response = perform_pdf_upload(location, file_path, metadata)
+        response = perform_pdf_upload(location, file_path, metadata, form)
 
         [response.status, uuid]
       end
@@ -218,13 +213,15 @@ module SimpleFormsApi
         Rails.logger.info('Simple forms api - preparing to upload PDF to benefits intake', { location:, uuid: })
       end
 
-      def perform_pdf_upload(location, file_path, metadata)
-        lighthouse_service.perform_upload(
+      def perform_pdf_upload(location, file_path, metadata, form)
+        upload_params = {
           metadata: metadata.to_json,
           document: file_path,
           upload_url: location,
-          attachments:
-        )
+          attachments: form.data[:form_id] == 'vba_20_10207' ? form.get_attachments : nil
+        }.compact
+
+        lighthouse_service.perform_upload(**upload_params)
       end
 
       def form_is264555_and_should_use_lgy_api

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -71,6 +71,8 @@ module SimpleFormsApi
 
       private
 
+      attr_reader :attachments
+
       def lighthouse_service
         @lighthouse_service ||= BenefitsIntake::Service.new
       end
@@ -163,7 +165,11 @@ module SimpleFormsApi
         metadata = SimpleFormsApiSubmission::MetadataValidator.validate(form.metadata,
                                                                         zip_code_is_us_based: form.zip_code_is_us_based)
 
-        form.handle_attachments(file_path) if %w[vba_40_0247 vba_20_10207 vba_40_10007].include? form_id
+        if form_id == 'vba_20_10207'
+          @attachments = form.get_attachments
+        elsif %w[vba_40_0247 vba_40_10007].include?(form_id)
+          form.handle_attachments(file_path)
+        end
 
         [file_path, metadata, form]
       end
@@ -215,7 +221,8 @@ module SimpleFormsApi
         lighthouse_service.perform_upload(
           metadata: metadata.to_json,
           document: file_path,
-          upload_url: location
+          upload_url: location,
+          attachments:
         )
       end
 

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -166,7 +166,7 @@ module SimpleFormsApi
                                                                         zip_code_is_us_based: form.zip_code_is_us_based)
 
         if form_id == 'vba_20_10207'
-          @attachments = form.get_attachments
+          @attachments = form.get_attachments || []
         elsif %w[vba_40_0247 vba_40_10007].include?(form_id)
           form.handle_attachments(file_path)
         end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -71,8 +71,6 @@ module SimpleFormsApi
 
       private
 
-      attr_reader :attachments
-
       def lighthouse_service
         @lighthouse_service ||= BenefitsIntake::Service.new
       end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -165,8 +165,9 @@ module SimpleFormsApi
         metadata = SimpleFormsApiSubmission::MetadataValidator.validate(form.metadata,
                                                                         zip_code_is_us_based: form.zip_code_is_us_based)
 
+        @attachments = []
         if form_id == 'vba_20_10207'
-          @attachments = form.get_attachments || []
+          @attachments = form.get_attachments
         elsif %w[vba_40_0247 vba_40_10007].include?(form_id)
           form.handle_attachments(file_path)
         end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -71,8 +71,8 @@ module SimpleFormsApi
     end
 
     def zip_code_is_us_based
-      @data.dig('veteran_mailing_address',
-                'country') == 'USA' || @data.dig('non_veteran_mailing_address', 'country') == 'USA'
+      @data.dig('veteran_mailing_address', 'country') == 'USA' ||
+        @data.dig('non_veteran_mailing_address', 'country') == 'USA'
     end
 
     def handle_attachments(file_path)
@@ -135,8 +135,6 @@ module SimpleFormsApi
                         living_situations:, other_reasons:)
     end
 
-    private
-
     def get_attachments
       attachments = []
 
@@ -163,6 +161,8 @@ module SimpleFormsApi
 
       attachments
     end
+
+    private
 
     def veteran_ssn
       [

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -136,30 +136,21 @@ module SimpleFormsApi
     end
 
     def get_attachments
-      attachments = []
+      [].tap do |attachments|
+        %w[
+          als_documents
+          financial_hardship_documents
+          medal_award_documents
+          pow_documents
+          terminal_illness_documents
+          vsi_documents
+        ].each do |doc_type|
+          next unless @data[doc_type]
 
-      financial_hardship_documents = @data['financial_hardship_documents']
-      als_documents = @data['als_documents']
-      medal_award_documents = @data['medal_award_documents']
-      pow_documents = @data['pow_documents']
-      terminal_illness_documents = @data['terminal_illness_documents']
-      vsi_documents = @data['vsi_documents']
-
-      [
-        financial_hardship_documents,
-        als_documents,
-        medal_award_documents,
-        pow_documents,
-        terminal_illness_documents,
-        vsi_documents
-      ].compact.each do |documents|
-        confirmation_codes = []
-        documents&.map { |doc| confirmation_codes << doc['confirmation_code'] }
-
-        PersistentAttachment.where(guid: confirmation_codes).map { |attachment| attachments << attachment.to_pdf }
+          confirmation_codes = @data[doc_type].pluck('confirmation_code')
+          attachments.concat(PersistentAttachment.where(guid: confirmation_codes).map(&:to_pdf))
+        end
       end
-
-      attachments
     end
 
     private

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207_with_supporting_document.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207_with_supporting_document.json
@@ -1,0 +1,123 @@
+{
+  "form_number": "20-10207",
+  "preparer_type": "veteran",
+  "veteran_full_name": {
+    "first": "John",
+    "last": "Veteran"
+  },
+  "veteran_date_of_birth": "1980-01-01",
+  "veteran_id": {
+    "ssn": "321540987"
+  },
+  "living_situation": {
+    "overnight": true,
+    "losing_home": true,
+    "other_risk": true
+  },
+  "other_housing_risks": "Other housing risks",
+  "mailing_address_yes_no": true,
+  "veteran_mailing_address": {
+    "country": "USA",
+    "street": "123 Any St",
+    "city": "Anytown",
+    "state": "CA",
+    "postal_code": "12345"
+  },
+  "veteran_phone": "1234567890",
+  "veteran_email_address": "email@vet.com",
+  "other_reasons": {
+    "financial_hardship": true,
+    "als": true,
+    "terminal_illness": true,
+    "vsi_si": true,
+    "former_pow": true,
+    "medal_award": true,
+    "over_85": true
+  },
+  "pow_confinement_start_date": "2018-01-01",
+  "pow_confinement_end_date": "2018-02-03",
+  "pow_multiple_confinements": true,
+  "pow_confinement2start_date": "2018-11-01",
+  "pow_confinement2end_date": "2018-11-12",
+  "medical_treatments": [
+    {
+      "facility_name": "Facility Name1",
+      "facility_address": {
+        "country": "USA",
+        "street": "123 Any St",
+        "city": "Anytown",
+        "state": "CA",
+        "postal_code": "12345"
+      },
+      "start_date": "2013-01-05"
+    },
+    {
+      "facility_name": "Facility Name2",
+      "facility_address": {
+        "country": "USA",
+        "street": "123 Any St",
+        "city": "Anytown",
+        "state": "CA",
+        "postal_code": "12345"
+      },
+      "start_date": "2013-01-06"
+    }
+  ],
+  "point_of_contact_name": "Pointy McPointersons",
+  "point_of_contact_phone": "098-765-4321",
+  "statement_of_truth_signature": "John Veteran",
+  "financial_hardship_documents": [
+    {
+      "file_name": "Test File Name",
+      "file_size": 100,
+      "confirmation_number": "a-random-uuid",
+      "error_message": "",
+      "uploading": ""
+    }
+  ],
+  "terminal_illness_documents": [
+    {
+      "file_name": "Test File Name",
+      "file_size": 100,
+      "confirmation_number": "a-random-uuid",
+      "error_message": "",
+      "uploading": ""
+    }
+  ],
+  "als_documents": [
+    {
+      "file_name": "Test File Name",
+      "file_size": 100,
+      "confirmation_number": "a-random-uuid",
+      "error_message": "",
+      "uploading": ""
+    }
+  ],
+  "vsi_documents": [
+    {
+      "file_name": "Test File Name",
+      "file_size": 100,
+      "confirmation_number": "a-random-uuid",
+      "error_message": "",
+      "uploading": ""
+    }
+  ],
+  "pow_documents": [
+    {
+      "file_name": "Test File Name",
+      "file_size": 100,
+      "confirmation_number": "a-random-uuid",
+      "error_message": "",
+      "uploading": ""
+    }
+  ],
+  "medal_award_documents": [
+    {
+      "file_name": "Test File Name",
+      "file_size": 100,
+      "confirmation_number": "a-random-uuid",
+      "error_message": "",
+      "uploading": ""
+    }
+  ]
+}

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207_with_supporting_documents.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207_with_supporting_documents.json
@@ -68,54 +68,54 @@
   "statement_of_truth_signature": "John Veteran",
   "financial_hardship_documents": [
     {
-      "file_name": "Test File Name",
-      "file_size": 100,
-      "confirmation_number": "a-random-uuid",
+      "file_name": "Test File 01",
+      "file_size": 10,
+      "confirmation_code": "a-random-uuid-1",
       "error_message": "",
       "uploading": ""
     }
   ],
   "terminal_illness_documents": [
     {
-      "file_name": "Test File Name",
-      "file_size": 100,
-      "confirmation_number": "a-random-uuid",
+      "file_name": "Test File 02",
+      "file_size": 11,
+      "confirmation_code": "a-random-uuid-2",
       "error_message": "",
       "uploading": ""
     }
   ],
   "als_documents": [
     {
-      "file_name": "Test File Name",
-      "file_size": 100,
-      "confirmation_number": "a-random-uuid",
+      "file_name": "Test File 03",
+      "file_size": 12,
+      "confirmation_code": "a-random-uuid-3",
       "error_message": "",
       "uploading": ""
     }
   ],
   "vsi_documents": [
     {
-      "file_name": "Test File Name",
-      "file_size": 100,
-      "confirmation_number": "a-random-uuid",
+      "file_name": "Test File 04",
+      "file_size": 13,
+      "confirmation_code": "a-random-uuid-4",
       "error_message": "",
       "uploading": ""
     }
   ],
   "pow_documents": [
     {
-      "file_name": "Test File Name",
-      "file_size": 100,
-      "confirmation_number": "a-random-uuid",
+      "file_name": "Test File 05",
+      "file_size": 14,
+      "confirmation_code": "a-random-uuid-5",
       "error_message": "",
       "uploading": ""
     }
   ],
   "medal_award_documents": [
     {
-      "file_name": "Test File Name",
-      "file_size": 100,
-      "confirmation_number": "a-random-uuid",
+      "file_name": "Test File 06",
+      "file_size": 15,
+      "confirmation_code": "a-random-uuid-6",
       "error_message": "",
       "uploading": ""
     }

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -259,8 +259,10 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         let(:pdf_path) { Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf') }
         let(:attachment) { double }
         let(:lighthouse_service) { double }
+        let(:confirmation_number) { 'some_confirmation_number' }
 
         before do
+          sign_in
           allow(attachment).to receive(:to_pdf).and_return(pdf_path)
           allow(PersistentAttachment).to receive(:where).with(guid: ['a-random-uuid']).and_return([attachment])
         end
@@ -278,7 +280,10 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         end
 
         shared_examples 'handles multiple attachments' do |form_doc|
-          before { allow(lighthouse_service).to receive(:perform_upload) }
+          before do
+            allow_any_instance_of(SimpleFormsApi::V1::UploadsController).to receive(:lighthouse_service).and_return(lighthouse_service)
+            allow(lighthouse_service).to receive(:perform_upload).and_return([200, confirmation_number])
+          end
 
           let(:data) do
             fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', form_doc)


### PR DESCRIPTION
## Summary

- This work adds logic to separate attachments when submitting form `20-10207`
- This work also adds test coverage around the new logic

## Related issue(s)

- [Error: Form 20-10207 Max Document size exceeded](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1610)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?

- Simple Forms API -> form 20-10207

## Requested Feedback

Any
