### PR TITLE
[API-39901] Allow null separation location codes

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -729,7 +729,7 @@ module ClaimsApi
         service_periods.each_with_index do |service_period, idx|
           separation_location_code = service_period['separationLocationCode']
 
-          next if separation_location_ids.include?(separation_location_code)
+          next if separation_location_code.nil? || separation_location_ids.include?(separation_location_code)
 
           ClaimsApi::Logger.log('separation_location_codes', detail: 'Separation location code not found',
                                                              separation_locations:, separation_location_code:)

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
@@ -68,7 +68,7 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
       ] }
     end
 
-    let(:mixed_separation_codes) do
+    let(:valid_and_invalid_separation_codes) do
       { 'servicePeriods' => [
         {
           'serviceBranch' => 'Public Health Service',
@@ -84,6 +84,24 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
           'activeDutyEndDate' => '2023-10-30',
           'separationLocationCode' => '123456' # invalid
         }
+      ] }
+    end
+
+    let(:valid_and_no_separation_codes) do
+      { 'servicePeriods' => [
+        {
+          'serviceBranch' => 'Public Health Service',
+          'serviceComponent' => 'Active',
+          'activeDutyBeginDate' => '2008-11-14',
+          'activeDutyEndDate' => '2023-10-30',
+          'separationLocationCode' => '24912' # valid
+        },
+        {
+          'serviceBranch' => 'Public Health Service',
+          'serviceComponent' => 'Active',
+          'activeDutyBeginDate' => '2008-11-14',
+          'activeDutyEndDate' => '2023-10-30'
+        } # no separation location code
       ] }
     end
 
@@ -122,10 +140,19 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
 
       context 'when the location code is valid in some service periods and invalid in others' do
         it 'adds an error to the errors array' do
-          test_526_validation_instance.send(:validate_form_526_location_codes, mixed_separation_codes)
+          test_526_validation_instance.send(:validate_form_526_location_codes, valid_and_invalid_separation_codes)
           errors = test_526_validation_instance.send(:error_collection)
 
           expect(errors.size).to eq(1)
+        end
+      end
+
+      context 'when the location code is valid in some service periods and not present in others' do
+        it 'returns no errors' do
+          test_526_validation_instance.send(:validate_form_526_location_codes, valid_and_no_separation_codes)
+          errors = test_526_validation_instance.send(:error_collection)
+
+          expect(errors).to be_empty
         end
       end
     end


### PR DESCRIPTION
## Summary

When there is a separation location code among many service periods, we validate all service periodsʼ separation location codes, including periods which might not have a separation location code.

Add a guard to skip service periods that do not have a separation location code.

## Related issue(s)

[API-39901](https://jira.devops.va.gov/browse/API-39901)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

Disability compensation validation > separation location codes

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A