### PR TITLE
APi-40173-vdc-manage-rep-service

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -284,9 +284,9 @@ module ClaimsApi
       end
 
       ##
-      # VdcBean
+      # Vdc
       #
-      module VdcBean
+      module Vdc
         DEFINITION =
           Bean.new(
             path: 'VDC',
@@ -300,7 +300,7 @@ module ClaimsApi
       module ManageRepresentativeService
         DEFINITION =
           Service.new(
-            bean: VdcBean::DEFINITION,
+            bean: Vdc::DEFINITION,
             path: 'ManageRepresentativeService'
           )
 
@@ -344,7 +344,7 @@ module ClaimsApi
       module VeteranRepresentativeService
         DEFINITION =
           Service.new(
-            bean: VdcBean::DEFINITION,
+            bean: Vdc::DEFINITION,
             path: 'VeteranRepresentativeService'
           )
 

--- a/modules/claims_api/lib/bgs_service/local_bgs.rb
+++ b/modules/claims_api/lib/bgs_service/local_bgs.rb
@@ -23,7 +23,7 @@ module ClaimsApi
       StandardDataWebServiceBean/StandardDataWebService
       TrackedItemService/TrackedItemService
       VDC/VeteranRepresentativeService
-      VdcBean/ManageRepresentativeService
+      VDC/ManageRepresentativeService
       VnpAtchmsWebServiceBean/VnpAtchmsService
       VnpPersonWebServiceBean/VnpPersonService
       VnpProcFormWebServiceBean/VnpProcFormService

--- a/modules/claims_api/spec/lib/claims_api/find_definition_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/find_definition_spec.rb
@@ -118,7 +118,7 @@ describe ClaimsApi::LocalBGSRefactored::FindDefinition do
         end
       end
 
-      context 'VdcBean' do
+      context 'Vdc' do
         let(:endpoint) { 'VDC/ManageRepresentativeService' }
         let(:action) { 'readPOARequest' }
         let(:key) { 'POARequestRespondReturnVO' }
@@ -322,7 +322,7 @@ describe ClaimsApi::LocalBGSRefactored::FindDefinition do
         end
       end
 
-      context 'VdcBean' do
+      context 'Vdc' do
         let(:endpoint) { 'VDC/ManageRepresentativeService' }
 
         it 'response with the correct namespace' do


### PR DESCRIPTION
## Summary

- Updates VDC/ManageRepresentativeService in the definitions file, localBGS, and the spec.


## Related issue(s)

- [API-40173](https://jira.devops.va.gov/browse/API-40173)

## Testing done

- [x] *New code is covered by unit tests*
- rails c
```
@ssl_verify_mode =
if Settings.bgs.ssl_verify_mode == 'none'
OpenSSL::SSL::VERIFY_NONE
else
OpenSSL::SSL::VERIFY_PEER
end
ClaimsApi::LocalBGS.new(external_uid:'a', external_key:'b').fetch_namespace(Faraday::Connection.new(ssl: { verify_mode: @ssl_verify_mode }), 'VDC/ManageRepresentativeService')
```
- Postman: ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController#request_representative


## What areas of the site does it impact?
	modified:   modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
	modified:   modules/claims_api/lib/bgs_service/local_bgs.rb
	modified:   modules/claims_api/spec/lib/claims_api/find_definition_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature