### PR TITLE
[VI-467] Create MHVUserAccount model

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -286,6 +286,7 @@ app/models/message_thread_details.rb @department-of-veterans-affairs/vfs-mhv-sec
 app/models/message_thread.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/messaging_preference.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/mhv_opt_in_flag.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/mhv_user_account.rb @department-of-veterans-affairs/octo-identity
 app/models/mpi_data.rb @department-of-veterans-affairs/octo-identity
 app/models/old_email.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/onsite_notification.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1561,6 +1562,7 @@ spec/models/ivc_champva_forms_spec.rb @department-of-veterans-affairs/champva-en
 spec/models/lighthouse526_document_upload_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/message_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mhv_opt_in_flag_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/models/mhv_user_account_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/mpi_data_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/onsite_notification_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/persistent_attachments @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pensions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/mhv_user_account.rb
+++ b/app/models/mhv_user_account.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class MHVUserAccount
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :user_profile_id, :string
+  attribute :champ_va, :boolean
+  attribute :patient, :boolean
+  attribute :sm_account, :boolean
+
+  validates :user_profile_id, presence: true
+  validates :champ_va, :patient, :sm_account, inclusion: { in: [true, false] }
+end

--- a/spec/models/mhv_user_account_spec.rb
+++ b/spec/models/mhv_user_account_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MHVUserAccount, type: :model do
+  subject(:mhv_user_account) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      user_profile_id:,
+      champ_va:,
+      patient:,
+      sm_account:
+    }
+  end
+
+  let(:user_profile_id) { '123' }
+  let(:champ_va) { true }
+  let(:patient) { false }
+  let(:sm_account) { true }
+
+  context 'with valid attributes' do
+    it 'is valid' do
+      expect(mhv_user_account).to be_valid
+    end
+  end
+
+  context 'with invalid attributes' do
+    shared_examples 'is invalid' do
+      it 'is invalid' do
+        expect(mhv_user_account).not_to be_valid
+      end
+    end
+
+    context 'when user_profile_id is nil' do
+      let(:user_profile_id) { nil }
+
+      it_behaves_like 'is invalid'
+    end
+
+    context 'when champ_va is nil' do
+      let(:champ_va) { nil }
+
+      it_behaves_like 'is invalid'
+    end
+
+    context 'when patient is nil' do
+      let(:patient) { nil }
+
+      it_behaves_like 'is invalid'
+    end
+
+    context 'when sm_account is nil' do
+      let(:sm_account) { nil }
+
+      it_behaves_like 'is invalid'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create `MHVUserAccount` model. This model will be created from the MHV create_user_account response body:
   ```json
    {
      "user_profile_id": "12352",
      "champ_va": true,
      "patient": true,
      "sm_account": true
    }
    ```
- Uses ActiveModel attributes and validations
- Objects will be created and validated in a `MHVUserAccountCreator` service class

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-467

## Testing 
- create various objects in the console and call `.valid?` or `.validate!` on them
  - ```ruby
    attributes = {
      user_profile_id: '12352',
      champ_va: true,
      patient: true,
      sm_account: true
    }
    
    account = MHVUserAccount.new(attributes)
    account.validate! # true
     ```

  - ```ruby
    attributes = {
      user_profile_id: nil,
      champ_va: true,
      patient: true,
      sm_account: true
    }
    
    account = MHVUserAccount.new(attributes)
    account.validate! # Validation failed: User profile can't be blank
     ```
  - ```ruby
      attributes = {
        user_profile_id: 123,
        champ_va: 'false',
        patient: 'true',
        sm_account: 'false'
      }
      
      account = MHVUserAccount.new(attributes)
      account.validate! # true
       ```


## What areas of the site does it impact?
mhv user accounts

