### PR TITLE
Handle token related errors in appointments service

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -180,27 +180,30 @@ module VAOS
 
       private
 
-      def parse_possible_token_related_errors(e)
+      def parse_possible_token_related_errors(e) # rubocop:disable Metrics/MethodLength
         prefix = 'VAOS::V2::AppointmentService#get_appointments'
         sanitized_icn = VAOS::Anonymizers.anonymize_icns(user.icn)
         sanitized_message = VAOS::Anonymizers.anonymize_icns(e.message)
         case e
-        when Common::Client::Errors::ClientError
-          status = e.status
-          context = { error: e.body.present? ? e.body['error'] : '' }
-          message = "#{config.logging_prefix} token failed, status: #{status}"
-          Rails.logger.error("#{prefix} #{message}", status:, icn: sanitized_icn, context:)
-          return { message:, status:, icn: sanitized_icn, context: }
         when Common::Client::Errors::ParsingError
           Rails.logger.warn("#{prefix} token failed, parsing error", icn: sanitized_icn, context: sanitized_message)
+          sanitized_message
         when Common::Exceptions::GatewayTimeout
           Rails.logger.warn("#{prefix} token failed, gateway timeout", icn: sanitized_icn)
+          sanitized_message
         when MAP::SecurityToken::Errors::ApplicationMismatchError
           Rails.logger.warn("#{prefix} application mismatch", icn: sanitized_icn, context: sanitized_message)
+          sanitized_message
         when MAP::SecurityToken::Errors::MissingICNError
           Rails.logger.warn("#{prefix} missing ICN")
+          sanitized_message
+        when Common::Client::Errors::ClientError
+          status = e.status
+          context = e.body
+          message = "#{prefix} token failed, status: #{status}"
+          Rails.logger.warn(message.to_s, status:, icn: sanitized_icn, context:)
+          { message:, status:, icn: sanitized_icn, context: }
         end
-        sanitized_message
       end
 
       # Modifies the appointment, extracting individual fields from the appointment. This currently includes:

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -497,6 +497,108 @@ describe VAOS::V2::AppointmentsService do
         end
       end
     end
+
+    context 'when a MAP token error occurs' do
+      it 'logs missing ICN error' do
+        expected_error = MAP::SecurityToken::Errors::MissingICNError.new 'Missing ICN message'
+        # Set up SessionService to raise the expected error. Although the error should be raised by
+        # the MAP::SecurityToken::Service, it is easier to mock the behavior in this way for testing.
+        # This is functionally equivalent since SessionService calls the MAP::SecurityToken::Service
+        # in the :headers method.
+        allow_any_instance_of(VAOS::SessionService).to receive(:headers).and_raise(expected_error)
+        allow(Rails.logger).to receive(:warn).at_least(:once)
+        result = subject.get_appointments(start_date, end_date)
+        expect(Rails.logger).to have_received(:warn).with('VAOS::V2::AppointmentService#get_appointments missing ICN')
+        expect(result[:data]).to eq({})
+        expect(result[:meta][:failures]).to eq('Missing ICN message')
+      end
+
+      it 'logs application mismatch error' do
+        expected_error = MAP::SecurityToken::Errors::ApplicationMismatchError.new 'Application Mismatch message'
+        # Set up SessionService to raise the expected error. Although the error should be raised by
+        # the MAP::SecurityToken::Service, it is easier to mock the behavior in this way for testing.
+        # This is functionally equivalent since SessionService calls the MAP::SecurityToken::Service
+        # in the :headers method.
+        allow_any_instance_of(VAOS::SessionService).to receive(:headers).and_raise(expected_error)
+        allow(Rails.logger).to receive(:warn).at_least(:once)
+        result = subject.get_appointments(start_date, end_date)
+        expect(Rails.logger).to have_received(:warn).with(
+          'VAOS::V2::AppointmentService#get_appointments application mismatch',
+          {
+            icn: 'd12672eba61b7e9bc50bb6085a0697133a5fbadf195e6cade452ddaad7921c1d',
+            context: 'Application Mismatch message'
+          }
+        )
+        expect(result[:data]).to eq({})
+        expect(result[:meta][:failures]).to eq('Application Mismatch message')
+      end
+
+      it 'logs gateway timeout error' do
+        expected_error = Common::Exceptions::GatewayTimeout.new
+        # Set up SessionService to raise the expected error. Although the error should be raised by
+        # the MAP::SecurityToken::Service, it is easier to mock the behavior in this way for testing.
+        # This is functionally equivalent since SessionService calls the MAP::SecurityToken::Service
+        # in the :headers method.
+        allow_any_instance_of(VAOS::SessionService).to receive(:headers).and_raise(expected_error)
+        allow(Rails.logger).to receive(:warn).at_least(:once)
+        result = subject.get_appointments(start_date, end_date)
+        expect(Rails.logger).to have_received(:warn).with(
+          'VAOS::V2::AppointmentService#get_appointments token failed, gateway timeout',
+          {
+            icn: 'd12672eba61b7e9bc50bb6085a0697133a5fbadf195e6cade452ddaad7921c1d'
+          }
+        )
+        expect(result[:data]).to eq({})
+        expect(result[:meta][:failures]).to eq('Gateway timeout')
+      end
+
+      it 'logs parsing error' do
+        expected_error = Common::Client::Errors::ParsingError.new 'Parsing Error message'
+        # Set up SessionService to raise the expected error. Although the error should be raised by
+        # the MAP::SecurityToken::Service, it is easier to mock the behavior in this way for testing.
+        # This is functionally equivalent since SessionService calls the MAP::SecurityToken::Service
+        # in the :headers method.
+        allow_any_instance_of(VAOS::SessionService).to receive(:headers).and_raise(expected_error)
+        allow(Rails.logger).to receive(:warn).at_least(:once)
+        result = subject.get_appointments(start_date, end_date)
+        expect(Rails.logger).to have_received(:warn).with(
+          'VAOS::V2::AppointmentService#get_appointments token failed, parsing error',
+          {
+            icn: 'd12672eba61b7e9bc50bb6085a0697133a5fbadf195e6cade452ddaad7921c1d',
+            context: 'Parsing Error message'
+          }
+        )
+        expect(result[:data]).to eq({})
+        expect(result[:meta][:failures]).to eq('Parsing Error message')
+      end
+
+      it 'logs client error' do
+        expected_error = Common::Client::Errors::ClientError.new 'Parsing Error message', 400, 'additional details'
+        # Set up SessionService to raise the expected error. Although the error should be raised by
+        # the MAP::SecurityToken::Service, it is easier to mock the behavior in this way for testing.
+        # This is functionally equivalent since SessionService calls the MAP::SecurityToken::Service
+        # in the :headers method.
+        allow_any_instance_of(VAOS::SessionService).to receive(:headers).and_raise(expected_error)
+        allow(Rails.logger).to receive(:warn).at_least(:once)
+        result = subject.get_appointments(start_date, end_date)
+        expect(Rails.logger).to have_received(:warn).with(
+          'VAOS::V2::AppointmentService#get_appointments token failed, status: 400',
+          {
+            status: 400,
+            icn: 'd12672eba61b7e9bc50bb6085a0697133a5fbadf195e6cade452ddaad7921c1d',
+            context: 'additional details'
+          }
+        )
+        expect(result[:data]).to eq({})
+        expect(result[:meta][:failures])
+          .to eq({
+                   message: 'VAOS::V2::AppointmentService#get_appointments token failed, status: 400',
+                   status: 400,
+                   icn: 'd12672eba61b7e9bc50bb6085a0697133a5fbadf195e6cade452ddaad7921c1d',
+                   context: 'additional details'
+                 })
+      end
+    end
   end
 
   describe '#get_most_recent_visited_clinic_appointment' do


### PR DESCRIPTION
## Summary

- This PR adds some additional error handling and logging for common token errors
- Appointments (VAOS) team
- This is not controlled by a Flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90026

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
