### PR TITLE
Add Translator class for converting inquiry parameters

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -26,7 +26,7 @@ module AskVAApi
       end
 
       def upload_attachment
-        attachment_translation_map = fetch_parameters('attachment')
+        attachment_translation_map = fetch_parameters('attachments')
         result = Attachments::Uploader.new(
           convert_keys_to_camel_case(attachment_params, attachment_translation_map)
         ).call
@@ -75,7 +75,7 @@ module AskVAApi
       def convert_keys_to_camel_case(params, translation_map)
         params.each_with_object({}) do |(key, value), result_hash|
           if key == 'school_obj'
-            school_translation_map = fetch_parameters('school')
+            school_translation_map = fetch_parameters('school_obj')
             value = convert_keys_to_camel_case(value, school_translation_map)
           end
           camel_case_key = translation_map[key.to_sym]
@@ -88,13 +88,13 @@ module AskVAApi
       end
 
       def attachment_params
-        params.permit(fetch_parameters('attachment').keys).to_h
+        params.permit(fetch_parameters('attachments').keys).to_h
       end
 
       def inquiry_params
         params.permit(
           *fetch_parameters('inquiry').keys,
-          school_obj: fetch_parameters('school').keys
+          school_obj: fetch_parameters('school_obj').keys
         ).to_h
       end
 

--- a/modules/ask_va_api/app/lib/ask_va_api/translator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/translator.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module AskVAApi
+  class TranslatorError < StandardError; end
+
+  class Translator
+    attr_reader :inquiry_params, :optionset_entity_class, :retriever, :logger
+
+    def initialize(inquiry_params:, entity_class: Optionset::Entity)
+      @inquiry_params = inquiry_params
+      @translation_cache = {}
+      @optionset_entity_class = entity_class
+      @retriever = Optionset::Retriever
+      @logger = LogService.new
+    end
+
+    def call
+      payload = convert_keys_to_camel_case(inquiry_params, fetch_translation_map('inquiry'))
+
+      options.each do |option|
+        update_option_in_payload(payload, option)
+      end
+
+      payload
+    end
+
+    private
+
+    def convert_keys_to_camel_case(params, translation_map)
+      params.each_with_object({}) do |(key, value), result|
+        camel_case_key = translation_map[key.to_sym]
+
+        result[camel_case_key.to_sym] = case value
+                                        when Hash
+                                          convert_keys_to_camel_case(value, fetch_translation_map(key))
+                                        when Array
+                                          value.map { |v| convert_keys_to_camel_case(v, fetch_translation_map(key)) }
+                                        else
+                                          value
+                                        end
+      end
+    end
+
+    def update_option_in_payload(payload, option)
+      option_set = retrieve_option_set(option)
+      option_key = options_converter_hash[option]
+
+      return unless option_key
+
+      matching_option = option_set.find { |obj| obj.name == payload[option_key] }
+      payload[option_key] = matching_option.id if matching_option
+    rescue => e
+      log_error("update option #{option}", e)
+      raise TranslatorError, e if e.message.include?('Crm::CacheDataError')
+    end
+
+    def retrieve_option_set(option)
+      retriever.new(name: option, user_mock_data: nil, entity_class: optionset_entity_class).call
+    end
+
+    def options
+      @options ||= %w[
+        inquiryabout inquirysource inquirytype levelofauthentication
+        suffix veteranrelationship dependentrelationship responsetype
+      ]
+    end
+
+    def options_converter_hash
+      {
+        'inquiryabout' => :InquiryAbout,
+        'inquirysource' => :InquirySource,
+        'inquirytype' => :InquiryType,
+        'levelofauthentication' => :LevelOfAuthentication,
+        'suffix' => :Suffix,
+        'veteranrelationship' => :VeteranRelationship,
+        'dependentrelationship' => :DependantRelationship,
+        'responsetype' => :ResponseType
+      }
+    end
+
+    def fetch_translation_map(key)
+      @translation_cache[key] ||= I18n.t("ask_va_api.parameters.#{key}")
+    end
+
+    def log_error(action, exception)
+      logger.call(action) do |span|
+        span.set_tag('error', true)
+        span.set_tag('error.msg', exception.message)
+      end
+      Rails.logger.error("Error during #{action}: #{exception.message}")
+    end
+  end
+end

--- a/modules/ask_va_api/app/services/crm/cache_data.rb
+++ b/modules/ask_va_api/app/services/crm/cache_data.rb
@@ -1,42 +1,56 @@
 # frozen_string_literal: true
 
 module Crm
-  class CacheData
-    attr_reader :cache_client, :service
+  class CacheDataError < StandardError; end
+  class ApiServiceError < StandardError; end
+  class CacheStoreError < StandardError; end
 
-    def initialize(service: Service.new(icn: nil), cache_client: AskVAApi::RedisClient.new)
+  class CacheData
+    attr_reader :cache_client, :service, :cache_ttl
+
+    DEFAULT_TTL = 86_400
+
+    def initialize(service: Service.new(icn: nil), cache_client: AskVAApi::RedisClient.new, cache_ttl: DEFAULT_TTL)
       @cache_client = cache_client
       @service = service
+      @cache_ttl = cache_ttl
     end
 
     def call(endpoint:, cache_key:, payload: {})
-      data = cache_client.fetch(cache_key)
-
-      data = fetch_api_data(endpoint:, cache_key:, payload:) if data.nil?
-
-      data
+      fetch_cache_data(cache_key) || fetch_and_cache_data(endpoint:, cache_key:, payload:)
     rescue => e
-      ::ErrorHandler.handle_service_error(e)
+      raise CacheDataError, "#{e.class.name}: #{e.message}"
     end
 
-    def fetch_api_data(endpoint:, cache_key:, payload: {})
-      response = service.call(endpoint:, payload:)
-      data = handle_response_data(response)
-
-      cache_client.store_data(key: cache_key, data:, ttl: 86_400)
-
+    def fetch_and_cache_data(endpoint:, cache_key:, payload:)
+      data = fetch_api_data(endpoint:, payload:)
+      store_in_cache(cache_key, data) if data
       data
     end
 
     private
 
+    def fetch_cache_data(cache_key)
+      cache_client.fetch(cache_key)
+    rescue => e
+      raise CacheStoreError, "Cache store failure: #{e.message}"
+    end
+
+    def fetch_api_data(endpoint:, payload:)
+      response = service.call(endpoint:, payload:)
+      handle_response_data(response)
+    end
+
+    def store_in_cache(cache_key, data)
+      cache_client.store_data(key: cache_key, data:, ttl: cache_ttl)
+    rescue => e
+      raise CacheStoreError, "Failed to store data in cache: #{e.message}"
+    end
+
     def handle_response_data(response)
-      case response
-      when Hash
-        response
-      else
-        raise(StandardError, response.body)
-      end
+      return response if response.is_a?(Hash)
+
+      raise ApiServiceError, "Invalid response format: #{response.body}"
     end
   end
 end

--- a/modules/ask_va_api/config/locales/en.yml
+++ b/modules/ask_va_api/config/locales/en.yml
@@ -52,12 +52,8 @@ en:
       - code: 'CG ACAD'
         description: 'Coast Guard Academy'
     parameters:
-      attachment:
-        file_name: fileName
-        file_content: fileContent
-        inquiry_id: inquiryId
-        correspondence_id: correspondenceId
       inquiry:
+        attachments: ListOfAttachments
         are_you_the_dependent: AreYouTheDependent
         attachment_present: AttachmentPresent
         branch_of_service: BranchOfService
@@ -100,6 +96,8 @@ en:
         middle_name: MiddleName
         preferred_name: PreferredName
         pronouns: Pronouns
+        profile: Profile
+        response_type: ResponseType
         school_obj: SchoolObj
         street_address2: StreetAddress2
         submitter: Submitter
@@ -150,10 +148,41 @@ en:
         who_was_their_counselor: WhoWasTheirCounselor
         your_last_name: YourLastName
         zip_code: ZipCode
-      school:
+      profile: 
+        first_name: firstName
+        middle_name: middleName
+        last_name: lastName
+        preferred_name: preferredName
+        suffix: suffix
+        gender: gender
+        pronouns: pronouns
+        country: country
+        street: street
+        city: city
+        state: state
+        zip_code: zipCode
+        province: province
+        business_phone: businessPhone
+        personal_phone: personalPhone
+        personal_email: personalEmail
+        business_email: businessEmail
+        school_state: schoolState
+        school_facility_code: schoolFacilityCode
+        service_number: serviceNumber
+        claim_number: claimNumber
+        veteran_service_state_date: veteranServiceStateDate
+        veteran_service_end_date: veteranServiceEndDate
+        date_of_birth: dateOfBirth
+        edipi: edipi
+      school_obj:
         city: City
         institution_name: InstitutionName
         regional_office: RegionalOffice
         school_facility_code: SchoolFacilityCode
         state_abbreviation: StateAbbreviation
+      attachments:
+        file_name: fileName
+        file_content: fileContent
+        inquiry_id: inquiryId
+        correspondence_id: correspondenceId
 

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/translator_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/translator_spec.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AskVAApi::Translator do
+  subject(:translator) { AskVAApi::Translator.new(inquiry_params:) }
+
+  let(:inquiry_params) do
+    { 'are_you_the_dependent' => 'false',
+      'attachment_present' => 'true',
+      'branch_of_service' => '722310000',
+      'city' => 'Dallas',
+      'contact_method' => '722310000',
+      'country' => '722310186',
+      'daytime_phone' => '(989)898-9898',
+      'dependant_city' => nil,
+      'dependant_country' => '722310000',
+      'dependant_dob' => nil,
+      'dependant_email' => nil,
+      'dependant_first_name' => nil,
+      'dependant_gender' => nil,
+      'dependant_last_name' => nil,
+      'dependant_middle_name' => nil,
+      'dependant_province' => '722310005',
+      'dependant_relationship' => 'Other',
+      'dependant_ssn' => nil,
+      'dependant_state' => nil,
+      'dependant_street_address' => nil,
+      'dependant_zip_code' => nil,
+      'email_address' => 'vets.gov.user+119@gmail.com',
+      'email_confirmation' => 'vets.gov.user+119@gmail.com',
+      'first_name' => 'Glen',
+      'gender' => 'M',
+      'inquiry_about' => 'A general question',
+      'inquiry_category' => '5c524deb-d864-eb11-bb24-000d3a579c45',
+      'inquiry_source' => 'AVA',
+      'inquiry_subtopic' => '932a8586-e764-eb11-bb23-000d3a579c3f',
+      'inquiry_summary' => 'string',
+      'inquiry_topic' => '932a8586-e764-eb11-bb23-000d3a579c3f',
+      'inquiry_type' => 'Question',
+      'is_va_employee' => 'true',
+      'is_veteran' => 'true',
+      'is_veteran_an_employee' => 'true',
+      'is_veteran_deceased' => 'false',
+      'level_of_authentication' => 'Personal',
+      'medical_center' => '07a51029-6816-e611-9436-0050568d743d',
+      'middle_name' => 'Lee',
+      'preferred_name' => nil,
+      'pronouns' => 'He/Him',
+      'response_type' => 'Email',
+      'street_address2' => nil,
+      'submitter' => '42cc2a0a-2ebf-e711-9495-0050568d63d9',
+      'submitter_dependent' => '722310000',
+      'submitter_dob' => '1971-12-08',
+      'submitter_gender' => 'M',
+      'submitter_province' => '722310008',
+      'submitter_question' => 'I would like to know more about my claims',
+      'submitters_dod_id_edipi_number' => '987654321',
+      'submitter_ssn' => '796231077',
+      'submitter_state' => 'TX',
+      'submitter_state_of_residency' => 'TX',
+      'submitter_state_of_school' => 'TX',
+      'submitter_state_property' => 'TX',
+      'submitter_street_address' => '4343 Rosemeade Pkwy',
+      'submitter_vet_center' => '200ESR',
+      'submitter_zip_code_of_residency' => '75287-2950',
+      'suffix' => 'Jr',
+      'supervisor_flag' => 'true',
+      'va_employee_time_stamp' => nil,
+      'veteran_city' => 'Dallas',
+      'veteran_claim_number' => nil,
+      'veteran_country' => '722310186',
+      'veteran_date_of_death' => nil,
+      'veteran_dob' => '1971-12-08',
+      'veteran_dod_id_edipi_number' => '987654321',
+      'veteran_email' => 'vets.gov.user+119@gmail.com',
+      'veteran_email_confirmation' => 'vets.gov.user+119@gmail.com',
+      'veteran_enrolled' => 'true',
+      'veteran_first_name' => 'Glen',
+      'veteran_icn' => nil,
+      'veteran_last_name' => 'Wells',
+      'veteran_middle_name' => 'Lee',
+      'veteran_phone' => '(989)898-9898',
+      'veteran_prefered_name' => nil,
+      'veteran_pronouns' => 'He/Him',
+      'veteran_province' => '722310005',
+      'veteran_relationship' => 'VA Employee',
+      'veteran_service_end_date' => '01/01/2000',
+      'veteran_service_number' => nil,
+      'veteran_service_start_date' => nil,
+      'veteran_ssn' => '123456799',
+      'veterans_state' => '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
+      'veteran_street_address' => '4343 Rosemeade Pkwy',
+      'veteran_suffix' => '722310001',
+      'veteran_suite_apt_other' => nil,
+      'veteran_zip_code' => '75287-2950',
+      'who_was_their_counselor' => nil,
+      'your_last_name' => 'Wells',
+      'zip_code' => '75287-2950',
+      'profile' =>
+       { 'first_name' => 'Glen',
+         'middle_name' => 'M',
+         'last_name' => 'Wells',
+         'preferred_name' => nil,
+         'suffix' => '722310001',
+         'gender' => 'M',
+         'pronouns' => 'He/Him',
+         'country' => '722310186',
+         'street' => '4343 Rosemeade Pkwy',
+         'city' => 'Dallas',
+         'state' => 'TX',
+         'zip_code' => '75287-2950',
+         'province' => nil,
+         'business_phone' => '(989)898-9898',
+         'personal_phone' => '(989)898-9898',
+         'personal_email' => 'vets.gov.user+119@gmail.com',
+         'business_email' => 'vets.gov.user+119@gmail.com',
+         'school_state' => 'TX',
+         'school_facility_code' => '1000000898',
+         'service_number' => nil,
+         'claim_number' => nil,
+         'veteran_service_state_date' => nil,
+         'date_of_birth' => '1971-12-08',
+         'edipi' => nil },
+      'school_obj' =>
+       { 'city' => 'Dallas',
+         'institution_name' => "Kyle's Institution",
+         'regional_office' => '669cbc60-b58d-eb11-b1ac-001dd8309d89',
+         'school_facility_code' => '1000000898',
+         'state_abbreviation' => '80b9d1e0-d488-eb11-b1ac-001dd8309d89' },
+      'attachments' =>
+       [{ 'file_name' => 'testfile.pdf',
+          'file_content' => 'base64 string' }] }
+  end
+  let(:converted_payload) do
+    { AreYouTheDependent: 'false',
+      AttachmentPresent: 'true',
+      BranchOfService: '722310000',
+      City: 'Dallas',
+      ContactMethod: '722310000',
+      Country: '722310186',
+      DaytimePhone: '(989)898-9898',
+      DependantCity: nil,
+      DependantCountry: '722310000',
+      DependantDOB: nil,
+      DependantEmail: nil,
+      DependantFirstName: nil,
+      DependantGender: nil,
+      DependantLastName: nil,
+      DependantMiddleName: nil,
+      DependantProvince: '722310005',
+      DependantRelationship: 722_310_005,
+      DependantSSN: nil,
+      DependantState: nil,
+      DependantStreetAddress: nil,
+      DependantZipCode: nil,
+      EmailAddress: 'vets.gov.user+119@gmail.com',
+      EmailConfirmation: 'vets.gov.user+119@gmail.com',
+      FirstName: 'Glen',
+      Gender: 'M',
+      InquiryAbout: 722_310_003,
+      InquiryCategory: '5c524deb-d864-eb11-bb24-000d3a579c45',
+      InquirySource: 722_310_000,
+      InquirySubtopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
+      InquirySummary: 'string',
+      InquiryTopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
+      InquiryType: 722_310_001,
+      IsVAEmployee: 'true',
+      IsVeteran: 'true',
+      IsVeteranAnEmployee: 'true',
+      IsVeteranDeceased: 'false',
+      LevelOfAuthentication: 722_310_001,
+      MedicalCenter: '07a51029-6816-e611-9436-0050568d743d',
+      MiddleName: 'Lee',
+      PreferredName: nil,
+      Pronouns: 'He/Him',
+      ResponseType: 722_310_000,
+      StreetAddress2: nil,
+      Submitter: '42cc2a0a-2ebf-e711-9495-0050568d63d9',
+      SubmitterDependent: '722310000',
+      SubmitterDOB: '1971-12-08',
+      SubmitterGender: 'M',
+      SubmitterProvince: '722310008',
+      SubmitterQuestion: 'I would like to know more about my claims',
+      SubmittersDodIdEdipiNumber: '987654321',
+      SubmitterSSN: '796231077',
+      SubmitterState: 'TX',
+      SubmitterStateOfResidency: 'TX',
+      SubmitterStateOfSchool: 'TX',
+      SubmitterStateProperty: 'TX',
+      SubmitterStreetAddress: '4343 Rosemeade Pkwy',
+      SubmitterVetCenter: '200ESR',
+      SubmitterZipCodeOfResidency: '75287-2950',
+      Suffix: 722_310_000,
+      SupervisorFlag: 'true',
+      VaEmployeeTimeStamp: nil,
+      VeteranCity: 'Dallas',
+      VeteranClaimNumber: nil,
+      VeteranCountry: '722310186',
+      VeteranDateOfDeath: nil,
+      VeteranDOB: '1971-12-08',
+      VeteranDodIdEdipiNumber: '987654321',
+      VeteranEmail: 'vets.gov.user+119@gmail.com',
+      VeteranEmailConfirmation: 'vets.gov.user+119@gmail.com',
+      VeteranEnrolled: 'true',
+      VeteranFirstName: 'Glen',
+      VeteranICN: nil,
+      VeteranLastName: 'Wells',
+      VeteranMiddleName: 'Lee',
+      VeteranPhone: '(989)898-9898',
+      VeteranPreferedName: nil,
+      VeteranPronouns: 'He/Him',
+      VeteranProvince: '722310005',
+      VeteranRelationship: 722_310_019,
+      VeteranServiceEndDate: '01/01/2000',
+      VeteranServiceNumber: nil,
+      VeteranServiceStartDate: nil,
+      VeteranSSN: '123456799',
+      VeteransState: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
+      VeteranStreetAddress: '4343 Rosemeade Pkwy',
+      VeteranSuffix: '722310001',
+      VeteranSuiteAptOther: nil,
+      VeteranZipCode: '75287-2950',
+      WhoWasTheirCounselor: nil,
+      YourLastName: 'Wells',
+      ZipCode: '75287-2950',
+      Profile: { firstName: 'Glen',
+                 middleName: 'M',
+                 lastName: 'Wells',
+                 preferredName: nil,
+                 suffix: '722310001',
+                 gender: 'M',
+                 pronouns: 'He/Him',
+                 country: '722310186',
+                 street: '4343 Rosemeade Pkwy',
+                 city: 'Dallas',
+                 state: 'TX',
+                 zipCode: '75287-2950',
+                 province: nil,
+                 businessPhone: '(989)898-9898',
+                 personalPhone: '(989)898-9898',
+                 personalEmail: 'vets.gov.user+119@gmail.com',
+                 businessEmail: 'vets.gov.user+119@gmail.com',
+                 schoolState: 'TX',
+                 schoolFacilityCode: '1000000898',
+                 serviceNumber: nil,
+                 claimNumber: nil,
+                 veteranServiceStateDate: nil,
+                 dateOfBirth: '1971-12-08',
+                 edipi: nil },
+      SchoolObj: { City: 'Dallas',
+                   InstitutionName: "Kyle's Institution",
+                   RegionalOffice: '669cbc60-b58d-eb11-b1ac-001dd8309d89',
+                   SchoolFacilityCode: '1000000898',
+                   StateAbbreviation: '80b9d1e0-d488-eb11-b1ac-001dd8309d89' },
+      ListOfAttachments: [{ fileName: 'testfile.pdf',
+                            fileContent: 'base64 string' }] }
+  end
+  let(:cache_data_service) { instance_double(Crm::CacheData) }
+  let(:option_keys) do
+    %w[inquiryabout inquirysource inquirytype levelofauthentication suffix veteranrelationship
+       dependentrelationship responsetype]
+  end
+  let(:result) { subject.call }
+
+  context 'when succesful' do
+    let(:cache_data) do
+      lambda do |option|
+        {
+          'inquiryabout' => { Data: [{ Id: 722_310_003, Name: 'A general question' },
+                                     { Id: 722_310_000, Name: 'About Me, the Veteran' },
+                                     { Id: 722_310_002, Name: 'For the dependent of a Veteran' },
+                                     { Id: 722_310_001, Name: 'On behalf of a Veteran' }] },
+          'inquirysource' => { Data: [{ Id: 722_310_005, Name: 'Phone' },
+                                      { Id: 722_310_004, Name: 'US Mail' },
+                                      { Id: 722_310_000, Name: 'AVA' },
+                                      { Id: 722_310_001, Name: 'Email' },
+                                      { Id: 722_310_002, Name: 'Facebook' }] },
+          'inquirytype' => { Data: [{ Id: 722_310_000, Name: 'Compliment' },
+                                    { Id: 722_310_001, Name: 'Question' },
+                                    { Id: 722_310_002, Name: 'Service Complaint' },
+                                    { Id: 722_310_006, Name: 'Suggestion' },
+                                    { Id: 722_310_004, Name: 'Other' }] },
+          'levelofauthentication' => { Data: [{ Id: 722_310_002, Name: 'Authenticated' },
+                                              { Id: 722_310_000, Name: 'Unauthenticated' },
+                                              { Id: 722_310_001, Name: 'Personal' },
+                                              { Id: 722_310_003, Name: 'Business' }] },
+          'suffix' => { Data: [{ Id: 722_310_000, Name: 'Jr' },
+                               { Id: 722_310_001, Name: 'Sr' },
+                               { Id: 722_310_003, Name: 'II' },
+                               { Id: 722_310_004, Name: 'III' },
+                               { Id: 722_310_006, Name: 'IV' },
+                               { Id: 722_310_002, Name: 'V' },
+                               { Id: 722_310_005, Name: 'VI' }] },
+          'veteranrelationship' => { Data: [{ Id: 722_310_007, Name: 'Child' },
+                                            { Id: 722_310_008, Name: 'Guardian' },
+                                            { Id: 722_310_005, Name: 'Parent' },
+                                            { Id: 722_310_012, Name: 'Sibling' },
+                                            { Id: 722_310_015, Name: 'Spouse/Surviving Spouse' },
+                                            { Id: 722_310_004, Name: 'Ex-spouse' },
+                                            { Id: 722_310_010, Name: 'GI Bill Beneficiary' },
+                                            { Id: 722_310_018, Name: 'Other (Personal)' },
+                                            { Id: 722_310_000, Name: 'Attorney' },
+                                            { Id: 722_310_001, Name: 'Authorized 3rd Party' },
+                                            { Id: 722_310_020, Name: 'Fiduciary' },
+                                            { Id: 722_310_006, Name: 'Funeral Director' },
+                                            { Id: 722_310_016, Name: 'OJT/Apprenticeship Supervisor' },
+                                            { Id: 722_310_013, Name: 'School Certifying Official' },
+                                            { Id: 722_310_019, Name: 'VA Employee' },
+                                            { Id: 722_310_017, Name: 'VSO' },
+                                            { Id: 722_310_014, Name: 'Work Study Site Supervisor' },
+                                            { Id: 722_310_011, Name: 'Other (Business)' },
+                                            { Id: 722_310_002, Name: 'School Official (DO NOT USE)' },
+                                            { Id: 722_310_009, Name: 'Helpless Child' },
+                                            { Id: 722_310_003, Name: 'Dependent Child' }] },
+          'dependentrelationship' => { Data: [{ Id: 722_310_006, Name: 'Child' },
+                                              { Id: 722_310_009, Name: 'Parent' },
+                                              { Id: 722_310_008, Name: 'Spouse' },
+                                              { Id: 722_310_010, Name: 'Stepchild' },
+                                              { Id: 722_310_005, Name: 'Other' }] },
+          'responsetype' => { Data: [{ Id: 722_310_000, Name: 'Email' }, { Id: 722_310_001, Name: 'Phone' },
+                                     { Id: 722_310_002, Name: 'US Mail' }] }
+        }[option]
+      end
+    end
+    let(:result) { subject.call }
+
+    before do
+      allow(Crm::CacheData).to receive(:new).and_return(cache_data_service)
+
+      option_keys.each do |option|
+        allow(cache_data_service).to receive(:call).with(
+          endpoint: 'optionset',
+          cache_key: option,
+          payload: { name: "iris_#{option}" }
+        ).and_return(cache_data.call(option))
+      end
+    end
+
+    it 'translates the keys from snake_case to camel_case' do
+      expect(result.keys).to eq(converted_payload.keys)
+    end
+
+    it 'translates all the option keys from name to id' do
+      expect(result[:InquiryAbout]).to eq(converted_payload[:InquiryAbout])
+      expect(result[:InquirySource]).to eq(converted_payload[:InquirySource])
+      expect(result[:InquiryType]).to eq(converted_payload[:InquiryType])
+      expect(result[:LevelOfAuthentication]).to eq(converted_payload[:LevelOfAuthentication])
+      expect(result[:Suffix]).to eq(converted_payload[:Suffix])
+      expect(result[:VeteranRelationship]).to eq(converted_payload[:VeteranRelationship])
+      expect(result[:DependantRelationship]).to eq(converted_payload[:DependantRelationship])
+      expect(result[:ResponseType]).to eq(converted_payload[:ResponseType])
+    end
+
+    it 'translates inquiry_params to converted payload' do
+      expect(result).to eq(converted_payload)
+    end
+  end
+
+  context 'when an error occurs' do
+    let(:result) { subject.call }
+    let(:body) do
+      '{"Data":null,"Message":"Data Validation: Invalid OptionSet Name iris_inquiryabou, valid' \
+        ' values are iris_inquiryabout, iris_inquirysource, iris_inquirytype, iris_levelofauthentication,' \
+        ' iris_suffix, iris_veteranrelationship, iris_branchofservice, iris_country, iris_province,' \
+        ' iris_responsetype, iris_dependentrelationship, statuscode, iris_messagetype","ExceptionOccurred":' \
+        'true,"ExceptionMessage":"Data Validation: Invalid OptionSet Name iris_branchofservic, valid' \
+        ' values are iris_inquiryabout, iris_inquirysource, iris_inquirytype, iris_levelofauthentication,' \
+        ' iris_suffix, iris_veteranrelationship, iris_branchofservice, iris_country, iris_province,' \
+        ' iris_responsetype, iris_dependentrelationship, statuscode, iris_messagetype","MessageId":' \
+        '"6dfa81bd-f04a-4f39-88c5-1422d88ed3ff"}'
+    end
+    let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+
+    before do
+      allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
+      allow_any_instance_of(Crm::Service).to receive(:call)
+        .with(endpoint: 'optionset', payload: { name: 'iris_inquiryabout' }).and_return(failure)
+    end
+
+    it 'log to Datadog, when updating option fails' do
+      expect { result }.to raise_error(AskVAApi::TranslatorError)
+    end
+  end
+end

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/static_data_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/static_data_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe 'AskVAApi StaticData', type: :request do
       end
 
       it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
-                      'ErrorHandler::ServiceError: StandardError: {"Data":null,"Message":' \
+                      'Crm::CacheDataError: Crm::ApiServiceError: Invalid response format: {"Data":null,"Message":' \
                       '"Data Validation: Invalid OptionSet Name iris_branchofservic, ' \
                       'valid values are iris_inquiryabout, iris_inquirysource, iris_inquirytype,' \
                       ' iris_levelofauthentication, iris_suffix, iris_veteranrelationship,' \

--- a/modules/ask_va_api/spec/sidekiq/crm/topics_data_job_spec.rb
+++ b/modules/ask_va_api/spec/sidekiq/crm/topics_data_job_spec.rb
@@ -6,34 +6,33 @@ RSpec.describe Crm::TopicsDataJob, type: :job do
   include ActiveJob::TestHelper
 
   describe '#perform' do
-    let(:static_data_instance) { instance_double(Crm::CacheData) }
-    let(:logger) { instance_double(SemanticLogger::Logger) }
+    let(:cache_data_instance) { instance_double(Crm::CacheData) }
+    let(:logger) { instance_double(LogService) }
 
     before do
-      allow(Crm::CacheData).to receive(:new).and_return(static_data_instance)
-      allow(static_data_instance).to receive(:fetch_api_data)
-      allow(SemanticLogger).to receive(:[]).and_return(logger)
-      allow(logger).to receive(:error)
+      allow(Crm::CacheData).to receive(:new).and_return(cache_data_instance)
+      allow(cache_data_instance).to receive(:fetch_and_cache_data)
+      allow(LogService).to receive(:new).and_return(logger)
+      allow(logger).to receive(:call)
     end
 
     it 'creates an instance of Crm::CacheData and calls it' do
       described_class.new.perform
 
-      expect(Crm::CacheData).to have_received(:new)
-      expect(static_data_instance).to have_received(:fetch_api_data)
+      expect(cache_data_instance).to have_received(:fetch_and_cache_data)
     end
 
     context 'when an error occurs' do
       let(:error_message) { 'Failed to update static data' }
 
       before do
-        allow(static_data_instance).to receive(:fetch_api_data).and_raise(StandardError.new(error_message))
+        allow(cache_data_instance).to receive(:fetch_and_cache_data).and_raise(StandardError.new(error_message))
       end
 
       it 'logs the error' do
         expect { described_class.new.perform }.not_to raise_error
 
-        expect(logger).to have_received(:error).with(include(error_message))
+        expect(logger).to have_received(:call)
       end
     end
   end


### PR DESCRIPTION
## Summary

- **New `Translator` Class**:
    - Added a `Translator` class to handle the conversion of inquiry parameters by translating keys and values into the correct IDs required for CRM API payloads. This ensures seamless mapping of inquiry parameters to CRM-compatible formats for accurate data submission.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/1352

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
