### PR TITLE
Remove virtus from Preneeds::Attachment

### DIFF
--- a/app/models/preneeds/attachment.rb
+++ b/app/models/preneeds/attachment.rb
@@ -14,9 +14,7 @@ module Preneeds
   # @!attribute data_handler
   #   @return [String] auto-generated attachment id
   #
-  class Attachment
-    include Virtus.model
-
+  class Attachment < Preneeds::Base
     # string to populate #sending_source
     #
     VETS_GOV = 'vets.gov'


### PR DESCRIPTION
## Summary

- I accidentally left Virtus on Preneeds::Attachment

Original PR: https://github.com/department-of-veterans-affairs/vets-api/pull/18494

