### PR TITLE
[SIMPLE_FORMS] feat: add logic to properly upload files to S3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -609,6 +609,7 @@ app/uploaders/uploader_virus_scan.rb @department-of-veterans-affairs/va-api-engi
 app/uploaders/validate_pdf.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/vets_shrine.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/validators/token_util.rb @department-of-veterans-affairs/backend-review-group
+app/uploaders/veteran_facing_forms_remediation_uploader.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/account_login_statistics_job.rb @department-of-veterans-affairs/octo-identity
 app/sidekiq/benefits_intake_remediation_status_job.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/benefits_intake_status_job.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2105,6 +2105,7 @@ spec/uploaders/form1010cg/poa_uploader_spec.rb @department-of-veterans-affairs/v
 spec/uploaders/supporting_evidence_attachment_uploader_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/uploader_virus_scan_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/validate_pdf_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/uploaders/veteran_facing_forms_remediation_uploader_spec.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/prescription_details.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/backend-review-group
 modules/my_health/app/controllers/my_health/v1/prescriptions_controller.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/backend-review-group
 modules/my_health/spec/request/v1/prescriptions_request_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/backend-review-group

--- a/app/uploaders/veteran_facing_forms_remediation_uploader.rb
+++ b/app/uploaders/veteran_facing_forms_remediation_uploader.rb
@@ -15,7 +15,7 @@ class VeteranFacingFormsRemediationUploader < CarrierWave::Uploader::Base
   end
 
   def initialize(benefits_intake_uuid, directory)
-    raise 'The benefits_intake_uuid is missing.' if @benefits_intake_uuid.blank?
+    raise 'The benefits_intake_uuid is missing.' if benefits_intake_uuid.blank?
 
     super
     @benefits_intake_uuid = benefits_intake_uuid

--- a/app/uploaders/veteran_facing_forms_remediation_uploader.rb
+++ b/app/uploaders/veteran_facing_forms_remediation_uploader.rb
@@ -2,6 +2,7 @@
 
 class VeteranFacingFormsRemediationUploader < CarrierWave::Uploader::Base
   include SetAWSConfig
+  include UploaderVirusScan
 
   def size_range
     (1.byte)...(100_000_000.bytes)

--- a/app/uploaders/veteran_facing_forms_remediation_uploader.rb
+++ b/app/uploaders/veteran_facing_forms_remediation_uploader.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class VeteranFacingFormsRemediationUploader < CarrierWave::Uploader::Base
+  include SetAWSConfig
+
+  def size_range
+    (1.byte)...(100_000_000.bytes)
+  end
+
+  # All the same files allowed by benefits intake, with the
+  # addition of json for metadata and csv for manifest
+  def extension_allowlist
+    %w[bmp csv gif jpeg jpg json pdf png tif tiff txt]
+  end
+
+  def initialize(benefits_intake_uuid, directory)
+    raise 'The benefits_intake_uuid is missing.' if @benefits_intake_uuid.blank?
+
+    super
+    @benefits_intake_uuid = benefits_intake_uuid
+    @directory = directory
+
+    set_storage_options!
+  end
+
+  def store_dir
+    raise 'The s3 directory is missing.' if @directory.blank?
+
+    @directory
+  end
+
+  def set_storage_options!
+    # TODO: update this to vff specific S3 bucket once it has been created
+    s3_settings = Settings.reports.aws
+    #  defaults to CarrierWave::Storage::File if not AWS unless a real aws_access_key_id is set
+    if s3_settings.aws_access_key_id.present?
+      set_aws_config(
+        s3_settings.aws_access_key_id,
+        s3_settings.aws_secret_access_key,
+        s3_settings.region,
+        s3_settings.bucket
+      )
+    end
+  end
+end

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_archiver.rb
@@ -133,7 +133,7 @@ module SimpleFormsApi
       end
 
       def s3_uploader
-        @s3_uploader ||= VeteranFacingFormsRemediationUploader.new(benefits_intake_uuid, s3_directory_path)
+        @s3_uploader ||= VeteranFacingFormsRemediationUploader.new(benefits_intake_uuid, s3_submission_file_path)
       end
 
       def local_submission_file_path

--- a/spec/uploaders/veteran_facing_forms_remediation_uploader_spec.rb
+++ b/spec/uploaders/veteran_facing_forms_remediation_uploader_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VeteranFacingFormsRemediationUploader do
+  subject { described_class.new(benefits_intake_uuid, directory) }
+
+  let(:benefits_intake_uuid) { SecureRandom.uuid }
+  let(:directory) { '/some/path' }
+
+  it 'allows image, pdf, json, csv, and text files' do
+    expect(subject.extension_allowlist).to match_array %w[bmp csv gif jpeg jpg json pdf png tif tiff txt]
+  end
+
+  it 'returns a store directory containing benefits_intake_uuid' do
+    expect(subject.store_dir).to eq(directory)
+  end
+
+  it 'throws an error if no benefits_intake_uuid is given' do
+    expect { described_class.new(nil, directory) }.to raise_error(RuntimeError, 'The benefits_intake_uuid is missing.')
+  end
+
+  it 'throws an error if no directory is given' do
+    malformed_uploader = described_class.new(benefits_intake_uuid, nil)
+    expect { malformed_uploader.store_dir }.to raise_error(RuntimeError, 'The s3 directory is missing.')
+  end
+end


### PR DESCRIPTION
## Summary

- This work updates the submission archiver to properly submit files to S3

## Related issue(s)

- [Create Solution for adding Form Submission Remediation Documents to an S3 bucket](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1633)

## Testing done

- New code is NOT covered by unit tests YET. This is due to flaky tests bringing down the staging environment the other day. Tests to come!

## Requested Feedback

Any
