### PR TITLE
91824: Create Burials::Monitor and modify controller

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -839,6 +839,7 @@ lib/benefits_intake_service @department-of-veterans-affairs/benefits-dependents-
 lib/bgs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/bid @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/bip_claims @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/burials @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/carma @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/caseflow @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/central_mail @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1380,6 +1380,7 @@ spec/lib/bgs @department-of-veterans-affairs/benefits-dependents-management @dep
 spec/lib/bid @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/bip_claims @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/breakers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/burials @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/carma @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/caseflow @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/central_mail @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/burial_claims_controller.rb
+++ b/app/controllers/v0/burial_claims_controller.rb
@@ -25,20 +25,14 @@ module V0
       render(json: { data: { attributes: { state: 'error processing request' } } }, status: :unprocessable_entity)
     end
 
-    def create # rubocop:disable Metrics/MethodLength
+    def create
       PensionBurial::TagSentry.tag_sentry
 
       claim = create_claim
       monitor.track_create_attempt(claim, current_user)
 
-      unless claim.save
-        StatsD.increment("#{stats_key}.failure")
-        Sentry.set_tags(team: 'benefits-memorial-1') # tag sentry logs with team name
-        Rails.logger.error('Burial claim was not saved', {  error_messages: claim.errors,
-                                                            user_uuid: current_user&.uuid,
-                                                            in_progress_form_id: in_progress_form&.id })
-        raise Common::Exceptions::ValidationErrors, claim
-      end
+      track_claim_save_failure(claim) unless claim.save
+
       # this method also calls claim.process_attachments!
       claim.submit_to_structured_data_services!
 
@@ -80,6 +74,31 @@ module V0
 
     def in_progress_form
       current_user ? InProgressForm.form_for_user(claim.form_id, current_user) : nil
+    end
+
+    def track_claim_save_failure(claim)
+      StatsD.increment("#{stats_key}.failure")
+      Sentry.set_tags(team: 'benefits-memorial-1') # tag sentry logs with team name
+      Rails.logger.error('Burial claim was not saved', {  error_messages: claim.errors,
+                                                          user_uuid: current_user&.uuid,
+                                                          in_progress_form_id: in_progress_form&.id })
+      log_validation_error_to_metadata(in_progress_form, claim)
+      raise Common::Exceptions::ValidationErrors, claim
+    end
+
+    ##
+    # include validation error on in_progress_form metadata.
+    # `noop` if in_progress_form is `blank?`
+    #
+    # @param in_progress_form [InProgressForm]
+    # @param claim [Pensions::SavedClaim]
+    #
+    def log_validation_error_to_metadata(in_progress_form, claim)
+      return if in_progress_form.blank?
+
+      metadata = in_progress_form.metadata
+      metadata['submission']['error_message'] = claim&.errors&.errors&.to_s
+      in_progress_form.update(metadata:)
     end
 
     ##

--- a/app/controllers/v0/burial_claims_controller.rb
+++ b/app/controllers/v0/burial_claims_controller.rb
@@ -1,37 +1,35 @@
 # frozen_string_literal: true
 
 require 'pension_burial/tag_sentry'
+require 'burials/monitor'
 
 module V0
   class BurialClaimsController < ClaimsBaseController
     service_tag 'burial-application'
 
     def show
-      submission_attempt = determine_submission_attempt
+      claim = claim_class.find_by!(guid: params[:id])
+      form_submission = claim&.form_submissions&.last
+      submission_attempt = form_submission&.form_submission_attempts&.last
       if submission_attempt
         state = submission_attempt.aasm_state == 'failure' ? 'failure' : 'success'
         render(json: { data: { attributes: { state: } } })
       elsif central_mail_submission
         render json: CentralMailSubmissionSerializer.new(central_mail_submission)
-      else
-        Rails.logger.error("ActiveRecord::RecordNotFound: Claim submission not found for claim_id: #{params[:id]}")
-        render(json: { data: { attributes: { state: 'not found' } } }, status: :not_found)
       end
+    rescue ActiveRecord::RecordNotFound => e
+      monitor.track_show404(params[:id], current_user, e)
+      render(json: { data: { attributes: { state: 'not found' } } }, status: :not_found)
     rescue => e
-      Rails.logger.error(e.to_s)
+      monitor.track_show_error(params[:id], current_user, e)
       render(json: { data: { attributes: { state: 'error processing request' } } }, status: :unprocessable_entity)
     end
 
-    def create
+    def create # rubocop:disable Metrics/MethodLength
       PensionBurial::TagSentry.tag_sentry
 
-      claim = if Flipper.enabled?(:va_burial_v2)
-                # cannot parse a nil form, to pass unit tests do a check for form presence
-                form = filtered_params[:form]
-                claim_class.new(form:, formV2: form.present? ? JSON.parse(form)['formV2'] : nil)
-              else
-                claim_class.new(form: filtered_params[:form])
-              end
+      claim = create_claim
+      monitor.track_create_attempt(claim, current_user)
 
       unless claim.save
         StatsD.increment("#{stats_key}.failure")
@@ -45,8 +43,25 @@ module V0
       claim.submit_to_structured_data_services!
 
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.form_id}"
+
+      in_progress_form = current_user ? InProgressForm.form_for_user(claim.form_id, current_user) : nil
+      claim.form_start_date = in_progress_form.created_at if in_progress_form
+      monitor.track_create_success(in_progress_form, claim, current_user)
+
       clear_saved_form(claim.form_id)
       render json: SavedClaimSerializer.new(claim)
+    rescue => e
+      monitor.track_create_error(in_progress_form, claim, current_user, e)
+      raise e
+    end
+
+    def create_claim
+      if Flipper.enabled?(:va_burial_v2)
+        form = filtered_params[:form]
+        claim_class.new(form:, formV2: form.present? ? JSON.parse(form)['formV2'] : nil)
+      else
+        claim_class.new(form: filtered_params[:form])
+      end
     end
 
     def short_name
@@ -59,18 +74,21 @@ module V0
 
     private
 
-    def determine_submission_attempt
-      claim = claim_class.find_by(guid: params[:id])
-      form_submission = claim&.form_submissions&.last
-      form_submission&.form_submission_attempts&.last
-    end
-
     def central_mail_submission
       CentralMailSubmission.joins(:central_mail_claim).find_by(saved_claims: { guid: params[:id] })
     end
 
     def in_progress_form
       current_user ? InProgressForm.form_for_user(claim.form_id, current_user) : nil
+    end
+
+    ##
+    # retreive a monitor for tracking
+    #
+    # @return [Burials::Monitor]
+    #
+    def monitor
+      @monitor ||= Burials::Monitor.new
     end
   end
 end

--- a/lib/burials/monitor.rb
+++ b/lib/burials/monitor.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Burials
+  ##
+  # Monitor functions for Rails logging and StatsD
+  #
+  class Monitor
+    CLAIM_STATS_KEY = 'api.burial_claim'
+
+    ##
+    # log GET 404 from controller
+    # @see BurialClaimsController
+    #
+    # @param confirmation_number [UUID] saved_claim guid
+    # @param current_user [User]
+    # @param e [ActiveRecord::RecordNotFound]
+    #
+    def track_show404(confirmation_number, current_user, e)
+      Rails.logger.error('21P-530EZ submission not found',
+                         { confirmation_number:, user_uuid: current_user&.uuid, message: e&.message })
+    end
+
+    ##
+    # log GET 500 from controller
+    # @see BurialClaimsController
+    #
+    # @param confirmation_number [UUID] saved_claim guid
+    # @param current_user [User]
+    # @param e [Error]
+    #
+    def track_show_error(confirmation_number, current_user, e)
+      Rails.logger.error('21P-530EZ fetching submission failed',
+                         { confirmation_number:, user_uuid: current_user&.uuid, message: e&.message })
+    end
+
+    ##
+    # log POST processing started
+    # @see BurialClaimsController
+    #
+    # @param claim [Pension::SavedClaim]
+    # @param current_user [User]
+    #
+    def track_create_attempt(claim, current_user)
+      StatsD.increment("#{CLAIM_STATS_KEY}.attempt")
+      Rails.logger.info('21P-530EZ submission to Sidekiq begun',
+                        { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid })
+    end
+
+    ##
+    # log POST processing failure
+    # @see BurialClaimsController
+    #
+    # @param in_progress_form [InProgressForm]
+    # @param claim [SavedClaim::Burial]
+    # @param current_user [User]
+    # @param e [Error]
+    #
+    def track_create_error(in_progress_form, claim, current_user, e = nil)
+      StatsD.increment("#{CLAIM_STATS_KEY}.failure")
+      Rails.logger.error('21P-530EZ submission to Sidekiq failed',
+                         { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
+                           in_progress_form_id: in_progress_form&.id, errors: claim&.errors&.errors,
+                           message: e&.message })
+    end
+
+    ##
+    # log POST processing success
+    # @see BurialClaimsController
+    #
+    # @param in_progress_form [InProgressForm]
+    # @param claim [SavedClaim::Burial]
+    # @param current_user [User]
+    #
+    def track_create_success(in_progress_form, claim, current_user)
+      StatsD.increment("#{CLAIM_STATS_KEY}.success")
+      if claim.form_start_date
+        claim_duration = claim.created_at - claim.form_start_date
+        tags = ["form_id:#{claim.form_id}"]
+        StatsD.measure('saved_claim.time-to-file', claim_duration, tags:)
+      end
+      context = {
+        confirmation_number: claim&.confirmation_number,
+        user_uuid: current_user&.uuid,
+        in_progress_form_id: in_progress_form&.id
+      }
+      Rails.logger.info('21P-530EZ submission to Sidekiq success', context)
+    end
+  end
+end

--- a/spec/lib/burials/monitor_spec.rb
+++ b/spec/lib/burials/monitor_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../lib/burials/monitor'
+
+RSpec.describe Burials::Monitor do
+  let(:monitor) { described_class.new }
+  let(:claim_stats_key) { described_class::CLAIM_STATS_KEY }
+  let(:claim) { create(:burial_claim_v2) }
+  let(:ipf) { create(:in_progress_form) }
+
+  context 'with all params supplied' do
+    let(:current_user) { create(:user) }
+    let(:monitor_error) { create(:monitor_error) }
+    let(:lh_service) { OpenStruct.new(uuid: 'uuid') }
+
+    describe '#track_show404' do
+      it 'logs a not found error' do
+        log = '21P-530EZ submission not found'
+        payload = {
+          confirmation_number: claim.confirmation_number,
+          user_uuid: current_user.uuid,
+          message: monitor_error.message
+        }
+
+        expect(Rails.logger).to receive(:error).with(log, payload)
+
+        monitor.track_show404(claim.confirmation_number, current_user, monitor_error)
+      end
+    end
+
+    describe '#track_show_error' do
+      it 'logs a submission failed error' do
+        log = '21P-530EZ fetching submission failed'
+        payload = {
+          confirmation_number: claim.confirmation_number,
+          user_uuid: current_user.uuid,
+          message: monitor_error.message
+        }
+
+        expect(Rails.logger).to receive(:error).with(log, payload)
+
+        monitor.track_show_error(claim.confirmation_number, current_user, monitor_error)
+      end
+    end
+
+    describe '#track_create_attempt' do
+      it 'logs sidekiq started' do
+        log = '21P-530EZ submission to Sidekiq begun'
+        payload = {
+          confirmation_number: claim.confirmation_number,
+          user_uuid: current_user.uuid
+        }
+
+        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.attempt")
+        expect(Rails.logger).to receive(:info).with(log, payload)
+
+        monitor.track_create_attempt(claim, current_user)
+      end
+    end
+
+    describe '#track_create_error' do
+      it 'logs sidekiq failed' do
+        log = '21P-530EZ submission to Sidekiq failed'
+        payload = {
+          confirmation_number: claim.confirmation_number,
+          user_uuid: current_user.uuid,
+          in_progress_form_id: ipf.id,
+          errors: [], # mock claim does not have `errors`
+          message: monitor_error.message
+        }
+
+        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.failure")
+        expect(Rails.logger).to receive(:error).with(log, payload)
+
+        monitor.track_create_error(ipf, claim, current_user, monitor_error)
+      end
+    end
+
+    describe '#track_create_success' do
+      it 'logs sidekiq success' do
+        log = '21P-530EZ submission to Sidekiq success'
+        payload = {
+          confirmation_number: claim.confirmation_number,
+          user_uuid: current_user.uuid,
+          in_progress_form_id: ipf.id
+        }
+        claim.form_start_date = Time.zone.now
+
+        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.success")
+        expect(StatsD).to receive(:measure).with('saved_claim.time-to-file', claim.created_at - claim.form_start_date,
+                                                 tags: ["form_id:#{claim.form_id}"])
+        expect(Rails.logger).to receive(:info).with(log, payload)
+
+        monitor.track_create_success(ipf, claim, current_user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In an effort to remove zero silent errors, we wanted to clone the Pensions::Monitor for Burials.


## Summary

- Duplicate `Pensions::Monitor` into `Burials::Monitor`
- Update `burial_claims_controller` with monitor logic
- Add Rspec for new monitor
- Update burial controller tests to check for new monitors

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1278/views/6?pane=issue&itemId=77643998

## Testing done

- [ ] *New Rspec tests*
- [ ] *Manual Testing*

## Screenshots
_Note: Grabbed `SavedClaim::Burial.last.to_pdf` to confirm stamping still accurate on form_
<img width="935" alt="Screenshot 2024-09-19 at 5 58 09 PM" src="https://github.com/user-attachments/assets/9dbcdd4b-87b2-443d-bd13-1fa4b2032e78">

## What areas of the site does it impact?
21p-530ex form submissions

## Acceptance criteria

- [ ] The 21p-530ex form submissions remain unchanged in stamping and processing
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
