### PR TITLE
Fix data format for mailer

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -74,7 +74,7 @@ class FormSubmissionAttempt < ApplicationRecord
 
   def enqueue_result_email(notification_type)
     config = {
-      form_data: form_submission.form_data,
+      form_data: JSON.parse(form_submission.form_data),
       form_number: form_submission.form_type,
       confirmation_number: form_submission.benefits_intake_uuid,
       date_submitted: created_at.strftime('%B %d, %Y'),

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -270,11 +270,12 @@ module SimpleFormsApi
           confirmation_number:,
           date_submitted: Time.zone.today.strftime('%B %d, %Y')
         }
-        SimpleFormsApi::NotificationEmail.new(
+        notification_email = SimpleFormsApi::NotificationEmail.new(
           config,
           notification_type: :confirmation,
           user: @current_user
-        ).send
+        )
+        notification_email.send
       end
     end
   end

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -25,7 +25,12 @@ module SimpleFormsApi
       check_missing_keys(config)
 
       @form_data = config[:form_data]
-      @form_number = config[:form_number]
+      incoming_form_number = config[:form_number]
+      @form_number = if TEMPLATE_IDS.keys.include?(incoming_form_number)
+                       incoming_form_number
+                     else
+                       SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[incoming_form_number]
+                     end
       @confirmation_number = config[:confirmation_number]
       @date_submitted = config[:date_submitted]
       @lighthouse_updated_at = config[:lighthouse_updated_at]

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :form_submission do
     form_type { '21-4142' }
-    form_data { '' }
+    form_data { '{}' }
     benefits_intake_uuid { SecureRandom.uuid }
 
     trait :pending do


### PR DESCRIPTION
## Summary
This PR fixes a couple subtle bugs I found while testing the Simple Forms error emailer: the `form_data` and `form_number` were coming in incorrect.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1668
