### PR TITLE
[SIMPLE_FORMS] feat: add service to build a remediation archive for a given form submission

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
@@ -41,7 +41,7 @@ module SimpleFormsApi
           include_json_archive: true, # include the form data as a JSON object
           include_manifest: true, # include a CSV file containing manifest data
           include_text_archive: true, # include the form data as a text file
-          metadata: {}, # pertinent metadata for original file upload/submission
+          metadata: {} # pertinent metadata for original file upload/submission
         }
       end
 
@@ -72,7 +72,7 @@ module SimpleFormsApi
           zip_code_is_us_based: form.zip_code_is_us_based
         )
 
-        form.handle_attachments(file_path) if %w[vba_40_0247 vba_20_10207 vba_40_10007].include? form_number
+        form.handle_attachments(file_path) if %w[vba_40_0247 vba_40_10007].include? form_number
 
         @attachments = form.get_attachments if form_number == 'vba_20_10207'
         @file_path

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
@@ -32,7 +32,7 @@ module SimpleFormsApi
       private
 
       attr_reader :attachments, :benefits_intake_uuid, :file_path, :include_json_archive, :include_manifest,
-                  :include_text_archive, :metadata, :parent_dir, :submission
+                  :include_text_archive, :metadata, :submission
 
       def default_options
         {
@@ -42,7 +42,6 @@ module SimpleFormsApi
           include_manifest: true, # include a CSV file containing manifest data
           include_text_archive: true, # include the form data as a text file
           metadata: {}, # pertinent metadata for original file upload/submission
-          parent_dir: 'vff-simple-forms' # S3 bucket base directory where files live
         }
       end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
@@ -110,7 +110,6 @@ module SimpleFormsApi
       end
 
       def write_as_text_archive
-        form_data_hash['claim_date'] ||= submission.created_at.iso8601
         write_tempfile('form_text_archive.txt', form_data_hash.to_s)
       end
 
@@ -121,7 +120,6 @@ module SimpleFormsApi
       def write_attachments
         log_info("Processing #{attachments.count} attachments")
         attachments.each_with_index { |upload, i| process_attachment(i + 1, upload) }
-        write_attachment_failure_report if attachment_failures.present?
       rescue => e
         handle_upload_error(e)
       end
@@ -136,7 +134,6 @@ module SimpleFormsApi
       rescue => e
         attachment_failures << e
         handle_error('Attachment failure.', e)
-        raise e
       end
 
       def write_manifest
@@ -156,10 +153,6 @@ module SimpleFormsApi
         end
 
         file_path
-      end
-
-      def write_attachment_failure_report
-        write_tempfile('attachment_failures.txt', JSON.pretty_generate(attachment_failures))
       end
 
       def write_tempfile(file_name, payload)

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archive_builder.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'fileutils'
+
+# built in accordance with the following documentation:
+# https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/practices/zero-silent-failures/remediation.md
+module SimpleFormsApi
+  module S3
+    class SubmissionArchiveBuilder < Utils
+      def initialize(benefits_intake_uuid: nil, submission: nil, **options) # rubocop:disable Lint/MissingSuper
+        defaults = default_options.merge(options)
+
+        @submission = submission || FormSubmission.find_by(benefits_intake_uuid:)
+        raise 'Submission was not found' unless @submission
+
+        @benefits_intake_uuid = @submission.benefits_intake_uuid
+
+        assign_instance_variables(defaults)
+      end
+
+      def run
+        FileUtils.mkdir_p(temp_directory_path)
+
+        process_submission_files
+
+        temp_directory_path
+      rescue => e
+        handle_error("Failed building submission: #{submission.id}", e, { benefits_intake_uuid: })
+      end
+
+      private
+
+      attr_reader :attachments, :benefits_intake_uuid, :file_path, :include_json_archive, :include_manifest,
+                  :include_text_archive, :metadata, :parent_dir, :submission
+
+      def default_options
+        {
+          attachments: [], # an array of attachment confirmation codes
+          file_path: nil, # file path for the PDF file to be archived
+          include_json_archive: true, # include the form data as a JSON object
+          include_manifest: true, # include a CSV file containing manifest data
+          include_text_archive: true, # include the form data as a text file
+          metadata: {}, # pertinent metadata for original file upload/submission
+          parent_dir: 'vff-simple-forms' # S3 bucket base directory where files live
+        }
+      end
+
+      def process_submission_files
+        write_pdf
+        write_as_json_archive if include_json_archive
+        write_as_text_archive if include_text_archive
+        write_attachments unless attachments.empty?
+        write_manifest if include_manifest
+        write_metadata
+      end
+
+      def write_pdf
+        write_tempfile(submission_pdf_filename, File.read(generate_pdf_content))
+      end
+
+      # TODO: this will be pulled out to be more team agnostic
+      def generate_pdf_content
+        return file_path if file_path
+
+        form_number = SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[submission.form_type]
+        form = "SimpleFormsApi::#{form_number.titleize.gsub(' ', '')}".constantize.new(form_data_hash)
+        filler = SimpleFormsApi::PdfFiller.new(form_number:, form:)
+
+        @file_path = filler.generate(timestamp: submission.created_at)
+        @metadata = SimpleFormsApiSubmission::MetadataValidator.validate(
+          form.metadata,
+          zip_code_is_us_based: form.zip_code_is_us_based
+        )
+
+        form.handle_attachments(file_path) if %w[vba_40_0247 vba_20_10207 vba_40_10007].include? form_number
+
+        @attachments = form.get_attachments if form_number == 'vba_20_10207'
+        @file_path
+      end
+
+      def form_data_hash
+        @form_data_hash ||= JSON.parse(submission.form_data)
+      end
+
+      def submission_pdf_filename
+        @submission_pdf_filename ||= "form_#{form_data_hash['form_number']}.pdf"
+      end
+
+      def error_details(error)
+        "#{error.message}\n\n#{error.backtrace.join("\n")}"
+      end
+
+      def write_as_json_archive
+        write_tempfile('form_json_archive.json', JSON.pretty_generate(form_data_hash))
+      end
+
+      def write_as_text_archive
+        form_data_hash['claim_date'] ||= submission.created_at.iso8601
+        write_tempfile('form_text_archive.txt', form_data_hash.to_s)
+      end
+
+      def write_metadata
+        write_tempfile('metadata.json', metadata.to_json)
+      end
+
+      def write_attachments
+        log_info("Processing #{attachments.count} attachments")
+        attachments.each_with_index { |upload, i| process_attachment(i + 1, upload) }
+        write_attachment_failure_report if attachment_failures.present?
+      rescue => e
+        handle_upload_error(e)
+      end
+
+      def process_attachment(attachment_number, guid)
+        log_info("Processing attachment ##{attachment_number}: #{guid}")
+        attachment = PersistentAttachment.find_by(guid:).to_pdf
+        raise 'Local record not found' unless attachment
+
+        write_tempfile("attachment_#{attachment_number}.pdf", attachment)
+      rescue => e
+        attachment_failures << e
+        handle_error('Attachment failure.', e)
+        raise e
+      end
+
+      def write_manifest
+        file_name = "submission_#{benefits_intake_uuid}_#{submission.created_at}_manifest.csv"
+        file_path = File.join(temp_directory_path, file_name)
+
+        CSV.open(file_path, 'wb') do |csv|
+          csv << ['Submission DateTime', 'Form Type', 'VA.gov ID', 'Veteran ID', 'First Name', 'Last Name']
+          csv << [
+            submission.created_at,
+            form_data_hash['form_number'],
+            benefits_intake_uuid,
+            metadata['fileNumber'],
+            metadata['veteranFirstName'],
+            metadata['veteranLastName']
+          ]
+        end
+
+        file_path
+      end
+
+      def write_attachment_failure_report
+        write_tempfile('attachment_failures.txt', JSON.pretty_generate(attachment_failures))
+      end
+
+      def write_tempfile(file_name, payload)
+        File.write("#{temp_directory_path}#{file_name}", payload)
+      end
+
+      def attachment_failures
+        @attachment_failures ||= []
+      end
+
+      def temp_directory_path
+        @temp_directory_path ||= Rails.root.join("tmp/#{benefits_intake_uuid}-#{SecureRandom.hex}/").to_s
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/utils.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/utils.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'reports/uploader'
+
+module SimpleFormsApi
+  module S3
+    class Utils
+      private
+
+      def assign_instance_variables(defaults)
+        defaults.each do |key, value|
+          instance_variable_set("@#{key}", value)
+        end
+      end
+
+      def log_info(message, **details)
+        Rails.logger.info(message, details)
+      end
+
+      def log_error(message, error, **details)
+        Rails.logger.error(message, details.merge(error: error.message, backtrace: error.backtrace.first(5)))
+      end
+
+      def handle_error(message, error, context)
+        log_error(message, error, **context)
+        raise error
+      end
+
+      def s3_resource
+        @s3_resource ||= Reports::Uploader.new_s3_resource
+      end
+
+      def target_bucket
+        @target_bucket ||= Reports::Uploader.s3_bucket
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/spec/services/s3/submission_archive_builder_spec.rb
+++ b/modules/simple_forms_api/spec/services/s3/submission_archive_builder_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+RSpec.describe SimpleFormsApi::S3::SubmissionArchiveBuilder do
+  let(:form_id) { '21-10210' }
+  let(:form_data) { File.read("modules/simple_forms_api/spec/fixtures/form_json/vba_#{form_id.gsub('-', '_')}.json") }
+  let(:submission) { create(:form_submission, :pending, form_type: form_id, form_data:) }
+  let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
+  let(:archive_builder_instance) { described_class.new(benefits_intake_uuid:) }
+
+  before do
+    allow(FormSubmission).to receive(:find_by).and_return(submission)
+    allow_any_instance_of(described_class).to receive(:assign_instance_variables).and_call_original
+    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+  end
+
+  describe '#initialize' do
+    subject(:new) { archive_builder_instance }
+
+    let(:defaults) do
+      {
+        attachments: [],
+        file_path: nil,
+        include_json_archive: true,
+        include_manifest: true,
+        include_text_archive: true,
+        metadata: {},
+        parent_dir: 'vff-simple-forms'
+      }
+    end
+
+    it { is_expected.to have_received(:assign_instance_variables).with(defaults) } # rubocop:disable RSpec/SubjectStub
+  end
+
+  describe '#run' do
+    subject(:run) { archive_builder_instance.run }
+
+    it 'completes successfully' do
+      expect(run).to eq(Rails.root.join("tmp/#{benefits_intake_uuid}-random-letters-n-numbers/").to_s)
+    end
+  end
+end

--- a/modules/simple_forms_api/spec/services/s3/submission_archive_builder_spec.rb
+++ b/modules/simple_forms_api/spec/services/s3/submission_archive_builder_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe SimpleFormsApi::S3::SubmissionArchiveBuilder do
         include_json_archive: true,
         include_manifest: true,
         include_text_archive: true,
-        metadata: {},
-        parent_dir: 'vff-simple-forms'
+        metadata: {}
       }
     end
 


### PR DESCRIPTION
## Summary

- This work adds the ability to build a remediation archive based upon a form submission benefits_intake_uuid or a file path where a submitted form submission is being stored locally
- This work also adds RSpec unit test coverage for the "happy path" of this service. More test coverage to come

## Related issue(s)

- [Create PoC for adding filled in PDFs to an S3 bucket](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1633)

## Testing done

- [x] *New code is covered by unit tests*

## Requested Feedback

Any
