### PR TITLE
[dbx-88683] run 526 state logging nightly

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -62,7 +62,7 @@ PERIODIC_JOBS = lambda { |mgr|
   mgr.register('0 2 * * 0', 'Form526ParanoidSuccessPollingJob')
 
   # Log the state of Form 526 submissions to hydrate Datadog monitor
-  mgr.register('5 4 * * 7', 'Form526StateLoggingJob')
+  mgr.register('0 3 * * *', 'Form526StateLoggingJob')
 
   # Clear out processed 22-1990 applications that are older than 1 month
   mgr.register('0 0 * * *', 'EducationForm::DeleteOldApplications')


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Increase the frequency of our 526 state logging to every night. This provides OCTO admin with a near-real time number to lessen the reliance on Developer production access (other option is run this on an Argo terminal)

## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=79465229)
- [Affected dashboard](https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/benefits---form-526-disability-compensation?fromUser=false&refresh_mode=sliding&from_ts=1723484820226&to_ts=1726076820226&live=true)

## Testing done

- nothing to test

## What areas of the site does it impact?
Form 526 State logging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (n/a)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
