### PR TITLE
API-40293-add-logger-for-pdf-validate-investigation

### DIFF
--- a/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
@@ -28,6 +28,13 @@ module ClaimsApi
 
           file_name = "#{SecureRandom.hex}.pdf"
           path = ::Common::FileHelpers.generate_clamav_temp_file(pdf_string, file_name)
+          # temporary debugging of clam av
+          log_job_progress(
+            auto_claim.id,
+            "526EZ PDF generator PDF existence check: #{File.exist?(path)}, file size : #{File.size?(path)}",
+            auto_claim.transaction_id
+          )
+
           upload = ActionDispatch::Http::UploadedFile.new({
                                                             filename: file_name,
                                                             type: 'application/pdf',


### PR DESCRIPTION
## Summary
* Adds a log out at one of the spots we are seeing failures in an effort to get some insights into why the change to clamav is causing upload failures.
	* Checks for existence
	* Logs file size

## Related issue(s)
* [API-40293](https://jira.devops.va.gov/browse/API-40293)
* [Slack Support thread](https://lighthouseva.slack.com/archives/CBU0KDSB1/p1726848103765629)

## Testing done


## Screenshots
<img width="1064" alt="Screenshot 2024-09-23 at 7 54 17 AM" src="https://github.com/user-attachments/assets/26191007-3710-4d7c-878c-d801aaa8d4a7">

## What areas of the site does it impact?
[*(Describe what parts of the site are impacted and*if*code touched other areas)*](modified:   modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
