### PR TITLE
Don't retry specs

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -135,14 +135,9 @@ jobs:
 
       - name: Run Specs
         timeout-minutes: 20
-        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 3 # Seconds
-          max_attempts: 3
-          command: |
-            docker compose -f docker-compose.test.yml run web bash \
-              -c "CI=true DISABLE_BOOTSNAP=true bundle exec parallel_rspec spec/ modules/ -n 13 -o '--color --tty'"
+        run: |
+          docker compose -f docker-compose.test.yml run web bash \
+          -c "CI=true DISABLE_BOOTSNAP=true bundle exec parallel_rspec spec/ modules/ -n 13 -o '--color --tty'"
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Specs are frequently timing out which sometimes hides the test failures that need to be fixed in order for the tests to pass and not time out. 

## Related issue(s)
https://dsva.slack.com/archives/C0460N83Y9G/p1726685200107339

## Testing done
Ryan M is on BE support and will know if this is having the desired impact. 

## What areas of the site does it impact?
The test run part of CI.
