### PR TITLE
DBEX/92496: add transactionId to LH Submit request bodies

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -144,7 +144,7 @@ module EVSS
         body = transform_service.transform(submission.form['form526'])
         # 2. send transformed submission data to LH endpoint
         benefits_claims_service = BenefitsClaims::Service.new(icn)
-        raw_response = benefits_claims_service.submit526(body, nil, nil { transaction_id: })
+        raw_response = benefits_claims_service.submit526(body, nil, nil, { transaction_id: })
         raw_response_body = if raw_response.body.is_a? String
                               JSON.parse(raw_response.body)
                             else

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -140,10 +140,11 @@ module EVSS
       def send_submission_data_to_lighthouse(submission, icn)
         # 1. transform submission data to LH format
         transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
+        transaction_id = submission.auth_headers['va_eauth_service_transaction_id']
         body = transform_service.transform(submission.form['form526'])
         # 2. send transformed submission data to LH endpoint
         benefits_claims_service = BenefitsClaims::Service.new(icn)
-        raw_response = benefits_claims_service.submit526(body)
+        raw_response = benefits_claims_service.submit526(body, nil, nil { transaction_id: })
         raw_response_body = if raw_response.body.is_a? String
                               JSON.parse(raw_response.body)
                             else

--- a/lib/disability_compensation/providers/generate_pdf/evss_generate_pdf_provider.rb
+++ b/lib/disability_compensation/providers/generate_pdf/evss_generate_pdf_provider.rb
@@ -15,6 +15,7 @@ class EvssGeneratePdfProvider
                  EVSS::DisabilityCompensationForm::NonBreakeredService.new(auth_headers)
                end
   end
+
   def generate_526_pdf(form_content, _transaction_id = nil)
     @service.get_form526(form_content)
   end

--- a/lib/disability_compensation/providers/generate_pdf/evss_generate_pdf_provider.rb
+++ b/lib/disability_compensation/providers/generate_pdf/evss_generate_pdf_provider.rb
@@ -15,8 +15,7 @@ class EvssGeneratePdfProvider
                  EVSS::DisabilityCompensationForm::NonBreakeredService.new(auth_headers)
                end
   end
-
-  def generate_526_pdf(form_content)
+  def generate_526_pdf(form_content, _transaction_id = nil)
     @service.get_form526(form_content)
   end
 end

--- a/lib/disability_compensation/providers/generate_pdf/generate_pdf_provider.rb
+++ b/lib/disability_compensation/providers/generate_pdf/generate_pdf_provider.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GeneratePdfProvider
-  def self.generate_526_pdf(_form_content)
+  def self.generate_526_pdf(_form_content, _transaction_id)
     raise NotImplementedError, 'Do not use base module methods. Override this method in implementation class.'
   end
 end

--- a/lib/disability_compensation/providers/generate_pdf/lighthouse_generate_pdf_provider.rb
+++ b/lib/disability_compensation/providers/generate_pdf/lighthouse_generate_pdf_provider.rb
@@ -3,13 +3,15 @@
 require 'disability_compensation/providers/generate_pdf/generate_pdf_provider'
 
 class LighthouseGeneratePdfProvider
+  include GeneratePdfProvider
+
   def initialize(icn)
     @icn = icn
   end
 
-  def generate_526_pdf(form_content)
+  def generate_526_pdf(form_content, transaction_id)
     body = transform_service.transform(JSON.parse(form_content))
-    service.submit526(body, nil, nil, { generate_pdf: true })
+    service.submit526(body, nil, nil, { generate_pdf: true, transaction_id: })
   end
 
   def transform_service

--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -78,7 +78,8 @@ module EVSS
       }.freeze
 
       # takes known EVSS Form526Submission format and converts it to a Lighthouse request body
-      # evss_data will look like JSON.parse(form526_submission.form_data)
+      # @param evss_data will look like JSON.parse(form526_submission.form_data)
+      # @return Requests::Form526
       def transform(evss_data)
         form526 = evss_data['form526']
         lh_request_body = Requests::Form526.new

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -114,10 +114,11 @@ module BenefitsClaims
     # @option options [hash] :auth_params a hash to send in auth params to create the access token
     # @option options [hash] :generate_pdf call the generatePdf endpoint to receive the 526 pdf
     # @option options [hash] :asynchronous call the asynchronous endpoint
+    # @option options [hash] :transaction_id submission endpoint tracking
     def submit526(body, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
       endpoint, path = submit_endpoint(options)
 
-      body = prepare_submission_body(body)
+      body = prepare_submission_body(body, options[:transaction_id])
 
       response = config.post(
         path,
@@ -144,7 +145,7 @@ module BenefitsClaims
     def validate526(body, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
       endpoint = '{icn}/526/validate'
       path = "#{@icn}/526/validate"
-      body = prepare_submission_body(body)
+      body = prepare_submission_body(body, options[:transaction_id])
 
       response = config.post(
         path,
@@ -162,24 +163,27 @@ module BenefitsClaims
 
     private
 
-    def build_request_body(body)
+    def build_request_body(body, transaction_id = "vagov-#{SecureRandom}")
       body = body.as_json
       if body.dig('data', 'attributes').nil?
         body = {
           data: {
             type: 'form/526',
             attributes: body
+          },
+          meta: {
+            transaction_id:
           }
         }
       end
       body.as_json.deep_transform_keys { |k| k.camelize(:lower) }
     end
 
-    def prepare_submission_body(body)
+    def prepare_submission_body(body, transaction_id)
       # if we're coming straight from the transformation service without
       # making this a jsonapi request body first ({data: {type:, attributes}}),
       # this will put it in the correct format for transmission
-      body = build_request_body(body)
+      body = build_request_body(body, transaction_id)
 
       # Inflection settings force 'current_va_employee' to render as 'currentVAEmployee' in the above camelize() call
       # Since Lighthouse needs 'currentVaEmployee', the following workaround renames it.

--- a/lib/sidekiq/form526_backup_submission_process/processor.rb
+++ b/lib/sidekiq/form526_backup_submission_process/processor.rb
@@ -347,8 +347,8 @@ module Sidekiq
       def get_form_from_external_api(headers, provider, form_json)
         # get the "breakered" version
         service = choose_provider(headers, provider, breakered: true)
-
-        service.generate_526_pdf(form_json)
+        transaction_id = headers['va_eauth_service_transaction_id']
+        service.generate_526_pdf(form_json, transaction_id)
       end
 
       def get_uploads

--- a/spec/lib/disability_compensation/providers/generate_pdf/generate_pdf_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/generate_pdf/generate_pdf_provider_spec.rb
@@ -6,7 +6,7 @@ require 'disability_compensation/providers/generate_pdf/generate_pdf_provider'
 RSpec.describe GeneratePdfProvider do
   it 'always raises an error on the BRDProvider base module' do
     expect do
-      subject.generate_526_pdf({})
+      subject.generate_526_pdf({}, nil)
     end.to raise_error NotImplementedError
   end
 end

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe BenefitsClaims::Service do
 
       describe 'when posting a form526' do
         it 'has formatted request body data correctly' do
+          transaction_id = "vagov"
           body = @service.send(:prepare_submission_body,
                                {
                                  'serviceInformation' => {
@@ -93,7 +94,7 @@ RSpec.describe BenefitsClaims::Service do
                                      }
                                    }
                                  }
-                               })
+                               }, transaction_id)
 
           expect(body).to eq({
                                'data' => {
@@ -109,6 +110,9 @@ RSpec.describe BenefitsClaims::Service do
                                      }
                                    }
                                  }
+                               },
+                               'meta' => {
+                                 'transactionId' => 'vagov'
                                }
                              })
         end

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe BenefitsClaims::Service do
 
       describe 'when posting a form526' do
         it 'has formatted request body data correctly' do
-          transaction_id = "vagov"
+          transaction_id = 'vagov'
           body = @service.send(:prepare_submission_body,
                                {
                                  'serviceInformation' => {


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- add `meta.transactionId` to LH submit endpoint requests

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#92496

## Testing done

- [x] *New code is covered by unit tests*
- use _**updated**_ [test harness](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/benefits/scripts/526/TREX/DEBUG/form526_submit.rb) to send submit request to LH staging environment or follow this:
1. have a `Form526Submission `on hand as `@submission` (i.e. `@submission = Form526Submission.first`)
2. `@transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new`
3. `@body = @transform_service.transform(@submission.form['form526'])`
4. `@service = BenefitsClaims::Service.new(@submission.user_account.icn)`
5. this is the new part
```
transaction_id = @submission.auth_headers['va_eauth_service_transaction_id']
@response = @service.submit526(@body, nil, nil, { generate_pdf:, transaction_id: })
```
6. at this point you can check `@service.send(:prepare_submission_body, @body.as_json)` to see the meta in the request body
7. or check `@response.body['meta']` to see what you sent to lighthouse

## Screenshots
![image](https://github.com/user-attachments/assets/57d42066-3b2f-4c2a-9c8e-ffe270c9677a)


## What areas of the site does it impact?
Form526 2022 form version submission to lighthouse

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

