### PR TITLE
Use random value in Simple Forms PDF stamping file paths

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -169,26 +169,26 @@ module SimpleFormsApi
       end
 
       def upload_pdf(file_path, metadata, form)
-        location, uuid = prepare_for_upload(form)
+        location, uuid = prepare_for_upload(form, file_path)
         log_upload_details(location, uuid)
         response = perform_pdf_upload(location, file_path, metadata)
 
         [response.status, uuid]
       end
 
-      def prepare_for_upload(form)
+      def prepare_for_upload(form, file_path)
         Rails.logger.info('Simple forms api - preparing to request upload location from Lighthouse',
                           form_id: get_form_id)
         location, uuid = lighthouse_service.request_upload
-        stamp_pdf_with_uuid(form, uuid)
+        stamp_pdf_with_uuid(form, uuid, file_path)
         create_form_submission_attempt(uuid)
 
         [location, uuid]
       end
 
-      def stamp_pdf_with_uuid(form, uuid)
+      def stamp_pdf_with_uuid(form, uuid, stamped_template_path)
         # Stamp uuid on 40-10007
-        pdf_stamper = SimpleFormsApi::PdfStamper.new(stamped_template_path: 'tmp/vba_40_10007-tmp.pdf', form:)
+        pdf_stamper = SimpleFormsApi::PdfStamper.new(stamped_template_path:, form:)
         pdf_stamper.stamp_uuid(uuid)
       end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb
@@ -31,8 +31,8 @@ module SimpleFormsApi
     private
 
     def prepare_to_generate_pdf
-      generated_form_path = Rails.root.join("tmp/#{name}-tmp.pdf").to_s
-      stamped_template_path = Rails.root.join("tmp/#{name}-stamped.pdf").to_s
+      generated_form_path = Rails.root.join("tmp/#{name}-#{SecureRandom.hex}-tmp.pdf").to_s
+      stamped_template_path = Rails.root.join("tmp/#{name}-#{SecureRandom.hex}-stamped.pdf").to_s
 
       copy_from_tempfile(stamped_template_path)
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
@@ -44,7 +44,7 @@ module SimpleFormsApi
 
       # Stamp uuid on 40-10007
       uuid = upload_location.dig('data', 'id')
-      SimpleFormsApi::PdfStamper.new(stamped_template_path: 'tmp/vba_40_10007-tmp.pdf', form:).stamp_uuid(uuid)
+      SimpleFormsApi::PdfStamper.new(stamped_template_path: file_path, form:).stamp_uuid(uuid)
 
       { uuid:, location: upload_location.dig('data', 'attributes', 'location') }
     end

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -43,12 +43,11 @@ describe SimpleFormsApi::PdfFiller do
         let(:form) { "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
         let(:name) { SecureRandom.hex }
 
+        before { allow(SecureRandom).to receive(:hex).and_return(pseudorandom_value) }
         after { FileUtils.rm_f(expected_pdf_path) }
 
         context 'when a legitimate JSON payload is provided' do
           it 'properly fills out the associated PDF' do
-            allow(SecureRandom).to receive(:hex).and_return(pseudorandom_value)
-
             expect do
               described_class.new(form_number:, form:, name:).generate
             end.to change { File.exist?(expected_pdf_path) }.from(false).to(true)

--- a/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_filler_spec.rb
@@ -36,8 +36,9 @@ describe SimpleFormsApi::PdfFiller do
     forms.each do |file_name|
       context "when mapping the pdf data given JSON file: #{file_name}" do
         let(:form_number) { file_name.gsub('-min', '') }
-        let(:expected_pdf_path) { Rails.root.join("tmp/#{name}-tmp.pdf") }
-        let(:expected_stamped_path) { Rails.root.join("tmp/#{name}-stamped.pdf") }
+        let(:pseudorandom_value) { 'abc123' }
+        let(:expected_pdf_path) { Rails.root.join("tmp/#{name}-#{pseudorandom_value}-tmp.pdf") }
+        let(:expected_stamped_path) { Rails.root.join("tmp/#{name}-#{pseudorandom_value}-stamped.pdf") }
         let(:data) { JSON.parse(File.read("modules/simple_forms_api/spec/fixtures/form_json/#{file_name}.json")) }
         let(:form) { "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
         let(:name) { SecureRandom.hex }
@@ -46,6 +47,8 @@ describe SimpleFormsApi::PdfFiller do
 
         context 'when a legitimate JSON payload is provided' do
           it 'properly fills out the associated PDF' do
+            allow(SecureRandom).to receive(:hex).and_return(pseudorandom_value)
+
             expect do
               described_class.new(form_number:, form:, name:).generate
             end.to change { File.exist?(expected_pdf_path) }.from(false).to(true)


### PR DESCRIPTION
## Summary
This PR adds a random value to every temporarily saved file path. The hope here is to avoid the odd error in prod where a file can't be stamped because that path is not found. My hunch is that this arises from a race condition where one process deletes a file that another process was depending on. We'll see...
