### PR TITLE
Fixing flaky lighthouse benefits document spec

### DIFF
--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -19,7 +19,7 @@ module BenefitsDocuments
     DOCUMENTS_PATH = "#{BASE_PATH}/documents".freeze
     DOCUMENTS_STATUS_PATH = "#{BASE_PATH}/uploads/status".freeze
     TOKEN_PATH = 'oauth2/benefits-documents/system/v1/token'
-    QA_TESTING_DOMAIN = 'https://dev-api.va.gov'
+    QA_TESTING_DOMAIN = Settings.lighthouse.benefits_documents.host
 
     ##
     # @return [Config::Options] Settings for benefits_claims API.


### PR DESCRIPTION
## Summary

- This PR fixes a class of spec around benefits documents that occurred because of a mocked access token route that was mocking dev instead of sandbox