### PR TITLE
VACMS-11520: Remove no longer used pdf_warning_banner feature flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -937,10 +937,6 @@ features:
   organic_conversion_experiment:
     actor_type: user
     description: Toggle to enable login.gov create account experiment
-  pdf_warning_banner:
-    description: When enabled, will allow display of PDF cert warnings in find-a-form
-    actor_type: user
-    enable_in_development: true
   pension_income_and_assets_clarification:
     actor_type: user
     description: >


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Removes a no longer used `pdf_warning_banner` feature flag
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)* N/A
- *(Which team do you work for, does your team own the maintenance of this component?)* Sitewide Team, yes
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- [issue](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11520)
- [code removal](https://github.com/department-of-veterans-affairs/vets-website/pull/31708)
- [deprecation](https://github.com/department-of-veterans-affairs/content-build/pull/1426/files)
- [epic](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10956)

## Testing done

- [ ] *New code is covered by unit tests* (No new code)
- No changes to behavior. Removed no longer used flipper
- Tested by verifying it does not result in new errors when viewing forms

## What areas of the site does it impact?
None as the feature using this flag has already been fully deprecated

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

