### PR TITLE
92006 remove travel claims v1 configs

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -683,23 +683,23 @@
 
 #Travel Claim VEIS Auth (BTSSS)
 - :name: "Travel Claim VEIS Auth Service"
-  :base_uri: <%= "#{URI(Settings.check_in.travel_reimbursement_api.auth_url).host}:#{URI(Settings.check_in.travel_reimbursement_api.auth_url).port}" %>
+  :base_uri: <%= "#{URI(Settings.check_in.travel_reimbursement_api_v2.auth_url).host}:#{URI(Settings.check_in.travel_reimbursement_api_v2.auth_url).port}" %>
   :endpoints:
     - :method: :post
-      :path: <%= "/#{Settings.check_in.travel_reimbursement_api.tenant_id}/oauth2/v2.0/token" %>
+      :path: <%= "/#{Settings.check_in.travel_reimbursement_api_v2.tenant_id}/oauth2/v2.0/token" %>
       :file_path: "/travel_claim/token/default"
       :response_delay: 0.3
 
 #Travel Claim Ingest Service (BTSSS)
 - :name: "Travel Claim Ingest Service"
-  :base_uri: <%= "#{URI(Settings.check_in.travel_reimbursement_api.claims_url).host}:#{URI(Settings.check_in.travel_reimbursement_api.claims_url).port}" %>
+  :base_uri: <%= "#{URI(Settings.check_in.travel_reimbursement_api_v2.claims_url).host}:#{URI(Settings.check_in.travel_reimbursement_api_v2.claims_url).port}" %>
   :endpoints:
     - :method: :post
-      :path: <%= "/#{Settings.check_in.travel_reimbursement_api.claims_base_path}/api/ClaimIngest/submitclaim" %>
+      :path: <%= "/#{Settings.check_in.travel_reimbursement_api_v2.claims_base_path}/api/ClaimIngest/submitclaim" %>
       :file_path: "/travel_claim/submitclaim/default"
       :response_delay: 15
     - :method: :post
-      :path: <%= "/#{Settings.check_in.travel_reimbursement_api.claims_base_path}/api/ClaimIngest/V1/GetClaimsStatus" %>
+      :path: <%= "/#{Settings.check_in.travel_reimbursement_api_v2.claims_base_path}/api/ClaimIngest/V1/GetClaimsStatus" %>
       :file_path: "/travel_claim/claimstatus/default"
       :response_delay: 1
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -158,10 +158,6 @@ features:
     actor_type: user
     description: Enables travel reimbursement workflow for day-of check-in application.
     enable_in_development: true
-  check_in_experience_travel_api_v2_cutover:
-    actor_type: user
-    description: Cuts over to new EIS endpoint path, client_id, and keys for BTSSS
-    enable_in_development: true
   check_in_experience_cerner_travel_claims_enabled:
     actor_type: user
     description: Enables travel claims filing for Oracle Health (Cerner) sites

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -273,14 +273,12 @@ chip:
     tenant_id: 12345678-aaaa-bbbb-cccc-269c51a7d380
 
 check_in:
-  travel_reimbursement_api:
-    auth_url: https://login.microsoftonline.us
+  travel_reimbursement_api_v2:
     auth_url_v2: https://login.microsoftonline.us
     tenant_id: fake_template_id
     client_id: fake_client_id
     client_secret: fake_client_secret
     scope: fake_scope/.default
-    claims_url: https://dev.integration.d365.va.gov
     claims_url_v2: https://dev.integration.d365.va.gov
     claims_base_path: EC/ClaimIngestSvc
     subscription_key: fake_subscription_key

--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -30,11 +30,7 @@ module TravelClaim
     end
 
     def initialize(opts)
-      @settings = if Flipper.enabled?('check_in_experience_travel_api_v2_cutover')
-                    Settings.check_in.travel_reimbursement_api_v2
-                  else
-                    Settings.check_in.travel_reimbursement_api
-                  end
+      @settings = Settings.check_in.travel_reimbursement_api_v2
       @check_in = opts[:check_in]
     end
 

--- a/modules/check_in/app/services/travel_claim/redis_client.rb
+++ b/modules/check_in/app/services/travel_claim/redis_client.rb
@@ -13,7 +13,7 @@ module TravelClaim
     end
 
     def initialize
-      @settings = Settings.check_in.travel_reimbursement_api
+      @settings = Settings.check_in.travel_reimbursement_api_v2
     end
 
     def token

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -10,7 +10,6 @@ describe TravelClaim::Client do
 
   before do
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
-    allow(Flipper).to receive(:enabled?).with('check_in_experience_travel_api_v2_cutover').and_return(false)
   end
 
   describe '.build' do

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -399,7 +399,7 @@ describe TravelClaim::Client do
 
       it 'returns single subscription key in headers' do
         with_settings(Settings, vsp_environment: 'staging') do
-          with_settings(Settings.check_in.travel_reimbursement_api, subscription_key: 'subscription_key') do
+          with_settings(Settings.check_in.travel_reimbursement_api_v2, subscription_key: 'subscription_key') do
             expect(subject.send(:claims_default_header)).to eq(resp_headers)
           end
         end
@@ -417,7 +417,7 @@ describe TravelClaim::Client do
 
       it 'returns both subscription keys in headers' do
         with_settings(Settings, vsp_environment: 'production') do
-          with_settings(Settings.check_in.travel_reimbursement_api,
+          with_settings(Settings.check_in.travel_reimbursement_api_v2,
                         { e_subscription_key: 'e_key', s_subscription_key: 's_key' }) do
             expect(subject.send(:claims_default_header)).to eq(resp_headers)
           end

--- a/modules/check_in/spec/sidekiq/travel_claim_status_check_worker_spec.rb
+++ b/modules/check_in/spec/sidekiq/travel_claim_status_check_worker_spec.rb
@@ -269,7 +269,6 @@ describe CheckIn::TravelClaimStatusCheckWorker, type: :worker do
   before do
     allow(TravelClaim::RedisClient).to receive(:build).and_return(redis_client)
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
-    allow(Flipper).to receive(:enabled?).with('check_in_experience_travel_api_v2_cutover').and_return(false)
 
     allow(redis_client).to receive_messages(patient_cell_phone:, token: redis_token, icn:,
                                             station_number:, facility_type: nil)

--- a/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
+++ b/modules/check_in/spec/sidekiq/travel_claim_submission_worker_spec.rb
@@ -222,7 +222,6 @@ describe CheckIn::TravelClaimSubmissionWorker, type: :worker do
   before do
     allow(TravelClaim::RedisClient).to receive(:build).and_return(redis_client)
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
-    allow(Flipper).to receive(:enabled?).with('check_in_experience_travel_api_v2_cutover').and_return(false)
     allow(Flipper).to receive(:enabled?).with(:check_in_experience_check_claim_status_on_timeout)
                                         .and_return(true)
 


### PR DESCRIPTION
## Summary
We have been using updated v2 configs (which included new path and api keys) for more than a week now and they are confirmed working in production. This PR removes the older v1 configs to prevent future confusion.

There will be an accompanying PR in the vsp-infra-application-manifests repo.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/92006

## Testing done
- [x] rspecs
- [x] local integration testing


## What areas of the site does it impact?
check in experience travel claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
