### PR TITLE
[API-39968] Add log to separation location code validation

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -724,13 +724,15 @@ module ClaimsApi
           return
         end
 
-        ClaimsApi::Logger.log('separation_location_codes', detail: 'Retrieved separation locations',
-                                                           separation_locations:)
-
         separation_location_ids = separation_locations.pluck(:id).to_set(&:to_s)
 
         service_periods.each_with_index do |service_period, idx|
-          next if separation_location_ids.include?(service_period['separationLocationCode'])
+          separation_location_code = service_period['separationLocationCode']
+
+          next if separation_location_ids.include?(separation_location_code)
+
+          ClaimsApi::Logger.log('separation_location_codes', detail: 'Separation location code not found',
+                                                             separation_locations:, separation_location_code:)
 
           collect_error_messages(
             source: "/serviceInformation/servicePeriods/#{idx}/separationLocationCode",

--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -706,7 +706,7 @@ module ClaimsApi
         )
       end
 
-      def validate_form_526_location_codes(service_information)
+      def validate_form_526_location_codes(service_information) # rubocop:disable Metrics/MethodLength
         service_periods = service_information['servicePeriods']
         any_code_present = service_periods.any? do |service_period|
           service_period['separationLocationCode'].present?
@@ -723,6 +723,9 @@ module ClaimsApi
           )
           return
         end
+
+        ClaimsApi::Logger.log('separation_location_codes', detail: 'Retrieved separation locations',
+                                                           separation_locations:)
 
         separation_location_ids = separation_locations.pluck(:id).to_set(&:to_s)
 


### PR DESCRIPTION
## Summary

Add log to debug separation location codes.

## Related issue(s)

[API-39968](https://jira.devops.va.gov/browse/API-39968)

## Testing done

1. Manually submit a separation location code to the `/v2/veterans/:id/526/validate` endpoint;
2. Observe log output:
   ```
   2024-09-09 15:25:03.965299 I [79719:puma srv tp 002] Rails -- ClaimsApi :: separation_location_codes :: {"detail":"Retrieved separation locations","separation_locations":[{"id":24912,"description":"AF Academy"},…
   ```
## Screenshots

N/A

## What areas of the site does it impact?

526 disability compensation validation - separation location code

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A