### PR TITLE
VEBT-580: Show conditional benefit received/applied for 1995 spool file & remove benefit feature flag

### DIFF
--- a/app/sidekiq/education_form/forms/va_1995.rb
+++ b/app/sidekiq/education_form/forms/va_1995.rb
@@ -22,11 +22,7 @@ module EducationForm::Forms
     end
 
     def form_benefit
-      if Settings.vsp_environment.eql?('production')
-        @applicant.benefit&.titleize
-      else
-        @applicant.benefitUpdate&.titleize
-      end
+      @applicant.benefitUpdate&.titleize
     end
 
     def header_form_type

--- a/app/sidekiq/education_form/templates/1995.erb
+++ b/app/sidekiq/education_form/templates/1995.erb
@@ -1,5 +1,9 @@
 <%= parse_with_template_path('header_1995') %>
+<% if @applicant.benefitAppliedFor -%>
 <%= @applicant.benefitAppliedFor&.titleize %>
+<% else -%>
+<%= form_benefit %>
+<% end -%>
 *START*
 VA Form 22-1995
 OMB Control #: 2900-0074

--- a/spec/fixtures/education_benefits_claims/1995/ch30_guardian_not_graduated.json
+++ b/spec/fixtures/education_benefits_claims/1995/ch30_guardian_not_graduated.json
@@ -18,7 +18,6 @@
   "benefit": "chapter30",
   "benefitUpdate": "chapter30",
   "changeAnotherBenefit": "Yes",
-  "benefitAppliedFor": "chapter1606",
   "remarks": "remarks",
   "programName": "program name",
   "privacyAgreementAccepted": true,

--- a/spec/fixtures/education_benefits_claims/1995/ch30_guardian_not_graduated.spl
+++ b/spec/fixtures/education_benefits_claims/1995/ch30_guardian_not_graduated.spl
@@ -7,7 +7,7 @@ TESTER
 V1995
 
 
-Chapter1606
+Chapter30
 *START*
 VA Form 22-1995
 OMB Control #: 2900-0074
@@ -51,7 +51,7 @@ Benefit Most Recently Received: Chapter30
 
 Select Another Benefit: Yes
 
-Benefit Being Applied For: Chapter1606
+Benefit Being Applied For:
 
 Type of Education or Training:
 Education or Career Goal:

--- a/spec/fixtures/education_benefits_claims/1995/minimal.json
+++ b/spec/fixtures/education_benefits_claims/1995/minimal.json
@@ -19,6 +19,6 @@
 	"applicantGender": "F",
   	"dateOfBirth": "1970-01-01",
 	"changeAnotherBenefit": "Yes",
-	"benefitAppliedFor": "chapter30",
+	"benefitUpdate": "chapter35",
 	"email": "test@sample.com",
 	"bankAccount": {}}

--- a/spec/fixtures/education_benefits_claims/1995/minimal.spl
+++ b/spec/fixtures/education_benefits_claims/1995/minimal.spl
@@ -7,7 +7,7 @@ FAKE
 V1995
 
 
-Chapter30
+Chapter35
 *START*
 VA Form 22-1995
 OMB Control #: 2900-0074
@@ -40,14 +40,23 @@ Preferred Method of Contact: mail
 Direct Deposit:     Type of Account:
 Routing/Transit #:    Account #:
 
+                 DEA, CH35 SPONSOR/SERVICE MEMBER INFORMATION
+                 --------------------------------------------
+
+Name:
+
+SSN:
+
+VA File Number: 12345678
+
                   TYPE AND PROGRAM OF EDUCATION OR TRAINING
                   -----------------------------------------
 
-Benefit Most Recently Received:
+Benefit Most Recently Received: Chapter35
 
 Select Another Benefit: Yes
 
-Benefit Being Applied For: Chapter30
+Benefit Being Applied For:
 
 Type of Education or Training:
 Education or Career Goal:


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper)*: No
- *(Summarize the changes that have been made to the platform)*: Show conditional benefit received/applied for 1995 spool file & remove benefit feature flag
- *(If bug, how to reproduce)*: N/A
- *(What is the solution, why is this the solution?)*: Need to show benefit received when benefitAppliedFor is blank
- *(Which team do you work for, does your team own the maintenance of this component?)*: VEBT
- *(If introducing a flipper, what is the success criteria being targeted?):* N/A

## Related issue(s)

- [VEBT-580](https://jira.devops.va.gov/browse/VEBT-580)
- [Github 18597](https://github.com/department-of-veterans-affairs/vets-api/issues/18597)

## Testing done

- [ x] *New code is covered by unit tests* 
- *Describe what the old behavior was prior to the change* Nothing was displayed if benefitAppliedFor was blank.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing* Submit 1995 form and check resulting spool file.

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)* 1995 spool file

## Acceptance criteria

- [x ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x ]  No error nor warning in the console.
- [x ]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x]  Feature/bug has a monitor built into Datadog (if applicable)

