### PR TITLE
API-40254-5103-bd-upload-errors

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/service_base.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/service_base.rb
@@ -34,6 +34,10 @@ module ClaimsApi
       end
     end
 
+    def retry_limits_for_notification
+      [11]
+    end
+
     protected
 
     def preserve_original_form_data(form_data)

--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -105,7 +105,7 @@ module ClaimsApi
       payload = {}
       auth_headers = claim.auth_headers
       veteran_name = compact_veteran_name(auth_headers['va_eauth_firstName'], auth_headers['va_eauth_lastName'])
-      birls_file_num = determine_birls_file_number(doc_type, auth_headers) if %w[L075 L190].include?(doc_type)
+      birls_file_num = determine_birls_file_number(doc_type, auth_headers)
       claim_id = get_claim_id(doc_type, claim)
       file_name = generate_file_name(doc_type:, veteran_name:, claim_id:, original_filename:, action:)
       participant_id = pctpnt_vet_id if %w[L075 L190 L705].include?(doc_type)
@@ -122,9 +122,9 @@ module ClaimsApi
     end
 
     def determine_birls_file_number(doc_type, auth_headers)
-      if %w[L122 L705].include?(doc_type)
+      if %w[L122].include?(doc_type)
         birls_file_num = auth_headers['va_eauth_birlsfilenumber']
-      elsif %w[L075 L190].include?(doc_type)
+      elsif %w[L075 L190 L705].include?(doc_type)
         birls_file_num = nil
       end
       birls_file_num

--- a/modules/claims_api/lib/bd/bd.rb
+++ b/modules/claims_api/lib/bd/bd.rb
@@ -105,7 +105,7 @@ module ClaimsApi
       payload = {}
       auth_headers = claim.auth_headers
       veteran_name = compact_veteran_name(auth_headers['va_eauth_firstName'], auth_headers['va_eauth_lastName'])
-      birls_file_num = determine_birls_file_number(doc_type, auth_headers)
+      birls_file_num = determine_birls_file_number(doc_type, auth_headers) if %w[L075 L190].include?(doc_type)
       claim_id = get_claim_id(doc_type, claim)
       file_name = generate_file_name(doc_type:, veteran_name:, claim_id:, original_filename:, action:)
       participant_id = pctpnt_vet_id if %w[L075 L190 L705].include?(doc_type)

--- a/modules/claims_api/spec/lib/claims_api/bd_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bd_spec.rb
@@ -203,6 +203,14 @@ describe ClaimsApi::BD do
         expect(js['data']['systemName']).to eq 'VA.gov'
         expect(js['data']['trackedItemIds']).to eq [234, 235]
       end
+
+      it 'sends only a participant id and not a file number for 5103' do
+        result = subject.send(:generate_upload_body, claim: ews, doc_type: 'L705', original_filename: '5103.pdf',
+                                                     pdf_path:, action: 'post', pctpnt_vet_id: '123456789')
+        js = JSON.parse(result[:parameters].read)
+        expect(js['data']['fileNumber']).not_to be_truthy
+        expect(js['data']['fileNumber']).to eq(nil)
+      end
     end
 
     describe '#build_body' do

--- a/modules/claims_api/spec/sidekiq/evidence_waiver_builder_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/evidence_waiver_builder_job_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe ClaimsApi::EvidenceWaiverBuilderJob, type: :job do
     end
   end
 
+  describe '#retry_limits_for_notification' do
+    it "provides the method definition for sidekiq 'retry_monitoring.rb'" do
+      res = described_class.new.retry_limits_for_notification
+      expect(res).to eq([11])
+      expect(described_class.new.respond_to?(:retry_limits_for_notification)).to eq(true)
+    end
+  end
+
   describe 'when an errored job has exhausted its retries' do
     it 'logs to the ClaimsApi Logger' do
       error_msg = 'An error occurred from the Evidence Waiver Builder Job'


### PR DESCRIPTION
## Summary

- Adds method to service_base for retry_limits_for_notification based on this [DataDog stack trace](https://vagov.ddog-gov.com/logs?query=trace_id%3A3752143384880475127%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZIHJZD3uW_8qQAAAAAAAAAYAAAAAEFaSUhKWm5TQUFCUU1oQjAwanlBbndCRwAAACQAAAAAMDE5MjA3MjUtOWFmMC00YzFiLTk3Y2QtNTYwMmU3ZmJlMWFk&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1726695755447&to_ts=1726697756390&live=false)
- Adds corresponding test. 
- Adds logic to exclude file number in a BD upload if the doc type is 'L705'. 
- Adds corresponding  test.


## Related issue(s)

- [API-40254](https://jira.devops.va.gov/browse/API-40254)

## Testing done

- [X] *New code is covered by unit tests*



## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/service_base.rb
	modified:   modules/claims_api/lib/bd/bd.rb
	modified:   modules/claims_api/spec/lib/claims_api/bd_spec.rb
	modified:   modules/claims_api/spec/sidekiq/evidence_waiver_builder_job_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature