### PR TITLE
Postman tests post install/upgrade

### DIFF
--- a/chart/templates/postman-test.yaml
+++ b/chart/templates/postman-test.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -7,9 +8,9 @@ metadata:
 spec:
   containers:
     - name: postman
-      image: "{{ .Values.image.testRepository }}:{{ .Values.image.tag }}"
+      image: "{{ $root.Values.image.value }}:{{ $root.Values.image.tag }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       env:
         - name: "API_URL"
-          value: "https://dev-api.va.gov"
+          value: "https://{{ $root.Values.domain }}"
   restartPolicy: Never

--- a/chart/templates/postman-test.yaml
+++ b/chart/templates/postman-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "vets-api-postman-test"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  containers:
+    - name: postman
+      image: "{{ .Values.image.testRepository }}:{{ .Values.image.tag }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      env:
+        - name: "API_URL"
+          value: "https://dev-api.va.gov"
+  restartPolicy: Never

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,8 +1,10 @@
 appName:
 target_env:
+domain:
 manualRoll:
 image:
   value:
+  testRepository: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/vets-api-postman
   tag:
   pullPolicy: Always
 vsp_environment:


### PR DESCRIPTION


## Summary

- changes to parent helm chart to include a post install/upgrade postman test - confirming basic functionality of vets-api in the cluster.

## Related issue(s)

- [EKS Testing: Reliability; Create a helm test after sync hook](https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/91595)
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3105
- https://github.com/department-of-veterans-affairs/vets-api/pull/18536

## Testing done

- These changes were testing in preview environment deployments, as well as targetting dev, sandbox, staging and production from a local container and a container running in a preview environment


## What areas of the site does it impact?
deployment

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

NOTE - these PRs must be merged prior to merging this PR - 
https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3105
https://github.com/department-of-veterans-affairs/vets-api/pull/18536

