### PR TITLE
Log and Silence 503/504 Errors in LGY Service

### DIFF
--- a/app/controllers/v0/coe_controller.rb
+++ b/app/controllers/v0/coe_controller.rb
@@ -56,9 +56,15 @@ module V0
           document_data = build_document_data(attachment)
 
           response = lgy_service.post_document(payload: document_data)
-          unless response.status == 201
-            status = response.status
-            break
+          begin
+            unless response.status == 201
+              status = response.status
+              break
+            end
+          rescue Common::Client::Errors::ClientError => e
+            raise e unless [502, 503].include(e.status)
+
+            Rails.logger.info('Received LGY server error:', { status: e.status, messsage: e.message, body: e.body })
           end
         end
       end

--- a/app/models/saved_claim/coe_claim.rb
+++ b/app/models/saved_claim/coe_claim.rb
@@ -19,6 +19,10 @@ class SavedClaim::CoeClaim < SavedClaim
       process_attachments!
       response['reference_number']
     end
+  rescue Common::Client::Errors::ClientError => e
+    raise e unless [502, 503].include(e.status)
+
+    Rails.logger.info('Received LGY server error:', { status: e.status, messsage: e.message, body: e.body })
   end
 
   def regional_office


### PR DESCRIPTION
## Summary
- Do not bubble error if error is raised due to HTTP status codes 503 or 504 in the COE claims requests to the LGY API

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92416

## Testing done
- TODO

## What areas of the site does it impact?
COE claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
