### PR TITLE
[Disability Benefits] Add in "toxic exposure" to event exposure text

### DIFF
--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -582,8 +582,8 @@ module EVSS
       end
 
       def format_exposure_text(cause, related_to_toxic_exposure)
-        text = TOXIC_EXPOSURE_CAUSE_MAP[cause.upcase.to_sym]
-        text.sub(/[.]?$/, '; toxic exposure.') if related_to_toxic_exposure
+        cause_text = TOXIC_EXPOSURE_CAUSE_MAP[cause.upcase.to_sym].dup
+        related_to_toxic_exposure ? cause_text.sub!(/[.]?$/, '; toxic exposure.') : cause_text
       end
 
       # rubocop:disable Naming/PredicateName

--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -6,11 +6,11 @@ module EVSS
   module DisabilityCompensationForm
     class Form526ToLighthouseTransform # rubocop:disable Metrics/ClassLength
       TOXIC_EXPOSURE_CAUSE_MAP = {
-        NEW: 'My condition was caused by an injury or exposure during my military service; toxic exposure.',
+        NEW: 'My condition was caused by an injury or exposure during my military service.',
         WORSENED: 'My condition existed before I served in the military, but it got worse because of my military ' \
-                  'service; toxic exposure.',
-        VA: 'My condition was caused by an injury or event that happened when I was receiving VA care; toxic exposure.',
-        SECONDARY: 'My condition was caused by another service-connected disability I already have; toxic exposure.'
+                  'service.',
+        VA: 'My condition was caused by an injury or event that happened when I was receiving VA care.',
+        SECONDARY: 'My condition was caused by another service-connected disability I already have.'
       }.freeze
 
       GULF_WAR_LOCATIONS = {
@@ -566,7 +566,8 @@ module EVSS
             dis.is_related_to_toxic_exposure = is_related_to_toxic_exposure(dis.name, toxic_exposure_conditions)
           end
           dis.classification_code = disability_source['classificationCode'] if disability_source['classificationCode']
-          dis.service_relevance = disability_source['serviceRelevance'] || ''
+          dis.service_relevance = set_service_relevance(dis.is_related_to_toxic_exposure,
+                                                        disability_source['serviceRelevance'])
           dis.rated_disability_id = disability_source['ratedDisabilityId'] if disability_source['ratedDisabilityId']
           dis.diagnostic_code = disability_source['diagnosticCode'] if disability_source['diagnosticCode']
           if disability_source['secondaryDisabilities']
@@ -577,6 +578,16 @@ module EVSS
           end
 
           dis
+        end
+      end
+
+      def set_service_relevance(related_to_toxic_exposure, service_relevance)
+        if related_to_toxic_exposure && service_relevance.present?
+          "#{service_relevance}; toxic exposure".to_s
+        elsif service_relevance.present?
+          service_relevance
+        else
+          ''
         end
       end
 

--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -6,11 +6,11 @@ module EVSS
   module DisabilityCompensationForm
     class Form526ToLighthouseTransform # rubocop:disable Metrics/ClassLength
       TOXIC_EXPOSURE_CAUSE_MAP = {
-        NEW: 'My condition was caused by an injury or exposure during my military service.',
+        NEW: 'My condition was caused by an injury or exposure during my military service; toxic exposure.',
         WORSENED: 'My condition existed before I served in the military, but it got worse because of my military ' \
-                  'service.',
-        VA: 'My condition was caused by an injury or event that happened when I was receiving VA care.',
-        SECONDARY: 'My condition was caused by another service-connected disability I already have.'
+                  'service; toxic exposure.',
+        VA: 'My condition was caused by an injury or event that happened when I was receiving VA care; toxic exposure.',
+        SECONDARY: 'My condition was caused by another service-connected disability I already have; toxic exposure.'
       }.freeze
 
       GULF_WAR_LOCATIONS = {

--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -566,29 +566,24 @@ module EVSS
             dis.is_related_to_toxic_exposure = is_related_to_toxic_exposure(dis.name, toxic_exposure_conditions)
           end
           dis.classification_code = disability_source['classificationCode'] if disability_source['classificationCode']
-          dis.service_relevance = set_service_relevance(dis.is_related_to_toxic_exposure,
-                                                        disability_source['serviceRelevance'])
+          dis.service_relevance = disability_source['serviceRelevance'] || ''
           dis.rated_disability_id = disability_source['ratedDisabilityId'] if disability_source['ratedDisabilityId']
           dis.diagnostic_code = disability_source['diagnosticCode'] if disability_source['diagnosticCode']
           if disability_source['secondaryDisabilities']
             dis.secondary_disabilities = transform_secondary_disabilities(disability_source)
           end
           if disability_source['cause'].present?
-            dis.exposure_or_event_or_injury = TOXIC_EXPOSURE_CAUSE_MAP[disability_source['cause'].upcase.to_sym]
+            dis.exposure_or_event_or_injury = format_exposure_text(disability_source['cause'],
+                                                                   dis.is_related_to_toxic_exposure)
           end
 
           dis
         end
       end
 
-      def set_service_relevance(related_to_toxic_exposure, service_relevance)
-        if related_to_toxic_exposure && service_relevance.present?
-          "#{service_relevance}; toxic exposure".to_s
-        elsif service_relevance.present?
-          service_relevance
-        else
-          ''
-        end
+      def format_exposure_text(cause, related_to_toxic_exposure)
+        text = TOXIC_EXPOSURE_CAUSE_MAP[cause.upcase.to_sym]
+        text.sub(/[.]?$/, '; toxic exposure.') if related_to_toxic_exposure
       end
 
       # rubocop:disable Naming/PredicateName

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -236,8 +236,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       toxic_exposure_conditions = submission.form['form526']['form526']['toxicExposure']['conditions']
       results = transformer.send(:transform_disabilities, data, toxic_exposure_conditions)
       expect(results.first.is_related_to_toxic_exposure).to eq(true)
-      exposure_text = 'My condition was caused by an injury or event that happened when I was receiving VA care; toxic exposure.'
-      expect(results.first.exposure_or_event_or_injury).to eq(exposure_text)
+      text = 'My condition was caused by an injury or event that happened when I was receiving VA care; toxic exposure.'
+      expect(results.first.exposure_or_event_or_injury).to eq(text)
       expect(results.last.is_related_to_toxic_exposure).to eq(false)
     end
 

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -244,7 +244,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       results = transformer.send(:transform_disabilities, data, toxic_exposure_conditions)
       cause_map = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform::TOXIC_EXPOSURE_CAUSE_MAP
       expect(results.first.exposure_or_event_or_injury).to eq(cause_map[:VA])
-      expect(results.first.exposure_or_event_or_injury).to eq("My condition was caused by an injury or event that happened when I was receiving VA care; toxic exposure.")
       expect(results[1].exposure_or_event_or_injury).to eq(cause_map[:NEW])
       expect(results[2].exposure_or_event_or_injury).to eq(cause_map[:WORSENED])
       expect(results.last.exposure_or_event_or_injury).to eq(cause_map[:SECONDARY])

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -236,6 +236,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       toxic_exposure_conditions = submission.form['form526']['form526']['toxicExposure']['conditions']
       results = transformer.send(:transform_disabilities, data, toxic_exposure_conditions)
       expect(results.first.is_related_to_toxic_exposure).to eq(true)
+      exposure_text = 'My condition was caused by an injury or event that happened when I was receiving VA care; toxic exposure.'
+      expect(results.first.exposure_or_event_or_injury).to eq(exposure_text)
       expect(results.last.is_related_to_toxic_exposure).to eq(false)
     end
 
@@ -243,10 +245,10 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       toxic_exposure_conditions = submission.form['form526']['form526']['toxicExposure']['conditions']
       results = transformer.send(:transform_disabilities, data, toxic_exposure_conditions)
       cause_map = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform::TOXIC_EXPOSURE_CAUSE_MAP
-      expect(results.first.exposure_or_event_or_injury).to eq(cause_map[:VA])
-      expect(results[1].exposure_or_event_or_injury).to eq(cause_map[:NEW])
-      expect(results[2].exposure_or_event_or_injury).to eq(cause_map[:WORSENED])
-      expect(results.last.exposure_or_event_or_injury).to eq(cause_map[:SECONDARY])
+      expect(results.first.exposure_or_event_or_injury).to eq(cause_map[:VA].sub(/[.]?$/, '; toxic exposure.'))
+      expect(results[1].exposure_or_event_or_injury).to eq(cause_map[:NEW].sub(/[.]?$/, '; toxic exposure.'))
+      expect(results[2].exposure_or_event_or_injury).to eq(cause_map[:WORSENED].sub(/[.]?$/, '; toxic exposure.'))
+      expect(results.last.exposure_or_event_or_injury).to eq(cause_map[:SECONDARY].sub(/[.]?$/, '; toxic exposure.'))
     end
   end
 

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -248,7 +248,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(results.first.exposure_or_event_or_injury).to eq(cause_map[:VA].sub(/[.]?$/, '; toxic exposure.'))
       expect(results[1].exposure_or_event_or_injury).to eq(cause_map[:NEW].sub(/[.]?$/, '; toxic exposure.'))
       expect(results[2].exposure_or_event_or_injury).to eq(cause_map[:WORSENED].sub(/[.]?$/, '; toxic exposure.'))
-      expect(results.last.exposure_or_event_or_injury).to eq(cause_map[:SECONDARY].sub(/[.]?$/, '; toxic exposure.'))
+      # last condition is not a toxic exposure condition
+      expect(results.last.exposure_or_event_or_injury).to eq(cause_map[:SECONDARY])
     end
   end
 

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -244,6 +244,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       results = transformer.send(:transform_disabilities, data, toxic_exposure_conditions)
       cause_map = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform::TOXIC_EXPOSURE_CAUSE_MAP
       expect(results.first.exposure_or_event_or_injury).to eq(cause_map[:VA])
+      expect(results.first.exposure_or_event_or_injury).to eq("My condition was caused by an injury or event that happened when I was receiving VA care; toxic exposure.")
       expect(results[1].exposure_or_event_or_injury).to eq(cause_map[:NEW])
       expect(results[2].exposure_or_event_or_injury).to eq(cause_map[:WORSENED])
       expect(results.last.exposure_or_event_or_injury).to eq(cause_map[:SECONDARY])


### PR DESCRIPTION
This PR adds in text indicating when a condition is caused by toxic exposure. 

## Summary

- *This work is behind a feature toggle (flipper): YES/NO* Toxic Exposure itself is, this text would only be shown if that feature toggle were on
- *(Summarize the changes that have been made to the platform)* Add text to PDF text for conditions
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)* DBEX Team 1
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira* https://app.zenhub.com/workspaces/disability-benefits-experience-team-1-63dbdb0a401c4400119d3a44/issues/gh/department-of-veterans-affairs/va.gov-team/87706
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

After:
<img width="973" alt="image" src="https://github.com/user-attachments/assets/e00994b5-4382-4ade-ac28-8b027667b459">

Before: 
<img width="875" alt="image" src="https://github.com/user-attachments/assets/1c6bbf62-1565-443b-ae68-fdaeca91b6b1">


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
