### PR TITLE
Pension 90726 temp file cleanup monitoring

### DIFF
--- a/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
+++ b/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
@@ -184,16 +184,14 @@ module Pensions
     end
 
     ##
-    # Delete temporary stamped PDF files for this job instance.
-    #
-    # @raise [PensionBenefitIntakeError] if unable to delete file
+    # Delete temporary stamped PDF files for this job instance
+    # catches any error, logs but does NOT re-raise - prevent job retry
     #
     def cleanup_file_paths
       Common::FileHelpers.delete_file_if_exists(@form_path) if @form_path
       @attachment_paths&.each { |p| Common::FileHelpers.delete_file_if_exists(p) }
     rescue => e
       @pension_monitor.track_file_cleanup_error(@claim, @intake_service, @user_account_uuid, e)
-      raise PensionBenefitIntakeError, e.message
     end
   end
 end

--- a/modules/pensions/lib/pensions/monitor.rb
+++ b/modules/pensions/lib/pensions/monitor.rb
@@ -196,6 +196,7 @@ module Pensions
     # @param e [Error]
     #
     def track_file_cleanup_error(claim, lighthouse_service, user_uuid, e)
+      StatsD.increment("#{SUBMISSION_STATS_KEY}.cleanup_failed")
       Rails.logger.error('Lighthouse::PensionBenefitIntakeJob cleanup failed',
                          {
                            claim_id: claim&.id,

--- a/modules/pensions/spec/sidekiq/pensions/pension_benefit_intake_job_spec.rb
+++ b/modules/pensions/spec/sidekiq/pensions/pension_benefit_intake_job_spec.rb
@@ -116,12 +116,9 @@ RSpec.describe Pensions::PensionBenefitIntakeJob, :uploader_helpers do
       allow(monitor).to receive(:track_file_cleanup_error)
     end
 
-    it 'returns expected hash' do
+    it 'errors and logs but does not reraise' do
       expect(monitor).to receive(:track_file_cleanup_error)
-      expect { job.send(:cleanup_file_paths) }.to raise_error(
-        Pensions::PensionBenefitIntakeJob::PensionBenefitIntakeError,
-        anything
-      )
+      job.send(:cleanup_file_paths)
     end
   end
 


### PR DESCRIPTION
## Summary

no longer raising error if issue during job cleanup

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/90726

## Testing done

- [x] *New code is covered by unit tests*
- local run of job, forcing an error during cleanup
- caught and message logged but no additional error

## What areas of the site does it impact?

pension

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
