### PR TITLE
remove source hash from mobile appt error

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -24,6 +24,8 @@ module Mobile
         )
 
         render json: Mobile::V0::AppointmentSerializer.new(page_appointments, page_meta_data), status:
+      rescue VAOS::ServiceException => e
+        raise Common::Exceptions::ServiceError.new(detail: e.errors.first&.detail)
       end
 
       def cancel

--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -25,7 +25,7 @@ module Mobile
 
         render json: Mobile::V0::AppointmentSerializer.new(page_appointments, page_meta_data), status:
       rescue VAOS::ServiceException => e
-        raise Common::Exceptions::ServiceError.new(detail: e.errors.first&.detail)
+        raise Common::Exceptions::BadGateway.new(detail: e.errors.first&.detail)
       end
 
       def cancel

--- a/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
@@ -688,14 +688,14 @@ RSpec.describe 'Mobile::V0::Appointments::VAOSV2', type: :request do
       describe 'appointment call returns 500 error' do
         # This is a requirement due to FE having a bug where a source field in the error
         # with a hash in it was causing long delays.
-        it 'returns error with no source hash' do
+        it 'returns 502 error with no source hash' do
           VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_500', match_requests_on: %i[method uri]) do
             get '/mobile/v0/appointments', headers: sis_headers
           end
-          expect(response.parsed_body.dig('errors', 0)).to eq({ 'title' => 'Unknown Service Error',
+          expect(response.parsed_body.dig('errors', 0)).to eq({ 'title' => 'Bad Gateway',
                                                                 'detail' => 'The resource could not be found',
-                                                                'code' => '500',
-                                                                'status' => '500' })
+                                                                'code' => '502',
+                                                                'status' => '502' })
         end
       end
     end

--- a/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
@@ -684,6 +684,20 @@ RSpec.describe 'Mobile::V0::Appointments::VAOSV2', type: :request do
           expect(response.parsed_body['meta']['upcomingDaysLimit']).to eq(7)
         end
       end
+
+      describe 'appointment call returns 500 error' do
+        # This is a requirement due to FE having a bug where a source field in the error
+        # with a hash in it was causing long delays.
+        it 'returns error with no source hash' do
+          VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointment_500', match_requests_on: %i[method uri]) do
+            get '/mobile/v0/appointments', headers: sis_headers
+          end
+          expect(response.parsed_body.dig('errors', 0)).to eq({ 'title' => 'Unknown Service Error',
+                                                                'detail' => 'The resource could not be found',
+                                                                'code' => '500',
+                                                                'status' => '500' })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
During a [Frontend bug investigation](https://app.zenhub.com/workspaces/va-mobile-60f1a34998bc75000f2a489f/issues/gh/department-of-veterans-affairs/va-mobile-app/4762) they discovered the source block of the appts error response is causing a long hang. this remaps the error to not use a source block
## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9510

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
