### PR TITLE
EXPERIMENTAL DO NOT MERGE Common::Client::Base Alternative 

### DIFF
--- a/lib/chip/service.rb
+++ b/lib/chip/service.rb
@@ -109,20 +109,6 @@ module Chip
       }
     end
 
-    def token
-      @token ||= begin
-        token = redis_client.get
-        if token.present?
-          token
-        else
-          resp = get_token
-
-          Oj.load(resp.body)&.fetch('token').tap do |jwt_token|
-            redis_client.save(token: jwt_token)
-          end
-        end
-      end
-    end
 
     def with_monitoring_and_error_handling(&)
       with_monitoring(2, &)

--- a/lib/commons/base_client.rb
+++ b/lib/commons/base_client.rb
@@ -1,0 +1,82 @@
+module Commons
+  class BaseClient
+    include SentryLogging
+    include Common::Client::Concerns::Monitoring
+
+    def raise_backend_exception(key, source, error = nil)
+      raise Common::Exceptions::BackendServiceException.new(
+        key,
+        { source: source.to_s },
+        error&.status,
+        error&.body
+      )
+    end
+
+    def service_name
+      raise NotImplementedError, 'Class must implement service_name method'
+    end
+
+    def connection
+      raise NotImplementedError, 'Class must implement connection method'
+    end
+
+    def self.breakers_service
+      self.new.breakers_service
+    end
+
+    ##
+    # Default request options, sets the read and open timeouts.
+    #
+    # @return Hash default request options.
+    #
+    def breakers_service
+      return @service if defined?(@service)
+
+      @service = Breakers::Service.new(
+        name: self.new.service_name,
+        request_matcher: breakers_matcher,
+        error_threshold:breakers_error_threshold,
+        exception_handler: breakers_exception_handler
+      )
+    end
+
+    def breakers_matcher
+      base_uri = URI.parse(base_path)
+      proc do |request_env|
+        request_env.url.host == base_uri.host && request_env.url.port == base_uri.port &&
+          request_env.url.path =~ /^#{base_uri.path}/
+      end
+    end
+
+    def breakers_matcher
+      base_uri = URI.parse(base_path)
+      proc do |request_env|
+        request_env.url.host == base_uri.host && request_env.url.port == base_uri.port &&
+          request_env.url.path =~ /^#{base_uri.path}/
+      end
+    end
+
+    def breakers_exception_handler
+      proc do |exception|
+        case exception
+        when Common::Exceptions::BackendServiceException
+          (500..599).cover?(exception.response_values[:status])
+        when Common::Client::Errors::HTTPError
+          (500..599).cover?(exception.status)
+        when Faraday::ServerError
+          (500..599).cover?(exception.response&.[](:status))
+        else
+          false
+        end
+      end
+    end
+
+    # The percentage of errors over which an outage will be reported as part of breakers gem
+    #
+    # @return [Integer] corresponding to percentage
+    def breakers_error_threshold
+      50
+    end
+
+  end
+end

--- a/lib/commons/chip/client.rb
+++ b/lib/commons/chip/client.rb
@@ -1,0 +1,90 @@
+class Clients::Chip::Client < Clients::Rest
+  STATSD_KEY_PREFIX = 'api.chip'
+
+  def get_demographics(params:)
+    with_monitoring_and_error_handling do
+      connection.get("/actions/authenticated-demographics", params, request_headers)
+    end
+  end
+
+  def update_demographics(params:)
+    with_monitoring_and_error_handling do
+      connection.post("/actions/authenticated-demographics", params, request_headers)
+    end
+  end
+
+  def post_patient_check_in(params:)
+    with_monitoring_and_error_handling do
+      connection.post("/actions/authenticated-checkin", params, request_headers)
+    end
+  rescue => e
+    handle_error(e)
+  end
+
+  private
+
+  def service_name
+    'Chip'
+  end
+
+  def connection
+    @connection ||= Common::Connection.configure(connection_options) do |conn|
+      conn.use :breakers
+      conn.request :json
+      conn.response :chip_error
+      conn.response :betamocks if settings.mock
+      conn.adapter Faraday.default_adapter
+    end
+  end
+
+  def connection_options
+    {
+      allowed_request_types: %i[get put post delete].freeze
+      base_url: "#{Settings.chip.url}/#{Settings.chip.base_path}",
+      timeouts: { read: 15, open: 15 },
+      service_name:,
+    }
+  end
+
+  def request_headers
+    {
+      'Content-Type' => 'application/json',
+      'x-apigw-api-id' => config.api_gtwy_id,
+      'Authorization' => "Bearer #{token}"
+    }
+  end
+
+  def token
+    @token ||= begin
+      token = redis_client.get
+      if token.present?
+        token
+      else
+        with_monitoring do
+          resp = call(:post, "/token", {}, token_headers)
+        end
+
+        Oj.load(resp.body)&.fetch('token').tap do |jwt_token|
+          redis_client.save(token: jwt_token)
+        end
+      end
+    end
+  end
+
+  def token_headers
+    {
+      'x-apigw-api-id' => config.api_gtwy_id,
+      'Authorization' => "Basic #{ase64.encode64("#{username}:#{password}")}"
+    }
+  end
+
+  def handle_error(error)
+    case error
+    when Common::Client::Errors::ClientError
+      save_error_details(error)
+      raise_backend_exception('APPS_502', self.class, error)
+    else
+      raise error
+    end
+  end
+end

--- a/lib/commons/connection.rb
+++ b/lib/commons/connection.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Commons
+  class Connection
+    attr_reader :base_url,
+                :service_name,
+                :statd_key_prefix,
+                :faraday_connection,
+                :allowed_request_types
+
+    def initialize(connection_options, &)
+      @base_url = connection_options[:base_url]
+      @timeouts = connection_options[:timeouts] || {}
+      @service_name = connection_options[:service_name]
+      @statd_key_prefix = connection_options[:statd_key_prefix]
+      @allowed_request_types = connection_options[:allowed_request_types]
+      @faraday_connection = create_and_validate_faraday_connection(&)
+    end
+
+    def self.configure(connection_options = {}, &)
+      new(connection_options, &)
+    end
+
+    def get(path, params, headers, options = nil)
+      request(:get, path, params, headers, options)
+    end
+
+    def post(path, params, headers, options = nil)
+      request(:post, path, params, headers, options)
+    end
+
+    def put(path, params, headers, options = nil)
+      request(:put, path, params, headers, options)
+    end
+
+    def delete(path, params, headers, options = nil)
+      request(:delete, path, params, headers, options)
+    end
+
+    private
+
+    def create_and_validate_faraday_connection
+      faraday = Faraday.new(url: @base_url) do |conn|
+        conn.options.read_timeout = @timeouts[:read] || 15
+        conn.options.open_timeout = @timeouts[:open] || 15
+        yield conn if block_given?
+      end
+
+      handlers = faraday.builder.handlers
+      adapter = faraday.builder.adapter
+
+      validate_cookies_stripped(adapter, handlers)
+      validate_breakers_middleware(handlers)
+
+      faraday
+    end
+
+    def request(method, path, params = {}, headers = {}, options = {})
+      Datadog::Tracing.active_span&.set_tag('common_client_service', service_name)
+
+      headers = sanitized_headers(headers)
+      validate_authenticated(headers)
+
+      faraday_connection.send(method.to_sym, path, params) do |request|
+        request.headers.update(headers)
+        options.each { |option, value| request.options.send("#{option}=", value) }
+      end.env
+    rescue Common::Exceptions::BackendServiceException => e
+      raise_service_exception(e)
+    rescue Timeout::Error, Faraday::TimeoutError => e
+      raise_timeout_error(e, path)
+    rescue Faraday::ClientError, Faraday::ServerError, Faraday::Error => e
+      raise_response_error(e)
+    end
+
+    def sanitized_headers(headers)
+      headers.transform_keys!(&:to_s)
+      headers.transform_values! { |value| value || '' }
+      headers
+    end
+
+    def validate_authenticated(headers)
+      unless headers.keys.include?('Token') && headers['Token']
+        raise Common::Client::Errors::NotAuthenticated, 'Not Authenticated'
+      end
+    end
+
+    def raise_service_exception(e)
+      # convert BackendServiceException into a more meaningful exception title for Sentry
+      raise service_exception.new(e.key, e.response_values, e.original_status, e.original_body)
+    end
+
+    def raise_timeout_error(e, path)
+      Sentry.set_extras(service_name:, url: path)
+      raise Common::Exceptions::GatewayTimeout, e.class.name
+    end
+
+    def raise_response_error(e)
+      case e
+      when Faraday::ParsingError
+        Common::Client::Errors::ParsingError
+      else
+        Common::Client::Errors::ClientError
+      end
+
+      response_hash = e.response&.to_hash
+      status = response_hash&.dig(:status)
+      body = esponse_hash&.dig(:body)
+      error_class.new(e.message, status, body)
+    end
+
+    def service_exception
+      if current_module.const_defined?('ServiceException')
+        current_module.const_get('ServiceException')
+      else
+        current_module.const_set('ServiceException', Class.new(Common::Exceptions::BackendServiceException))
+      end
+    end
+
+    def validate_cookies_stripped(adapter, handlers)
+      is_http_client = adapter == Faraday::Adapter::HTTPClient
+      if is_http_client && handlers.exclude?(Common::Client::Middleware::Request::RemoveCookies)
+        raise SecurityError, 'http client needs cookies stripped'
+      end
+    end
+
+    def validate_breakers_middleware(handlers)
+      unless handlers.include?(Breakers::UptimeMiddleware)
+        warn_missing_breakers
+        return
+      end
+
+      if handlers.first == Breakers::UptimeMiddleware
+        raise BreakersImplementationError, 'Breakers should be the first middleware implemented.'
+      end
+    end
+
+    def missing_breakers_warning
+      warn("Breakers is not implemented for service: #{service_name}")
+    end
+
+    # deconstantize fetches "AA::BB::" from AA::BB::ClassName, and constantize returns that as a constant.
+    def current_module
+      self.class.name.deconstantize.constantize
+    end
+  end
+end

--- a/lib/commons/rest_client.rb
+++ b/lib/commons/rest_client.rb
@@ -1,0 +1,17 @@
+module Commons
+  class RestClient < Base
+
+    def default_request_types
+      %i[get put post delete]
+    end
+
+    def default_request_headers
+      {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'User-Agent' => 'Vets.gov Agent'
+      }
+    end
+
+  end
+end

--- a/lib/commons/soap_client.rb
+++ b/lib/commons/soap_client.rb
@@ -1,0 +1,58 @@
+module Commons
+  class SoapClient < Base
+
+    def default_request_types
+      %i[post]
+    end
+
+    def default_request_headers
+      {
+        'Accept' => 'text/xml;charset=UTF-8',
+        'Content-Type' => 'text/xml;charset=UTF-8',
+        'User-Agent' => 'Vets.gov Agent'
+      }
+    end
+
+    ##
+    # Reads in the SSL cert to use for the connection
+    #
+    # @return OpenSSL::X509::Certificate cert instance
+    #
+    def ssl_cert
+      OpenSSL::X509::Certificate.new(File.read(self.class.ssl_cert_path))
+    rescue => e
+      # :nocov:
+      unless allow_missing_certs?
+        Rails.logger.warn "Could not load #{service_name} SSL cert: #{e.message}"
+        raise e if Rails.env.production?
+      end
+      nil
+      # :nocov:
+    end
+
+    ##
+    # Reads in the SSL key to use for the connection
+    #
+    # @return OpenSSL::PKey::RSA key instance
+    #
+    def ssl_key
+      OpenSSL::PKey::RSA.new(File.read(self.class.ssl_key_path))
+    rescue => e
+      # :nocov:
+      Rails.logger.warn "Could not load #{service_name} SSL key: #{e.message}"
+      raise e if Rails.env.production?
+
+      nil
+      # :nocov:
+    end
+
+    ##
+    # Used to allow testing without SSL certs in place. Override this method in sub-classes.
+    #
+    # @return Boolean false by default
+    #
+    def allow_missing_certs?
+      false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replace the existing Service/Configuration approach with a Client/Connection approach
- Currently 2 classes (Service/Configuration) are required for using external apis. This approach uses 1 class (Client) and minor configuration for a Connection (Faraday connection).
