### PR TITLE
[VI-473] MHV Account Creation Caching

### DIFF
--- a/app/services/mhv/user_account/creator.rb
+++ b/app/services/mhv/user_account/creator.rb
@@ -5,11 +5,11 @@ require 'mhv/account_creation/service'
 module MHV
   module UserAccount
     class Creator
-      attr_reader :user_verification, :cached
+      attr_reader :user_verification, :break_cache
 
-      def initialize(user_verification:, cached: true)
+      def initialize(user_verification:, break_cache: false)
         @user_verification = user_verification
-        @cached = cached
+        @break_cache = break_cache
       end
 
       def perform
@@ -33,8 +33,9 @@ module MHV
       end
 
       def mhv_account_creation_response
-        MHV::AccountCreation::Service.new
-                                     .create_account(icn:, email:, tou_occurred_at: current_tou_agreement.created_at)
+        tou_occurred_at = current_tou_agreement.created_at
+
+        mhv_client.create_account(icn:, email:, tou_occurred_at:, break_cache:)
       end
 
       def icn
@@ -51,6 +52,10 @@ module MHV
 
       def user_account
         @user_account ||= user_verification.user_account
+      end
+
+      def mhv_client
+        MHV::AccountCreation::Service.new
       end
 
       def validate!

--- a/spec/lib/mhv/account_creation/service_spec.rb
+++ b/spec/lib/mhv/account_creation/service_spec.rb
@@ -5,7 +5,7 @@ require 'mhv/account_creation/service'
 
 describe MHV::AccountCreation::Service do
   describe '#create_account' do
-    subject { described_class.new.create_account(icn:, email:, tou_occurred_at:) }
+    subject { described_class.new.create_account(icn:, email:, tou_occurred_at:, break_cache:) }
 
     let(:icn) { '10101V964144' }
     let(:email) { 'some-email@email.com' }
@@ -15,6 +15,7 @@ describe MHV::AccountCreation::Service do
     let(:log_prefix) { '[MHV][AccountCreation][Service]' }
     let(:account_creation_base_url) { 'https://apigw-intb.aws.myhealth.va.gov' }
     let(:account_creation_path) { 'v1/usermgmt/account-service/account' }
+    let(:break_cache) { false }
 
     before do
       allow(Rails.logger).to receive(:info)
@@ -22,9 +23,21 @@ describe MHV::AccountCreation::Service do
       allow_any_instance_of(SignInService::Sts).to receive(:base_url).and_return('https://staging-api.va.gov')
     end
 
+    context 'when making a request' do
+      let(:expected_tou_datetime) { tou_occurred_at.iso8601 }
+
+      it 'sends vaTermsOfUseDateTime in the correct format' do
+        VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
+          subject
+          expect(a_request(:post, "#{account_creation_base_url}/#{account_creation_path}")
+          .with(body: /"vaTermsOfUseDateTime":"#{expected_tou_datetime}"/)).to have_been_made
+        end
+      end
+    end
+
     context 'when the response is successful' do
       let(:expected_log_message) { "#{log_prefix} create_account success" }
-      let(:expected_log_payload) { { icn: } }
+      let(:expected_log_payload) { { icn:, account: expected_response_body, from_cache: expected_from_cache_log } }
       let(:expected_response_body) do
         {
           user_profile_id: '12345678',
@@ -36,26 +49,79 @@ describe MHV::AccountCreation::Service do
         }
       end
 
-      let(:expected_tou_datetime) { tou_occurred_at.iso8601 }
+      shared_examples 'a successful external request' do
+        it 'makes a request to the account creation service' do
+          VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
+            subject
+            expect(a_request(:post, "#{account_creation_base_url}/#{account_creation_path}")).to have_been_made
+          end
+        end
 
-      it 'sends vaTermsOfUseDateTime in the correct format' do
-        VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
-          subject
-          expect(a_request(:post, "#{account_creation_base_url}/#{account_creation_path}")
-          .with(body: /"vaTermsOfUseDateTime":"#{expected_tou_datetime}"/)).to have_been_made
+        it 'logs the create account request' do
+          VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
+            subject
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          end
+        end
+
+        it 'returns the expected response' do
+          VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
+            expect(subject).to eq(expected_response_body)
+          end
         end
       end
 
-      it 'logs the create account request' do
-        VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
-          subject
-          expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
-        end
+      context 'when the account is not in the cache' do
+        let(:expected_from_cache_log) { false }
+
+        it_behaves_like 'a successful external request'
       end
 
-      it 'returns the expected response' do
-        VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
-          expect(subject).to eq(expected_response_body)
+      context 'when the account is in the cache' do
+        let(:expected_from_cache_log) { true }
+        let(:expected_cache_key) { "mhv_account_creation_#{icn}" }
+        let(:expected_expires_in) { 1.day }
+
+        context 'when break_cache is false' do
+          before do
+            allow(Rails.cache).to receive(:fetch)
+              .with(expected_cache_key, force: break_cache, expires_in: expected_expires_in)
+              .and_return(expected_response_body)
+          end
+
+          it 'does not make a request to the account creation service' do
+            subject
+            expect(a_request(:post, "#{account_creation_base_url}/#{account_creation_path}")).not_to have_been_made
+          end
+
+          it 'logs the create account request' do
+            subject
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          end
+
+          it 'returns the expected response from the cache' do
+            expect(subject).to eq(expected_response_body)
+          end
+        end
+
+        context 'when break_cache is true' do
+          let(:break_cache) { true }
+          let(:expected_from_cache_log) { false }
+
+          before do
+            allow(Rails.cache).to receive(:fetch)
+              .with(expected_cache_key, force: break_cache, expires_in: expected_expires_in).and_call_original
+          end
+
+          it 'calls Rails.cache.fetch with force: true' do
+            VCR.use_cassette('mhv/account_creation/account_creation_service_200_response') do
+              subject
+              expect(Rails.cache).to have_received(:fetch)
+                .with(expected_cache_key, force: true, expires_in: expected_expires_in)
+            end
+          end
+
+          it_behaves_like 'a successful external request'
         end
       end
     end


### PR DESCRIPTION
## Summary
- Add caching to MHV account creation service
- Add optional params to break cache
- Update `MHV::UserAccount::Creator` to accept and pass break_cache to `MHV::AccountCreator::Service`

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-473

## Testing
- make sure your dev cache is on:
   ```bash
   rails dev:cache
   ```
- Test `MHV::AccountCreation::Service` cache:
   This is somewhat difficult since calls can only be made on staging and betamocks isn't setup yet
   - find a user_verification that has an accepted tou
      ```ruby
      user_verification = UserVerification.joins(user_account: :terms_of_use_agreements).where(terms_of_use_agreements: { response: 'accepted' }).last
      ```
    - Call `create_account`
       ```ruby
       require 'mhv/account_creation/service'

       icn = user_verification.user_account.icn
       tou_occurred_at = user_verification.user_account.terms_of_use_agreements.current.last.created_at
       email = user_verification.user_credential_email.credential_email  

       MHV::AccountCreation::Service.new.create_account(icn:, email:, tou_occurred_at:)
       ```

       This will fail but you will see an attempt at making an external call in your logs:
       ```ruby
       Rails -- [MHV][AccountCreation][Service] sts token request success -- { :user_identifier => "1008596379V859838" }
       Rails -- [MHV][AccountCreation][Service] create_account client_error -- { :error_message => "Failed to open TCP connection to apigw-intb.aws.myhealth.va.gov:443 (getaddrinfo: nodename nor servname provided, or not known)", :body => nil, :icn => "1008596379V859838" }
       ```
   - Manually cache a response
      ```ruby
      cache_key = "mhv_account_creation_#{icn}"

      response = {
        user_profile_id: '12345678',
         premium: true,
         champ_va: true,
         patient: true,
         sm_account_created: true,
         message: 'Existing MHV Account Found for ICN'
      }

      Rails.cache.write(cache_key, response, expires_in: 1.hour)
      ```
   - Call `create_account` again
      ```ruby  
       MHV::AccountCreation::Service.new.create_account(icn:, email:, tou_occurred_at:)
      ```
       You should get the response back that was cached
       ```ruby
       => 
      {:user_profile_id=>"12345678",
       :premium=>true,
       :champ_va=>true,
       :patient=>true,
       :sm_account_created=>true,
       :message=>"Existing MHV Account Found for ICN"} 
       ```

   - Test `break_cache`. Make sure your response is still cached from step above
      ```ruby
      # check if still cached
      Rails.cache.exist?(cache_key) # should be true

      MHV::AccountCreation::Service.new.create_account(icn:, email:, tou_occurred_at:, break_cache: true)
      ```
      You should see it attempt to make an external call. again, this will fail
      ```ruby
      Rails -- [MHV][AccountCreation][Service] sts token request success -- { :user_identifier => "1008596379V859838" }
      Rails -- [MHV][AccountCreation][Service] create_account client_error -- { :error_message => "Failed to open TCP connection to apigw-intb.aws.myhealth.va.gov:443 (getaddrinfo: nodename nor servname provided, or not known)", :body => nil, :icn => "1008596379V859838" }
      ```
- Test `MHV::UserAccount::Creator` the same way
   - Call creator when response isn't cached
     ```ruby
      # clear cache
      Rails.cache.clear
  
      user_verification = UserVerification.joins(user_account: :terms_of_use_agreements).where(terms_of_use_agreements: { response: 'accepted').last

      MHV::UserAccount::Creator.new(user_verification: ).perform
      ```
      This will fail but you will see an attempt to make an external call
      ```ruby
      Rails -- [MHV][AccountCreation][Service] sts token request success -- { :user_identifier => "1008596379V859838" }
      Rails -- [MHV][AccountCreation][Service] create_account client_error -- { :error_message => "Failed to open TCP connection to apigw-intb.aws.myhealth.va.gov:443 (getaddrinfo: nodename nor servname provided, or not known)", :body => nil, :icn => "1008596379V859838" }
      ```
  - Cache response and call creator again
     ```ruby
      icn = user_verification.user_account.icn
      cache_key = "mhv_account_creation_#{icn}"

      response = {
        user_profile_id: '12345678',
         premium: true,
         champ_va: true,
         patient: true,
         sm_account_created: true,
         message: 'Existing MHV Account Found for ICN'
      }

      Rails.cache.write(cache_key, response, expires_in: 1.hour)

     user_account = MHV::UserAccount::Creator.new(user_verification: ).perform
     ```
     you should get a `MHVUserAccount` with the same attributes as the cached response
     ```ruby
     user_account.attributes

     # {"user_profile_id"=>"12345678",
     #  "premium"=>true,
     #  "champ_va"=>true,
     #  "patient"=>true,
     #  "sm_account_created"=>true,
     #  "message"=>"Existing MHV Account Found for ICN"} 
     ```
  - Test calling creator with `break_cache` true
     ```ruby
     # check if it is still in the cache
     Rails.cache.exist?(cache_key)

     MHV::UserAccount::Creator.new(user_verification:, break_cache: true ).perform
     ```
     This will fail but you will see an attempt to make an external call
      ```ruby
      Rails -- [MHV][AccountCreation][Service] sts token request success -- { :user_identifier => "1008596379V859838" }
      Rails -- [MHV][AccountCreation][Service] create_account client_error -- { :error_message => "Failed to open TCP connection to apigw-intb.aws.myhealth.va.gov:443 (getaddrinfo: nodename nor servname provided, or not known)", :body => nil, :icn => "1008596379V859838" }
      ```
      

## What areas of the site does it impact?
MHV User Account

