### PR TITLE
Arf/86023/in progress forms.specs

### DIFF
--- a/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/representative_user_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/representative_user_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe AccreditedRepresentativePortal::RepresentativeUser, type: :model 
         expect(representative_user.errors[:icn]).to include(expected_error_message)
       end
     end
+
+    context 'when user_account_uuid is missing' do
+      let(:representative_user) { build(:representative_user, user_account_uuid: nil) }
+
+      it 'is invalid' do
+        expect(representative_user).not_to be_valid
+        expect(representative_user.errors[:user_account_uuid]).to include(expected_error_message)
+      end
+    end
   end
 
   describe 'alias attributes' do

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/form21a_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/form21a_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::Form21a', type: :request do
       let!(:in_progress_form) { create(:in_progress_form, form_id: '21a', user_uuid: representative_user.uuid) }
 
       it 'returns a successful response from the service and destroys in progress form' do
+        get('/accredited_representative_portal/v0/in_progress_forms/21a')
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response.keys).to contain_exactly('formData', 'metadata')
+
         allow(AccreditationService).to receive(:submit_form21a).and_return(
           instance_double(Faraday::Response, success?: true, body: { result: 'success' }.to_json, status: 200)
         )
@@ -26,7 +30,10 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::Form21a', type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(parsed_response).to eq('result' => 'success')
-        expect(InProgressForm.exists?(in_progress_form.id)).to be false
+
+        get('/accredited_representative_portal/v0/in_progress_forms/21a')
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response).to eq({})
       end
     end
 


### PR DESCRIPTION
Makes two small modifications to specs as requested at:
- [User `user_account_id` validation test](https://github.com/department-of-veterans-affairs/vets-api/pull/17805#discussion_r1752526643)
- [Assert IPF empty fetch response after successful 21a submit](https://github.com/department-of-veterans-affairs/vets-api/pull/17805#discussion_r1752528930)