### PR TITLE
docker compose update

### DIFF
--- a/docker-compose-clamav.yml
+++ b/docker-compose-clamav.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   clamav:
     volumes:

--- a/docker-compose-deps.yml
+++ b/docker-compose-deps.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   redis:
     image: redis:6.2-alpine

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 x-app: &common
   build:
     args:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   redis:
     image: public.ecr.aws/docker/library/redis:6.2-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 x-app: &common
   build:
     args:


### PR DESCRIPTION
removing version top-level element from docker compose files as they are deprecated

Please See: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete