### PR TITLE
Add comments to discourage use of the Central Mail Service

### DIFF
--- a/lib/central_mail/service.rb
+++ b/lib/central_mail/service.rb
@@ -19,7 +19,7 @@ module CentralMail
     # submissions to Lighthouse to monitor those submissions. See  #
     # here for more details:                                       #
     #                                                              #
-    # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/d24831944da993de2163ea622c5698b5138a3a6b/teams/benefits/playbooks/endpoint-monitoring.md
+    # https://depo-platform-documentation.scrollhelp.site/developer-docs/endpoint-monitoring
     ################################################################
 
     STATSD_KEY_PREFIX = 'api.central_mail'

--- a/lib/central_mail/service.rb
+++ b/lib/central_mail/service.rb
@@ -6,6 +6,22 @@ require_relative 'configuration'
 
 module CentralMail
   class Service < Common::Client::Base
+    ################################################################
+    # Please do not use this module. It has been superceded by the #
+    # Lighthouse::BenefitsIntake::Service module:                  #
+    #                                                              #
+    #   https://github.com/department-of-veterans-affairs/vets-api/blob/94f88d1bb55d961e036d6fed3117735d6b9074cd/lib/lighthouse/benefits_intake/service.rb
+    #
+    # The above-linked module sends submissions to Central Mail    #
+    # Processing through the Lighthouse Benefits Intake API        #
+    #                                                              #
+    # Additionally, it is the responsibility of any team sending   #
+    # submissions to Lighthouse to monitor those submissions. See  #
+    # here for more details:                                       #
+    #                                                              #
+    # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/d24831944da993de2163ea622c5698b5138a3a6b/teams/benefits/playbooks/endpoint-monitoring.md
+    ################################################################
+
     STATSD_KEY_PREFIX = 'api.central_mail'
     include Common::Client::Concerns::Monitoring
 

--- a/lib/lighthouse/benefits_intake/service.rb
+++ b/lib/lighthouse/benefits_intake/service.rb
@@ -20,7 +20,7 @@ module BenefitsIntake
     # Lighthouse to monitor those submissions. See here for more   #
     # details:                                                     #
     #                                                              #
-    # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/d24831944da993de2163ea622c5698b5138a3a6b/teams/benefits/playbooks/endpoint-monitoring.md
+    # https://depo-platform-documentation.scrollhelp.site/developer-docs/endpoint-monitoring
     ################################################################
     configuration BenefitsIntake::Configuration
 

--- a/lib/lighthouse/benefits_intake/service.rb
+++ b/lib/lighthouse/benefits_intake/service.rb
@@ -15,6 +15,13 @@ module BenefitsIntake
   # https://developer.va.gov/explore/api/benefits-intake/docs
   #
   class Service < Common::Client::Base
+    ################################################################
+    # It is the responsibility of any team sending submissions to  #
+    # Lighthouse to monitor those submissions. See here for more   #
+    # details:                                                     #
+    #                                                              #
+    # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/d24831944da993de2163ea622c5698b5138a3a6b/teams/benefits/playbooks/endpoint-monitoring.md
+    ################################################################
     configuration BenefitsIntake::Configuration
 
     # TODO: process document error similar to service exception


### PR DESCRIPTION
## Summary
This PR adds two comments to indicate that teams that submit anything to the Lighthouse Benefits Intake API have a responsibility to monitor those submissions. It also adds a comment discouraging people from using the Central Mail Service in favor of a Lighthouse Service.

## Related issue(s)
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1652
