### PR TITLE
Update tests for Simple Forms emails

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -74,10 +74,10 @@ module SimpleFormsApi
       return unless SUPPORTED_FORMS.include?(form_number)
 
       data = form_specific_data || empty_form_specific_data
-
       return if data[:email].blank? || data[:personalization]['first_name'].blank?
 
       template_id = TEMPLATE_IDS[form_number][notification_type]
+      return unless template_id
 
       if at
         VANotify::EmailJob.perform_at(

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -220,72 +220,93 @@ describe SimpleFormsApi::NotificationEmail do
         end
       end
     end
-  end
 
-  describe '40_0247' do
-    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-    let(:config) do
-      { form_data: data, form_number: 'vba_40_0247',
-        confirmation_number: 'confirmation_number', date_submitted: }
-    end
-
-    context 'when email is entered' do
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247.json'
-        )
-        JSON.parse(fixture_path.read)
+    describe '40_0247' do
+      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+      let(:config) do
+        { form_data: data, form_number: 'vba_40_0247',
+          confirmation_number: 'confirmation_number', date_submitted: }
       end
 
-      it 'sends the confirmation email' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
+      context 'template_id is provided', if: notification_type == :confirmation do
+        context 'when email is entered' do
+          let(:data) do
+            fixture_path = Rails.root.join(
+              'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247.json'
+            )
+            JSON.parse(fixture_path.read)
+          end
 
-        subject = described_class.new(config)
+          it 'sends the confirmation email' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject.send
+            subject = described_class.new(config, notification_type:)
 
-        expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'a@b.com',
-          'form40_0247_confirmation_email_template_id',
-          {
-            'first_name' => 'JOE',
-            'date_submitted' => date_submitted,
-            'confirmation_number' => 'confirmation_number',
-            'lighthouse_updated_at' => nil
-          }
-        )
+            subject.send
+
+            expect(VANotify::EmailJob).to have_received(:perform_async).with(
+              'a@b.com',
+              'form40_0247_confirmation_email_template_id',
+              {
+                'first_name' => 'JOE',
+                'date_submitted' => date_submitted,
+                'confirmation_number' => 'confirmation_number',
+                'lighthouse_updated_at' => nil
+              }
+            )
+          end
+        end
+
+        context 'when email is omitted' do
+          let(:data) do
+            fixture_path = Rails.root.join(
+              'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247-min.json'
+            )
+            JSON.parse(fixture_path.read)
+          end
+
+          context 'when user is signed in' do
+            let(:user) { create(:user, :loa3) }
+
+            it 'does not send the confirmation email' do
+              allow(VANotify::EmailJob).to receive(:perform_async)
+              expect(data['applicant_email']).to be_nil
+
+              subject = described_class.new(config, notification_type:)
+
+              subject.send
+
+              expect(VANotify::EmailJob).not_to have_received(:perform_async)
+            end
+          end
+
+          context 'when user is not signed in' do
+            it 'does not send the confirmation email' do
+              allow(VANotify::EmailJob).to receive(:perform_async)
+              expect(data['applicant_email']).to be_nil
+
+              subject = described_class.new(config, notification_type:)
+
+              subject.send
+
+              expect(VANotify::EmailJob).not_to have_received(:perform_async)
+            end
+          end
+        end
       end
-    end
 
-    context 'when email is omitted' do
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247-min.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
-
-      context 'when user is signed in' do
+      context 'template_id is missing', if: notification_type != :confirmation do
+        let(:data) do
+          fixture_path = Rails.root.join(
+            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247.json'
+          )
+          JSON.parse(fixture_path.read)
+        end
         let(:user) { create(:user, :loa3) }
 
-        it 'does not send the confirmation email' do
+        it 'sends nothing' do
           allow(VANotify::EmailJob).to receive(:perform_async)
-          expect(data['applicant_email']).to be_nil
-
-          subject = described_class.new(config)
-
-          subject.send
-
-          expect(VANotify::EmailJob).not_to have_received(:perform_async)
-        end
-      end
-
-      context 'when user is not signed in' do
-        it 'does not send the confirmation email' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          expect(data['applicant_email']).to be_nil
-
-          subject = described_class.new(config)
+          subject = described_class.new(config, notification_type:, user:)
 
           subject.send
 
@@ -293,54 +314,171 @@ describe SimpleFormsApi::NotificationEmail do
         end
       end
     end
-  end
 
-  describe '21_0845' do
-    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-    let(:data) do
-      fixture_path = Rails.root.join(
-        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0845.json'
-      )
-      JSON.parse(fixture_path.read)
-    end
-    let(:config) do
-      { form_data: data, form_number: 'vba_21_0845', confirmation_number: 'confirmation_number', date_submitted: }
-    end
-
-    describe 'signed in user' do
-      it 'non-veteran authorizer' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
-        data['authorizer_email'] = 'authorizer_email@example.com'
-
-        subject = described_class.new(config, user: create(:user))
-
-        subject.send
-
-        expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'authorizer_email@example.com',
-          'form21_0845_confirmation_email_template_id',
-          {
-            'first_name' => 'JACK',
-            'date_submitted' => date_submitted,
-            'confirmation_number' => 'confirmation_number',
-            'lighthouse_updated_at' => nil
-          }
+    describe '21_0845' do
+      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0845.json'
         )
+        JSON.parse(fixture_path.read)
+      end
+      let(:config) do
+        { form_data: data, form_number: 'vba_21_0845', confirmation_number: 'confirmation_number', date_submitted: }
       end
 
-      it 'veteran authorizer' do
+      describe 'signed in user' do
+        it 'non-veteran authorizer' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          data['authorizer_email'] = 'authorizer_email@example.com'
+
+          subject = described_class.new(config, notification_type:, user: create(:user))
+
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            'authorizer_email@example.com',
+            "form21_0845_#{notification_type}_email_template_id",
+            {
+              'first_name' => 'JACK',
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
+
+        it 'veteran authorizer' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          data['authorizer_type'] = 'veteran'
+
+          subject = described_class.new(config, notification_type:, user: create(:user))
+
+          allow(subject.user).to receive(:va_profile_email).and_return('abraham.lincoln@vets.gov')
+
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            'abraham.lincoln@vets.gov',
+            "form21_0845_#{notification_type}_email_template_id",
+            {
+              'first_name' => 'JOHN',
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
+      end
+
+      describe 'not signed in user' do
+        it 'non-veteran authorizer' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          # form requires email
+          data['authorizer_email'] = 'authorizer_email@example.com'
+
+          subject = described_class.new(config, notification_type:)
+
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            'authorizer_email@example.com',
+            "form21_0845_#{notification_type}_email_template_id",
+            {
+              'first_name' => 'JACK',
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
+
+        it 'veteran authorizer' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          # form does not require email
+          data['authorizer_type'] = 'veteran'
+
+          subject = described_class.new(config, notification_type:)
+
+          subject.send
+
+          expect(VANotify::EmailJob).not_to have_received(:perform_async)
+        end
+      end
+    end
+
+    describe '21_0966' do
+      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+      let(:config) do
+        { form_data: data, form_number: 'vba_21_0966',
+          confirmation_number: 'confirmation_number', date_submitted: }
+      end
+      let(:user) { create(:user, :loa3) }
+
+      context 'template_id is provided', if: notification_type == :confirmation do
+        it 'sends the confirmation email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+
+          subject = described_class.new(config, notification_type:, user:)
+
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            user.va_profile_email,
+            'form21_0966_confirmation_email_template_id',
+            {
+              'first_name' => user.first_name.upcase,
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil,
+              'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
+                                           ' (VA Form 21P-534 or VA Form 21P-534EZ)'
+            }
+          )
+        end
+      end
+
+      context 'template_id is missing', if: notification_type != :confirmation do
+        it 'sends nothing' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          subject = described_class.new(config, notification_type:, user:)
+
+          subject.send
+
+          expect(VANotify::EmailJob).not_to have_received(:perform_async)
+        end
+      end
+    end
+
+    describe '20_10206' do
+      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10206.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+      let(:config) do
+        { form_data: data, form_number: 'vba_20_10206',
+          confirmation_number: 'confirmation_number', date_submitted: }
+      end
+
+      it 'sends the email' do
         allow(VANotify::EmailJob).to receive(:perform_async)
-        data['authorizer_type'] = 'veteran'
 
-        subject = described_class.new(config, user: create(:user))
-
-        allow(subject.user).to receive(:va_profile_email).and_return('abraham.lincoln@vets.gov')
+        subject = described_class.new(config, notification_type:)
 
         subject.send
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'abraham.lincoln@vets.gov',
-          'form21_0845_confirmation_email_template_id',
+          'jv@example.com',
+          "form20_10206_#{notification_type}_email_template_id",
           {
             'first_name' => 'JOHN',
             'date_submitted' => date_submitted,
@@ -351,231 +489,127 @@ describe SimpleFormsApi::NotificationEmail do
       end
     end
 
-    describe 'not signed in user' do
-      it 'non-veteran authorizer' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
-        # form requires email
-        data['authorizer_email'] = 'authorizer_email@example.com'
-
-        subject = described_class.new(config)
-
-        subject.send
-
-        expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'authorizer_email@example.com',
-          'form21_0845_confirmation_email_template_id',
-          {
-            'first_name' => 'JACK',
-            'date_submitted' => date_submitted,
-            'confirmation_number' => 'confirmation_number',
-            'lighthouse_updated_at' => nil
-          }
-        )
+    describe '20_10207' do
+      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+      let(:config) do
+        { form_data: data, form_number: 'vba_20_10207',
+          confirmation_number: 'confirmation_number', date_submitted: }
       end
 
-      it 'veteran authorizer' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
-        # form does not require email
-        data['authorizer_type'] = 'veteran'
+      context 'veteran' do
+        let(:data) do
+          fixture_path = Rails.root.join(
+            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-veteran.json'
+          )
+          JSON.parse(fixture_path.read)
+        end
+        let(:user) { create(:user, :loa3) }
 
-        subject = described_class.new(config)
+        it 'sends the email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject.send
+          subject = described_class.new(config, notification_type:, user:)
 
-        expect(VANotify::EmailJob).not_to have_received(:perform_async)
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            user.va_profile_email,
+            "form20_10207_#{notification_type}_email_template_id",
+            {
+              'first_name' => 'JOHN',
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
       end
-    end
-  end
 
-  describe '21_0966' do
-    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-    let(:data) do
-      fixture_path = Rails.root.join(
-        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'
-      )
-      JSON.parse(fixture_path.read)
-    end
-    let(:config) do
-      { form_data: data, form_number: 'vba_21_0966',
-        confirmation_number: 'confirmation_number', date_submitted: }
-    end
-    let(:user) { create(:user, :loa3) }
+      context 'third-party-veteran' do
+        let(:data) do
+          fixture_path = Rails.root.join(
+            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-veteran.json'
+          )
+          JSON.parse(fixture_path.read)
+        end
+        let(:user) { create(:user, :loa3) }
 
-    it 'sends the confirmation email' do
-      allow(VANotify::EmailJob).to receive(:perform_async)
+        it 'sends the email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
 
-      subject = described_class.new(config, user:)
+          subject = described_class.new(config, notification_type:, user:)
 
-      subject.send
+          subject.send
 
-      expect(VANotify::EmailJob).to have_received(:perform_async).with(
-        user.va_profile_email,
-        'form21_0966_confirmation_email_template_id',
-        {
-          'first_name' => user.first_name.upcase,
-          'date_submitted' => date_submitted,
-          'confirmation_number' => 'confirmation_number',
-          'lighthouse_updated_at' => nil,
-          'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
-                                       ' (VA Form 21P-534 or VA Form 21P-534EZ)'
-        }
-      )
-    end
-  end
-
-  describe '20_10206' do
-    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-    let(:data) do
-      fixture_path = Rails.root.join(
-        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10206.json'
-      )
-      JSON.parse(fixture_path.read)
-    end
-    let(:config) do
-      { form_data: data, form_number: 'vba_20_10206',
-        confirmation_number: 'confirmation_number', date_submitted: }
-    end
-
-    it 'sends the confirmation email' do
-      allow(VANotify::EmailJob).to receive(:perform_async)
-
-      subject = described_class.new(config)
-
-      subject.send
-
-      expect(VANotify::EmailJob).to have_received(:perform_async).with(
-        'jv@example.com',
-        'form20_10206_confirmation_email_template_id',
-        {
-          'first_name' => 'JOHN',
-          'date_submitted' => date_submitted,
-          'confirmation_number' => 'confirmation_number',
-          'lighthouse_updated_at' => nil
-        }
-      )
-    end
-  end
-
-  describe '20_10207' do
-    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-    let(:config) do
-      { form_data: data, form_number: 'vba_20_10207',
-        confirmation_number: 'confirmation_number', date_submitted: }
-    end
-
-    context 'veteran' do
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-veteran.json'
-        )
-        JSON.parse(fixture_path.read)
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            user.va_profile_email,
+            "form20_10207_#{notification_type}_email_template_id",
+            {
+              'first_name' => 'JOE',
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
       end
-      let(:user) { create(:user, :loa3) }
 
-      it 'sends the confirmation email' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
+      context 'non-veteran' do
+        let(:data) do
+          fixture_path = Rails.root.join(
+            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-non-veteran.json'
+          )
+          JSON.parse(fixture_path.read)
+        end
+        let(:user) { create(:user, :loa3) }
 
-        subject = described_class.new(config, user:)
+        it 'sends the email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject.send
+          subject = described_class.new(config, notification_type:, user:)
 
-        expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
-          'form20_10207_confirmation_email_template_id',
-          {
-            'first_name' => 'JOHN',
-            'date_submitted' => date_submitted,
-            'confirmation_number' => 'confirmation_number',
-            'lighthouse_updated_at' => nil
-          }
-        )
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            user.va_profile_email,
+            "form20_10207_#{notification_type}_email_template_id",
+            {
+              'first_name' => 'JOHN',
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
       end
-    end
 
-    context 'third-party-veteran' do
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-veteran.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
-      let(:user) { create(:user, :loa3) }
+      context 'third-party-non-veteran' do
+        let(:data) do
+          fixture_path = Rails.root.join(
+            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-non-veteran.json'
+          )
+          JSON.parse(fixture_path.read)
+        end
+        let(:user) { create(:user, :loa3) }
 
-      it 'sends the confirmation email' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
+        it 'sends the email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject = described_class.new(config, user:)
+          subject = described_class.new(config, notification_type:, user:)
 
-        subject.send
+          subject.send
 
-        expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
-          'form20_10207_confirmation_email_template_id',
-          {
-            'first_name' => 'JOE',
-            'date_submitted' => date_submitted,
-            'confirmation_number' => 'confirmation_number',
-            'lighthouse_updated_at' => nil
-          }
-        )
-      end
-    end
-
-    context 'non-veteran' do
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-non-veteran.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
-      let(:user) { create(:user, :loa3) }
-
-      it 'sends the confirmation email' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
-
-        subject = described_class.new(config, user:)
-
-        subject.send
-
-        expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
-          'form20_10207_confirmation_email_template_id',
-          {
-            'first_name' => 'JOHN',
-            'date_submitted' => date_submitted,
-            'confirmation_number' => 'confirmation_number',
-            'lighthouse_updated_at' => nil
-          }
-        )
-      end
-    end
-
-    context 'third-party-non-veteran' do
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-non-veteran.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
-      let(:user) { create(:user, :loa3) }
-
-      it 'sends the confirmation email' do
-        allow(VANotify::EmailJob).to receive(:perform_async)
-
-        subject = described_class.new(config, user:)
-
-        subject.send
-
-        expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
-          'form20_10207_confirmation_email_template_id',
-          {
-            'first_name' => 'JOE',
-            'date_submitted' => date_submitted,
-            'confirmation_number' => 'confirmation_number',
-            'lighthouse_updated_at' => nil
-          }
-        )
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            user.va_profile_email,
+            "form20_10207_#{notification_type}_email_template_id",
+            {
+              'first_name' => 'JOE',
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
This PR is mostly concerned with updating tests for Simple Forms email notifications to handle the two new types of notifications (`error` and `received`). It also includes an important escape hatch in implementation, though, since we _can_ have missing `template_id`s and need a way to gracefully exit (without sending an email) in such cases.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1687

