### PR TITLE
Ask va api create background job for optionset and translator class

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -51,6 +51,9 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   # Update static data cache
   mgr.register('0 0 * * *', 'Crm::TopicsDataJob')
 
+  # Update Optionset data cache
+  mgr.register('0 0 * * *', 'Crm::OptionsetDataJob')
+
   # Update FormSubmissionAttempt status from Lighthouse Benefits Intake API
   mgr.register('0 0 * * *', 'BenefitsIntakeStatusJob')
 

--- a/modules/ask_va_api/app/lib/ask_va_api/base_retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/base_retriever.rb
@@ -36,12 +36,9 @@ module AskVAApi
     end
 
     def handle_response_data(response:, error_class:)
-      case response
-      when Hash
-        response[:Data]
-      else
-        raise(error_class, response.body)
-      end
+      return response[:Data] if response.is_a?(Hash)
+
+      raise(error_class, response.body)
     end
   end
 end

--- a/modules/ask_va_api/app/lib/ask_va_api/optionset/retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/optionset/retriever.rb
@@ -2,6 +2,8 @@
 
 module AskVAApi
   module Optionset
+    class OptionsetRetrieverError < StandardError; end
+
     class Retriever < BaseRetriever
       attr_reader :name
 
@@ -30,7 +32,8 @@ module AskVAApi
           data = File.read("modules/ask_va_api/config/locales/get_#{name}_mock_data.json")
           JSON.parse(data, symbolize_names: true)[:Data]
         else
-          Crm::CacheData.new.call(endpoint: 'optionset', cache_key: name, payload: { name: "iris_#{name}" })[:Data]
+          response = Crm::CacheData.new.call(endpoint: 'optionset', cache_key: name, payload: { name: "iris_#{name}" })
+          handle_response_data(response:, error_class: OptionsetRetrieverError)
         end
       end
     end

--- a/modules/ask_va_api/app/services/crm/cache_data.rb
+++ b/modules/ask_va_api/app/services/crm/cache_data.rb
@@ -1,42 +1,56 @@
 # frozen_string_literal: true
 
 module Crm
-  class CacheData
-    attr_reader :cache_client, :service
+  class CacheDataError < StandardError; end
+  class ApiServiceError < StandardError; end
+  class CacheStoreError < StandardError; end
 
-    def initialize(service: Service.new(icn: nil), cache_client: AskVAApi::RedisClient.new)
+  class CacheData
+    attr_reader :cache_client, :service, :cache_ttl
+
+    DEFAULT_TTL = 86_400
+
+    def initialize(service: Service.new(icn: nil), cache_client: AskVAApi::RedisClient.new, cache_ttl: DEFAULT_TTL)
       @cache_client = cache_client
       @service = service
+      @cache_ttl = cache_ttl
     end
 
     def call(endpoint:, cache_key:, payload: {})
-      data = cache_client.fetch(cache_key)
-
-      data = fetch_api_data(endpoint:, cache_key:, payload:) if data.nil?
-
-      data
+      fetch_cache_data(cache_key) || fetch_and_cache_data(endpoint:, cache_key:, payload:)
     rescue => e
-      ::ErrorHandler.handle_service_error(e)
+      raise CacheDataError, "#{e.class.name}: #{e.message}"
     end
 
-    def fetch_api_data(endpoint:, cache_key:, payload: {})
-      response = service.call(endpoint:, payload:)
-      data = handle_response_data(response)
-
-      cache_client.store_data(key: cache_key, data:, ttl: 86_400)
-
+    def fetch_and_cache_data(endpoint:, cache_key:, payload:)
+      data = fetch_api_data(endpoint:, payload:)
+      store_in_cache(cache_key, data) if data
       data
     end
 
     private
 
+    def fetch_cache_data(cache_key)
+      cache_client.fetch(cache_key)
+    rescue => e
+      raise CacheStoreError, "Cache store failure: #{e.message}"
+    end
+
+    def fetch_api_data(endpoint:, payload:)
+      response = service.call(endpoint:, payload:)
+      handle_response_data(response)
+    end
+
+    def store_in_cache(cache_key, data)
+      cache_client.store_data(key: cache_key, data:, ttl: cache_ttl)
+    rescue => e
+      raise CacheStoreError, "Failed to store data in cache: #{e.message}"
+    end
+
     def handle_response_data(response)
-      case response
-      when Hash
-        response
-      else
-        raise(StandardError, response.body)
-      end
+      return response if response.is_a?(Hash)
+
+      raise ApiServiceError, "Invalid response format: #{response.body}"
     end
   end
 end

--- a/modules/ask_va_api/app/sidekiq/crm/optionset_data_job.rb
+++ b/modules/ask_va_api/app/sidekiq/crm/optionset_data_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module Crm
+  class OptionsetDataJob
+    include Sidekiq::Job
+
+    # Schedule to run every 24 hours. Adjust as needed.
+    sidekiq_options retry: false, unique_for: 24.hours
+
+    def perform
+      options.each { |option| safely_retrieve_and_cache_optionset_data(option) }
+    end
+
+    private
+
+    def options
+      %w[
+        inquiryabout inquirysource inquirytype levelofauthentication
+        suffix veteranrelationship dependentrelationship responsetype
+      ]
+    end
+
+    # Safely retrieves data for a given option, continues on failure
+    def safely_retrieve_and_cache_optionset_data(option)
+      Crm::CacheData.new.fetch_and_cache_data(
+        endpoint: 'optionset',
+        cache_key: option,
+        payload: { name: "iris_#{option}" }
+      )
+    rescue => e
+      log_error(option, e)
+    end
+
+    def log_error(action, exception)
+      LogService.new.call(action) do |span|
+        span.set_tag('error', true)
+        span.set_tag('error.msg', exception.message)
+      end
+      Rails.logger.error("Error during #{action}: #{exception.message}")
+    end
+  end
+end

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/optionset/retriever_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/optionset/retriever_spec.rb
@@ -33,7 +33,7 @@ module AskVAApi
           end
         end
 
-        context 'when an error occur' do
+        context 'when an API error occur' do
           let(:retriever) { described_class.new(name: 'branchofservic', user_mock_data: false, entity_class:) }
           let(:body) do
             '{"Data":null,"Message":"Data Validation: Invalid OptionSet Name iris_branchofservic, valid' \

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/static_data_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/static_data_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe 'AskVAApi StaticData', type: :request do
       end
 
       it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
-                      'ErrorHandler::ServiceError: StandardError: {"Data":null,"Message":' \
+                      'Crm::CacheDataError: Crm::ApiServiceError: Invalid response format: {"Data":null,"Message":' \
                       '"Data Validation: Invalid OptionSet Name iris_branchofservic, ' \
                       'valid values are iris_inquiryabout, iris_inquirysource, iris_inquirytype,' \
                       ' iris_levelofauthentication, iris_suffix, iris_veteranrelationship,' \

--- a/modules/ask_va_api/spec/sidekiq/crm/optionset_data_job_spec.rb
+++ b/modules/ask_va_api/spec/sidekiq/crm/optionset_data_job_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crm::OptionsetDataJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let(:cache_data_instance) { instance_double(Crm::CacheData) }
+    let(:option_keys) do
+      %w[inquiryabout inquirysource inquirytype levelofauthentication suffix veteranrelationship
+         dependentrelationship responsetype]
+    end
+    let(:cache_data) do
+      lambda do |option|
+        {
+          'inquiryabout' => { Data: [{ Id: 722_310_003, Name: 'A general question' },
+                                     { Id: 722_310_000, Name: 'About Me, the Veteran' },
+                                     { Id: 722_310_002, Name: 'For the dependent of a Veteran' },
+                                     { Id: 722_310_001, Name: 'On behalf of a Veteran' }] },
+          'inquirysource' => { Data: [{ Id: 722_310_005, Name: 'Phone' },
+                                      { Id: 722_310_004, Name: 'US Mail' },
+                                      { Id: 722_310_000, Name: 'AVA' },
+                                      { Id: 722_310_001, Name: 'Email' },
+                                      { Id: 722_310_002, Name: 'Facebook' }] },
+          'inquirytype' => { Data: [{ Id: 722_310_000, Name: 'Compliment' },
+                                    { Id: 722_310_001, Name: 'Question' },
+                                    { Id: 722_310_002, Name: 'Service Complaint' },
+                                    { Id: 722_310_006, Name: 'Suggestion' },
+                                    { Id: 722_310_004, Name: 'Other' }] },
+          'levelofauthentication' => { Data: [{ Id: 722_310_002, Name: 'Authenticated' },
+                                              { Id: 722_310_000, Name: 'Unauthenticated' },
+                                              { Id: 722_310_001, Name: 'Personal' },
+                                              { Id: 722_310_003, Name: 'Business' }] },
+          'suffix' => { Data: [{ Id: 722_310_000, Name: 'Jr' },
+                               { Id: 722_310_001, Name: 'Sr' },
+                               { Id: 722_310_003, Name: 'II' },
+                               { Id: 722_310_004, Name: 'III' },
+                               { Id: 722_310_006, Name: 'IV' },
+                               { Id: 722_310_002, Name: 'V' },
+                               { Id: 722_310_005, Name: 'VI' }] },
+          'veteranrelationship' => { Data: [{ Id: 722_310_007, Name: 'Child' },
+                                            { Id: 722_310_008, Name: 'Guardian' },
+                                            { Id: 722_310_005, Name: 'Parent' },
+                                            { Id: 722_310_012, Name: 'Sibling' },
+                                            { Id: 722_310_015, Name: 'Spouse/Surviving Spouse' },
+                                            { Id: 722_310_004, Name: 'Ex-spouse' },
+                                            { Id: 722_310_010, Name: 'GI Bill Beneficiary' },
+                                            { Id: 722_310_018, Name: 'Other (Personal)' },
+                                            { Id: 722_310_000, Name: 'Attorney' },
+                                            { Id: 722_310_001, Name: 'Authorized 3rd Party' },
+                                            { Id: 722_310_020, Name: 'Fiduciary' },
+                                            { Id: 722_310_006, Name: 'Funeral Director' },
+                                            { Id: 722_310_016, Name: 'OJT/Apprenticeship Supervisor' },
+                                            { Id: 722_310_013, Name: 'School Certifying Official' },
+                                            { Id: 722_310_019, Name: 'VA Employee' },
+                                            { Id: 722_310_017, Name: 'VSO' },
+                                            { Id: 722_310_014, Name: 'Work Study Site Supervisor' },
+                                            { Id: 722_310_011, Name: 'Other (Business)' },
+                                            { Id: 722_310_002, Name: 'School Official (DO NOT USE)' },
+                                            { Id: 722_310_009, Name: 'Helpless Child' },
+                                            { Id: 722_310_003, Name: 'Dependent Child' }] },
+          'dependentrelationship' => { Data: [{ Id: 722_310_006, Name: 'Child' },
+                                              { Id: 722_310_009, Name: 'Parent' },
+                                              { Id: 722_310_008, Name: 'Spouse' },
+                                              { Id: 722_310_010, Name: 'Stepchild' },
+                                              { Id: 722_310_005, Name: 'Other' }] },
+          'responsetype' => { Data: [{ Id: 722_310_000, Name: 'Email' }, { Id: 722_310_001, Name: 'Phone' },
+                                     { Id: 722_310_002, Name: 'US Mail' }] }
+        }[option]
+      end
+    end
+
+    context 'when successful' do
+      before do
+        allow(Crm::CacheData).to receive(:new).and_return(cache_data_instance)
+        option_keys.each do |option|
+          allow(cache_data_instance).to receive(:fetch_and_cache_data).with(
+            endpoint: 'optionset',
+            cache_key: option,
+            payload: { name: "iris_#{option}" }
+          ).and_return(cache_data.call(option))
+        end
+      end
+
+      it 'creates an instance of Crm::CacheData for each option and calls it' do
+        described_class.new.perform
+
+        %w[
+          inquiryabout inquirysource inquirytype levelofauthentication
+          suffix veteranrelationship dependentrelationship responsetype
+        ].each do |option|
+          expect(cache_data_instance).to have_received(:fetch_and_cache_data).with(
+            endpoint: 'optionset',
+            cache_key: option,
+            payload: { name: "iris_#{option}" }
+          )
+        end
+
+        expect(cache_data_instance).to have_received(:fetch_and_cache_data).exactly(8).times
+      end
+    end
+
+    context 'when an error occurs during caching' do
+      let(:logger) { instance_double(LogService) }
+      let(:body) do
+        '{"Data":null,"Message":"Data Validation: Invalid OptionSet Name iris_branchofservic, valid' \
+          ' values are iris_inquiryabout, iris_inquirysource, iris_inquirytype, iris_levelofauthentication,' \
+          ' iris_suffix, iris_veteranrelationship, iris_branchofservice, iris_country, iris_province,' \
+          ' iris_responsetype, iris_dependentrelationship, statuscode, iris_messagetype","ExceptionOccurred":' \
+          'true,"ExceptionMessage":"Data Validation: Invalid OptionSet Name iris_branchofservic, valid' \
+          ' values are iris_inquiryabout, iris_inquirysource, iris_inquirytype, iris_levelofauthentication,' \
+          ' iris_suffix, iris_veteranrelationship, iris_branchofservice, iris_country, iris_province,' \
+          ' iris_responsetype, iris_dependentrelationship, statuscode, iris_messagetype","MessageId":' \
+          '"6dfa81bd-f04a-4f39-88c5-1422d88ed3ff"}'
+      end
+      let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+
+      before do
+        allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
+        allow_any_instance_of(Crm::Service).to receive(:call).and_return(failure)
+        allow(LogService).to receive(:new).and_return(logger)
+        allow(logger).to receive(:call)
+      end
+
+      it 'logs the error and continues processing when an error occurs' do
+        described_class.new.perform
+
+        expect(logger).to have_received(:call).exactly(8).times
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/spec/sidekiq/crm/topics_data_job_spec.rb
+++ b/modules/ask_va_api/spec/sidekiq/crm/topics_data_job_spec.rb
@@ -6,34 +6,33 @@ RSpec.describe Crm::TopicsDataJob, type: :job do
   include ActiveJob::TestHelper
 
   describe '#perform' do
-    let(:static_data_instance) { instance_double(Crm::CacheData) }
-    let(:logger) { instance_double(SemanticLogger::Logger) }
+    let(:cache_data_instance) { instance_double(Crm::CacheData) }
+    let(:logger) { instance_double(LogService) }
 
     before do
-      allow(Crm::CacheData).to receive(:new).and_return(static_data_instance)
-      allow(static_data_instance).to receive(:fetch_api_data)
-      allow(SemanticLogger).to receive(:[]).and_return(logger)
-      allow(logger).to receive(:error)
+      allow(Crm::CacheData).to receive(:new).and_return(cache_data_instance)
+      allow(cache_data_instance).to receive(:fetch_and_cache_data)
+      allow(LogService).to receive(:new).and_return(logger)
+      allow(logger).to receive(:call)
     end
 
     it 'creates an instance of Crm::CacheData and calls it' do
       described_class.new.perform
 
-      expect(Crm::CacheData).to have_received(:new)
-      expect(static_data_instance).to have_received(:fetch_api_data)
+      expect(cache_data_instance).to have_received(:fetch_and_cache_data)
     end
 
     context 'when an error occurs' do
       let(:error_message) { 'Failed to update static data' }
 
       before do
-        allow(static_data_instance).to receive(:fetch_api_data).and_raise(StandardError.new(error_message))
+        allow(cache_data_instance).to receive(:fetch_and_cache_data).and_raise(StandardError.new(error_message))
       end
 
       it 'logs the error' do
         expect { described_class.new.perform }.not_to raise_error
 
-        expect(logger).to have_received(:error).with(include(error_message))
+        expect(logger).to have_received(:call)
       end
     end
   end


### PR DESCRIPTION
## Summary

1. **New `OptionsetDataJob` for Cache Hydration**:
    - Implemented a background job to refresh the optionset data cache, which ensures that the `Translator` class can efficiently access up-to-date data.
    - The job runs every 24 hours to keep data related to inquiry types, authentication levels, and relationships current.
2. **Enhanced `Crm::CacheData` Class**:
    - Added granular error handling with the introduction of `CacheStoreError` and `ApiServiceError` for distinguishing between cache and API failures.
    - Made cache TTL configurable for greater flexibility via the `initialize` method.
    - Improved modularity by separating responsibilities for fetching and storing data, while refining error handling to rescue and re-raise only specific errors.
3. **`TopicDataJob` Alignment**:
    - Refactored `TopicDataJob` to align with the recent modifications in the `Crm::CacheData` class, ensuring compatibility and proper functioning after updates to the caching mechanism.
4. **Refactor and Error Handling Improvements**:
    - Refactored `BaseRetriever` and `Optionset::Retriever` classes to improve readability and maintainability.
    - Introduced robust error handling in `Optionset::Retriever` to enhance fault tolerance and simplify debugging.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/1352

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected