### PR TITLE
[API-38807] Validate claimant is a dependent (POA V2)

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -141,10 +141,13 @@ module ClaimsApi
           validate_poa_code!(poa_code)
           validate_poa_code_for_current_user!(poa_code) if header_request? && !token.client_credentials_token?
           if Flipper.enabled?(:lighthouse_claims_api_poa_dependent_claimants) && form_attributes['claimant'].present?
-            service = ClaimsApi::DependentClaimantVerificationService.new(target_veteran.participant_id,
-                                                                          form_attributes.dig('claimant', 'firstName'),
-                                                                          form_attributes.dig('claimant', 'lastName'),
-                                                                          poa_code)
+            veteran_participant_id = target_veteran.participant_id
+            claimant_first_name = form_attributes.dig('claimant', 'firstName')
+            claimant_last_name = form_attributes.dig('claimant', 'lastName')
+            service = ClaimsApi::DependentClaimantVerificationService.new(veteran_participant_id:,
+                                                                          claimant_first_name:,
+                                                                          claimant_last_name:,
+                                                                          poa_code:)
             service.validate_poa_code_exists!
             service.validate_dependent_by_participant_id!
           end

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
@@ -42,12 +42,16 @@ module ClaimsApi
         private
 
         def shared_form_validation(form_number)
-          target_veteran
+          base = form_number == '2122' ? 'serviceOrganization' : 'representative'
+          poa_code = form_attributes.dig(base, 'poaCode')
+
           # Custom validations for POA submission, we must check this first
-          @claims_api_forms_validation_errors = validate_form_2122_and_2122a_submission_values(user_profile)
+          @claims_api_forms_validation_errors = validate_form_2122_and_2122a_submission_values(
+            target_veteran.participant_id, user_profile, poa_code
+          )
           # JSON validations for POA submission, will combine with previously captured errors and raise
           validate_json_schema(form_number.upcase)
-          @rep_id = validate_registration_number!(form_number)
+          @rep_id = validate_registration_number!(base, poa_code)
 
           add_claimant_data_to_form if user_profile
           # if we get here there were only validations file errors
@@ -57,10 +61,8 @@ module ClaimsApi
           end
         end
 
-        def validate_registration_number!(form_number)
-          base = form_number == '2122' ? 'serviceOrganization' : 'representative'
+        def validate_registration_number!(base, poa_code)
           rn = form_attributes.dig(base, 'registrationNumber')
-          poa_code = form_attributes.dig(base, 'poaCode')
           rep = ::Veteran::Service::Representative.where('? = ANY(poa_codes) AND representative_id = ?',
                                                          poa_code,
                                                          rn).order(created_at: :desc).first

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -10,12 +10,15 @@ module ClaimsApi
         FORM_NUMBER = 'POA_REQUEST'
 
         def request_representative
-          target_veteran
-          @claims_api_forms_validation_errors = validate_form_2122_and_2122a_submission_values(user_profile)
+          poa_code = form_attributes.dig('poa', 'poaCode')
+          @claims_api_forms_validation_errors = validate_form_2122_and_2122a_submission_values(
+            target_veteran.participant_id, user_profile, poa_code
+          )
+
           validate_json_schema(FORM_NUMBER)
           validate_accredited_representative(form_attributes.dig('poa', 'registrationNumber'),
-                                             form_attributes.dig('poa', 'poaCode'))
-          validate_accredited_organization(form_attributes.dig('poa', 'poaCode'))
+                                             poa_code)
+          validate_accredited_organization(poa_code)
 
           # if we get here, the only errors not raised are form value validation errors
           if @claims_api_forms_validation_errors

--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/power_of_attorney_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/power_of_attorney_validation.rb
@@ -5,20 +5,21 @@
 module ClaimsApi
   module V2
     module PowerOfAttorneyValidation
-      def validate_form_2122_and_2122a_submission_values(user_profile)
-        validate_claimant(user_profile)
+      def validate_form_2122_and_2122a_submission_values(veteran_participant_id, user_profile, poa_code)
+        validate_claimant(veteran_participant_id, user_profile, poa_code)
         # collect errors and pass back to the controller
         raise_error_collection if @errors
       end
 
       private
 
-      def validate_claimant(user_profile)
+      def validate_claimant(veteran_participant_id, user_profile, poa_code)
         return if form_attributes['claimant'].blank?
 
         validate_claimant_id_included(user_profile)
         validate_address
         validate_relationship
+        validate_dependent_claimant(veteran_participant_id, user_profile, poa_code)
       end
 
       def validate_address
@@ -94,6 +95,38 @@ module ClaimsApi
           )
         end
       end
+
+      # rubocop:disable Metrics/MethodLength
+      def validate_dependent_claimant(veteran_participant_id, user_profile, poa_code)
+        unless Flipper.enabled?(:lighthouse_claims_api_poa_dependent_claimants) && form_attributes['claimant'].present?
+          return
+        end
+
+        claimant = user_profile.profile
+        service = ClaimsApi::DependentClaimantVerificationService.new(veteran_participant_id:,
+                                                                      claimant_first_name: claimant.given_names.first,
+                                                                      claimant_last_name: claimant.family_name,
+                                                                      claimant_participant_id: claimant.participant_id,
+                                                                      poa_code:)
+        begin
+          service.validate_poa_code_exists!
+        rescue ::Common::Exceptions::UnprocessableEntity
+          collect_error_messages(
+            source: '/poaCode',
+            detail: ClaimsApi::DependentClaimantVerificationService::POA_CODE_NOT_FOUND_ERROR_MESSAGE
+          )
+        end
+
+        begin
+          service.validate_dependent_by_participant_id!
+        rescue ::Common::Exceptions::UnprocessableEntity
+          collect_error_messages(
+            source: '/claimant/claimantId',
+            detail: ClaimsApi::DependentClaimantVerificationService::CLAIMANT_NOT_A_DEPENDENT_ERROR_MESSAGE
+          )
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
 
       def validate_claimant_id_included(user_profile)
         claimant_icn = form_attributes.dig('claimant', 'claimantId')

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::2122', type: :request do
                                                first_name: 'George', last_name: 'Washington')
       Veteran::Service::Organization.create!(poa: organization_poa_code,
                                              name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
+
+      Flipper.disable(:lighthouse_claims_api_poa_dependent_claimants)
     end
 
     describe 'submit2122' do
@@ -267,7 +269,7 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::2122', type: :request do
                                 'power_of_attorney', '2122', 'valid.json').read
               end
 
-              it 'returns a success response' do
+              it 'returns an error response' do
                 mock_ccg(scopes) do |auth_header|
                   allow_any_instance_of(local_bgs).to receive(:find_poa_history_by_ptcpnt_id)
                     .and_return({ person_poa_history: nil })
@@ -322,6 +324,95 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::2122', type: :request do
                     expect(response).to have_http_status(:ok)
                     expect(response_body['type']).to eq('form/21-22/validation')
                     expect(response_body['attributes']['status']).to eq('valid')
+                  end
+                end
+              end
+
+              context 'when the lighthouse_claims_api_poa_dependent_claimants feature is enabled' do
+                let(:request_body) do
+                  Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                  'power_of_attorney', '2122', 'valid.json').read
+                end
+                let(:user_profile) do
+                  MPI::Responses::FindProfileResponse.new(
+                    status: :ok,
+                    profile: MPI::Models::MviProfile.new(
+                      given_names: %w[Not Under],
+                      family_name: 'Test',
+                      participant_id: '123'
+                    )
+                  )
+                end
+
+                before do
+                  Flipper.enable(:lighthouse_claims_api_poa_dependent_claimants)
+
+                  allow_any_instance_of(ClaimsApi::V2::Veterans::PowerOfAttorney::BaseController)
+                    .to receive(:user_profile).and_return(user_profile)
+                end
+
+                context 'and the request includes a claimant' do
+                  it 'calls validate_poa_code_exists! and validate_dependent_by_participant_id!' do
+                    VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
+                      mock_ccg(%w[claim.write claim.read]) do |auth_header|
+                        json = JSON.parse(request_body)
+                        json['data']['attributes']['claimant'] = { claimantId: '123' }
+                        request_body = json.to_json
+
+                        expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                          .to receive(:validate_poa_code_exists!)
+                        expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                          .to receive(:validate_dependent_by_participant_id!)
+
+                        post validate2122_path, params: request_body, headers: auth_header
+                      end
+                    end
+                  end
+                end
+
+                context 'and the request does not include a claimant' do
+                  it 'does not call validate_poa_code_exists! and validate_dependent_by_participant_id!' do
+                    VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
+                      mock_ccg(%w[claim.write claim.read]) do |auth_header|
+                        json = JSON.parse(request_body)
+                        request_body = json.to_json
+
+                        expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                          .not_to receive(:validate_poa_code_exists!)
+                        expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                          .not_to receive(:validate_dependent_by_participant_id!)
+
+                        post validate2122_path, params: request_body, headers: auth_header
+                      end
+                    end
+                  end
+                end
+              end
+
+              context 'when the lighthouse_claims_api_poa_dependent_claimants feature is disabled' do
+                let(:request_body) do
+                  Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                  'power_of_attorney', '2122', 'valid.json').read
+                end
+
+                before do
+                  Flipper.disable(:lighthouse_claims_api_poa_dependent_claimants)
+                end
+
+                it 'does not call validate_poa_code_exists! and validate_dependent_by_participant_id!' do
+                  VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
+                    mock_ccg(%w[claim.write claim.read]) do |auth_header|
+                      json = JSON.parse(request_body)
+                      json['data']['attributes']['claimant'] = { claimantId: '123' }
+                      request_body = json.to_json
+
+                      expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                        .not_to receive(:validate_poa_code_exists!)
+                      expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                        .not_to receive(:validate_dependent_by_participant_id!)
+
+                      post validate2122_path, params: request_body, headers: auth_header
+                    end
                   end
                 end
               end

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122a_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122a_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::2122a', type: :request do
                                                first_name: 'Abraham', last_name: 'Lincoln')
       Veteran::Service::Representative.create!(representative_id: '999999999999', poa_codes: [organization_poa_code],
                                                first_name: 'George', last_name: 'Washington')
+
+      Flipper.disable(:lighthouse_claims_api_poa_dependent_claimants)
     end
 
     describe 'appoint_individual' do
@@ -505,6 +507,95 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::2122a', type: :request do
                         expect(response_body['title']).to eq('Resource not found')
                         expect(response_body['status']).to eq('404')
                         expect(response_body['detail']).to eq(detail)
+                      end
+                    end
+                  end
+
+                  context 'when the lighthouse_claims_api_poa_dependent_claimants feature is enabled' do
+                    let(:request_body) do
+                      Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                      'power_of_attorney', '2122a', 'valid.json').read
+                    end
+                    let(:user_profile) do
+                      MPI::Responses::FindProfileResponse.new(
+                        status: :ok,
+                        profile: MPI::Models::MviProfile.new(
+                          given_names: %w[Not Under],
+                          family_name: 'Test',
+                          participant_id: '123'
+                        )
+                      )
+                    end
+
+                    before do
+                      Flipper.enable(:lighthouse_claims_api_poa_dependent_claimants)
+
+                      allow_any_instance_of(ClaimsApi::V2::Veterans::PowerOfAttorney::BaseController)
+                        .to receive(:user_profile).and_return(user_profile)
+                    end
+
+                    context 'and the request includes a claimant' do
+                      it 'calls validate_poa_code_exists! and validate_dependent_by_participant_id!' do
+                        VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
+                          mock_ccg(%w[claim.write claim.read]) do |auth_header|
+                            json = JSON.parse(request_body)
+                            json['data']['attributes']['claimant'] = { claimantId: '123' }
+                            request_body = json.to_json
+
+                            expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                              .to receive(:validate_poa_code_exists!)
+                            expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                              .to receive(:validate_dependent_by_participant_id!)
+
+                            post validate2122a_path, params: request_body, headers: auth_header
+                          end
+                        end
+                      end
+                    end
+
+                    context 'and the request does not include a claimant' do
+                      it 'does not call validate_poa_code_exists! and validate_dependent_by_participant_id!' do
+                        VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
+                          mock_ccg(%w[claim.write claim.read]) do |auth_header|
+                            json = JSON.parse(request_body)
+                            request_body = json.to_json
+
+                            expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                              .not_to receive(:validate_poa_code_exists!)
+                            expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                              .not_to receive(:validate_dependent_by_participant_id!)
+
+                            post validate2122a_path, params: request_body, headers: auth_header
+                          end
+                        end
+                      end
+                    end
+                  end
+
+                  context 'when the lighthouse_claims_api_poa_dependent_claimants feature is disabled' do
+                    let(:request_body) do
+                      Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
+                                      'power_of_attorney', '2122a', 'valid.json').read
+                    end
+
+                    before do
+                      Flipper.disable(:lighthouse_claims_api_poa_dependent_claimants)
+                    end
+
+                    it 'does not call validate_poa_code_exists! and validate_dependent_by_participant_id!' do
+                      VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
+                        mock_ccg(%w[claim.write claim.read]) do |auth_header|
+                          json = JSON.parse(request_body)
+                          json['data']['attributes']['claimant'] = { claimantId: '123' }
+                          request_body = json.to_json
+
+                          expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                            .not_to receive(:validate_poa_code_exists!)
+                          expect_any_instance_of(ClaimsApi::DependentClaimantVerificationService)
+                            .not_to receive(:validate_dependent_by_participant_id!)
+
+                          post validate2122a_path, params: request_body, headers: auth_header
+                        end
                       end
                     end
                   end

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/power_of_attorney_request_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::PowerOfAttorneyRequest', type: :
                                              first_name: 'Abraham', last_name: 'Lincoln',
                                              user_types: ['veteran_service_officer'])
     Veteran::Service::Organization.create!(poa: '067', name: 'DISABLED AMERICAN VETERANS')
+
+    Flipper.disable(:lighthouse_claims_api_poa_dependent_claimants)
   end
 
   context 'CCG (Client Credentials Grant) flow' do

--- a/modules/claims_api/spec/services/dependent_claimant_verification_service_spec.rb
+++ b/modules/claims_api/spec/services/dependent_claimant_verification_service_spec.rb
@@ -7,11 +7,14 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
     let(:valid_participant_id_one_dependent) { 600052699 } # rubocop:disable Style/NumericLiterals
     let(:valid_participant_id_two_dependents) { 600049324 } # rubocop:disable Style/NumericLiterals
 
-    context 'when the dependent name belongs to a participant with one dependent' do
+    context 'when the claimant name belongs to a participantʼs (one) dependent' do
       let(:valid_first_name) { 'margie' } # case should not matter
       let(:valid_last_name) { 'CURTIS' }
 
-      subject { described_class.new(valid_participant_id_one_dependent, valid_first_name, valid_last_name, nil) }
+      subject do
+        described_class.new(veteran_participant_id: valid_participant_id_one_dependent,
+                            claimant_first_name: valid_first_name, claimant_last_name: valid_last_name)
+      end
 
       it 'returns nil and does not raise an error' do
         VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_one_dependent') do
@@ -23,8 +26,11 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
       end
     end
 
-    context 'when the dependent name does not belong to a participant with one dependent' do
-      subject { described_class.new(valid_participant_id_one_dependent, 'BAD', 'NAME', nil) }
+    context 'when the claimant name does not belong to a participantʼs (one) dependent' do
+      subject do
+        described_class.new(veteran_participant_id: valid_participant_id_one_dependent, claimant_first_name: 'BAD',
+                            claimant_last_name: 'NAME')
+      end
 
       it 'raises an error' do
         VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_one_dependent') do
@@ -35,11 +41,14 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
       end
     end
 
-    context 'when the dependent name belongs to a participant with two dependents' do
+    context 'when the claimant name belongs to one of participantʼs (many) dependents' do
       let(:valid_first_name) { 'MARK' }
       let(:valid_last_name) { ' bailey ' } # case and whitespace should not matter
 
-      subject { described_class.new(valid_participant_id_two_dependents, valid_first_name, valid_last_name, nil) }
+      subject do
+        described_class.new(veteran_participant_id: valid_participant_id_two_dependents,
+                            claimant_first_name: valid_first_name, claimant_last_name: valid_last_name)
+      end
 
       it 'returns nil and does not raise an error' do
         VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_two_dependents') do
@@ -51,20 +60,83 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
       end
     end
 
-    context 'when the dependent name does not belong to a participant with two dependents' do
-      subject { described_class.new(valid_participant_id_two_dependents, 'bad', 'name', nil) }
+    context 'when the claimant name does not belong to one of participantʼs (many) dependents' do
+      subject do
+        described_class.new(veteran_participant_id: valid_participant_id_two_dependents, claimant_first_name: 'bad',
+                            claimant_last_name: 'name')
+      end
 
       it 'raises an error' do
         VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_two_dependents') do
           expect do
             subject.validate_dependent_by_participant_id!
           end.to raise_error(Common::Exceptions::UnprocessableEntity)
+        end
+      end
+    end
+
+    context 'when the claimant provides a valid participant_id of claimantʼs dependent' do
+      let(:valid_claimant_participant_id) { 600052700 } # rubocop:disable Style/NumericLiterals
+
+      subject do
+        described_class.new(veteran_participant_id: valid_participant_id_one_dependent, claimant_first_name: 'any',
+                            claimant_last_name: 'name', claimant_participant_id: valid_claimant_participant_id)
+      end
+
+      it 'returns nil and does not raise an error regardless of name' do
+        VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_one_dependent') do
+          expect do
+            ret = subject.validate_dependent_by_participant_id!
+            expect(ret).to eq(nil)
+          end.not_to raise_error
+        end
+      end
+    end
+
+    context 'when the claimant provides an invalid participant_id but a valid first and last name' do
+      let(:valid_first_name) { 'MARGIE' }
+      let(:valid_last_name) { 'CURTIS' }
+
+      subject do
+        described_class.new(veteran_participant_id: valid_participant_id_one_dependent,
+                            claimant_first_name: valid_first_name, claimant_last_name: valid_last_name,
+                            claimant_participant_id: 'bad')
+      end
+
+      it 'raises an error' do
+        VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_one_dependent') do
+          expect do
+            subject.validate_dependent_by_participant_id!
+          end.to raise_error(Common::Exceptions::UnprocessableEntity)
+        end
+      end
+    end
+
+    # NOTE: This test is the same as the first test but with a different description to emphasize that
+    # we will fall back to name matching if the claimant_participant_id is not provided.
+    context 'when the claimant provides no claimant_participant_id but a valid first and last name' do
+      let(:valid_first_name) { 'MARGIE' }
+      let(:valid_last_name) { 'CURTIS' }
+
+      subject do
+        described_class.new(veteran_participant_id: valid_participant_id_one_dependent,
+                            claimant_first_name: valid_first_name, claimant_last_name: valid_last_name)
+
+        it 'returns nil and does not raise an error' do
+          VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_one_dependent') do
+            expect do
+              ret = subject.validate_dependent_by_participant_id!
+              expect(ret).to eq(nil)
+            end.not_to raise_error
+          end
         end
       end
     end
 
     context 'when the participant_id is invalid or has no dependents' do
-      subject { described_class.new(123, 'any', 'name', nil) }
+      subject do
+        described_class.new(veteran_participant_id: 'bad', claimant_first_name: 'any', claimant_last_name: 'name')
+      end
 
       it 'raises an error' do
         VCR.use_cassette('claims_api/bgs/person_web_service/find_dependents_by_ptcpnt_id_no_dependents') do
@@ -76,7 +148,9 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
     end
 
     context 'when the participant_id is blank' do
-      subject { described_class.new('', 'any', 'name', nil) }
+      subject do
+        described_class.new(veteran_participant_id: '', claimant_first_name: 'any', claimant_last_name: 'name')
+      end
 
       it 'raises an error' do
         expect do
@@ -86,7 +160,9 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
     end
 
     context 'when the participant_id is nil' do
-      subject { described_class.new(nil, 'any', 'name', nil) }
+      subject do
+        described_class.new(veteran_participant_id: nil, claimant_first_name: 'any', claimant_last_name: 'name')
+      end
 
       it 'raises an error' do
         expect do
@@ -99,7 +175,7 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
   describe '#validate_poa_code_exists!' do
     let(:valid_poa_code) { '002' }
 
-    subject { described_class.new(nil, nil, nil, valid_poa_code) }
+    subject { described_class.new(poa_code: valid_poa_code) }
 
     context 'when the poa_code is valid' do
       it 'returns nil and does not raise an error' do
@@ -113,7 +189,7 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
     end
 
     context 'when the poa_code is invalid' do
-      subject { described_class.new(nil, nil, nil, 'bad') }
+      subject { described_class.new(poa_code: 'bad') }
 
       it 'raises an error' do
         VCR.use_cassette('claims_api/bgs/standard_data_web_service/find_poas') do
@@ -125,7 +201,7 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
     end
 
     context 'when the poa_code is blank' do
-      subject { described_class.new(nil, nil, nil, '') }
+      subject { described_class.new(poa_code: '') }
 
       it 'raises an error' do
         expect do
@@ -135,7 +211,7 @@ Rspec.describe ClaimsApi::DependentClaimantVerificationService do
     end
 
     context 'when the poa_code is nil' do
-      subject { described_class.new(nil, nil, nil, nil) }
+      subject { described_class.new(poa_code: nil) }
 
       it 'raises an error' do
         expect do


### PR DESCRIPTION
## Summary

Refactor the Dependent Claimant Verification Service to also allow the claimant to provide a participant ID. We prefer the participant ID (retrieved from MPI) over the first/last name matching.

But we only have the claimant’s participant ID in v2 (and even then, it can be hit or miss from MPI). So fallback to the name comparison if the claimant does not provide a participant ID. v1 should still work with the claimant‘s first and last name.

Add the dependent claimant validation to v2.

Add and update tests to reflect the above. This work is behind a feature flag.

## Related issue(s)

[API-38807](https://jira.devops.va.gov/browse/API-38807)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

POA v1 and v2 dependent claimant validation.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Feedback on the design of the service and integration with v1/v2 welcome!