### PR TITLE
[API-40228] Add 422 example to v1 claim status docs

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -979,6 +979,71 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Unprocessable Entity",
+                      "detail": "Unknown EVSS Async Error",
+                      "code": "422",
+                      "status": "422"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail",
+                          "code",
+                          "status"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "code": {
+                            "type": "string",
+                            "description": "HTTP error code"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/modules/claims_api/spec/requests/v1/rswag_claims_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_claims_spec.rb
@@ -286,6 +286,44 @@ Rspec.describe 'EVSS Claims management', openapi_spec: 'modules/claims_api/app/s
           end
         end
       end
+
+      describe 'Getting a 422 response' do
+        response '422', 'Unprocessable Entity' do
+          schema JSON.parse(Rails.root.join('spec', 'support', 'schemas', 'claims_api', 'errors',
+                                            'default.json').read)
+
+          let(:scopes) { %w[claim.read] }
+          let(:claim) do
+            create(:auto_established_claim_with_supporting_documents, :status_errored)
+          end
+          let(:id) { claim.id }
+
+          before do |example|
+            stub_poa_verification
+
+            claim.evss_response = [] # induce a 422 response
+            allow(ClaimsApi::AutoEstablishedClaim).to receive(:find_by).and_return(claim)
+
+            mock_acg(scopes) do
+              VCR.use_cassette('claims_api/bgs/claims/claim') do
+                submit_request(example.metadata)
+              end
+            end
+          end
+
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end
+
+          it 'returns a 422 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add 422 spec to and update v1 `/claims/{id}` swagger example.

## Related issue(s)

[API-40228](https://jira.devops.va.gov/browse/API-40228)

## Testing done

- [x] *New code is covered by unit tests*
- Documentation viewed locally

## Screenshots
![422](https://github.com/user-attachments/assets/03a56c2a-456c-4c5f-b6a0-fa1f8b328557)


## What areas of the site does it impact?

v1 claim status spec and swagger

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

N/A
