### PR TITLE
Rename Preneeds::Base to Preneeds::VirtusBase

### DIFF
--- a/app/models/preneeds/address.rb
+++ b/app/models/preneeds/address.rb
@@ -16,7 +16,7 @@ module Preneeds
   # @!attribute postal_code
   #   @return [String] address postal code
   #
-  class Address < Preneeds::Base
+  class Address < Preneeds::VirtusBase
     attribute :street, String
     attribute :street2, String
     attribute :city, String

--- a/app/models/preneeds/applicant.rb
+++ b/app/models/preneeds/applicant.rb
@@ -18,7 +18,7 @@ module Preneeds
   # @!attribute name
   #   @return [Preneeds::FullName] applicant's name
   #
-  class Applicant < Preneeds::Base
+  class Applicant < Preneeds::VirtusBase
     attribute :applicant_email, String
     attribute :applicant_phone_number, String
     attribute :applicant_relationship_to_claimant, String

--- a/app/models/preneeds/burial_form.rb
+++ b/app/models/preneeds/burial_form.rb
@@ -33,7 +33,7 @@ module Preneeds
   # @!attribute veteran
   #   @return [Preneeds::Veteran] Veteran object.  Veteran is the person who is the owner of the benefit.
   #
-  class BurialForm < Preneeds::Base
+  class BurialForm < Preneeds::VirtusBase
     # Preneeds Burial Form official form id
     #
     FORM = '40-10007'

--- a/app/models/preneeds/claimant.rb
+++ b/app/models/preneeds/claimant.rb
@@ -22,7 +22,7 @@ module Preneeds
   # @!attribute address
   #   @return [Preneeds::Address] claimant's address
   #
-  class Claimant < Preneeds::Base
+  class Claimant < Preneeds::VirtusBase
     attribute :date_of_birth, String
     attribute :desired_cemetery, String
     attribute :email, String

--- a/app/models/preneeds/currently_buried_person.rb
+++ b/app/models/preneeds/currently_buried_person.rb
@@ -10,7 +10,7 @@ module Preneeds
   # @!attribute name
   #   @return [Preneeds::FullName] currently buried person's full name
   #
-  class CurrentlyBuriedPerson < Preneeds::Base
+  class CurrentlyBuriedPerson < Preneeds::VirtusBase
     attribute :cemetery_number, String
     attribute :name, Preneeds::FullName
 

--- a/app/models/preneeds/date_range.rb
+++ b/app/models/preneeds/date_range.rb
@@ -8,7 +8,7 @@ module Preneeds
   # @!attribute to
   #   @return [String] 'to' date
   #
-  class DateRange < Preneeds::Base
+  class DateRange < Preneeds::VirtusBase
     attribute :from, String
     attribute :to, String
 

--- a/app/models/preneeds/full_name.rb
+++ b/app/models/preneeds/full_name.rb
@@ -16,7 +16,7 @@ module Preneeds
   # @!attribute suffix
   #   @return [String] name suffix
   #
-  class FullName < Preneeds::Base
+  class FullName < Preneeds::VirtusBase
     attribute :first, String
     attribute :last, String
     attribute :maiden, String

--- a/app/models/preneeds/preneed_attachment_hash.rb
+++ b/app/models/preneeds/preneed_attachment_hash.rb
@@ -11,7 +11,7 @@ module Preneeds
   # @!attribute name
   #   @return [String] attachment file name
   #
-  class PreneedAttachmentHash < Preneeds::Base
+  class PreneedAttachmentHash < Preneeds::VirtusBase
     attribute :confirmation_code, String
     attribute :attachment_id, String
     attribute :name, String

--- a/app/models/preneeds/race.rb
+++ b/app/models/preneeds/race.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Preneeds
-  class Race < Preneeds::Base
+  class Race < Preneeds::VirtusBase
     ATTRIBUTE_MAPPING = {
       'I' => :is_american_indian_or_alaskan_native,
       'A' => :is_asian,

--- a/app/models/preneeds/service_record.rb
+++ b/app/models/preneeds/service_record.rb
@@ -16,7 +16,7 @@ module Preneeds
   # @!attribute date_range
   #   @return [Preneeds::DateRange] service date range
   #
-  class ServiceRecord < Preneeds::Base
+  class ServiceRecord < Preneeds::VirtusBase
     attribute :service_branch, String
     attribute :discharge_type, String
     attribute :highest_rank, String

--- a/app/models/preneeds/veteran.rb
+++ b/app/models/preneeds/veteran.rb
@@ -34,7 +34,7 @@ module Preneeds
   # @!attribute service_records
   #   @return [Array<Preneeds::ServiceRecord>] veteran's service records
   #
-  class Veteran < Preneeds::Base
+  class Veteran < Preneeds::VirtusBase
     attribute :date_of_birth, String
     attribute :date_of_death, String
     attribute :gender, String

--- a/app/models/preneeds/virtus_base.rb
+++ b/app/models/preneeds/virtus_base.rb
@@ -4,7 +4,7 @@ module Preneeds
   # Parent class for other Preneeds Burial form related models
   # Should not be initialized directly
   #
-  class Base
+  class VirtusBase
     extend ActiveModel::Naming
     include Virtus.model(nullify_blank: true)
 


### PR DESCRIPTION
## Summary

- Rename `Preneeds::Base` to `Preneeds::VirtusBase`
- The intention is remove the `virtus` gem and this is an intermediate PR to help keep PRs small

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92438

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  Preneeds::Base subclasses use updated base class name