### PR TITLE
Add MHV::UserAccount::Creator service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -456,6 +456,7 @@ app/services/identity @department-of-veterans-affairs/octo-identity
 app/services/identity/account_creator.rb @department-of-veterans-affairs/octo-identity
 app/services/login @department-of-veterans-affairs/octo-identity
 app/services/medical_copays @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
+app/services/mhv/user_account @department-of-veterans-affairs/octo-identity
 app/services/mhv_account_type_service.rb @department-of-veterans-affairs/octo-identity
 app/services/mhv_logging_service.rb @department-of-veterans-affairs/octo-identity
 app/services/rapid_ready_for_decision @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1774,6 +1775,7 @@ spec/services/hca/overrides_parser_spec.rb @department-of-veterans-affairs/vfs-1
 spec/services/identity @department-of-veterans-affairs/octo-identity
 spec/services/login @department-of-veterans-affairs/octo-identity
 spec/services/medical_copays @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
+spec/services/mhv/user_account @department-of-veterans-affairs/octo-identity
 spec/services/mhv_account_type_service_spec.rb @department-of-veterans-affairs/octo-identity
 spec/services/mhv_logging_service_spec.rb @department-of-veterans-affairs/octo-identity
 spec/services/rapid_ready_for_decision @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/mhv_user_account.rb
+++ b/app/models/mhv_user_account.rb
@@ -5,10 +5,12 @@ class MHVUserAccount
   include ActiveModel::Attributes
 
   attribute :user_profile_id, :string
+  attribute :premium, :boolean
   attribute :champ_va, :boolean
   attribute :patient, :boolean
-  attribute :sm_account, :boolean
+  attribute :sm_account_created, :boolean
+  attribute :message, :string
 
   validates :user_profile_id, presence: true
-  validates :champ_va, :patient, :sm_account, inclusion: { in: [true, false] }
+  validates :premium, :champ_va, :patient, :sm_account_created, inclusion: { in: [true, false] }
 end

--- a/app/services/mhv/user_account/creator.rb
+++ b/app/services/mhv/user_account/creator.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'mhv/account_creation/service'
+
+module MHV
+  module UserAccount
+    class Creator
+      attr_reader :user_verification, :cached
+
+      def initialize(user_verification:, cached: true)
+        @user_verification = user_verification
+        @cached = cached
+      end
+
+      def perform
+        validate!
+        create_mhv_user_account!
+      rescue ActiveModel::ValidationError, Errors::ValidationError => e
+        log_and_raise_error(e, :validation)
+      rescue Common::Client::Errors::Error => e
+        log_and_raise_error(e, :client)
+      rescue => e
+        log_and_raise_error(e, :creator)
+      end
+
+      private
+
+      def create_mhv_user_account!
+        account = MHVUserAccount.new(mhv_account_creation_response)
+        account.validate!
+
+        account
+      end
+
+      def mhv_account_creation_response
+        MHV::AccountCreation::Service.new
+                                     .create_account(icn:, email:, tou_occurred_at: current_tou_agreement.created_at)
+      end
+
+      def icn
+        @icn ||= user_account.icn
+      end
+
+      def email
+        @email ||= user_verification.user_credential_email&.credential_email
+      end
+
+      def current_tou_agreement
+        @current_tou_agreement ||= user_account.terms_of_use_agreements.current.last
+      end
+
+      def user_account
+        @user_account ||= user_verification.user_account
+      end
+
+      def validate!
+        errors = [
+          ('ICN must be present' if icn.blank?),
+          ('Email must be present' if email.blank?),
+          ('Current terms of use agreement must be present' if current_tou_agreement.blank?),
+          ("Current terms of use agreement must be 'accepted'" unless current_tou_agreement&.accepted?)
+        ].compact
+
+        raise Errors::ValidationError, errors.join(', ') if errors.present?
+      end
+
+      def log_and_raise_error(error, type = nil)
+        klass = case type
+                when :validation
+                  Errors::ValidationError
+                when :client
+                  Errors::MHVClientError
+                else
+                  Errors::CreatorError
+                end
+
+        Rails.logger.error("[MHV][UserAccount][Creator] #{type} error", error_message: error.message, icn:)
+        raise klass, error.message
+      end
+    end
+  end
+end

--- a/app/services/mhv/user_account/errors.rb
+++ b/app/services/mhv/user_account/errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module MHV
+  module UserAccount
+    module Errors
+      class UserAccountError < StandardError; end
+      class CreatorError < UserAccountError; end
+      class ValidationError < UserAccountError; end
+      class MHVClientError < UserAccountError; end
+    end
+  end
+end

--- a/lib/mhv/account_creation/service.rb
+++ b/lib/mhv/account_creation/service.rb
@@ -17,6 +17,7 @@ module MHV
       rescue Common::Client::Errors::ParsingError, Common::Client::Errors::ClientError => e
         Rails.logger.error("#{config.logging_prefix} create_account #{e.class.name.demodulize.underscore}",
                            { error_message: e.message, body: e.body, icn: })
+        raise
       end
 
       private
@@ -41,7 +42,14 @@ module MHV
       end
 
       def normalize_response_body(response_body)
-        response_body.deep_transform_keys { |key| key.underscore.to_sym }
+        {
+          user_profile_id: response_body['mhv_userprofileid'],
+          premium: response_body['isPremium'],
+          champ_va: response_body['isChampVA'],
+          patient: response_body['isPatient'],
+          sm_account_created: response_body['isSMAccountCreated'],
+          message: response_body['message']
+        }
       end
     end
   end

--- a/spec/lib/mhv/account_creation/service_spec.rb
+++ b/spec/lib/mhv/account_creation/service_spec.rb
@@ -27,11 +27,11 @@ describe MHV::AccountCreation::Service do
       let(:expected_log_payload) { { icn: } }
       let(:expected_response_body) do
         {
-          mhv_userprofileid: '12345678',
-          is_premium: true,
-          is_champ_va: true,
-          is_patient: true,
-          is_sm_account_created: true,
+          user_profile_id: '12345678',
+          premium: true,
+          champ_va: true,
+          patient: true,
+          sm_account_created: true,
           message: 'Existing MHV Account Found for ICN'
         }
       end
@@ -70,9 +70,9 @@ describe MHV::AccountCreation::Service do
         }
       end
 
-      it 'logs the client error' do
+      it 'logs and re-raises the client error' do
         VCR.use_cassette('mhv/account_creation/account_creation_service_400_response') do
-          subject
+          expect { subject }.to raise_error(Common::Client::Errors::ClientError)
           expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
         end
       end
@@ -88,9 +88,9 @@ describe MHV::AccountCreation::Service do
         }
       end
 
-      it 'logs the parsing error' do
+      it 'logs and re-raises the parsing error' do
         VCR.use_cassette('mhv/account_creation/account_creation_service_500_response') do
-          subject
+          expect { subject }.to raise_error(Common::Client::Errors::ParsingError)
           expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
         end
       end
@@ -100,9 +100,9 @@ describe MHV::AccountCreation::Service do
       let(:expected_log_message) { "#{log_prefix} sts token request failed" }
       let(:expected_log_payload) { { user_identifier: icn, error_message: 'Service account config not found' } }
 
-      it 'logs the STS token request failure' do
+      it 'logs and re-raises the STS token request failure' do
         VCR.use_cassette('sign_in_service/sts/sts_token_400_response') do
-          subject
+          expect { subject }.to raise_error(Common::Client::Errors::ClientError)
           expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
         end
       end

--- a/spec/models/mhv_user_account_spec.rb
+++ b/spec/models/mhv_user_account_spec.rb
@@ -8,25 +8,43 @@ RSpec.describe MHVUserAccount, type: :model do
   let(:attributes) do
     {
       user_profile_id:,
+      premium:,
       champ_va:,
       patient:,
-      sm_account:
+      sm_account_created:,
+      message:
     }
   end
 
   let(:user_profile_id) { '123' }
+  let(:premium) { true }
   let(:champ_va) { true }
   let(:patient) { false }
-  let(:sm_account) { true }
+  let(:sm_account_created) { true }
+  let(:message) { 'some-message' }
 
   context 'with valid attributes' do
-    it 'is valid' do
-      expect(mhv_user_account).to be_valid
+    shared_examples 'a valid user account' do
+      it 'is valid' do
+        expect(mhv_user_account).to be_valid
+      end
+    end
+
+    context 'when all attributes are present' do
+      it 'is valid' do
+        expect(mhv_user_account).to be_valid
+      end
+    end
+
+    context 'when message is nil' do
+      let(:message) { nil }
+
+      it_behaves_like 'a valid user account'
     end
   end
 
   context 'with invalid attributes' do
-    shared_examples 'is invalid' do
+    shared_examples 'an invalid user account' do
       it 'is invalid' do
         expect(mhv_user_account).not_to be_valid
       end
@@ -35,25 +53,31 @@ RSpec.describe MHVUserAccount, type: :model do
     context 'when user_profile_id is nil' do
       let(:user_profile_id) { nil }
 
-      it_behaves_like 'is invalid'
+      it_behaves_like 'an invalid user account'
+    end
+
+    context 'when premium is nil' do
+      let(:premium) { nil }
+
+      it_behaves_like 'an invalid user account'
     end
 
     context 'when champ_va is nil' do
       let(:champ_va) { nil }
 
-      it_behaves_like 'is invalid'
+      it_behaves_like 'an invalid user account'
     end
 
     context 'when patient is nil' do
       let(:patient) { nil }
 
-      it_behaves_like 'is invalid'
+      it_behaves_like 'an invalid user account'
     end
 
-    context 'when sm_account is nil' do
-      let(:sm_account) { nil }
+    context 'when sm_account_created is nil' do
+      let(:sm_account_created) { nil }
 
-      it_behaves_like 'is invalid'
+      it_behaves_like 'an invalid user account'
     end
   end
 end

--- a/spec/services/mhv/user_account/creator_spec.rb
+++ b/spec/services/mhv/user_account/creator_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mhv/account_creation/service'
+
+RSpec.describe MHV::UserAccount::Creator do
+  subject { described_class.new(user_verification:, cached:) }
+
+  let(:user_account) { create(:user_account, icn:) }
+  let(:user_verification) { create(:user_verification, user_account:, user_credential_email:) }
+  let(:user_credential_email) { create(:user_credential_email, credential_email: email) }
+  let!(:terms_of_use_agreement) { create(:terms_of_use_agreement, user_account:) }
+  let(:icn) { '10101V964144' }
+  let(:email) { 'some-email@email.com' }
+  let(:tou_occurred_at) { terms_of_use_agreement.created_at }
+  let(:cached) { true }
+  let(:mhv_client) { instance_double(MHV::AccountCreation::Service) }
+  let(:mhv_response_body) do
+    {
+      user_profile_id: '12345678',
+      premium: true,
+      champ_va: true,
+      patient: true,
+      sm_account_created: true
+    }
+  end
+
+  before do
+    allow(MHV::AccountCreation::Service).to receive(:new).and_return(mhv_client)
+    allow(mhv_client).to receive(:create_account).and_return(mhv_response_body)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  describe '#perform' do
+    shared_examples 'an invalid creator' do
+      let(:expected_log_payload) { { error_message: /#{expected_error_message}/, icn: } }
+      let(:expected_log_message) { '[MHV][UserAccount][Creator] validation error' }
+
+      it 'logs and raises an error' do
+        expect { subject.perform }.to raise_error(MHV::UserAccount::Errors::ValidationError)
+        expect(Rails.logger).to have_received(:error).with(expected_log_message,
+                                                           expected_log_payload)
+      end
+    end
+
+    describe 'validations' do
+      context 'when icn is not present' do
+        let(:icn) { nil }
+        let(:expected_error_message) { 'ICN must be present' }
+
+        it_behaves_like 'an invalid creator'
+      end
+
+      context 'when email is not present' do
+        let(:user_credential_email) { nil }
+        let(:expected_error_message) { 'Email must be present' }
+
+        it_behaves_like 'an invalid creator'
+      end
+    end
+
+    context 'when tou_occurred_at is not present' do
+      let(:terms_of_use_agreement) { nil }
+      let(:expected_error_message) { 'Current terms of use agreement must be present' }
+
+      it_behaves_like 'an invalid creator'
+    end
+
+    context 'when current_tou_agreement is not accepted' do
+      let(:terms_of_use_agreement) { create(:terms_of_use_agreement, user_account:, response: :declined) }
+      let(:expected_error_message) { "Current terms of use agreement must be 'accepted'" }
+
+      it_behaves_like 'an invalid creator'
+    end
+
+    context 'when icn, email, and tou_occurred_at are present' do
+      it 'calls MHV::AccountCreation::Service#create_account with the expected params' do
+        subject.perform
+        expect(mhv_client).to have_received(:create_account).with(icn:, email:, tou_occurred_at:)
+      end
+    end
+  end
+
+  context 'when the mhv response is successful' do
+    context 'when the MHVUserAccount is valid' do
+      it 'retuns a MHVUserAccount' do
+        mhv_user_account = subject.perform
+        expect(mhv_user_account).to be_a(MHVUserAccount)
+        expect(mhv_user_account).to be_valid
+      end
+    end
+
+    context 'when the MHVUserAccount is invalid' do
+      let(:mhv_response_body) do
+        {
+          user_profile_id: nil,
+          premium: true,
+          champ_va: true,
+          patient: true,
+          sm_account_created: true
+        }
+      end
+
+      let(:expected_log_message) { '[MHV][UserAccount][Creator] validation error' }
+      let(:expected_log_payload) do
+        {
+          error_message: 'Validation failed: User profile can\'t be blank',
+          icn:
+        }
+      end
+
+      it 'logs and raises an error' do
+        expect { subject.perform }.to raise_error(MHV::UserAccount::Errors::ValidationError)
+        expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
+      end
+    end
+  end
+
+  context 'when the mhv response is not successful' do
+    let(:expected_log_message) { '[MHV][UserAccount][Creator] client error' }
+    let(:expected_log_payload) do
+      {
+        error_message: 'error',
+        icn:
+      }
+    end
+
+    before do
+      allow(mhv_client).to receive(:create_account).and_raise(Common::Client::Errors::ClientError, 'error')
+    end
+
+    it 'logs and raises an error' do
+      expect { subject.perform }.to raise_error(MHV::UserAccount::Errors::MHVClientError)
+      expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
+    end
+  end
+
+  context 'when an unexpected error occurs' do
+    let(:expected_log_message) { '[MHV][UserAccount][Creator] creator error' }
+    let(:expected_log_payload) do
+      {
+        error_message: 'error',
+        icn:
+      }
+    end
+
+    before do
+      allow(mhv_client).to receive(:create_account).and_raise(StandardError, 'error')
+    end
+
+    it 'logs and raises an error' do
+      expect { subject.perform }.to raise_error(MHV::UserAccount::Errors::CreatorError)
+      expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Creates a `MHV::UserAccount::Creator` service object. This class takes in a `user_verification` and optional `cached` args. This class then calls `MHV::AccountCreator::Service.create_account` which makes an external call to MHV then a `MHVUserAccount` is created from the response. 
- `cached` will be added to the external `create_account` call in an upcoming PR

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-469

## Testing done
- in rails console test the class by passing a user_verification you have locally
  - a `user_verification.user_account.terms_of_use_agreements` needs to exist
 -  This is difficult to test without being on staging but the validations and object creation with a dummy response can be tested.
    - in the [mhv_account_creation_response](https://github.com/department-of-veterans-affairs/vets-api/blob/2ee69f5120ccb4789f931a08e9832691341f800e/app/services/mhv/user_account/creator.rb#L35-L38) method add a dummy response
     ```ruby
      def mhv_account_creation_response
        {
          user_profile_id: '12345678',
          premium: true,
          champ_va: true,
          patient: true,
          sm_account_created: true,
          message: 'some message'
        }
      end
     ````
  - start a rails console - `rails c`
  - find a `user_verification` with an accepted tou
    ```ruby
    user_verification =UserVerification.joins(user_account: :terms_of_use_agreements).where(terms_of_use_agreements: { response: 'accepted' } ).last
    ```
  - call the creator with the `user_verification`. you should get an `MHVUserAccount` object with the same values as the dummy response
    ```ruby
    mhv_user_account = MHV::UserAccount::Creator.new(user_verification:).perform
    mhv_user_account.attributes
    ```

## What areas of the site does it impact?
MHV user account
