### PR TITLE
[SIMPLE_FORMS] feat: build out submission builder service object

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_builder.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_builder.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module SimpleFormsApi
+  module S3
+    class SubmissionBuilder < Utils
+      attr_reader :file_path, :submission, :attachments, :metadata
+
+      def initialize(benefits_intake_uuid:) # rubocop:disable Lint/MissingSuper
+        validate_input(benefits_intake_uuid)
+
+        @submission = FormSubmission.find_by(benefits_intake_uuid:)
+        validate_submission
+
+        @attachments = []
+        @metadata = {}
+
+        hydrate_submission
+      rescue => e
+        handle_error('SubmissionBuilder initialization failed', e)
+      end
+
+      private
+
+      def validate_input(benefits_intake_uuid)
+        raise ArgumentError, 'No benefits_intake_uuid was provided' unless benefits_intake_uuid
+      end
+
+      def validate_submission
+        raise 'Submission was not found or invalid' unless @submission&.benefits_intake_uuid
+        raise 'Submission cannot be built: Only VFF forms are supported' unless vff_form?
+      end
+
+      def hydrate_submission
+        form_number = fetch_submission_form_number
+        form = build_form(form_number)
+
+        filler = PdfFiller.new(form_number:, form:)
+        handle_submission_data(filler, form, form_number)
+      rescue => e
+        handle_error('Error rebuilding submission', e)
+      end
+
+      def fetch_submission_form_number
+        vff_forms_map.fetch(submission.form_type)
+      end
+
+      def build_form(form_number)
+        form_class = "SimpleFormsApi::#{form_number.titleize.delete(' ')}".constantize
+        form_class.new(form_data_hash)
+      rescue NameError => e
+        handle_error("Form class not found for #{form_number}", e)
+      end
+
+      def handle_submission_data(filler, form, form_number)
+        @file_path = generate_file(filler)
+        validate_metadata(form)
+        process_attachments(form, form_number)
+      rescue => e
+        handle_error('Error handling submission data', e)
+      end
+
+      def generate_file(filler)
+        filler.generate(timestamp: submission.created_at)
+      end
+
+      def validate_metadata(form)
+        @metadata = SimpleFormsApiSubmission::MetadataValidator.validate(
+          form.metadata,
+          zip_code_is_us_based: form.zip_code_is_us_based
+        )
+      rescue => e
+        handle_error('Metadata validation failed', e)
+      end
+
+      def process_attachments(form, form_number)
+        case form_number
+        when 'vba_40_0247', 'vba_40_10007'
+          form.handle_attachments(file_path)
+        when 'vba_20_10207'
+          @attachments = form.get_attachments
+        end
+      rescue => e
+        handle_error("Attachment handling failed for #{form_number}", e)
+      end
+
+      def form_data_hash
+        @form_data_hash ||= JSON.parse(submission.form_data)
+      rescue JSON::ParserError => e
+        handle_error('Error parsing form data', e)
+      end
+
+      def vff_forms_map
+        SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP
+      end
+
+      def vff_form?
+        vff_forms_map.key?(submission.form_type)
+      end
+
+      def log_error(message, error, **details)
+        Rails.logger.error(message, details.merge(error: error.message, backtrace: error.backtrace.first(5)))
+      end
+
+      def handle_error(message, error, context = {})
+        log_error(message, error, **context)
+        raise error
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/lib/tasks/archive_download.rake
+++ b/modules/simple_forms_api/lib/tasks/archive_download.rake
@@ -28,13 +28,14 @@ namespace :simple_forms_api do
       delete_temp_file(zip_file_path)
     rescue => e
       puts "Error processing benefits_intake_uuid #{uuid}: #{e.message}"
+      raise e
     end
   end
 end
 
 def zip_directory(dir_path)
   puts "Zipping temporary directory: #{dir_path}"
-  zip_file_path = "#{dir_path}.zip"
+  zip_file_path = "#{dir_path.chop}.zip"
   system("zip -r #{zip_file_path} #{dir_path}")
   zip_file_path
 end

--- a/modules/simple_forms_api/spec/services/s3/submission_builder_spec.rb
+++ b/modules/simple_forms_api/spec/services/s3/submission_builder_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+RSpec.describe SimpleFormsApi::S3::SubmissionBuilder do
+  let(:form_type) { '21-10210' }
+  let(:form_doc) { "vba_#{form_type.gsub('-', '_')}.json" }
+  let(:form_data) do
+    fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', form_doc)
+    File.read(fixture_path)
+  end
+  let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+  let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
+  let(:builder_instance) { described_class.new(benefits_intake_uuid:) }
+
+  before do
+    allow(FormSubmission).to receive(:find_by).and_return(submission)
+    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+    allow_any_instance_of(described_class).to receive(:hydrate_submission).and_call_original
+  end
+
+  describe '#initialize' do
+    subject(:new) { builder_instance }
+
+    context 'when benefits_intake_uuid is valid' do
+      it { is_expected.to have_received(:hydrate_submission) } # rubocop:disable RSpec/SubjectStub
+
+      it 'generates a valid file_path' do
+        expect(new.file_path).to include('/tmp/vba_21_10210-random-letters-n-numbers-tmp.pdf')
+      end
+
+      it 'generates a valid submission' do
+        expect(new.submission).to be(submission)
+      end
+
+      it 'defaults to an empty array for attachments' do
+        expect(new.attachments).to eq([])
+      end
+
+      it 'generates valid metadata' do
+        expect(new.metadata).to eq(
+          {
+            'veteranFirstName' => 'John',
+            'veteranLastName' => 'Veteran',
+            'fileNumber' => '222773333',
+            'zipCode' => '12345',
+            'source' => 'VA Platform Digital Forms',
+            'docType' => '21-10210',
+            'businessLine' => 'CMP'
+          }
+        )
+      end
+
+      context 'when the form is 20-10207 and has attachments' do
+        let(:form_type) { '20-10207' }
+        let(:form_doc) { 'vba_20_10207_with_supporting_documents.json' }
+
+        it 'generates a valid array of attachments' do
+          expect(new.attachments).to eq([])
+        end
+      end
+    end
+
+    context 'when benefits_intake_uuid is nil' do
+      let(:benefits_intake_uuid) { nil }
+
+      before { allow(FormSubmission).to receive(:find_by).and_call_original }
+
+      it 'raises an error' do
+        expect { new }.to raise_exception('No benefits_intake_uuid was provided')
+      end
+    end
+
+    context 'when benefits_intake_uuid is invalid' do
+      let(:benefits_intake_uuid) { 'complete-nonsense' }
+
+      before { allow(FormSubmission).to receive(:find_by).and_call_original }
+
+      it 'raises an error' do
+        expect { new }.to raise_exception('Submission was not found or invalid')
+      end
+    end
+
+    context 'when the associated form submission is not VFF in nature' do
+      let(:submission) { create(:form_submission, :pending, form_type: '12-34567', form_data:) }
+
+      it 'raises an error' do
+        expect { new }.to raise_exception('Submission cannot be built: Only VFF forms are supported')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- This work adds the ability to build a submission and all its required data for archiving/submission
- This work also adds RSpec unit test coverage

## Related issue(s)

- [Create PoC for adding filled in PDFs to an S3 bucket](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1633)

## Testing done

- [x] *New code is covered by unit tests*

## Requested Feedback

Any
