### PR TITLE
Updates error message for retries

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/error/lighthouse_error_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/error/lighthouse_error_mapper.rb
@@ -16,7 +16,7 @@ module ClaimsApi
           submit: 'The claim could not be established',
           disabled: 'this claim has been disabled',
           submit_save_draftForm_MaxEPCode: 'The Maximum number of EP codes have been reached for this benefit type claim code', # rubocop:disable Layout/LineLength
-          submit_noRetryError: 'This job is no longer able to be re-tried',
+          submit_noRetryError: 'Claim could not be established. Retries will fail.',
           header_va_eauth_birlsfilenumber_Invalid: 'There is a problem with your birls file number. Please submit an issue at ask.va.gov or call 1-800-MyVA411 (800-698-2411) for assistance.' # rubocop:disable Layout/LineLength
         }.freeze
 


### PR DESCRIPTION
## Summary

- Replace 'This job is no longer able to be re-tried' with 'Claim could not be established. Retries will fail.'
 

## Related issue(s)

- [API-40222](https://jira.devops.va.gov/browse/API-40222)

## Testing done

- [ ] *New code is covered by unit tests*



## What areas of the site does it impact?
modified:   modules/claims_api/lib/claims_api/v2/error/lighthouse_error_mapper.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature