### PR TITLE
API-37310 - Rename error class and filename, update refs in code

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
@@ -187,7 +187,7 @@ module ClaimsApi
           validate_veteran_name(true)
           # if we get here there were only validations file errors
           if @claims_api_forms_validation_errors
-            raise ::ClaimsApi::Common::Exceptions::Lighthouse::JsonDisabilityCompensationValidationError,
+            raise ::ClaimsApi::Common::Exceptions::Lighthouse::JsonFormValidationError,
                   @claims_api_forms_validation_errors
           end
         end

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
@@ -52,7 +52,7 @@ module ClaimsApi
           add_claimant_data_to_form if user_profile
           # if we get here there were only validations file errors
           if @claims_api_forms_validation_errors
-            raise ::ClaimsApi::Common::Exceptions::Lighthouse::JsonDisabilityCompensationValidationError,
+            raise ::ClaimsApi::Common::Exceptions::Lighthouse::JsonFormValidationError,
                   @claims_api_forms_validation_errors
           end
         end

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -19,7 +19,7 @@ module ClaimsApi
 
           # if we get here, the only errors not raised are form value validation errors
           if @claims_api_forms_validation_errors
-            raise ::ClaimsApi::Common::Exceptions::Lighthouse::JsonDisabilityCompensationValidationError,
+            raise ::ClaimsApi::Common::Exceptions::Lighthouse::JsonFormValidationError,
                   @claims_api_forms_validation_errors
           end
 

--- a/modules/claims_api/lib/claims_api/common/exceptions/lighthouse/json_form_validation_error.rb
+++ b/modules/claims_api/lib/claims_api/common/exceptions/lighthouse/json_form_validation_error.rb
@@ -5,8 +5,8 @@ module ClaimsApi
     module Exceptions
       module Lighthouse
         # This class is specifically for handling the collected errors
-        # from the 526 validations file
-        class JsonDisabilityCompensationValidationError < StandardError
+        # from form 526 and POA validations
+        class JsonFormValidationError < StandardError
           def initialize(errors)
             @errors = { errors: } # errors comes in as an array from the JSON validator
 

--- a/modules/claims_api/lib/claims_api/v2/error/lighthouse_error_handler.rb
+++ b/modules/claims_api/lib/claims_api/v2/error/lighthouse_error_handler.rb
@@ -2,7 +2,7 @@
 
 require 'claims_api/common/exceptions/lighthouse/token_validation_error'
 require 'claims_api/common/exceptions/lighthouse/json_validation_error'
-require 'claims_api/common/exceptions/lighthouse/json_disability_compensation_validation_error'
+require 'claims_api/common/exceptions/lighthouse/json_form_validation_error'
 require 'claims_api/common/exceptions/lighthouse/backend_service_exception'
 require './lib/common/exceptions/backend_service_exception'
 require 'claims_api/common/exceptions/lighthouse/unprocessable_entity'
@@ -48,7 +48,7 @@ module ClaimsApi
             rescue_from ::ClaimsApi::Common::Exceptions::Lighthouse::UnprocessableEntity do |err|
               render_error(err)
             end
-            rescue_from ::ClaimsApi::Common::Exceptions::Lighthouse::JsonDisabilityCompensationValidationError do |errs|
+            rescue_from ::ClaimsApi::Common::Exceptions::Lighthouse::JsonFormValidationError do |errs|
               render_validation_errors(errs)
             end
           end

--- a/modules/claims_api/spec/lib/claims_api/v2/error/lighthouse_error_handler_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/error/lighthouse_error_handler_spec.rb
@@ -37,7 +37,7 @@ describe ApplicationController, type: :controller do
             source: '/directDeposit/routingNumber', title: 'Unprocessable entity', status: '422' }
         ]
 
-      raise ClaimsApi::Common::Exceptions::Lighthouse::JsonDisabilityCompensationValidationError, errors_array
+      raise ClaimsApi::Common::Exceptions::Lighthouse::JsonFormValidationError, errors_array
     end
 
     def raise_invalid_token


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Renames error class used for form validation errors to be more generic to reflect use outside of 526

## Related issue(s)

[API-37310](https://jira.devops.va.gov/browse/API-37310)

## Testing done

- [ ] *New code is covered by unit tests*
- Confirmed validation error handling still works as expected for 526 and POA

## What areas of the site does it impact?
Disability compensation and POA form validation error handling

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
