### PR TITLE
9140 payment info errors

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/payment_information_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/payment_information_controller.rb
@@ -119,7 +119,7 @@ module Mobile
         errors << "Payment account info missing for user #{current_user.uuid}" if data.payment_account.nil?
         return if errors.empty?
 
-        raise Common::Exceptions::UnprocessableEntity.new(detail: errors)
+        raise Common::Exceptions::UnprocessableEntity.new(detail: errors.join('. '))
       end
     end
   end

--- a/modules/mobile/spec/requests/mobile/v0/payment_information/benefits_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/payment_information/benefits_spec.rb
@@ -88,10 +88,8 @@ RSpec.describe 'Mobile::V0::PaymentInformation::Benefits', type: :request do
               'errors' => [
                 {
                   'title' => 'Unprocessable Entity',
-                  'detail' => [
-                    "Control information missing for user #{user.uuid}",
-                    "Payment account info missing for user #{user.uuid}"
-                  ],
+                  'detail' => "Control information missing for user #{user.uuid}. \
+Payment account info missing for user #{user.uuid}",
                   'code' => '422',
                   'status' => '422'
                 }

--- a/modules/mobile/spec/requests/mobile/v0/payment_information/benefits_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/payment_information/benefits_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe 'Mobile::V0::PaymentInformation::Benefits', type: :request do
       end
     end
 
+    context 'when response body is missing control_information or payment_account' do
+      it 'returns not found' do
+        # i'm choosing to stub instead of creating a new cassette because this is a temporary fix
+        allow_any_instance_of(Lighthouse::DirectDeposit::Response).to receive(:control_information).and_return(nil)
+
+        VCR.use_cassette('lighthouse/direct_deposit/show/200_valid') do
+          get '/mobile/v0/payment-information/benefits', headers: sis_headers
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
     context 'with a 500 server error type' do
       it 'returns a service error response' do
         VCR.use_cassette('lighthouse/direct_deposit/show/errors/400_unspecified_error') do


### PR DESCRIPTION
## Summary

- This fixes a 500 error that has been observed in DataDog
- The problem occurs when the direct deposit response lacks control information
- We've talked to the lighthouse team and the team upstream of lighthouse. 
- The upstream team says the only reason this information would be missing is if the user isn't found. 
- The lighthouse team says this isn't possible at all, which is why I've chosen to return unprocessable entity instead of not found. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9140

## Testing done

Specs.

## Screenshots


## What areas of the site does it impact?
Only impacts the payment information show method.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

