### PR TITLE
Use form_submission_attempt to get more data in mailer

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -16,7 +16,7 @@ class FormSubmissionAttempt < ApplicationRecord
   self.ignored_columns += %w[error_message response]
 
   def benefits_intake_uuid
-    benefits_intake_uuid || form_submission.benefits_intake_uuid
+    self[:benefits_intake_uuid] || form_submission.benefits_intake_uuid
   end
 
   aasm do

--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -15,6 +15,10 @@ class FormSubmissionAttempt < ApplicationRecord
   # If we get around to doing that, we shouldn't need the following line.
   self.ignored_columns += %w[error_message response]
 
+  def benefits_intake_uuid
+    benefits_intake_uuid || form_submission.benefits_intake_uuid
+  end
+
   aasm do
     after_all_transitions :log_status_change
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -23,8 +23,8 @@ module SimpleFormsApi
     SUPPORTED_FORMS = TEMPLATE_IDS.keys
 
     def initialize(form_submission_attempt:, notification_type: :confirmation, user: nil)
-      @form_data = form_submission_attempt.form_data
-      @form_number = form_submission_attempt.form_type
+      @form_data = JSON.parse(form_submission_attempt.form_submission.form_data)
+      @form_number = V1::UploadsController::FORM_NUMBER_MAP[form_submission_attempt.form_submission.form_type]
       @confirmation_number = form_submission_attempt.benefits_intake_uuid
       @lighthouse_updated_at = form_submission_attempt.lighthouse_updated_at
       @originally_submitted_at = form_submission_attempt.created_at

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -25,7 +25,7 @@ module SimpleFormsApi
     def initialize(form_submission_attempt:, notification_type: :confirmation, user: nil)
       @form_data = JSON.parse(form_submission_attempt.form_submission.form_data)
       @form_number = V1::UploadsController::FORM_NUMBER_MAP[form_submission_attempt.form_submission.form_type]
-      @confirmation_number = form_submission_attempt.benefits_intake_uuid
+      @confirmation_number = form_submission_attempt.benefits_intake_uuid || form_submission_attempt.confirmation_number
       @lighthouse_updated_at = form_submission_attempt.lighthouse_updated_at
       @originally_submitted_at = form_submission_attempt.created_at
       @notification_type = notification_type

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
             it 'catches the exception and sends a PDF to Central Mail instead' do
               expect_any_instance_of(SimpleFormsApi::V1::UploadsController).to receive(
                 :upload_pdf
-              ).and_return([:ok, 'confirmation number'])
+              ).and_return([:ok, build(:form_submission_attempt)])
               fixture_path = Rails.root.join(
                 'modules',
                 'simple_forms_api',
@@ -220,7 +220,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           before do
             allow(BenefitsIntake::Service).to receive(:new).and_return(lighthouse_service)
             allow_any_instance_of(SimpleFormsApi::V1::UploadsController).to(
-              receive(:prepare_for_upload).and_return(%w[location uuid])
+              receive(:prepare_for_upload).and_return(['location', build(:form_submission_attempt)])
             )
             allow_any_instance_of(SimpleFormsApi::V1::UploadsController).to(
               receive(:log_upload_details).and_return(true)
@@ -635,7 +635,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
       sign_in
     end
 
-    let(:confirmation_number) { 'some_confirmation_number' }
+    let(:confirmation_number) { SecureRandom.uuid }
 
     describe '21_4142' do
       let(:data) do
@@ -644,11 +644,15 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-4142') }
+      let(:form_submission_attempt) do
+        create(:form_submission_attempt, benefits_intake_uuid: confirmation_number, form_submission:)
+      end
 
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
         allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf).and_return([200, confirmation_number])
+          .to receive(:upload_pdf).and_return([200, form_submission_attempt])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -660,7 +664,8 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           {
             'first_name' => 'VETERAN',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => confirmation_number
+            'confirmation_number' => confirmation_number,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -668,7 +673,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
       it 'unsuccessful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
         allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf).and_return([500, confirmation_number])
+          .to receive(:upload_pdf).and_return([500, form_submission_attempt])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -685,11 +690,15 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-10210') }
+      let(:form_submission_attempt) do
+        create(:form_submission_attempt, benefits_intake_uuid: confirmation_number, form_submission:)
+      end
 
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
         allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf).and_return([200, confirmation_number])
+          .to receive(:upload_pdf).and_return([200, form_submission_attempt])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -701,7 +710,8 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           {
             'first_name' => 'JACK',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => confirmation_number
+            'confirmation_number' => confirmation_number,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -709,7 +719,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
       it 'unsuccessful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
         allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf).and_return([500, confirmation_number])
+          .to receive(:upload_pdf).and_return([500, form_submission_attempt])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -731,12 +741,16 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21P-0847') }
+      let(:form_submission_attempt) do
+        create(:form_submission_attempt, benefits_intake_uuid: confirmation_number, form_submission:)
+      end
 
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
         allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf).and_return([200, confirmation_number])
+          .to receive(:upload_pdf).and_return([200, form_submission_attempt])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -748,7 +762,8 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           {
             'first_name' => 'ARTHUR',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => confirmation_number
+            'confirmation_number' => confirmation_number,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -757,7 +772,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
         allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf).and_return([500, confirmation_number])
+          .to receive(:upload_pdf).and_return([500, form_submission_attempt])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -774,11 +789,15 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-0972') }
+      let(:form_submission_attempt) do
+        create(:form_submission_attempt, benefits_intake_uuid: confirmation_number, form_submission:)
+      end
 
       it 'successful submission' do
         allow(VANotify::EmailJob).to receive(:perform_async)
         allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-          .to receive(:upload_pdf).and_return([200, confirmation_number])
+          .to receive(:upload_pdf).and_return([200, form_submission_attempt])
 
         post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -790,7 +809,8 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           {
             'first_name' => 'PREPARE',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => confirmation_number
+            'confirmation_number' => confirmation_number,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -815,6 +835,10 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
             'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'
           )
           JSON.parse(fixture_path.read)
+        end
+        let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-0966') }
+        let(:form_submission_attempt) do
+          create(:form_submission_attempt, benefits_intake_uuid: confirmation_number, form_submission:)
         end
 
         before do
@@ -846,6 +870,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
                 'first_name' => 'ABRAHAM',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => confirmation_number,
+                'lighthouse_updated_at' => nil,
                 'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
                                              ' (VA Form 21P-534 or VA Form 21P-534EZ)'
               }
@@ -856,7 +881,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         context 'non-veteran preparer' do
           it 'successful submission' do
             allow_any_instance_of(SimpleFormsApi::V1::UploadsController)
-              .to receive(:upload_pdf).and_return([200, confirmation_number])
+              .to receive(:upload_pdf).and_return([200, form_submission_attempt])
 
             post '/simple_forms_api/v1/simple_forms', params: data
 
@@ -869,6 +894,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
                 'first_name' => 'ABRAHAM',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => confirmation_number,
+                'lighthouse_updated_at' => nil,
                 'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
                                              ' (VA Form 21P-534 or VA Form 21P-534EZ)'
               }

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -12,6 +12,8 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-10210') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
 
       context 'flipper is on' do
         before do
@@ -23,8 +25,7 @@ describe SimpleFormsApi::NotificationEmail do
           data['claim_ownership'] = 'self'
           data['claimant_type'] = 'veteran'
 
-          subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
-                                        confirmation_number: 'confirmation_number', notification_type:)
+          subject = described_class.new(form_submission_attempt:, notification_type:)
 
           subject.send
 
@@ -39,8 +40,7 @@ describe SimpleFormsApi::NotificationEmail do
 
         it 'does not send the email' do
           allow(VANotify::EmailJob).to receive(:perform_async)
-          subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
-                                        confirmation_number: 'confirmation_number', notification_type:)
+          subject = described_class.new(form_submission_attempt:, notification_type:)
 
           subject.send
 
@@ -56,6 +56,8 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-10210') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
 
       describe 'users own claim' do
         it 'is a veteran' do
@@ -63,8 +65,7 @@ describe SimpleFormsApi::NotificationEmail do
           data['claim_ownership'] = 'self'
           data['claimant_type'] = 'veteran'
 
-          subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
-                                        confirmation_number: 'confirmation_number', notification_type:)
+          subject = described_class.new(form_submission_attempt:, notification_type:)
 
           subject.send
 
@@ -74,7 +75,8 @@ describe SimpleFormsApi::NotificationEmail do
             {
               'first_name' => 'JOHN',
               'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => 'confirmation_number'
+              'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+              'lighthouse_updated_at' => nil
             }
           )
         end
@@ -84,8 +86,7 @@ describe SimpleFormsApi::NotificationEmail do
           data['claim_ownership'] = 'self'
           data['claimant_type'] = 'non-veteran'
 
-          subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
-                                        confirmation_number: 'confirmation_number', notification_type:)
+          subject = described_class.new(form_submission_attempt:, notification_type:)
 
           subject.send
 
@@ -95,7 +96,8 @@ describe SimpleFormsApi::NotificationEmail do
             {
               'first_name' => 'JOE',
               'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => 'confirmation_number'
+              'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+              'lighthouse_updated_at' => nil
             }
           )
         end
@@ -107,8 +109,7 @@ describe SimpleFormsApi::NotificationEmail do
           data['claim_ownership'] = 'third-party'
           data['claimant_type'] = 'veteran'
 
-          subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
-                                        confirmation_number: 'confirmation_number', notification_type:)
+          subject = described_class.new(form_submission_attempt:, notification_type:)
 
           subject.send
 
@@ -118,7 +119,8 @@ describe SimpleFormsApi::NotificationEmail do
             {
               'first_name' => 'JACK',
               'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => 'confirmation_number'
+              'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+              'lighthouse_updated_at' => nil
             }
           )
         end
@@ -128,8 +130,7 @@ describe SimpleFormsApi::NotificationEmail do
           data['claim_ownership'] = 'third-party'
           data['claimant_type'] = 'non-veteran'
 
-          subject = described_class.new(form_data: data, form_number: 'vba_21_10210',
-                                        confirmation_number: 'confirmation_number', notification_type:)
+          subject = described_class.new(form_submission_attempt:, notification_type:)
 
           subject.send
 
@@ -139,7 +140,8 @@ describe SimpleFormsApi::NotificationEmail do
             {
               'first_name' => 'JACK',
               'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => 'confirmation_number'
+              'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+              'lighthouse_updated_at' => nil
             }
           )
         end
@@ -155,15 +157,13 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '40-0247') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
 
       it 'sends the confirmation email' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_40_0247',
-          confirmation_number: 'confirmation_number'
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation)
 
         subject.send
 
@@ -173,7 +173,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JOE',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -186,6 +187,8 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '40-0247') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
 
       context 'when user is signed in' do
         let(:user) { create(:user, :loa3) }
@@ -194,12 +197,7 @@ describe SimpleFormsApi::NotificationEmail do
           allow(VANotify::EmailJob).to receive(:perform_async)
           expect(data['applicant_email']).to be_nil
 
-          subject = described_class.new(
-            form_data: data,
-            form_number: 'vba_40_0247',
-            confirmation_number: 'confirmation_number',
-            user:
-          )
+          subject = described_class.new(form_submission_attempt:, notification_type: :confirmation)
 
           subject.send
 
@@ -212,12 +210,7 @@ describe SimpleFormsApi::NotificationEmail do
           allow(VANotify::EmailJob).to receive(:perform_async)
           expect(data['applicant_email']).to be_nil
 
-          subject = described_class.new(
-            form_data: data,
-            form_number: 'vba_40_0247',
-            confirmation_number: 'confirmation_number',
-            user: nil
-          )
+          subject = described_class.new(form_submission_attempt:, notification_type: :confirmation)
 
           subject.send
 
@@ -234,18 +227,15 @@ describe SimpleFormsApi::NotificationEmail do
       )
       JSON.parse(fixture_path.read)
     end
+    let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-0845') }
+    let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
 
     describe 'signed in user' do
       it 'non-veteran authorizer' do
         allow(VANotify::EmailJob).to receive(:perform_async)
         data['authorizer_email'] = 'authorizer_email@example.com'
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_21_0845',
-          confirmation_number: 'confirmation_number',
-          user: create(:user)
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation, user: create(:user))
 
         subject.send
 
@@ -255,7 +245,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JACK',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -264,12 +255,7 @@ describe SimpleFormsApi::NotificationEmail do
         allow(VANotify::EmailJob).to receive(:perform_async)
         data['authorizer_type'] = 'veteran'
 
-        subject = described_class.new(
-          user: create(:user),
-          form_data: data,
-          form_number: 'vba_21_0845',
-          confirmation_number: 'confirmation_number'
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation, user: create(:user))
 
         allow(subject.user).to receive(:va_profile_email).and_return('abraham.lincoln@vets.gov')
 
@@ -281,7 +267,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JOHN',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -293,11 +280,7 @@ describe SimpleFormsApi::NotificationEmail do
         # form requires email
         data['authorizer_email'] = 'authorizer_email@example.com'
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_21_0845',
-          confirmation_number: 'confirmation_number'
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation)
 
         subject.send
 
@@ -307,7 +290,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JACK',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -317,11 +301,7 @@ describe SimpleFormsApi::NotificationEmail do
         # form does not require email
         data['authorizer_type'] = 'veteran'
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_21_0845',
-          confirmation_number: 'confirmation_number'
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation)
 
         subject.send
 
@@ -337,17 +317,14 @@ describe SimpleFormsApi::NotificationEmail do
       )
       JSON.parse(fixture_path.read)
     end
+    let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '21-0966') }
+    let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
     let(:user) { create(:user, :loa3) }
 
     it 'sends the confirmation email' do
       allow(VANotify::EmailJob).to receive(:perform_async)
 
-      subject = described_class.new(
-        form_data: data,
-        form_number: 'vba_21_0966',
-        confirmation_number: 'confirmation_number',
-        user:
-      )
+      subject = described_class.new(form_submission_attempt:, notification_type: :confirmation, user:)
 
       subject.send
 
@@ -357,7 +334,8 @@ describe SimpleFormsApi::NotificationEmail do
         {
           'first_name' => user.first_name.upcase,
           'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-          'confirmation_number' => 'confirmation_number',
+          'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+          'lighthouse_updated_at' => nil,
           'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
                                        ' (VA Form 21P-534 or VA Form 21P-534EZ)'
         }
@@ -372,15 +350,13 @@ describe SimpleFormsApi::NotificationEmail do
       )
       JSON.parse(fixture_path.read)
     end
+    let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '20-10206') }
+    let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
 
     it 'sends the confirmation email' do
       allow(VANotify::EmailJob).to receive(:perform_async)
 
-      subject = described_class.new(
-        form_data: data,
-        form_number: 'vba_20_10206',
-        confirmation_number: 'confirmation_number'
-      )
+      subject = described_class.new(form_submission_attempt:, notification_type: :confirmation)
 
       subject.send
 
@@ -390,7 +366,8 @@ describe SimpleFormsApi::NotificationEmail do
         {
           'first_name' => 'JOHN',
           'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-          'confirmation_number' => 'confirmation_number'
+          'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+          'lighthouse_updated_at' => nil
         }
       )
     end
@@ -404,17 +381,14 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '20-10207') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
       let(:user) { create(:user, :loa3) }
 
       it 'sends the confirmation email' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_20_10207',
-          confirmation_number: 'confirmation_number',
-          user:
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation, user:)
 
         subject.send
 
@@ -424,7 +398,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JOHN',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -437,17 +412,14 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '20-10207') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
       let(:user) { create(:user, :loa3) }
 
       it 'sends the confirmation email' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_20_10207',
-          confirmation_number: 'confirmation_number',
-          user:
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation, user:)
 
         subject.send
 
@@ -457,7 +429,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JOE',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -470,17 +443,14 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '20-10207') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
       let(:user) { create(:user, :loa3) }
 
       it 'sends the confirmation email' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_20_10207',
-          confirmation_number: 'confirmation_number',
-          user:
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation, user:)
 
         subject.send
 
@@ -490,7 +460,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JOHN',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end
@@ -503,17 +474,14 @@ describe SimpleFormsApi::NotificationEmail do
         )
         JSON.parse(fixture_path.read)
       end
+      let(:form_submission) { create(:form_submission, form_data: data.to_json, form_type: '20-10207') }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
       let(:user) { create(:user, :loa3) }
 
       it 'sends the confirmation email' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject = described_class.new(
-          form_data: data,
-          form_number: 'vba_20_10207',
-          confirmation_number: 'confirmation_number',
-          user:
-        )
+        subject = described_class.new(form_submission_attempt:, notification_type: :confirmation, user:)
 
         subject.send
 
@@ -523,7 +491,8 @@ describe SimpleFormsApi::NotificationEmail do
           {
             'first_name' => 'JOE',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'confirmation_number' => 'confirmation_number'
+            'confirmation_number' => form_submission_attempt.benefits_intake_uuid,
+            'lighthouse_updated_at' => nil
           }
         )
       end

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :form_submission do
     form_type { '21-4142' }
+    benefits_intake_uuid { SecureRandom.uuid }
 
     trait :pending do
       benefits_intake_uuid { '6d8433c1-cd55-4c24-affd-f592287a7572' }


### PR DESCRIPTION
## Summary
This PR refactors the `SimpleFormsApi::NotificationEmail` so that it can get its data from a `FormSubmissionAttempt` and thereby also gain access to the coveted `lighthouse_updated_at` field.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1668
