### PR TITLE
[SIMPLE_FORMS] feat: update uploads controller to archive and return presigned_url

### DIFF
--- a/app/uploaders/simple_forms_api/form_remediation/uploader.rb
+++ b/app/uploaders/simple_forms_api/form_remediation/uploader.rb
@@ -31,8 +31,13 @@ module SimpleFormsApi
         @directory
       end
 
-      def get_s3_link(file_path)
-        s3_obj(file_path).presigned_url(:get, expires_in: 30.minutes.to_i)
+      def get_s3_link(file_path, filename = nil)
+        filename ||= File.basename(file_path)
+        s3_obj(file_path).presigned_url(
+          :get,
+          expires_in: 30.minutes.to_i,
+          response_content_disposition: "attachment; filename=\"#{filename}\""
+        )
       end
 
       def get_s3_file(from_path, to_path)

--- a/config/features.yml
+++ b/config/features.yml
@@ -1205,6 +1205,10 @@ features:
     actor_type: user
     description: Displays an alert to users on 5490 intro page that the Backend Service is Down.
     enable_in_development: false
+  submission_pdf_s3_upload:
+    actor_type: user
+    description: Used to toggle use of uploading a submission pdf to S3 and returning a pre-signed url.
+    enable_in_development: false
   meb_1606_30_automation:
     actor_type: user
     description: Enables MEB form to handle Chapter 1606/30 forms as well as Chapter 33.

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -121,7 +121,7 @@ module SimpleFormsApi
         parsed_form_data = JSON.parse(params.to_json)
         file_path, metadata, form = get_file_paths_and_metadata(parsed_form_data)
 
-        status, confirmation_number = upload_pdf(file_path, metadata, form)
+        status, confirmation_number, submission = upload_pdf(file_path, metadata, form)
 
         form.track_user_identity(confirmation_number)
 
@@ -129,12 +129,14 @@ module SimpleFormsApi
           'Simple forms api - sent to benefits intake',
           { form_number: params[:form_number], status:, uuid: confirmation_number }
         )
+        presigned_s3_url = send_pdf_to_s3(confirmation_number, file_path, metadata, submission)
 
         if status == 200 && Flipper.enabled?(:simple_forms_email_confirmations)
           send_confirmation_email(parsed_form_data, form_id, confirmation_number)
         end
 
-        { json: get_json(confirmation_number || nil, form_id), status: }
+        json = get_json(confirmation_number || nil, form_id, presigned_s3_url)
+        { json:, status: }
       end
 
       def get_file_paths_and_metadata(parsed_form_data)
@@ -160,11 +162,11 @@ module SimpleFormsApi
       end
 
       def upload_pdf(file_path, metadata, form)
-        location, uuid = prepare_for_upload(form, file_path)
+        location, uuid, submission = prepare_for_upload(form, file_path)
         log_upload_details(location, uuid)
         response = perform_pdf_upload(location, file_path, metadata, form)
 
-        [response.status, uuid]
+        [response.status, uuid, submission]
       end
 
       def prepare_for_upload(form, file_path)
@@ -172,9 +174,9 @@ module SimpleFormsApi
                           form_id: get_form_id)
         location, uuid = lighthouse_service.request_upload
         stamp_pdf_with_uuid(form, uuid, file_path)
-        create_form_submission_attempt(uuid)
+        attempt = create_form_submission_attempt(uuid)
 
-        [location, uuid]
+        [location, uuid, attempt.form_submission]
       end
 
       def stamp_pdf_with_uuid(form, uuid, stamped_template_path)
@@ -211,6 +213,21 @@ module SimpleFormsApi
         }.compact
 
         lighthouse_service.perform_upload(**upload_params)
+      end
+
+      def send_pdf_to_s3(benefits_intake_uuid, file_path, metadata, submission)
+        submission_archiver = SimpleFormsApi::S3Service::SubmissionArchiver.new(
+          attachments: get_form_id == 'vba_20_10207' ? form.get_attachments : [],
+          benefits_intake_uuid:,
+          file_path:,
+          metadata:,
+          submission:
+        )
+        submission_archiver.run
+      end
+
+      def form_is264555_and_should_use_lgy_api
+        params[:form_number] == '26-4555' && icn
       end
 
       def icn

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -129,7 +129,7 @@ module SimpleFormsApi
           'Simple forms api - sent to benefits intake',
           { form_number: params[:form_number], status:, uuid: confirmation_number }
         )
-        presigned_s3_url = upload_pdf_to_s3(confirmation_number, file_path, metadata, submission)
+        presigned_s3_url = upload_pdf_to_s3(confirmation_number, file_path, metadata, submission, form)
 
         if status == 200 && Flipper.enabled?(:simple_forms_email_confirmations)
           send_confirmation_email(parsed_form_data, form_id, confirmation_number)
@@ -215,9 +215,9 @@ module SimpleFormsApi
         lighthouse_service.perform_upload(**upload_params)
       end
 
-      def upload_pdf_to_s3(id, file_path, metadata, submission)
+      def upload_pdf_to_s3(id, file_path, metadata, submission, form)
         config = SimpleFormsApi::FormRemediation::Configuration::VffConfig.new
-        attachments = get_form_id == 'vba_20_10207' ? form.fetch_attachment_guids : []
+        attachments = get_form_id == 'vba_20_10207' ? form.attachment_guids : []
         s3_client = config.s3_client.new(
           config:, type: :submission, id:, submission:, attachments:, file_path:, metadata:
         )

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -216,14 +216,14 @@ module SimpleFormsApi
       end
 
       def send_pdf_to_s3(benefits_intake_uuid, file_path, metadata, submission)
-        submission_archiver = SimpleFormsApi::S3Service::SubmissionArchiver.new(
+        submission_archiver = SimpleFormsApi::S3::SubmissionArchiver.new(
           attachments: get_form_id == 'vba_20_10207' ? form.get_attachments : [],
           benefits_intake_uuid:,
           file_path:,
           metadata:,
           submission:
         )
-        submission_archiver.run
+        submission_archiver.upload(type: :submission)
       end
 
       def form_is264555_and_should_use_lgy_api

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -110,20 +110,14 @@ module SimpleFormsApi
     end
 
     def get_attachments
-      fetch_attachment_guids.map { |guid| PersistentAttachment.where(guid:).map(&:to_pdf) }
+      PersistentAttachment.where(guid: attachment_guids).map(&:to_pdf)
     end
 
-    def fetch_attachment_guids
-      [].tap do |uuids|
-        doc_types = %w[als_documents financial_hardship_documents medal_award_documents pow_documents
-                       terminal_illness_documents vsi_documents]
+    def attachment_guids
+      doc_types = %w[als_documents financial_hardship_documents medal_award_documents pow_documents
+                     terminal_illness_documents vsi_documents]
 
-        doc_types.each do |doc_type|
-          next unless @data[doc_type]
-
-          uuids.concat(@data[doc_type].pluck('confirmation_code'))
-        end
-      end
+      doc_types.flat_map { |type| @data[type]&.pluck('confirmation_code') }.compact
     end
 
     private

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -110,19 +110,18 @@ module SimpleFormsApi
     end
 
     def get_attachments
-      [].tap do |attachments|
-        %w[
-          als_documents
-          financial_hardship_documents
-          medal_award_documents
-          pow_documents
-          terminal_illness_documents
-          vsi_documents
-        ].each do |doc_type|
+      fetch_attachment_guids.map { |guid| PersistentAttachment.where(guid:).map(&:to_pdf) }
+    end
+
+    def fetch_attachment_guids
+      [].tap do |uuids|
+        doc_types = %w[als_documents financial_hardship_documents medal_award_documents pow_documents
+                       terminal_illness_documents vsi_documents]
+
+        doc_types.each do |doc_type|
           next unless @data[doc_type]
 
-          confirmation_codes = @data[doc_type].pluck('confirmation_code')
-          attachments.concat(PersistentAttachment.where(guid: confirmation_codes).map(&:to_pdf))
+          uuids.concat(@data[doc_type].pluck('confirmation_code'))
         end
       end
     end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -122,6 +122,8 @@ module SimpleFormsApi
       end
 
       def presign_required?
+        return true if upload_type == :submission
+
         config.presign_s3_url
       end
     end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -12,14 +12,10 @@ module SimpleFormsApi
       def initialize(config:, **options)
         @config = config
         @temp_directory_path = config.temp_directory_path
-        @include_manifest = config.include_manifest
-        @include_metadata = config.include_metadata
-        @manifest_entry = nil
+        @pdf_already_exists = File.exist?(options[:file_path])
 
         assign_data(options)
         hydrate_submission_data
-
-        @form_number = JSON.parse(submission&.form_data)['form_number']
       rescue => e
         config.handle_error("#{self.class.name} initialization failed", e)
       end
@@ -41,16 +37,16 @@ module SimpleFormsApi
 
       private
 
-      attr_reader :archive_type, :attachments, :config, :file_path, :form_number, :id, :include_manifest,
-                  :include_metadata, :manifest_entry, :metadata, :submission, :temp_directory_path
+      attr_reader :archive_type, :attachments, :config, :file_path, :id, :metadata, :pdf_already_exists, :submission,
+                  :temp_directory_path
 
       def assign_data(options)
-        @archive_type = options[:type] || :remediation
-        @attachments = options[:attachments] || []
-        @file_path = options[:file_path]
+        @archive_type ||= options[:type] || :remediation
+        @attachments ||= options[:attachments]
+        @file_path ||= options[:file_path]
         @id = options[:submission]&.send(config.id_type) || options[:id]
-        @metadata = options[:metadata]
-        @submission = options[:submission]
+        @metadata ||= options[:metadata]
+        @submission ||= options[:submission]
       end
 
       def submission_already_hydrated?
@@ -78,8 +74,8 @@ module SimpleFormsApi
         [
           -> { write_pdf },
           -> { write_attachments if attachments&.any? },
-          -> { build_manifest_csv_entry if include_manifest },
-          -> { write_metadata if include_metadata }
+          -> { build_manifest_csv_entry if config.include_manifest },
+          -> { write_metadata if config.include_metadata }
         ].each do |task|
           safely_execute_task(task)
         end
@@ -109,8 +105,14 @@ module SimpleFormsApi
         create_file("attachment_#{attachment_number}__#{submission_file_name}.pdf", File.read(file_path), 'attachment')
       end
 
-      def build_manifest_csv_entry
-        @manifest_entry = [
+      def manifest_data_exists?
+        submission&.created_at && form_number && id && metadata
+      end
+
+      def manifest_entry
+        return nil unless manifest_data_exists?
+
+        [
           submission.created_at,
           form_number,
           id,
@@ -128,6 +130,11 @@ module SimpleFormsApi
 
       def submission_file_name
         @submission_file_name ||= unique_file_name(form_number, id)
+      end
+
+      def form_number
+        @form_number ||= metadata&.dig('docType') ||
+                         (submission && JSON.parse(submission.form_data)&.dig('form_number'))
       end
     end
   end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -12,25 +12,20 @@ module SimpleFormsApi
       def initialize(config:, **options)
         @config = config
         @temp_directory_path = config.temp_directory_path
-        @pdf_already_exists = File.exist?(options[:file_path])
+        @pdf_already_exists = options[:file_path] && File.exist?(options[:file_path])
 
-        assign_data(options)
-        hydrate_submission_data
+        initialize_data(options)
+        hydrate_submission_data unless data_hydrated?
       rescue => e
         config.handle_error("#{self.class.name} initialization failed", e)
       end
 
       def build!
         create_directory!(temp_directory_path)
-        process_submission_files
+        process_files
 
-        path = if archive_type == :submission
-                 "#{submission_file_name}.pdf"
-               else
-                 zip_directory!(config.parent_dir, temp_directory_path, submission_file_name)
-               end
-
-        [path, manifest_entry]
+        final_path = determine_final_path
+        [final_path, manifest_entry]
       rescue => e
         config.handle_error("Failed building submission: #{id}", e)
       end
@@ -40,48 +35,51 @@ module SimpleFormsApi
       attr_reader :archive_type, :attachments, :config, :file_path, :id, :metadata, :pdf_already_exists, :submission,
                   :temp_directory_path
 
-      def assign_data(options)
-        @archive_type ||= options[:type] || :remediation
+      def initialize_data(options)
+        @archive_type ||= options.fetch(:type, :remediation)
         @attachments ||= options[:attachments]
         @file_path ||= options[:file_path]
-        @id = options[:submission]&.send(config.id_type) || options[:id]
+        @id ||= fetch_id(options)
         @metadata ||= options[:metadata]
         @submission ||= options[:submission]
       end
 
-      def submission_already_hydrated?
+      def fetch_id(options)
+        options[:submission]&.send(config.id_type) || options[:id]
+      end
+
+      def data_hydrated?
         submission && file_path && attachments && metadata
       end
 
       def hydrate_submission_data
-        return if submission_already_hydrated?
-
         raise "No #{config.id_type} was provided" unless id
 
         built_submission = config.remediation_data_class.new(id:, config:).hydrate!
 
-        assign_data(
+        initialize_data(
           attachments: built_submission.attachments,
           file_path: built_submission.file_path,
           id: built_submission.submission&.send(config.id_type),
           metadata: built_submission.metadata,
           submission: built_submission.submission,
-          type: @archive_type
+          type: archive_type
         )
       end
 
-      def process_submission_files
+      def process_files
+        processing_tasks.each { |task| safely_execute(task) }
+      end
+
+      def processing_tasks
         [
           -> { write_pdf },
           -> { write_attachments if attachments&.any? },
-          -> { build_manifest_csv_entry if config.include_manifest },
           -> { write_metadata if config.include_metadata }
-        ].each do |task|
-          safely_execute_task(task)
-        end
+        ]
       end
 
-      def safely_execute_task(task)
+      def safely_execute(task)
         task.call
       rescue => e
         config.handle_error("Error during processing task: #{task.source_location}", e)
@@ -105,12 +103,16 @@ module SimpleFormsApi
         create_file("attachment_#{attachment_number}__#{submission_file_name}.pdf", File.read(file_path), 'attachment')
       end
 
-      def manifest_data_exists?
+      def data_exists_for_manifest?
         submission&.created_at && form_number && id && metadata
       end
 
+      def should_include_manifest?
+        config.include_manifest && data_exists_for_manifest? && archive_type == :remediation
+      end
+
       def manifest_entry
-        return nil unless manifest_data_exists?
+        return unless should_include_manifest?
 
         [
           submission.created_at,
@@ -128,13 +130,22 @@ module SimpleFormsApi
         config.handle_error("Failed writing #{file_description} file #{file_name} for submission: #{id}", e)
       end
 
+      def determine_final_path
+        return "#{submission_file_name}.pdf" if archive_type == :submission
+
+        zip_directory!(config.parent_dir, temp_directory_path, submission_file_name)
+      end
+
       def submission_file_name
         @submission_file_name ||= unique_file_name(form_number, id)
       end
 
       def form_number
-        @form_number ||= metadata&.dig('docType') ||
-                         (submission && JSON.parse(submission.form_data)&.dig('form_number'))
+        @form_number ||= metadata&.dig('docType') || submission_form_number
+      end
+
+      def submission_form_number
+        submission ? JSON.parse(submission.form_data)['form_number'] : nil
       end
     end
   end

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
     allow(SimpleFormsApi::FormRemediation::S3Client).to receive(:new).and_return(mock_s3_client)
     allow(mock_s3_client).to receive(:upload).and_return(presigned_s3_url)
     allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
-    allow(Flipper).to receive(:enabled?).with(:submission_pdf_s3_upload).and_return(true)
   end
 
   describe '#submit' do
@@ -55,6 +54,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           original_method.call(args[0], random_string)
         end
         Flipper.disable(:simple_forms_email_confirmations)
+        Flipper.enable(:submission_pdf_s3_upload)
       end
 
       after do
@@ -62,6 +62,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         VCR.eject_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
         Common::FileHelpers.delete_file_if_exists(metadata_file)
         Flipper.enable(:simple_forms_email_confirmations)
+        Flipper.disable(:submission_pdf_s3_upload)
       end
 
       shared_examples 'form submission' do |form, is_authenticated|

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -203,16 +203,14 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
 
       context 'request with attached documents' do
         let(:pdf_path) { Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf') }
-        let(:attachment) { double }
         let(:lighthouse_service) { double }
         let(:confirmation_number) { 'some_confirmation_number' }
 
         before do
           sign_in
-          allow(attachment).to receive(:to_pdf).and_return(pdf_path)
-          allow(PersistentAttachment).to(
-            receive(:where).with(guid: [a_string_matching(/a-random-uuid/)]).and_return([attachment])
-          )
+          allow(PersistentAttachment).to receive(:where) do |args|
+            args[:guid].map { instance_double(PersistentAttachment, to_pdf: pdf_path) }
+          end
         end
 
         shared_examples 'submits successfully' do |form_doc|

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -8,24 +8,27 @@ require 'lgy/service'
 
 RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
   forms = [
-    # TODO: Restore this test when we release 26-4555 to production.
-    # 'vba_26_4555.json',
+    'vba_20_10206.json',
+    'vba_20_10207-non-veteran.json',
+    'vba_20_10207-veteran.json',
+    'vba_21_0845.json',
+    'vba_21_0966.json',
+    'vba_21_0972.json',
+    'vba_21_10210.json',
     'vba_21_4138.json',
     'vba_21_4142.json',
-    'vba_21_10210.json',
     'vba_21p_0847.json',
-    'vba_21_0972.json',
-    'vba_21_0845.json',
+    # 'vba_26_4555.json', # TODO: Restore this test when we release 26-4555 to production.
     'vba_40_0247.json',
-    'vba_21_0966.json',
-    'vba_20_10206.json',
-    'vba_40_10007.json',
-    'vba_20_10207-veteran.json',
-    'vba_20_10207-non-veteran.json'
+    'vba_40_10007.json'
   ]
 
-  unauthenticated_forms = %w[vba_40_0247.json vba_21_10210.json vba_21p_0847.json
-                             vba_40_10007.json]
+  unauthenticated_forms = %w[
+    vba_21_10210.json
+    vba_21p_0847.json
+    vba_40_0247.json
+    vba_40_10007.json
+  ]
   authenticated_forms = forms - unauthenticated_forms
 
   describe '#submit' do

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
     allow(SimpleFormsApi::FormRemediation::S3Client).to receive(:new).and_return(mock_s3_client)
     allow(mock_s3_client).to receive(:upload).and_return(presigned_s3_url)
     allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
+    allow(Flipper).to receive(:enabled?).with(:submission_pdf_s3_upload).and_return(true)
   end
 
   describe '#submit' do

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
   let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
   let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
   let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
-  let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
+  let(:type) { :remediation }
+  let(:benefits_intake_uuid) { submission&.benefits_intake_uuid }
   let(:metadata) do
     {
       veteranFirstName: 'John',
@@ -35,7 +36,10 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
     )
   end
   let(:config) { SimpleFormsApi::FormRemediation::Configuration::VffConfig.new }
-  let(:submission_archive_instance) { described_class.new(id: benefits_intake_uuid, config:) }
+  let(:id_archive_instance) { described_class.new(id: benefits_intake_uuid, config:, type:) }
+  let(:data_archive_instance) do
+    described_class.new(id: benefits_intake_uuid, config:, submission:, file_path:, attachments:, metadata:, type:)
+  end
   let(:temp_file_path) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
 
   before do
@@ -48,7 +52,12 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
     allow(File).to receive_messages(write: true, directory?: true)
     allow(CSV).to receive(:open).and_return(true)
     allow(FileUtils).to receive(:mkdir_p).and_return(true)
-    allow(submission_archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
+    allow(id_archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
+      s3_dir = build_path(:dir, parent_dir, 'remediation')
+      s3_file_path = build_path(:file, s3_dir, filename, ext: '.zip')
+      build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
+    end
+    allow(data_archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
       s3_dir = build_path(:dir, parent_dir, 'remediation')
       s3_file_path = build_path(:file, s3_dir, filename, ext: '.zip')
       build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
@@ -56,86 +65,194 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
   end
 
   describe '#initialize' do
-    subject(:new) { submission_archive_instance }
+    context 'when initialized with a valid id' do
+      subject(:new) { id_archive_instance }
 
-    context 'when initialized with a valid benefits_intake_uuid' do
       it 'successfully completes initialization' do
         expect { new }.not_to raise_exception
+      end
+
+      context 'when no id is passed' do
+        it 'raises an exception' do
+          expect { described_class.new(id: nil, config:, type:) }.to(
+            raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
+          )
+        end
+      end
+
+      context 'when no config is passed' do
+        it 'raises an exception' do
+          expect { described_class.new(id: benefits_intake_uuid, config: nil, type:) }.to(
+            raise_exception(SimpleFormsApi::FormRemediation::NoConfigurationError, 'No configuration was provided')
+          )
+        end
       end
     end
 
     context 'when initialized with valid hydrated submission data' do
-      let(:submission_archive_instance) do
-        described_class.new(config:, submission:, file_path:, attachments:, metadata:)
-      end
+      subject(:new) { data_archive_instance }
 
       it 'successfully completes initialization' do
         expect { new }.not_to raise_exception
       end
-    end
 
-    context 'when no id is passed' do
-      it 'raises an exception' do
-        expect do
-          described_class.new(id: nil, config:)
-        end.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
-      end
-    end
+      context 'when no submission is passed' do
+        let(:submission) { nil }
+        let(:benefits_intake_uuid) { 'random-letters-n-numbers' }
 
-    context 'when no config is passed' do
-      it 'raises an exception' do
-        expect do
-          described_class.new(id: benefits_intake_uuid, config: nil)
-        end.to raise_exception(NoMethodError, "undefined method `handle_error' for nil")
+        it 'successfully completes initialization' do
+          expect { new }.not_to raise_exception
+        end
+
+        context 'when no id is passed' do
+          it 'raises an exception' do
+            expect do
+              described_class.new(id: nil, config:, submission:, file_path:, attachments:, metadata:, type:)
+            end.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
+          end
+        end
       end
     end
   end
 
   describe '#build!' do
-    subject(:build_archive) { submission_archive_instance.build! }
-
     let(:zip_file_path) { "#{temp_file_path}/#{submission_file_path}.zip" }
 
     before { build_archive }
 
-    context 'when properly initialized' do
-      it 'builds the zip path correctly' do
-        expect(build_archive[0]).to include(zip_file_path)
-      end
+    context 'when archiving a remediation package' do
+      context 'when initialized with a valid id' do
+        subject(:build_archive) { id_archive_instance.build! }
 
-      it 'builds the manifest entry correctly' do
-        expect(build_archive[1]).to eq(
-          [
-            submission.created_at,
-            form_type,
-            benefits_intake_uuid,
-            metadata['fileNumber'],
-            metadata['veteranFirstName'],
-            metadata['veteranLastName']
-          ]
-        )
-      end
+        it 'builds the zip path correctly' do
+          expect(build_archive[0]).to include(zip_file_path)
+        end
 
-      it 'writes the submission pdf file' do
-        expect(File).to have_received(:write).with(
-          "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-        )
-      end
+        it 'builds the manifest entry correctly' do
+          expect(build_archive[1]).to eq(
+            [
+              submission.created_at,
+              form_type,
+              benefits_intake_uuid,
+              metadata['fileNumber'],
+              metadata['veteranFirstName'],
+              metadata['veteranLastName']
+            ]
+          )
+        end
 
-      it 'writes the attachment files' do
-        attachments.each_with_index do |_, i|
+        it 'writes the submission pdf file' do
           expect(File).to have_received(:write).with(
-            "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+            "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+          )
+        end
+
+        it 'writes the attachment files' do
+          attachments.each_with_index do |_, i|
+            expect(File).to have_received(:write).with(
+              "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+            )
+          end
+        end
+
+        it 'zips the directory' do
+          expect(id_archive_instance).to have_received(:zip_directory!).with(
+            config.parent_dir,
+            a_string_including('/tmp/random-letters-n-numbers-archive/'),
+            a_string_including(submission_file_path)
           )
         end
       end
 
-      it 'zips the directory' do
-        expect(submission_archive_instance).to have_received(:zip_directory!).with(
-          config.parent_dir,
-          a_string_including('/tmp/random-letters-n-numbers-archive/'),
-          a_string_including(submission_file_path)
-        )
+      context 'when initialized with valid submission data' do
+        subject(:build_archive) { data_archive_instance.build! }
+
+        it 'builds the zip path correctly' do
+          expect(build_archive[0]).to include(zip_file_path)
+        end
+
+        it 'builds the manifest entry correctly' do
+          expect(build_archive[1]).to eq(
+            [
+              submission.created_at,
+              form_type,
+              benefits_intake_uuid,
+              metadata['fileNumber'],
+              metadata['veteranFirstName'],
+              metadata['veteranLastName']
+            ]
+          )
+        end
+
+        it 'writes the submission pdf file' do
+          expect(File).to have_received(:write).with(
+            "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+          )
+        end
+
+        it 'writes the attachment files' do
+          attachments.each_with_index do |_, i|
+            expect(File).to have_received(:write).with(
+              "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+            )
+          end
+        end
+
+        it 'zips the directory' do
+          expect(data_archive_instance).to have_received(:zip_directory!).with(
+            config.parent_dir,
+            a_string_including('/tmp/random-letters-n-numbers-archive/'),
+            a_string_including(submission_file_path)
+          )
+        end
+      end
+
+      context 'when archiving a submission' do
+        let(:type) { :submission }
+
+        context 'when initialized with a valid id' do
+          subject(:build_archive) { id_archive_instance.build! }
+
+          it 'builds the pdf path correctly' do
+            expect(build_archive[0]).to include(submission_file_path)
+          end
+
+          it 'does not build the manifest entry' do
+            expect(build_archive[1]).to eq(nil)
+          end
+
+          it 'writes the submission pdf file' do
+            expect(File).to have_received(:write).with(
+              "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+            )
+          end
+
+          it 'does not zip the directory' do
+            expect(id_archive_instance).not_to have_received(:zip_directory!)
+          end
+        end
+
+        context 'when initialized with valid submission data' do
+          subject(:build_archive) { data_archive_instance.build! }
+
+          it 'builds the pdf path correctly' do
+            expect(build_archive[0]).to include(submission_file_path)
+          end
+
+          it 'does not build the manifest entry' do
+            expect(build_archive[1]).to eq(nil)
+          end
+
+          it 'writes the submission pdf file' do
+            expect(File).to have_received(:write).with(
+              "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+            )
+          end
+
+          it 'does not zip the directory' do
+            expect(data_archive_instance).not_to have_received(:zip_directory!)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *This PR introduces logic to archive submissions and upload the resulting PDFs to S3, generating a pre-signed URL that is returned in the confirmation response. It includes updates to existing archival logic, refactoring of tests, and implementation of a feature flag to manage the deployment of the new S3-related functionality.*
- *The solution leverages AWS pre-signed URLs to securely provide access to the uploaded PDFs, allowing users to download the PDFs directly from S3. The implementation also includes setting the `Content-Disposition` header to ensure the correct filename is presented during downloads.*
- *I work for the Veteran Facing Forms team, and our team will maintain this component.*
- *The success criteria for the feature toggle include verifying that PDFs are correctly uploaded to S3 and that the pre-signed URL is only included in the response when the feature flag is enabled.*

## Related issue(s)

- *[Implement S3 PDF Storage and Pre-Signed URL Generation for Successful Submissions](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1622)*
- *[Epic: S3 PDF Management](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/epic/gh/department-of-veterans-affairs/va.gov-team-forms/1610)*

## Testing done

- [x] *New code is covered by unit tests*
- *To verify the changes, the following steps were taken:*
  - *Unit tests were written and updated to cover the new S3 upload functionality.*
  - *Tests ensure that PDFs are correctly uploaded to S3 and that pre-signed URLs are generated and included in the confirmation response.*
  - *Validation checks ensure that the `Content-Disposition` header is correctly set for all generated URLs.*
  - *Feature flag tests were created to confirm that the new functionality is only active when the feature toggle is enabled.*
  - *The new feature was tested across various scenarios, including successful uploads, failed uploads, and scenarios where S3 is unreachable.*
- *If this work is behind a flipper:*
  - *Tests were written for both the scenarios where the feature toggle is enabled and disabled. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *The feature will be gradually rolled out using the feature flag, with monitoring to confirm correct functionality before full deployment.*

## What areas of the site does it impact?
*This PR impacts the backend submission process for form submissions, specifically the functionality that generates and archives PDFs. It also touches the area of the code responsible for returning confirmation responses to users. Code changes ensure that the pre-signed URL is only included when the feature flag is enabled.*

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [ ] Documentation has been updated (link to documentation).
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [ ] Feature/bug has a monitor built into Datadog (if applicable).
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected.
- [ ] I added a screenshot of the developed feature: N/A (No visual changes, backend functionality only).

## Requested Feedback

*Please review the implementation of the S3 upload logic and the feature toggle to ensure they align with best practices. Feedback on test coverage, especially edge cases around error handling and feature flag scenarios, would be appreciated.*