### PR TITLE
Stop using generate_clamav_temp_file

### DIFF
--- a/lib/common/convert_to_pdf.rb
+++ b/lib/common/convert_to_pdf.rb
@@ -9,7 +9,7 @@ module Common
     end
 
     def run
-      in_file = Common::FileHelpers.generate_clamav_temp_file(@file.read)
+      in_file = Common::FileHelpers.generate_random_file(@file.read)
       return in_file if @file.content_type == Mime[:pdf].to_s
 
       unless @file.content_type.starts_with?('image/')

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
       VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
       VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
       allow(Common::FileHelpers).to receive(:random_file_path).and_return(file_seed)
-      allow(Common::FileHelpers).to receive(:generate_clamav_temp_file).and_wrap_original do |original_method, *args|
-        original_method.call(args[0], random_string)
-      end
     end
 
     after do

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -37,9 +37,6 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
         VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
         allow(Common::FileHelpers).to receive(:random_file_path).and_return(file_seed)
-        allow(Common::FileHelpers).to receive(:generate_clamav_temp_file).and_wrap_original do |original_method, *args|
-          original_method.call(args[0], random_string)
-        end
         Flipper.disable(:simple_forms_email_confirmations)
       end
 


### PR DESCRIPTION
## Summary
This PR makes `Common::ConvertToPdf` use `generate_random_file` instead of `generate_clamav_temp_file`. We want to do this because we've been seeing errors in Datadog around the clamav file paths being absent. This alternative seems to work in other instances so hopefully it works here too.