### PR TITLE
Bump google-protobuf 4.28.1 -> 4.28.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,8 +512,13 @@ GEM
       thor (>= 0.20, < 2.a)
     google-cloud-env (2.1.1)
       faraday (>= 1.0, < 3.a)
-    google-protobuf (4.28.1)
+    google-protobuf (4.28.2)
       bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.2-java)
+      bigdecimal
+      ffi (~> 1)
+      ffi-compiler (~> 1)
       rake (>= 13)
     googleauth (1.11.0)
       faraday (>= 1.0, < 3.a)


### PR DESCRIPTION
## Summary

- Bump google-protobuf 4.28.1 -> 4.28.2
- fixes CVE https://github.com/department-of-veterans-affairs/vets-api/security/dependabot/48