### PR TITLE
[SIMPLE_FORMS] feat: build out submission archiver service object

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'fileutils'
+
+# Built in accordance with the following documentation:
+# https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/practices/zero-silent-failures/remediation.md
+module SimpleFormsApi
+  module S3
+    class SubmissionArchiver < Utils
+      class << self
+        def fetch_presigned_url(benefits_intake_uuid)
+          new(benefits_intake_uuid:).generate_presigned_url
+        end
+
+        def fetch_s3_submission(benefits_intake_uuid)
+          new(benefits_intake_uuid:).download(:submission)
+        end
+
+        def fetch_s3_archive(benefits_intake_uuid)
+          new(benefits_intake_uuid:).download(:archive)
+        end
+      end
+
+      def initialize(benefits_intake_uuid:, **options) # rubocop:disable Lint/MissingSuper
+        raise 'No benefits_intake_uuid was provided' unless benefits_intake_uuid
+
+        @benefits_intake_uuid = benefits_intake_uuid
+        @temp_directory_path = build_submission_archive(benefits_intake_uuid:, **options)
+        @parent_dir = options[:parent_dir] || 'vff-simple-forms'
+      end
+
+      def upload
+        log_info("Uploading archive: #{benefits_intake_uuid} to S3 bucket")
+
+        upload_temp_folder_to_s3
+        cleanup
+        s3_directory_path
+      rescue => e
+        handle_error("Failed archive upload: #{benefits_intake_uuid}", e)
+      end
+
+      def download(type = :submission)
+        log_info("Downloading #{type}: #{benefits_intake_uuid} to temporary directory: #{temp_directory_path}")
+        send("download_#{type}_from_s3")
+      rescue => e
+        handle_error("Failed #{type} download: #{benefits_intake_uuid}", e)
+      end
+
+      def cleanup
+        FileUtils.rm_rf(temp_directory_path)
+      end
+
+      private
+
+      attr_reader :benefits_intake_uuid, :parent_dir, :submission
+
+      def build_submission_archive(**)
+        SubmissionArchiveBuilder.new(**).run
+      end
+
+      def upload_temp_folder_to_s3
+        Find.find(temp_directory_path) do |path|
+          next if File.directory?(path)
+
+          relative_path = path.sub(temp_directory_path, '')
+          File.open(path, 'rb') { |file| save_file_to_s3(file.read) }
+          generate_presigned_url if relative_path == submission_pdf_filename
+        end
+      end
+
+      def download_archive_from_s3
+        archive_object_collection.each do |object|
+          local_file_path = build_local_file_path(object.key)
+          object.get(response_target: local_file_path)
+        end
+      end
+
+      def download_submission_from_s3
+        submission_object.get(response_target: local_submission_file_path)
+        local_submission_file_path
+      end
+
+      def build_local_file_path(s3_key)
+        local_path = s3_key.sub(s3_directory_path, '')
+        FileUtils.mkdir_p(File.dirname("#{temp_directory_path}/#{local_path}"))
+        "#{temp_directory_path}/#{local_path}"
+      end
+
+      def generate_presigned_url
+        submission_object.presigned_url(:get, expires_in: 30.minutes.to_i)
+      end
+
+      def save_file_to_s3(content)
+        submission_object.tap { |obj| obj.put(body: content) }
+      end
+
+      def submission_object
+        s3_resource.bucket(target_bucket).object(s3_submission_file_path)
+      end
+
+      def archive_object_collection
+        s3_resource.bucket(target_bucket).objects(prefix: s3_directory_path)
+      end
+
+      def s3_submission_file_path
+        "#{s3_directory_path}/#{submission_pdf_filename}"
+      end
+
+      def submission_pdf_filename
+        submission_form_number = JSON.parse(submission.form_data)['form_number']
+        @submission_pdf_filename ||= "form_#{submission_form_number}.pdf"
+      end
+
+      def s3_directory_path
+        @s3_directory_path ||= "#{parent_dir}/#{benefits_intake_uuid}"
+      end
+
+      def local_submission_file_path
+        @local_submission_file_path ||= build_local_file_path(s3_submission_file_path)
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
@@ -34,9 +34,9 @@ module SimpleFormsApi
       def upload
         log_info("Uploading archive: #{benefits_intake_uuid} to S3 bucket")
 
-        upload_temp_folder_to_s3
+        presigned_url = upload_temp_folder_to_s3
         cleanup
-        s3_directory_path
+        presigned_url
       rescue => e
         handle_error("Failed archive upload: #{benefits_intake_uuid}", e)
       end
@@ -71,11 +71,12 @@ module SimpleFormsApi
       end
 
       def upload_temp_folder_to_s3
-        Find.find(temp_directory_path) do |path|
+        Dir.glob("#{temp_directory_path}/**/*").each do |path|
           next if File.directory?(path)
 
           relative_path = path.sub(temp_directory_path, '')
           File.open(path, 'rb') { |file| save_file_to_s3(file.read) }
+
           generate_presigned_url if relative_path == submission_pdf_filename
         end
       end

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
@@ -34,9 +34,9 @@ module SimpleFormsApi
       def upload
         log_info("Uploading archive: #{benefits_intake_uuid} to S3 bucket")
 
-        presigned_url = upload_temp_folder_to_s3
+        upload_temp_folder_to_s3
         cleanup
-        presigned_url
+        generate_presigned_url
       rescue => e
         handle_error("Failed archive upload: #{benefits_intake_uuid}", e)
       end
@@ -74,10 +74,7 @@ module SimpleFormsApi
         Dir.glob("#{temp_directory_path}/**/*").each do |path|
           next if File.directory?(path)
 
-          relative_path = path.sub(temp_directory_path, '')
           File.open(path, 'rb') { |file| save_file_to_s3(file.read) }
-
-          generate_presigned_url if relative_path == submission_pdf_filename
         end
       end
 

--- a/modules/simple_forms_api/spec/services/s3/submission_archiver_spec.rb
+++ b/modules/simple_forms_api/spec/services/s3/submission_archiver_spec.rb
@@ -8,36 +8,160 @@ RSpec.describe SimpleFormsApi::S3::SubmissionArchiver do
   let(:form_type) { '21-10210' }
   let(:form_data) { File.read("modules/simple_forms_api/spec/fixtures/form_json/vba_#{form_type.gsub('-', '_')}.json") }
   let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+  let(:metadata) do
+    {
+      'veteranFirstName' => 'John',
+      'veteranLastName' => 'Veteran',
+      'fileNumber' => '222773333',
+      'zipCode' => '12345',
+      'source' => 'VA Platform Digital Forms',
+      'docType' => form_type,
+      'businessLine' => 'CMP'
+    }
+  end
   let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
-  let(:temp_directory_path) { Rails.root.join("tmp/#{benefits_intake_uuid}-random-letters-n-numbers/").to_s }
+  let(:randomness) { 'random-letters-n-numbers' }
+  let(:file_path) { Rails.root.join("tmp/#{benefits_intake_uuid}-#{randomness}/").to_s }
+  let(:archive) { OpenStruct.new(submission:, file_path:, attachments: [], metadata:) }
 
   before do
     allow(FormSubmission).to receive(:find_by).and_return(submission)
-    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+    allow(SecureRandom).to receive(:hex).and_return(randomness)
     allow_any_instance_of(described_class).to receive(:build_submission_archive).and_call_original
     allow_any_instance_of(described_class).to receive(:log_info).and_call_original
+    allow_any_instance_of(described_class).to receive(:upload_temp_folder_to_s3).and_return('/things/stuff/')
+    allow_any_instance_of(described_class).to receive(:cleanup).and_return(true)
+    allow_any_instance_of(SimpleFormsApi::S3::SubmissionArchiveBuilder).to receive(:run).and_return(file_path)
   end
 
   describe '#initialize' do
-    subject(:new_instance) { archive_submission_instance }
-
-    let(:archive_submission_instance) { described_class.new(benefits_intake_uuid:) }
+    subject(:instance) { described_class.new(benefits_intake_uuid:) }
 
     it { is_expected.to have_received(:build_submission_archive) }
   end
 
-  xdescribe '#upload' do
-    subject(:upload) { described_class.new(benefits_intake_uuid:).upload }
+  describe '#upload' do
+    subject(:upload) { instance.upload }
 
-    it { is_expected.to have_received(:log_info).with("Processing submission: #{benefits_intake_uuid}") }
+    let(:instance) { described_class.new(benefits_intake_uuid:) }
 
-    context 'when an error occurs'
+    context 'when no errors occur' do
+      it 'logs a notification upon starting' do
+        upload
+        log_message = "Uploading archive: #{benefits_intake_uuid} to S3 bucket"
+        expect(instance).to have_received(:log_info).with(log_message)
+      end
+
+      it 'returns the s3 directory' do
+        expect(upload).to eq("vff-simple-forms/#{benefits_intake_uuid}")
+      end
+
+      context 'when a different parent_dir is provided' do
+        let(:instance) { described_class.new(parent_dir: 'super-great-forms-team', benefits_intake_uuid:) }
+
+        it 'returns the s3 directory' do
+          expect(upload).to eq("super-great-forms-team/#{benefits_intake_uuid}")
+        end
+      end
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(Find).to receive(:find).and_raise(StandardError, 'oopsy')
+        allow(Rails.logger).to receive(:error).and_call_original
+        allow(instance).to receive(:upload_temp_folder_to_s3).and_call_original
+      end
+
+      let(:instance) { described_class.new(benefits_intake_uuid:) }
+
+      it 'raises the error' do
+        expect { upload }.to raise_exception(StandardError, 'oopsy')
+      end
+    end
   end
 
-  describe '#download'
-  describe '#cleanup'
-  describe '.fetch_presigned_url'
-  describe '.fetch_s3_submission'
-  describe '.fetch_s3_archive'
+  describe '#download' do
+    subject(:download) { instance.download(type) }
+
+    before do
+      allow(instance).to receive(:download_archive_from_s3).and_return('/s3_directory_path/')
+      allow(instance).to receive(:download_submission_from_s3).and_return('/s3_directory_path/submission.pdf')
+    end
+
+    let(:instance) { described_class.new(benefits_intake_uuid:) }
+
+    context 'submission' do
+      let(:type) { :submission }
+
+      context 'when no errors occur' do
+        it 'logs a notification upon starting' do
+          download
+          log_message = "Downloading #{type}: #{benefits_intake_uuid} to temporary directory: #{file_path}"
+          expect(instance).to have_received(:log_info).with(log_message)
+        end
+
+        it 'returns the s3 directory' do
+          expect(download).to eq('/s3_directory_path/submission.pdf')
+        end
+      end
+
+      context 'when an error occurs' do
+        before do
+          allow(Reports::Uploader).to receive(:new_s3_resource).and_raise(StandardError, 'oopsy')
+          allow(Rails.logger).to receive(:error).and_call_original
+          allow(instance).to receive(:download_submission_from_s3).and_call_original
+        end
+
+        let(:instance) { described_class.new(benefits_intake_uuid:) }
+
+        it 'raises the error' do
+          expect { download }.to raise_exception(StandardError, 'oopsy')
+        end
+      end
+    end
+
+    context 'archive' do
+      let(:type) { :archive }
+
+      context 'when no errors occur' do
+        it 'logs a notification upon starting' do
+          download
+          log_message = "Downloading #{type}: #{benefits_intake_uuid} to temporary directory: #{file_path}"
+          expect(instance).to have_received(:log_info).with(log_message)
+        end
+
+        it 'returns the s3 directory' do
+          expect(download).to eq('/s3_directory_path/')
+        end
+
+        context 'when a different parent_dir is provided' do
+          let(:instance) { described_class.new(parent_dir: 'super-great-forms-team', benefits_intake_uuid:) }
+
+          it 'returns the s3 directory' do
+            expect(download).to eq('/s3_directory_path/')
+          end
+        end
+      end
+
+      context 'when an error occurs' do
+        before do
+          allow(Reports::Uploader).to receive(:new_s3_resource).and_raise(StandardError, 'oopsy')
+          allow(Rails.logger).to receive(:error).and_call_original
+          allow(instance).to receive(:download_archive_from_s3).and_call_original
+        end
+
+        let(:instance) { described_class.new(benefits_intake_uuid:) }
+
+        it 'raises the error' do
+          expect { download }.to raise_exception(StandardError, 'oopsy')
+        end
+      end
+    end
+  end
+
+  describe '#cleanup' # TODO: add this coverage in future PR
+  describe '.fetch_presigned_url' # TODO: add this coverage in future PR
+  describe '.fetch_s3_submission' # TODO: add this coverage in future PR
+  describe '.fetch_s3_archive' # TODO: add this coverage in future PR
 end
 # rubocop:enable RSpec/SubjectStub

--- a/modules/simple_forms_api/spec/services/s3/submission_archiver_spec.rb
+++ b/modules/simple_forms_api/spec/services/s3/submission_archiver_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+# rubocop:disable RSpec/SubjectStub
+RSpec.describe SimpleFormsApi::S3::SubmissionArchiver do
+  let(:form_type) { '21-10210' }
+  let(:form_data) { File.read("modules/simple_forms_api/spec/fixtures/form_json/vba_#{form_type.gsub('-', '_')}.json") }
+  let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+  let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
+  let(:temp_directory_path) { Rails.root.join("tmp/#{benefits_intake_uuid}-random-letters-n-numbers/").to_s }
+
+  before do
+    allow(FormSubmission).to receive(:find_by).and_return(submission)
+    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+    allow_any_instance_of(described_class).to receive(:build_submission_archive).and_call_original
+    allow_any_instance_of(described_class).to receive(:log_info).and_call_original
+  end
+
+  describe '#initialize' do
+    subject(:new_instance) { archive_submission_instance }
+
+    let(:archive_submission_instance) { described_class.new(benefits_intake_uuid:) }
+
+    it { is_expected.to have_received(:build_submission_archive) }
+  end
+
+  xdescribe '#upload' do
+    subject(:upload) { described_class.new(benefits_intake_uuid:).upload }
+
+    it { is_expected.to have_received(:log_info).with("Processing submission: #{benefits_intake_uuid}") }
+
+    context 'when an error occurs'
+  end
+
+  describe '#download'
+  describe '#cleanup'
+  describe '.fetch_presigned_url'
+  describe '.fetch_s3_submission'
+  describe '.fetch_s3_archive'
+end
+# rubocop:enable RSpec/SubjectStub


### PR DESCRIPTION
## Summary

- This work creates the submission archiver service object
- This work also adds RSpec unit test coverage

## Related issue(s)

- [Create PoC for adding filled in PDFs to an S3 bucket](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1633)

## Testing done

- [x] *New code is covered by unit tests*

## Requested Feedback

Any
