### PR TITLE
[VI-466] update mhv account creation's host, add request key

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -562,7 +562,8 @@ mhv:
     x_auth_key: fake-x-auth-key
   account_creation:
     mock: true
-    host: https://mhv-intb-api.myhealth.va.gov
+    host: https://apigw-intb.aws.myhealth.va.gov
+    access_key: some-access-key
     sts:
       service_account_id: c34b86f2130ff3cd4b1d309bc09d8740
       issuer: http://localhost:3000

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -165,7 +165,7 @@ btsss.update!(
 mhv_ac = SignIn::ServiceAccountConfig.find_or_initialize_by(service_account_id: 'c34b86f2130ff3cd4b1d309bc09d8740')
 mhv_ac.update!(
   description: 'MHV Account Creation - localhost',
-  scopes: ['https://mhv-intb-api.myhealth.va.gov/mhvapi/v1/usermgmt/account-service/account',
+  scopes: ['https://apigw-intb.aws.myhealth.va.gov/v1/usermgmt/account-service/account',
            'http://localhost:3000/sts/terms_of_use/current_status'],
   access_token_audience: 'http://localhost:3000',
   access_token_user_attributes: ['icn'],

--- a/lib/mhv/account_creation/configuration.rb
+++ b/lib/mhv/account_creation/configuration.rb
@@ -15,7 +15,7 @@ module MHV
       end
 
       def account_creation_path
-        'mhvapi/v1/usermgmt/account-service/account'
+        'v1/usermgmt/account-service/account'
       end
 
       def logging_prefix
@@ -36,6 +36,10 @@ module MHV
 
       def tou_doc_title
         'VA Enterprise Terms of Use'
+      end
+
+      def access_key
+        Settings.mhv.account_creation.access_key
       end
 
       def connection

--- a/lib/mhv/account_creation/service.rb
+++ b/lib/mhv/account_creation/service.rb
@@ -34,7 +34,10 @@ module MHV
       end
 
       def authenticated_header(icn:)
-        { 'Authorization' => "Bearer #{config.sts_token(user_identifier: icn)}" }
+        {
+          'Authorization' => "Bearer #{config.sts_token(user_identifier: icn)}",
+          'x-api-key' => config.access_key
+        }
       end
 
       def normalize_response_body(response_body)

--- a/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_200_response.yml
+++ b/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_200_response.yml
@@ -54,7 +54,7 @@ http_interactions:
   recorded_at: Thu, 29 Aug 2024 02:31:02 GMT
 - request:
     method: post
-    uri: "https://mhv-intb-api.myhealth.va.gov/mhvapi/v1/usermgmt/account-service/account"
+    uri: "https://apigw-intb.aws.myhealth.va.gov/v1/usermgmt/account-service/account"
     body:
       encoding: UTF-8
       string: '{"icn":"10101V964144","email":"some-email@email.com","vaTermsOfUseStatus":"accepted","vaTermsOfUseDateTime":"2017-07-26T19:56:07Z","vaTermsOfUseRevision":"3","vaTermsOfUseLegalVersion":"1.0","vaTermsOfUseDocTitle":"VA Enterprise Terms of Use"}'

--- a/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_400_response.yml
+++ b/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_400_response.yml
@@ -54,7 +54,7 @@ http_interactions:
   recorded_at: Thu, 29 Aug 2024 02:31:02 GMT
 - request:
     method: post
-    uri: "https://mhv-intb-api.myhealth.va.gov/mhvapi/v1/usermgmt/account-service/account"
+    uri: "https://apigw-intb.aws.myhealth.va.gov/v1/usermgmt/account-service/account"
     body:
       encoding: UTF-8
       string: '{"icn":"10101V964144","email":"some-email@email.com","vaTermsOfUseStatus":"accepted","vaTermsOfUseDateTime":"2017-07-26T19:56:07Z","vaTermsOfUseRevision":"3","vaTermsOfUseLegalVersion":"1.0","vaTermsOfUseDocTitle":"VA Enterprise Terms of Use"}'

--- a/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_500_response.yml
+++ b/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_500_response.yml
@@ -54,7 +54,7 @@ http_interactions:
   recorded_at: Thu, 29 Aug 2024 02:31:02 GMT
 - request:
     method: post
-    uri: "https://mhv-intb-api.myhealth.va.gov/mhvapi/v1/usermgmt/account-service/account"
+    uri: "https://apigw-intb.aws.myhealth.va.gov/v1/usermgmt/account-service/account"
     body:
       encoding: UTF-8
       string: '{"icn":"10101V964144","email":"some-email@email.com","vaTermsOfUseStatus":"accepted","vaTermsOfUseDateTime":"2017-07-26T19:56:07Z","vaTermsOfUseRevision":"3","vaTermsOfUseLegalVersion":"1.0","vaTermsOfUseDocTitle":"VA Enterprise Terms of Use"}'


### PR DESCRIPTION
## Summary
Update mhv account creation's host, route, and key.

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-466
- https://jira.devops.va.gov/browse/VI-465
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3097

## Testing
### setup
- seed database - `rails db:deed`
- add `conn.request :curl` to the faraday connection: lib/mhv/account_creation/configuration#45
   ```ruby
   def connection
      Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
         
        conn.use :breakers
        conn.use Faraday::Response::RaiseError
        conn.adapter Faraday.default_adapter
        conn.request :curl
        conn.response :json
        conn.response :betamocks if Settings.mhv.account_creation.mock
      end
   end
   ````
- start server and a console
  - `rails s`
  - `rails c`

### test request
in the console:
- load service
   ```ruby
   require 'mhv/account_creation/service'
   ```
- make request
  ```ruby
  MHV::AccountCreation::Service.new.create_account(icn: '123455v67890', email: 'email@email.com', tou_occurred_at: Time.current)
  ```
  you should see a curl request logged like:
  ```bash
  curl -v -X POST \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  -H 'User-Agent: Vets.gov Agent' \
  -H 'Authorization: Bearer eyJhbGci...U2cRiTQ' \
  -H 'x-api-key: some-request-key' \
  -d '{"icn":"123455v67890","email":"email@email.com","vaTermsOfUseDateTime":"2024-09-11T18:54:47.326Z","vaTermsOfUseStatus":"accepted","vaTermsOfUseRevision":"3","vaTermsOfUseLegalVersion":"1.0","vaTermsOfUseDocTitle":"VA Enterprise Terms of Use"}' \
  "https://apigw-intb.aws.myhealth.va.gov/v1/usermgmt/account-service/account"
  ```
