### PR TITLE
Support colon in user comments

### DIFF
--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       community_cares_base
       status { 'proposed' }
       reason_code do
-        { 'text': 'test request' }
+        { 'text': 'colon:in:comment' }
       end
     end
 
@@ -216,7 +216,7 @@ FactoryBot.define do
       va_base
       status { 'booked' }
       reason_code do
-        { 'text': 'reasonCode:ROUTINEVISIT|comments:test' }
+        { 'text': 'reasonCode:ROUTINEVISIT|comments:colon:in:comment' }
       end
     end
 
@@ -224,7 +224,7 @@ FactoryBot.define do
       va_base
       status { 'cancelled' }
       reason_code do
-        { 'text': 'reasonCode:ROUTINEVISIT|comments:test' }
+        { 'text': 'reasonCode:ROUTINEVISIT|comments:colon:in:comment' }
       end
     end
 
@@ -247,7 +247,7 @@ FactoryBot.define do
       va_proposed_base
       kind { 'clinic' }
       reason_code do
-        { 'text': 'station id: 983|preferred modality: FACE TO FACE|phone number: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:test' } # rubocop:disable Layout/LineLength
+        { 'text': 'station id: 983|preferred modality: FACE TO FACE|phone number: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:colon:in:comment' } # rubocop:disable Layout/LineLength
       end
     end
 
@@ -322,7 +322,7 @@ FactoryBot.define do
       with_direct_scheduling_base
 
       reason_code do
-        { 'text': 'test booked' }
+        { 'text': 'colon:in:comment' }
       end
     end
 

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -28,7 +28,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :community_cares_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
-      expect(appt[:patient_comments]).to eq('test request')
+      expect(appt[:patient_comments]).to eq('colon:in:comment')
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
       expect(appt[:preferred_modality]).to be_nil
@@ -38,7 +38,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :ds_cc_booked_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
-      expect(appt[:patient_comments]).to eq('test booked')
+      expect(appt[:patient_comments]).to eq('colon:in:comment')
       expect(appt[:reason_for_appointment]).to be_nil
       expect(appt[:preferred_dates]).to be_nil
       expect(appt[:preferred_modality]).to be_nil
@@ -48,7 +48,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :va_booked_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
-      expect(appt[:patient_comments]).to eq('test')
+      expect(appt[:patient_comments]).to eq('colon:in:comment')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
       expect(appt[:preferred_dates]).to be_nil
       expect(appt[:preferred_modality]).to be_nil
@@ -58,7 +58,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       appt = FactoryBot.build(:appointment_form_v2, :va_cancelled_valid_reason_code_text).attributes
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact]).to eq({})
-      expect(appt[:patient_comments]).to eq('test')
+      expect(appt[:patient_comments]).to eq('colon:in:comment')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
       expect(appt[:preferred_dates]).to be_nil
       expect(appt[:preferred_modality]).to be_nil
@@ -69,7 +69,7 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       subject.extract_reason_code_fields(appt)
       expect(appt[:contact][:telecom][0]).to eq({ type: 'phone', value: '6195551234' })
       expect(appt[:contact][:telecom][1]).to eq({ type: 'email', value: 'myemail72585885@unattended.com' })
-      expect(appt[:patient_comments]).to eq('test')
+      expect(appt[:patient_comments]).to eq('colon:in:comment')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
       expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
                                             'Wed, June 26, 2024 in the afternoon'])
@@ -87,6 +87,27 @@ describe VAOS::V2::AppointmentsReasonCodeService do
         expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
                                               'Wed, June 26, 2024 in the afternoon'])
         expect(appt[:preferred_modality]).to eq('In person')
+      end
+    end
+  end
+
+  describe '#parse_reason_code_text' do
+    [
+      ['', {}],
+      ['key', {}],
+      ['key:', {}],
+      ['key:value', { 'key' => 'value' }],
+      [' key : value ', { 'key' => 'value' }],
+      ['key:value:invalid', {}],
+      ['comments', {}],
+      ['comments:', {}],
+      ['comments:text', { 'comments' => 'text' }],
+      [' comments : text ', { 'comments' => 'text' }],
+      ['comments:key:value', { 'comments' => 'key:value' }],
+      [' comments : key : value ', { 'comments' => 'key : value' }]
+    ].each do |input, output|
+      it "#{input} returns #{output}" do
+        expect(subject.send(:parse_reason_code_text, input)).to eq(output)
       end
     end
   end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Since we allow colons in user comments, we cannot rely on it to be a reliable key-value pair separator and need to modify our tokenization logic to account for them when extracting the comments field from the reason code text.
- Appointments (VAOS) team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92704

## Testing done

- [x] *New code is covered by unit tests*
- The previous logic did not allow for colon in user comments, this change now accounts for this.

## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
