### PR TITLE
Dbx 18456/break out state snapshot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -641,10 +641,11 @@ app/sidekiq/feature_cleaner_job.rb @department-of-veterans-affairs/va-api-engine
 app/sidekiq/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form1095 @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_confirmation_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/form526_failure_state_snapshot_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_paranoid_success_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/sidekiq/form526_state_logging_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_status_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_failed_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/form526_submission_processing_report_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/gi_bill_feedback_submission_job.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/identity @department-of-veterans-affairs/octo-identity
@@ -1342,9 +1343,10 @@ spec/sidekiq/facilities @department-of-veterans-affairs/vfs-facilities-frontend 
 spec/sidekiq/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form1095 @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form526_confirmation_email_job_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/form526_failure_state_snapshot_job_spec.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form526_paranoid_success_polling_job_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/form526_state_logging_job_spec.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form526_status_polling_job_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/form526_submission_processing_report_job_spec.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form5655 @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/gi_bill_feedback_submission_job_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers

--- a/app/sidekiq/form526_failure_state_snapshot_job.rb
+++ b/app/sidekiq/form526_failure_state_snapshot_job.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Log information about Form526Submission state to populate an admin facing Datadog dashboard
+class Form526FailureStateSnapshotJob
+  include Sidekiq::Job
+  sidekiq_options retry: false
+
+  STATSD_PREFIX = 'form526.state.snapshot'
+
+  def perform
+    write_failure_snapshot
+  rescue => e
+    Rails.logger.error('Error logging 526 state snapshot',
+                       class: self.class.name,
+                       message: e.try(:message))
+  end
+
+  def write_failure_snapshot
+    state_as_counts.each do |description, count|
+      StatsD.gauge("#{STATSD_PREFIX}.#{description}", count)
+    end
+  end
+
+  def state_as_counts
+    @state_as_counts ||= {}.tap do |abbreviation|
+      snapshot_state.each do |dp, ids|
+        abbreviation[:"#{dp}_count"] = ids.count
+      end
+    end
+  end
+
+  def snapshot_state
+    @snapshot_state ||= load_snapshot_state
+  end
+
+  def load_snapshot_state
+    {
+      total_awaiting_backup_status: Form526Submission.pending_backup.pluck(:id).sort,
+      total_incomplete_type: Form526Submission.incomplete_type.pluck(:id).sort,
+      total_failure_type: Form526Submission.failure_type.pluck(:id).sort
+    }
+  end
+end

--- a/app/sidekiq/form526_submission_processing_report_job.rb
+++ b/app/sidekiq/form526_submission_processing_report_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Log information about Form526Submission state to populate an admin facing Datadog dashboard
-class Form526StateLoggingJob
+class Form526SubmissionProcessingReportJob
   include Sidekiq::Job
   sidekiq_options retry: false
 
@@ -9,7 +9,6 @@ class Form526StateLoggingJob
 
   END_DATE = Time.zone.today.beginning_of_day
   START_DATE = END_DATE - 1.week
-  STATSD_PREFIX = 'form526.state'
 
   def initialize(start_date: START_DATE, end_date: END_DATE)
     @start_date = start_date
@@ -17,7 +16,6 @@ class Form526StateLoggingJob
   end
 
   def perform
-    write_as_gauges
     write_as_log
   rescue => e
     Rails.logger.error('Error logging 526 state data',
@@ -29,41 +27,21 @@ class Form526StateLoggingJob
 
   def write_as_log
     Rails.logger.info('Form 526 State Data',
-                      state_log: counts_with_failures,
+                      state_log: state_as_counts,
                       start_date:,
                       end_date:)
   end
 
-  def counts_with_failures
-    counts = state_as_counts
-    counts[:total_failure_type_ids] = total_failure_type
-    counts
-  end
-
-  def base_state
-    @base_state ||= timeboxed_state.merge(all_time_state)
-  end
-
   def state_as_counts
     @state_as_counts ||= {}.tap do |abbreviation|
-      base_state.each do |dp, ids|
+      timeboxed_state.each do |dp, ids|
         abbreviation[:"#{dp}_count"] = ids.count
       end
     end
   end
 
-  def write_as_gauges
-    state_as_counts.each do |description, count|
-      StatsD.gauge("#{STATSD_PREFIX}.#{description}", count)
-    end
-  end
-
   def timeboxed_state
     @timeboxed_state ||= load_timeboxed_state
-  end
-
-  def all_time_state
-    @all_time_state ||= load_all_time_state
   end
 
   def load_timeboxed_state
@@ -76,25 +54,8 @@ class Form526StateLoggingJob
     }
   end
 
-  def load_all_time_state
-    {
-      total_awaiting_backup_status: Form526Submission.pending_backup.pluck(:id).sort,
-      total_incomplete_type: Form526Submission.incomplete_type.pluck(:id).sort,
-      total_failure_type:
-    }
-  end
-
-  def total_failure_type
-    @total_failure_type ||= Form526Submission.failure_type.pluck(:id).sort
-  end
-
   def sub_arel
     @sub_arel ||= Form526Submission.arel_table
-  end
-
-  def combined_pending_types_for(submissions)
-    submissions.incomplete.pluck(:id) +
-      submissions.in_process.pluck(:id)
   end
 
   def backup_submissions

--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -66,8 +66,11 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   # Checks all 'success' type submissions in LH to ensure they haven't changed
   mgr.register('0 2 * * 0', 'Form526ParanoidSuccessPollingJob')
 
-  # Log the state of Form 526 submissions to hydrate Datadog monitor
-  mgr.register('0 3 * * *', 'Form526StateLoggingJob')
+  # Log a report of 526 submission processing for a given timebox
+  mgr.register('5 4 * * 7', 'Form526SubmissionProcessingReportJob')
+
+  # Log a snapshot of everything in a full failure type state
+  mgr.register('5 * * * *', 'Form526FailureStateSnapshotJob')
 
   # Clear out processed 22-1990 applications that are older than 1 month
   mgr.register('0 0 * * *', 'EducationForm::DeleteOldApplications')

--- a/lib/scopes/form526_submission_state.rb
+++ b/lib/scopes/form526_submission_state.rb
@@ -112,7 +112,7 @@ module Scopes
 
       scope :failure_type, lambda {
         # filtering in stages avoids timeouts. see doc for more info
-        allids = all.pluck(:id)
+        allids = where(submitted_claim_id: nil).pluck(:id)
         filter1 = where(id: allids - accepted_to_primary_path.pluck(:id)).pluck(:id)
         filter2 = where(id: filter1 - accepted_to_backup_path.pluck(:id)).pluck(:id)
         filter3 = where(id: filter2 - remediated.pluck(:id)).pluck(:id)

--- a/spec/sidekiq/form526_failure_state_snapshot_job_spec.rb
+++ b/spec/sidekiq/form526_failure_state_snapshot_job_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Form526FailureStateSnapshotJob, type: :worker do
+  before do
+    Sidekiq::Job.clear_all
+  end
+
+  let!(:olden_times) { (Form526Submission::MAX_PENDING_TIME + 1.day).ago }
+  let!(:modern_times) { 2.days.ago }
+  let!(:end_date) { Time.zone.today.beginning_of_day }
+  let!(:start_date) { end_date - 1.week }
+
+  describe '526 state logging' do
+    let!(:new_unprocessed) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission)
+      end
+    end
+    let!(:old_unprocessed) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission)
+      end
+    end
+    let!(:new_primary_success) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_submitted_claim_id, :with_one_succesful_job)
+      end
+    end
+    let!(:old_primary_success) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :with_submitted_claim_id, :with_one_succesful_job)
+      end
+    end
+    let!(:new_backup_pending) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :backup_path, :with_failed_primary_job)
+      end
+    end
+    let!(:old_backup_pending) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :backup_path, :with_failed_primary_job)
+      end
+    end
+    let!(:new_backup_success) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :backup_path, :paranoid_success, :with_failed_primary_job)
+      end
+    end
+    let!(:old_backup_success) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :backup_path, :paranoid_success, :with_failed_primary_job)
+      end
+    end
+    let!(:new_backup_vbms) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :backup_path, :backup_accepted, :with_failed_primary_job)
+      end
+    end
+    let!(:old_backup_vbms) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :backup_path, :backup_accepted, :with_failed_primary_job)
+      end
+    end
+    let!(:new_backup_rejected) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :backup_path, :backup_rejected, :with_failed_primary_job)
+      end
+    end
+    let!(:old_backup_rejected) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :backup_path, :backup_rejected, :with_failed_primary_job)
+      end
+    end
+    let!(:new_double_job_failure) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_failed_primary_job, :with_failed_backup_job)
+      end
+    end
+    let!(:old_double_job_failure) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :with_failed_primary_job, :with_failed_backup_job)
+      end
+    end
+    let!(:new_double_job_failure_remediated) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_failed_primary_job, :with_failed_backup_job, :remediated)
+      end
+    end
+    let!(:old_double_job_failure_remediated) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :with_failed_primary_job, :with_failed_backup_job, :remediated)
+      end
+    end
+    let!(:new_double_job_failure_de_remediated) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_failed_primary_job, :with_failed_backup_job, :no_longer_remediated)
+      end
+    end
+    let!(:old_double_job_failure_de_remediated) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :with_failed_primary_job, :with_failed_backup_job, :no_longer_remediated)
+      end
+    end
+    let!(:new_no_job_remediated) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :remediated)
+      end
+    end
+    let!(:old_no_job_remediated) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :remediated)
+      end
+    end
+    let!(:new_backup_paranoid) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :backup_path, :with_failed_primary_job, :paranoid_success)
+      end
+    end
+    let!(:old_backup_paranoid) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :backup_path, :with_failed_primary_job, :paranoid_success)
+      end
+    end
+    let!(:still_running_with_retryable_errors) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_one_failed_job)
+      end
+    end
+    # RARE EDGECASES
+    let!(:new_no_job_de_remediated) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :no_longer_remediated)
+      end
+    end
+    let!(:old_no_job_de_remediated) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :no_longer_remediated)
+      end
+    end
+    let!(:new_double_success) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_submitted_claim_id, :backup_path)
+      end
+    end
+    let!(:old_double_success) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :with_submitted_claim_id, :backup_path)
+      end
+    end
+    let!(:new_triple_success) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_submitted_claim_id, :backup_path, :remediated)
+      end
+    end
+    let!(:old_triple_success) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :with_submitted_claim_id, :backup_path, :remediated)
+      end
+    end
+    let!(:new_double_success_de_remediated) do
+      Timecop.freeze(modern_times) do
+        create(:form526_submission, :with_submitted_claim_id, :backup_path, :no_longer_remediated)
+      end
+    end
+    let!(:old_double_success_de_remediated) do
+      Timecop.freeze(olden_times) do
+        create(:form526_submission, :with_submitted_claim_id, :backup_path, :no_longer_remediated)
+      end
+    end
+    let!(:new_remediated_and_de_remediated) do
+      sub = Timecop.freeze(modern_times) do
+        create(:form526_submission, :remediated)
+      end
+      Timecop.freeze(modern_times + 1.hour) do
+        create(:form526_submission_remediation,
+               form526_submission: sub,
+               lifecycle: ['i am no longer remediated'],
+               success: false)
+      end
+      sub
+    end
+    let!(:old_remediated_and_de_remediated) do
+      sub = Timecop.freeze(olden_times) do
+        create(:form526_submission, :remediated)
+      end
+      Timecop.freeze(olden_times + 1.hour) do
+        create(:form526_submission_remediation,
+               form526_submission: sub,
+               lifecycle: ['i am no longer remediated'],
+               success: false)
+      end
+      sub
+    end
+
+    it 'logs 526 state metrics correctly' do
+      expected_log = {
+        total_awaiting_backup_status: [
+          new_backup_pending.id
+        ].sort,
+        total_incomplete_type: [
+          still_running_with_retryable_errors.id,
+          new_unprocessed.id,
+          new_backup_pending.id,
+          new_no_job_de_remediated.id,
+          new_remediated_and_de_remediated.id
+        ].sort,
+        total_failure_type: [
+          old_unprocessed.id,
+          old_backup_pending.id,
+          new_backup_rejected.id,
+          old_backup_rejected.id,
+          old_double_job_failure.id,
+          old_double_job_failure_de_remediated.id,
+          old_no_job_de_remediated.id,
+          old_remediated_and_de_remediated.id,
+          new_double_job_failure.id,
+          new_double_job_failure_de_remediated.id
+        ].sort
+      }
+
+      expect(described_class.new.snapshot_state).to eq(expected_log)
+    end
+
+    it 'writes counts as Stats D gauges' do
+      prefix = described_class::STATSD_PREFIX
+
+      expect(StatsD).to receive(:gauge).with("#{prefix}.total_awaiting_backup_status_count", 1)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.total_incomplete_type_count", 5)
+      expect(StatsD).to receive(:gauge).with("#{prefix}.total_failure_type_count", 10)
+
+      described_class.new.perform
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- break out our 526 state logging job into logical chunks
  - `Form526FailureStateSnapshotJob` will run hourly, giving a clear picture of how many submissions require manual intervention
  - `Form526SubmissionProcessingReportJob` provides a weekly report on how many submissions were processed, how many succeeded on what path, how many failed, etc

## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=79953572)
- [Why we need a state snapshot](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/the-526-failure-saftey-net.md)

## Testing done

- [x] *New code is covered by unit tests*
- Previously the `Form526StateLoggingJob` was running too frequently for our weekly report, but not frequently enough for our 'failure state snapshot'. It was also confusing people trying to grok why the snapshot had a timebox
- Both of these have been verified working in production console in Argo

## What areas of the site does it impact?
526 Failure reporting

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (see above)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature (n/A)

