### PR TITLE
[DBX-88683] address last minute 526 success scope case

### DIFF
--- a/lib/scopes/form526_submission_state.rb
+++ b/lib/scopes/form526_submission_state.rb
@@ -108,8 +108,6 @@ module Scopes
         filter5 = where(id: filter4 - success_by_age.pluck(:id)).pluck(:id)
         filter_final = where(id: filter5 - incomplete_type.pluck(:id)).pluck(:id)
 
-        # submitted_claim_id: nil addresses an edge case where happy path succeeds
-        # during the above query building
         where(id: filter_final, submitted_claim_id: nil)
       }
     end

--- a/lib/scopes/form526_submission_state.rb
+++ b/lib/scopes/form526_submission_state.rb
@@ -108,7 +108,9 @@ module Scopes
         filter5 = where(id: filter4 - success_by_age.pluck(:id)).pluck(:id)
         filter_final = where(id: filter5 - incomplete_type.pluck(:id)).pluck(:id)
 
-        where(id: filter_final)
+        # submitted_claim_id: nil addresses an edge case where happy path succeeds
+        # during the above query building
+        where(id: filter_final, submitted_claim_id: nil)
       }
     end
     # rubocop:enable Metrics/BlockLength

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Form526Submission do
         )
       end
 
-      it 'handles the edge case where an in process sub succeeds during query building' do
+      it 'handles the edge case where an sub succeeds during query building' do
         expired.update!(submitted_claim_id: 'abc123')
 
         expect(Form526Submission.failure_type).to contain_exactly(

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -262,6 +262,17 @@ RSpec.describe Form526Submission do
           exhausted_backup
         )
       end
+
+      it 'handles the edge case where an in process sub succeeds during query building' do
+        expired.update!(submitted_claim_id: 'abc123')
+
+        expect(Form526Submission.failure_type).to contain_exactly(
+          rejected_backup,
+          old_no_longer_remediated,
+          failed_backup,
+          exhausted_backup
+        )
+      end
     end
   end
 

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Form526Submission do
         )
       end
 
-      it 'handles the edge case where an sub succeeds during query building' do
+      it 'handles the edge case where a submission succeeds during query building' do
         expired.update!(submitted_claim_id: 'abc123')
 
         expect(Form526Submission.failure_type).to contain_exactly(


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- There is an edge case documented (link below) where a submission would be included in the original `all` scope, but then succeed before the `in_process` scope is considered. This is a side effect of our need to filter the submissions iteratively, instead of finding them in a single query as this was causing PG timeouts.

## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=71313591)
- [Updated documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/526_scopes.md#failure_type-edge-case)

## Testing done

- [x] *New code is covered by unit tests*
- see documentation for problem description
- This has been verified to work in a production console, as this is the only reliable way given our problem with timeouts

## What areas of the site does it impact?
Form 526 state

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution (this will unblock that)
- [x]  Documentation has been updated (see above)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature (n/a)
