### PR TITLE
Removed unused sidekiq setting

### DIFF
--- a/app/sidekiq/central_mail/submit_central_form686c_job.rb
+++ b/app/sidekiq/central_mail/submit_central_form686c_job.rb
@@ -17,8 +17,6 @@ module CentralMail
     STATSD_KEY_PREFIX = 'worker.submit_686c_674_backup_submission'
     RETRY = 14
 
-    sidekiq_options retry: false
-
     attr_reader :claim, :form_path, :attachment_paths
 
     class CentralMailResponseError < StandardError; end


### PR DESCRIPTION
## Summary

As identified in this ticket, we do not need the extra invalid config:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/92135

