### PR TITLE
Add remaining email template id references

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1308,15 +1308,27 @@ vanotify:
         form1995_confirmation_email: form1995_confirmation_email_template_id
         form21_0966_confirmation_email: form21_0966_confirmation_email_template_id
         form21_0972_confirmation_email: form21_0972_confirmation_email_template_id
+        form21_0972_error_email: form21_0972_error_email_template_id
+        form21_0972_received_email: form21_0972_received_email_template_id
         form21_10203_confirmation_email: form21_10203_confirmation_email_template_id
         form21_10210_confirmation_email: form21_10210_confirmation_email_template_id
         form21_10210_error_email: form21_10210_error_email_template_id
         form21_10210_received_email: form21_10210_received_email_template_id
         form20_10206_confirmation_email: form20_10206_confirmation_email_template_id
+        form20_10206_error_email: form20_10206_error_email_template_id
+        form20_10206_received_email: form20_10206_received_email_template_id
         form20_10207_confirmation_email: form20_10207_confirmation_email_template_id
+        form20_10207_error_email: form20_10207_error_email_template_id
+        form20_10207_received_email: form20_10207_received_email_template_id
         form21_0845_confirmation_email: form21_0845_confirmation_email_template_id
+        form21_0845_error_email: form21_0845_error_email_template_id
+        form21_0845_received_email: form21_0845_received_email_template_id
         form21p_0847_confirmation_email: form21p_0847_confirmation_email_template_id
+        form21p_0847_error_email: form21p_0847_error_email_template_id
+        form21p_0847_received_email: form21p_0847_received_email_template_id
         form21_4142_confirmation_email: form21_4142_confirmation_email_template_id
+        form21_4142_error_email: form21_4142_error_email_template_id
+        form21_4142_received_email: form21_4142_received_email_template_id
         form40_0247_confirmation_email: form40_0247_confirmation_email_template_id
         form526_confirmation_email: fake_template_id
         form526_submission_failed_email: fake_template_id

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -5,19 +5,51 @@ module SimpleFormsApi
     attr_reader :form_number, :confirmation_number, :date_submitted, :lighthouse_updated_at, :notification_type, :user
 
     TEMPLATE_IDS = {
-      'vba_21_0845' => { confirmation: Settings.vanotify.services.va_gov.template_id.form21_0845_confirmation_email },
-      'vba_21p_0847' => { confirmation: Settings.vanotify.services.va_gov.template_id.form21p_0847_confirmation_email },
-      'vba_21_0966' => { confirmation: Settings.vanotify.services.va_gov.template_id.form21_0966_confirmation_email },
-      'vba_21_0972' => { confirmation: Settings.vanotify.services.va_gov.template_id.form21_0972_confirmation_email },
-      'vba_21_4142' => { confirmation: Settings.vanotify.services.va_gov.template_id.form21_4142_confirmation_email },
+      'vba_21_0845' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form21_0845_confirmation_email,
+        error: Settings.vanotify.services.va_gov.template_id.form21_0845_error_email,
+        received: Settings.vanotify.services.va_gov.template_id.form21_0845_received_email
+      },
+      'vba_21p_0847' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form21p_0847_confirmation_email,
+        error: Settings.vanotify.services.va_gov.template_id.form21p_0847_error_email,
+        received: Settings.vanotify.services.va_gov.template_id.form21p_0847_received_email
+      },
+      'vba_21_0966' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form21_0966_confirmation_email,
+        error: nil,
+        received: nil
+      },
+      'vba_21_0972' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form21_0972_confirmation_email,
+        error: Settings.vanotify.services.va_gov.template_id.form21_0972_error_email,
+        received: Settings.vanotify.services.va_gov.template_id.form21_0972_received_email
+      },
+      'vba_21_4142' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form21_4142_confirmation_email,
+        error: Settings.vanotify.services.va_gov.template_id.form21_4142_error_email,
+        received: Settings.vanotify.services.va_gov.template_id.form21_4142_received_email
+      },
       'vba_21_10210' => {
         confirmation: Settings.vanotify.services.va_gov.template_id.form21_10210_confirmation_email,
         error: Settings.vanotify.services.va_gov.template_id.form21_10210_error_email,
         received: Settings.vanotify.services.va_gov.template_id.form21_10210_received_email
       },
-      'vba_20_10206' => { confirmation: Settings.vanotify.services.va_gov.template_id.form20_10206_confirmation_email },
-      'vba_20_10207' => { confirmation: Settings.vanotify.services.va_gov.template_id.form20_10207_confirmation_email },
-      'vba_40_0247' => { confirmation: Settings.vanotify.services.va_gov.template_id.form40_0247_confirmation_email }
+      'vba_20_10206' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form20_10206_confirmation_email,
+        error: Settings.vanotify.services.va_gov.template_id.form20_10206_error_email,
+        received: Settings.vanotify.services.va_gov.template_id.form20_10206_received_email
+      },
+      'vba_20_10207' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form20_10207_confirmation_email,
+        error: Settings.vanotify.services.va_gov.template_id.form20_10207_error_email,
+        received: Settings.vanotify.services.va_gov.template_id.form20_10207_received_email
+      },
+      'vba_40_0247' => {
+        confirmation: Settings.vanotify.services.va_gov.template_id.form40_0247_confirmation_email,
+        error: nil,
+        received: nil
+      }
     }.freeze
     SUPPORTED_FORMS = TEMPLATE_IDS.keys
 


### PR DESCRIPTION
## Summary
This PR adds the remaining email template id references for Veteran Facing Forms.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1687
