### PR TITLE
send CG claim created_at to CARMA as submitted_at metadata

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -66,6 +66,9 @@ features:
   caregiver_browser_monitoring_enabled:
     actor_type: user
     description: Enables Datadog Real Time User Monitoring
+  caregiver_carma_submitted_at:
+    actor_type: user
+    description: Enables sending CARMA the creation timestamp of a claim as a metadata submitted_at value
   hca_browser_monitoring_enabled:
     actor_type: user
     description: Enables browser monitoring for the health care application.

--- a/lib/carma/models/metadata.rb
+++ b/lib/carma/models/metadata.rb
@@ -9,13 +9,15 @@ module CARMA
     class Metadata < Base
       request_payload_key :claim_id,
                           :claim_guid,
+                          :submitted_at,
                           :veteran,
                           :primary_caregiver,
                           :secondary_caregiver_one,
                           :secondary_caregiver_two
 
       attr_accessor       :claim_id,
-                          :claim_guid
+                          :claim_guid,
+                          :submitted_at
 
       attr_reader         :veteran,
                           :primary_caregiver,
@@ -25,6 +27,7 @@ module CARMA
       def initialize(args = {})
         @claim_id = args[:claim_id]
         @claim_guid = args[:claim_guid]
+        @submitted_at = args[:submitted_at]
 
         self.veteran = args[:veteran] || {}
         self.primary_caregiver = args[:primary_caregiver]

--- a/lib/carma/models/submission.rb
+++ b/lib/carma/models/submission.rb
@@ -19,6 +19,17 @@ module CARMA
       # @return [CARMA::Models::Submission] A CARMA Submission model object
       #
       def self.from_claim(claim, metadata = {})
+        if Flipper.enabled?(:caregiver_carma_submitted_at)
+          return new(
+            data: claim.parsed_form,
+            metadata: metadata.merge(
+              claim_id: claim.id,
+              claim_guid: claim.guid,
+              submitted_at: claim.created_at&.iso8601
+            )
+          )
+        end
+
         new(
           data: claim.parsed_form,
           metadata: metadata.merge(claim_id: claim.id, claim_guid: claim.guid)

--- a/spec/lib/carma/models/metadata_spec.rb
+++ b/spec/lib/carma/models/metadata_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
     end
   end
 
+  describe '#submitted_at' do
+    it 'is accessible' do
+      claim_created_at = DateTime.now.iso8601
+      subject.submitted_at = claim_created_at
+      expect(subject.submitted_at).to eq(claim_created_at)
+    end
+  end
+
   describe '#veteran' do
     it 'is accessible' do
       subject.veteran = { icn: 'ABCD1234', is_veteran: true }
@@ -87,10 +95,12 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
       expect(subject.secondary_caregiver_two).to eq(nil)
     end
 
-    it 'accepts :claim_id, :veteran, :primary_caregiver, :secondary_caregiver_one, :secondary_caregiver_two' do
+    it 'accepts claim_id, submitted_at, veteran, primary_caregiver, secondary_caregiver_one, secondary_caregiver_two' do
+      claim_created_at = DateTime.now.iso8601
       subject = described_class.new(
         claim_id: 123,
         claim_guid: 'my-uuid',
+        submitted_at: claim_created_at,
         veteran: {
           icn: 'VET1234',
           is_veteran: true
@@ -108,6 +118,7 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
 
       expect(subject.claim_id).to eq(123)
       expect(subject.claim_guid).to eq('my-uuid')
+      expect(subject.submitted_at).to eq(claim_created_at)
       expect(subject.veteran.icn).to eq('VET1234')
       expect(subject.veteran.is_veteran).to eq(true)
       expect(subject.primary_caregiver.icn).to eq('PC1234')
@@ -126,6 +137,7 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
         %i[
           claim_id
           claim_guid
+          submitted_at
           veteran
           primary_caregiver
           secondary_caregiver_one
@@ -151,6 +163,7 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
             {
               'claimId' => 123,
               'claimGuid' => 'my-uuid',
+              'submittedAt' => nil,
               'veteran' => {
                 'icn' => nil,
                 'isVeteran' => nil
@@ -179,6 +192,7 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
             {
               'claimId' => 123,
               'claimGuid' => 'my-uuid',
+              'submittedAt' => nil,
               'veteran' => {
                 'icn' => nil,
                 'isVeteran' => nil
@@ -196,9 +210,11 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
 
     context 'with a maximum data set' do
       it 'can receive :to_request_payload' do
+        claim_created_at = DateTime.now.iso8601
         subject = described_class.new(
           claim_id: 123,
           claim_guid: 'my-uuid',
+          submitted_at: claim_created_at,
           veteran: {
             icn: 'VET1234',
             is_veteran: true
@@ -218,6 +234,7 @@ RSpec.describe CARMA::Models::Metadata, type: :model do
           {
             'claimId' => 123,
             'claimGuid' => 'my-uuid',
+            'submittedAt' => claim_created_at,
             'veteran' => {
               'icn' => 'VET1234',
               'isVeteran' => true


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): YES*: `caregiver_carma_submitted_at`
- Add `submitted_at` subattribute to submission metadata, set to the claim's `created_at`
- 10-10 Health Enrollment EZ/CG Team
- *(If introducing a flipper, what is the success criteria being targeted?)* enabling the flag sends the expected data

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93116

## Testing done

- [x] *New code is covered by unit tests*
- Before: send the same data but without the submitted_at metadata attribute
- After: include the attribute
- locally, I added console output to confirm that the relevant attribute was set:
```
[...] "metadata" => { "claimId" => 5, "claimGuid" => "fb23e7f2-3121-47e9-af41-009194867c1b", "submittedAt" => "2024-09-20T18:05:20Z", [...]
```

- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- Fill out a CG application, and submit it
- Confirm that CARMA receives submission with the attribute set
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
  - since the functionality doesn't require a login, we can confirm when enabled in Staging, merge to Production, then enable the feature flag universally.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
