### PR TITLE
92457-89743: Remove Toggles for Direct Deposit Single Form

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -985,18 +985,6 @@ features:
   profile_show_credential_retirement_messaging:
     actor_type: user
     description: Show/hide MHV and DS Logon credential retirement messaging in profile
-  profile_show_direct_deposit_single_form:
-    actor_type: user
-    description: Show/hide the single direct deposit form in profile for all users
-  profile_show_direct_deposit_single_form_uat:
-    actor_type: user
-    description: Show/hide the single direct deposit form just for users during UAT only
-  profile_show_direct_deposit_single_form_alert:
-    actor_type: user
-    description: Show/hide an alert with information around migrating to a single direct deposit form in profile
-  profile_show_direct_deposit_single_form_edu_downtime:
-    actor_type: user
-    description: Show/hide the edu direct deposit form and instead display a downtime message in its place
   profile_show_payments_notification_setting:
     actor_type: user
     description: Show/Hide the payments section of notifications in profile

--- a/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe V0::Profile::DirectDepositsController, type: :controller do
     token = 'abcdefghijklmnop'
     allow_any_instance_of(DirectDeposit::Configuration).to receive(:access_token).and_return(token)
     allow(Rails.logger).to receive(:info)
-    Flipper.disable(:profile_show_direct_deposit_single_form)
   end
 
   describe '#show' do


### PR DESCRIPTION
## Summary

This PR removes the following four toggles that were previously used to control various aspects of the direct deposit single form on the Profile page. Now that we are using the single form for the Direct Deposit page in production, these toggles are no longer needed:

### Removed Toggles:

1. **`profile_show_direct_deposit_single_form`:** 
   - **Description:** Show/hide the single direct deposit form in profile for all users.
   
2. **`profile_show_direct_deposit_single_form_uat`:** 
   - **Description:** Show/hide the single direct deposit form just for users during UAT only.
   
3. **`profile_show_direct_deposit_single_form_alert`:** 
   - **Description:** Show/hide an alert with information around migrating to a single direct deposit form in profile.
   
4. **`profile_show_direct_deposit_single_form_edu_downtime`:**
   - **Description:** Show/hide the EDU direct deposit form and instead display a downtime message in its place.

Since we are now fully using the single form for Direct Deposit in production, these toggles no longer serve any purpose and are being removed.

### Changes

- Removed the four toggles listed above.
- Cleaned up any references to these toggles from the codebase.

**Timeframe for toggle**

These toggles were introduced to manage the rollout and testing of the single direct deposit form in various environments. Now that the single form is fully live in production, the toggles are no longer required. The toggles can be safely removed, as all users are now using the single form.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89743
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92457

## Testing done

Test locally

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile > Direct Deposit

## Acceptance criteria

- [x] Toggle removed
- [ ]  No error nor warning in the console.
