### PR TITLE
dbex/93079: uniqify multiple exposures

### DIFF
--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -291,6 +291,17 @@ module EVSS
                                                        MULTIPLE_EXPOSURES_TYPE[:hazard])
         end
 
+        # multiple exposures could have repeated values that LH will not accept in the primary path.
+        # remove them!
+        multiple_exposures.uniq! do |exposure|
+          [
+            exposure.exposure_dates.begin_date,
+            exposure.exposure_dates.end_date,
+            exposure.exposure_location,
+            exposure.hazard_exposed_to
+          ]
+        end
+
         toxic_exposure_target.multiple_exposures = multiple_exposures
 
         toxic_exposure_target

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -53,6 +53,33 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(result.toxic_exposure.multiple_exposures.class).to eq(Array)
       expect(result.claim_notes).to eq('some overflow text')
     end
+
+    it 'sends uniq values in multiple exposures array' do
+      expect(transformer).to receive(:evss_claims_process_type)
+        .with(data['form526'])
+        .and_return('STANDARD_CLAIM_PROCESS')
+      # "airspace" is the repeated multiple exposure
+      data['form526']['toxicExposure'].merge!({
+                                                'gulfWar2001Details' =>
+                                                  { 'airspace' => { 'startDate' => '2014-01-26',
+                                                                    'endDate' => '2014-02-28' },
+                                                    'yemen' => { 'startDate' => '2014-01-26',
+                                                                 'endDate' => '2014-02-28' },
+                                                    'djibouti' => { 'startDate' => '2014-01-26',
+                                                                    'endDate' => '2014-02-28' } },
+                                                'gulfWar2001' => { 'djibouti' => true, 'yemen' => true,
+                                                                   'airspace' => true },
+                                                'gulfWar1990Details' =>
+                     { 'airspace' => { 'startDate' => '2014-01-26', 'endDate' => '2014-02-28' },
+                       'somalia' => { 'startDate' => '2014-01-26', 'endDate' => '2014-02-28' },
+                       'kuwait' => { 'startDate' => '2014-01-26', 'endDate' => '2014-02-28' } },
+                                                'gulfWar1990' => { 'kuwait' => true, 'somalia' => true,
+                                                                   'airspace' => true }
+                                              })
+      result = transformer.transform(data)
+      # since this is now a uniq list, it is now 12 items instead of 13
+      expect(result.toxic_exposure.multiple_exposures.count).to eq(12)
+    end
   end
 
   describe 'optional request objects are correctly rendered' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- ensures toxicExposures.multipleExposures are truly unique from one another

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#93079

## Testing done

- [x] *New code is covered by unit tests*
- form526 submission requests to LH were failing if the user chose more than one of the same location per exposure event
  - now they shouldn't!

## Screenshots
n/a

## What areas of the site does it impact?
Form526 primary path submission job - less 422s due to this fix :)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
