### PR TITLE
[SIMPLE_FORMS] fix update submission archive builder logic to fix bugs

### DIFF
--- a/modules/simple_forms_api/lib/tasks/archive_forms_by_uuid.rake
+++ b/modules/simple_forms_api/lib/tasks/archive_forms_by_uuid.rake
@@ -2,11 +2,11 @@
 
 # Invoke this as follows:
 #  Set the parameters as variables ahead of time:
-#    rails simple_forms_api:archive_forms_by_uuid[benefits_intake_uuids, parent_dir]
+#    bundle exec rails simple_forms_api:archive_forms_by_uuid[benefits_intake_uuids, parent_dir]
 #  Pass in UUIDs only if default parent_dir is appropriate:
-#    rails simple_forms_api:archive_forms_by_uuid[abc-123 def-456]
-# Pass in new directory to override default:
-#    rails simple_forms_api:archive_forms_by_uuid[abc-123 def-456,custom-directory]
+#    bundle exec rails simple_forms_api:archive_forms_by_uuid[abc-123 def-456]
+#  Pass in new directory to override default:
+#    bundle exec rails simple_forms_api:archive_forms_by_uuid[abc-123 def-456,custom-directory]
 namespace :simple_forms_api do
   desc 'Kick off the SubmissionArchiveHandler to archive submissions to S3 and print presigned URLs'
   task :archive_forms_by_uuid, %i[benefits_intake_uuids parent_dir] => :environment do |_, args|

--- a/modules/simple_forms_api/spec/services/s3/submission_archiver_spec.rb
+++ b/modules/simple_forms_api/spec/services/s3/submission_archiver_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe SimpleFormsApi::S3::SubmissionArchiver, skip: 'These are flaky, n
     allow_any_instance_of(described_class).to receive(:upload_temp_folder_to_s3).and_return('/things/stuff/')
     allow_any_instance_of(described_class).to receive(:cleanup).and_return(true)
     allow_any_instance_of(described_class).to receive(:generate_presigned_url).and_return('/s3_url/stuff.pdf')
-    allow_any_instance_of(SimpleFormsApi::S3::SubmissionArchiveBuilder).to receive(:run).and_return(file_path)
+    allow_any_instance_of(SimpleFormsApi::S3::SubmissionArchiveBuilder).to(
+      receive(:run).and_return([file_path, submission])
+    )
   end
 
   describe '#initialize' do


### PR DESCRIPTION
## Summary

- This work updates the submission archive builder in accordance with VBA direction
- This work also fixes minor bugs with may cause the builder to fail

## Related issue(s)

- [Create Solution for adding Form Submission Remediation Documents to an S3 bucket](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1633)

## Testing done

- New code is NOT covered by unit tests YET. This is due to flaky tests bringing down the staging environment yesterday. Tests to come!

## Requested Feedback

Any
