### PR TITLE
[VI-468] Add mhv_user_account to User

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'mhv/account_creation/service'
 
 RSpec.describe User, type: :model do
   subject { described_class.new(build(:user)) }
@@ -1236,6 +1237,104 @@ RSpec.describe User, type: :model do
         Flipper.disable(:veteran_onboarding_beta_flow)
         Flipper.disable(:veteran_onboarding_show_to_newly_onboarded)
         expect(user.show_onboarding_flow_on_login).to be_falsey
+      end
+    end
+  end
+
+  describe '#mhv_user_account' do
+    let(:user) { build(:user, :loa3, vha_facility_ids:) }
+    let(:vha_facility_ids) { %w[450MH] }
+    let(:icn) { user.icn }
+
+    let!(:user_verification) do
+      create(:idme_user_verification, idme_uuid: user.idme_uuid, user_credential_email:, user_account:)
+    end
+    let(:user_credential_email) { create(:user_credential_email) }
+    let(:user_account) { create(:user_account, icn:) }
+    let!(:terms_of_use_agreement) { create(:terms_of_use_agreement, user_account:, response: terms_of_use_response) }
+    let(:terms_of_use_response) { 'accepted' }
+
+    let(:mhv_client) { MHV::AccountCreation::Service.new }
+    let(:mhv_response) do
+      {
+        user_profile_id: '12345678',
+        premium: true,
+        champ_va: true,
+        patient: true,
+        sm_account_created: true,
+        message: 'some-message'
+      }
+    end
+
+    before do
+      allow(Rails.logger).to receive(:info)
+    end
+
+    context 'when the user is a va_patient' do
+      before do
+        allow(MHV::AccountCreation::Service).to receive(:new).and_return(mhv_client)
+        allow(mhv_client).to receive(:create_account).and_return(mhv_response)
+      end
+
+      context 'when the user has all required attributes' do
+        it 'returns a MHVUserAccount with the expected attributes' do
+          mhv_user_account = user.mhv_user_account
+
+          expect(mhv_user_account).to be_a(MHVUserAccount)
+          expect(mhv_user_account.attributes).to eq(mhv_response.with_indifferent_access)
+        end
+      end
+
+      context 'when there is an error creating the account' do
+        shared_examples 'mhv_user_account error' do
+          let(:expected_log_message) { '[User] mhv_user_account error' }
+          let(:expected_log_payload) { { error_message: /#{expected_error_message}/, icn: user.icn } }
+
+          it 'logs an error and returns nil' do
+            expect(user.mhv_user_account).to be_nil
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          end
+        end
+
+        context 'when the user does not have a terms_of_use_agreement' do
+          let(:terms_of_use_agreement) { nil }
+          let(:expected_error_message) { 'Current terms of use agreement must be present' }
+
+          it_behaves_like 'mhv_user_account error'
+        end
+
+        context 'when the user has not accepted the terms of use' do
+          let(:terms_of_use_response) { 'declined' }
+          let(:expected_error_message) { "Current terms of use agreement must be 'accepted'" }
+
+          it_behaves_like 'mhv_user_account error'
+        end
+
+        context 'when the user does not have a user_credential_email' do
+          let(:user_credential_email) { nil }
+          let(:expected_error_message) { 'Email must be present' }
+
+          it_behaves_like 'mhv_user_account error'
+        end
+
+        context 'when the user does not have an icn' do
+          let(:icn) { nil }
+          let(:expected_error_message) { 'ICN must be present' }
+
+          it_behaves_like 'mhv_user_account error'
+        end
+      end
+    end
+
+    context 'when the user is not a va_patient' do
+      let(:vha_facility_ids) { [] }
+      let(:expected_log_message) { '[User] mhv_user_account error' }
+      let(:expected_log_payload) { { error_message: expected_error_message, icn: user.icn } }
+      let(:expected_error_message) { 'User has no va_treatment_facility_ids' }
+
+      it 'logs an error and returns nil' do
+        expect(user.mhv_user_account).to be_nil
+        expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
       end
     end
   end


### PR DESCRIPTION
## Summary
- add `mhv_user_account` to `User`. Calls `MHV::UserAccount::Creator`
- This will on populate a user has:
  - `va_treatment_facility_ids`
  - `icn`
  - `credential_email`
  - `accepted` current `terms_of_use_agreement`

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-468

## Testing 
- add `conn.request :curl` to the mhv account_creation service [connection](https://github.com/department-of-veterans-affairs/vets-api/blob/7bbbff9d456f560a2879c669b31dd707b51cb651/lib/mhv/account_creation/configuration.rb#L45-L53)
   ```ruby
   def connection
      Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
        conn.use :breakers
        conn.use Faraday::Response::RaiseError
        conn.adapter Faraday.default_adapter
        conn.request :curl
        conn.response :json
        conn.response :betamocks if Settings.mhv.account_creation.mock
      end
    end
   ```
- Start vets-api and vets-website
- Login with a user that is a `va_patient`.  - `vets.gov.user+1` works
- Accept terms if you haven't already
- Find the `lgoingov_uuid` or `idme_uuid` of the user you logged in with - `http://localhost:3000/v0/user`
- in the rails console, find the User and call `mhv_user_account`
   ```ruby
   user = User.find({logingov_uuid of idme_uuid}}
   user.mhv_user_account
   ```
   
   This wont work since this is only reachable on staging.
   You should see the curl request logged and some other logs about the attempted request
   ```ruby
   Rails -- [MHV][AccountCreation][Service] sts token request success -- { :user_identifier => "1008596379V859838" }
   WARN -- : curl -v -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'User-Agent: Vets.gov Agent' -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3...' -H 'x-api-key: some-access-key' -d '{"icn":"1008596379V859838","email":"vets.gov.user+1@gmail.com","vaTermsOfUseDateTime":"2024-05-14T15:29:19Z","vaTermsOfUseStatus":"accepted","vaTermsOfUseRevision":"3","vaTermsOfUseLegalVersion":"1.0","vaTermsOfUseDocTitle":"VA Enterprise Terms of Use"}' "https://apigw-intb.aws.myhealth.va.gov/v1/usermgmt/account-service/account"
   Rails -- [MHV][AccountCreation][Service] create_account client_error -- { :error_message => "Failed to open TCP connection to apigw-intb.aws.myhealth.va.gov:443 (getaddrinfo: nodename nor servname provided, or not known)", :body => nil, :icn => "1008596379V859838" }
   Rails -- [MHV][UserAccount][Creator] client error -- { :error_message => "Failed to open TCP connection to apigw-intb.aws.myhealth.va.gov:443 (getaddrinfo: nodename nor servname provided, or not known)", :icn => "1008596379V859838" }
   Rails -- [User] mhv_user_account error -- { :error_message => "Failed to open TCP connection to apigw-intb.aws.myhealth.va.gov:443 (getaddrinfo: nodename nor servname provided, or not known)", :icn => "1008596379V859838" }
   ```



## Screenshots
_Note: Optional_

## What areas of the site does it impact?
`User`, `MHVUserAccount`

