### PR TITLE
remove access keys for aws ivc

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,8 +67,8 @@ session_cookie:
   secure: false
 
 sign_in:
-  jwt_encode_key: "spec/fixtures/sign_in/privatekey.pem"
-  jwt_old_encode_key: "spec/fixtures/sign_in/privatekey_old.pem"
+  jwt_encode_key: 'spec/fixtures/sign_in/privatekey.pem'
+  jwt_old_encode_key: 'spec/fixtures/sign_in/privatekey_old.pem'
   cookies_secure: false
   info_cookie_domain: localhost
   auto_uplevel: true
@@ -101,8 +101,8 @@ clamav:
   mock: false
   # host & port here are only used in development here:
   # config/initializers/clamav.rb
-  host: "clamav"
-  port: "3310"
+  host: 'clamav'
+  port: '3310'
 
 db_encryption_key: f01ff8ebd1a2b053ad697ae1f0d86adb
 
@@ -660,8 +660,8 @@ ask_va_api:
 claims_api:
   pdf_generator_526:
     url: ~
-    path: "/form-526ez-pdf-generator/v1/forms/"
-    content_type: "application/vnd.api+json"
+    path: '/form-526ez-pdf-generator/v1/forms/'
+    content_type: 'application/vnd.api+json'
   report_enabled: false
   audit_enabled: false
   s3:
@@ -1511,8 +1511,8 @@ chip:
   mock: true
   mobile_app:
     tenant_id: 6f1c8b41-9c77-469d-852d-269c51a7d380
-    username: "testuser"
-    password: "12345"
+    username: 'testuser'
+    password: '12345'
 
 check_in:
   vaos:
@@ -1752,8 +1752,8 @@ avs:
   api_jwt: abcd1234abcd1234abcd1234abcd1234abcd1234
 
 brd:
-  api_key: "fake_key"
-  base_name: "https://something.fake.va.gov"
+  api_key: 'fake_key'
+  base_name: 'https://something.fake.va.gov'
 
 travel_pay:
   sts:
@@ -1801,8 +1801,8 @@ vye:
     bucket: ~
 
 schema_contract:
-  appointments_index: "modules/vaos/app/schemas/appointments_index.json"
-  test_index: "spec/fixtures/schema_contract/test_schema.json"
+  appointments_index: 'modules/vaos/app/schemas/appointments_index.json'
+  test_index: 'spec/fixtures/schema_contract/test_schema.json'
 
 form_mock_ae_design_patterns:
   prefill: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,8 +67,8 @@ session_cookie:
   secure: false
 
 sign_in:
-  jwt_encode_key: 'spec/fixtures/sign_in/privatekey.pem'
-  jwt_old_encode_key: 'spec/fixtures/sign_in/privatekey_old.pem'
+  jwt_encode_key: "spec/fixtures/sign_in/privatekey.pem"
+  jwt_old_encode_key: "spec/fixtures/sign_in/privatekey_old.pem"
   cookies_secure: false
   info_cookie_domain: localhost
   auto_uplevel: true
@@ -101,8 +101,8 @@ clamav:
   mock: false
   # host & port here are only used in development here:
   # config/initializers/clamav.rb
-  host: 'clamav'
-  port: '3310'
+  host: "clamav"
+  port: "3310"
 
 db_encryption_key: f01ff8ebd1a2b053ad697ae1f0d86adb
 
@@ -660,8 +660,8 @@ ask_va_api:
 claims_api:
   pdf_generator_526:
     url: ~
-    path: '/form-526ez-pdf-generator/v1/forms/'
-    content_type: 'application/vnd.api+json'
+    path: "/form-526ez-pdf-generator/v1/forms/"
+    content_type: "application/vnd.api+json"
   report_enabled: false
   audit_enabled: false
   s3:
@@ -1511,8 +1511,8 @@ chip:
   mock: true
   mobile_app:
     tenant_id: 6f1c8b41-9c77-469d-852d-269c51a7d380
-    username: 'testuser'
-    password: '12345'
+    username: "testuser"
+    password: "12345"
 
 check_in:
   vaos:
@@ -1716,15 +1716,12 @@ form1095_b:
 
 ivc_forms:
   s3:
-    aws_access_key_id: ~
-    aws_secret_access_key: ~
     bucket: "bucket"
     enabled: true
     region: "region"
   sidekiq:
     missing_form_status_job:
       enabled: true
-
 
 coverband:
   github_organization: ~
@@ -1755,9 +1752,8 @@ avs:
   api_jwt: abcd1234abcd1234abcd1234abcd1234abcd1234
 
 brd:
-  api_key: 'fake_key'
-  base_name: 'https://something.fake.va.gov'
-
+  api_key: "fake_key"
+  base_name: "https://something.fake.va.gov"
 
 travel_pay:
   sts:
@@ -1805,8 +1801,8 @@ vye:
     bucket: ~
 
 schema_contract:
-  appointments_index: 'modules/vaos/app/schemas/appointments_index.json'
-  test_index: 'spec/fixtures/schema_contract/test_schema.json'
+  appointments_index: "modules/vaos/app/schemas/appointments_index.json"
+  test_index: "spec/fixtures/schema_contract/test_schema.json"
 
 form_mock_ae_design_patterns:
   prefill: true

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -80,8 +80,6 @@ module IvcChampva
     def client
       @client ||= IvcChampva::S3.new(
         region: Settings.ivc_forms.s3.region,
-        access_key_id: Settings.ivc_forms.s3.aws_access_key_id,
-        secret_access_key: Settings.ivc_forms.s3.aws_secret_access_key,
         bucket: Settings.ivc_forms.s3.bucket
       )
     end

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -2,12 +2,10 @@
 
 module IvcChampva
   class S3
-    attr_reader :region, :access_key_id, :secret_access_key, :bucket
+    attr_reader :region, :bucket
 
-    def initialize(region:, access_key_id:, secret_access_key:, bucket:)
+    def initialize(region:, bucket:)
       @region = region
-      @access_key_id = access_key_id
-      @secret_access_key = secret_access_key
       @bucket = bucket
     end
 
@@ -42,9 +40,7 @@ module IvcChampva
 
     def client
       @client ||= Aws::S3::Client.new(
-        region:,
-        access_key_id:,
-        secret_access_key:
+        region:
       )
     end
 

--- a/modules/ivc_champva/spec/services/s3_spec.rb
+++ b/modules/ivc_champva/spec/services/s3_spec.rb
@@ -5,8 +5,6 @@ require 'common/file_helpers'
 
 describe IvcChampva::S3 do
   let(:region) { 'test-region' }
-  let(:access_key_id) { 'test-access-key' }
-  let(:secret_access_key) { 'test-secret-key' }
   let(:bucket_name) { 'test-bucket' }
   let(:bucket) { instance_double(Aws::S3::Bucket) }
   let(:object) { instance_double(Aws::S3::Object) }
@@ -15,8 +13,6 @@ describe IvcChampva::S3 do
   let(:s3_instance) do
     IvcChampva::S3.new(
       region: region,
-      access_key_id: access_key_id,
-      secret_access_key: secret_access_key,
       bucket: bucket_name
     )
   end


### PR DESCRIPTION

## Summary

The DOCMP PEGA team removed the requirement for access key ID and access secret key. So instead, we are using Roles for Identity Access Management. This was completed using Terraform.



## Testing done

- [ ] *New code is covered by unit tests*




## What areas of the site does it impact?
All IVC CHAMPVA and FMP forms

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
