### PR TITLE
Remove virtus from HCA::UserAttributes

### DIFF
--- a/lib/hca/user_attributes.rb
+++ b/lib/hca/user_attributes.rb
@@ -1,26 +1,49 @@
 # frozen_string_literal: true
 
-class HCA::UserAttributes
-  include ActiveModel::Validations
-  include Virtus.model(nullify_blank: true)
+module HCA
+  class UserAttributes
+    include ActiveModel::Model
+    include ActiveModel::Validations
 
-  attribute :first_name, String
-  attribute :middle_name, String
-  attribute :last_name, String
-  attribute :birth_date, String
-  attribute :ssn, String
+    validates :first_name, presence: true
+    validates :last_name, presence: true
+    validates :birth_date, presence: true
+    validates :ssn, presence: true
 
-  validates(:first_name, :last_name, :birth_date, :ssn, presence: true)
+    attr_accessor :first_name,
+                  :middle_name,
+                  :last_name,
+                  :birth_date,
+                  :ssn,
+                  :gender
 
-  # These attributes, along with uuid, are required by mpi/service.
-  # They can be nil as they're not part of the HCA form
-  attr_reader :mhv_icn, :edipi, :gender, :authn_context, :idme_uuid, :logingov_uuid
+    # These attributes, along with uuid, are required by mpi/service.
+    # They can be nil as they're not part of the HCA form
+    attr_reader :mhv_icn, :edipi, :authn_context, :idme_uuid, :logingov_uuid
 
-  def ssn=(new_ssn)
-    super(new_ssn&.gsub(/\D/, ''))
-  end
+    def initialize(first_name:, middle_name:, last_name:, birth_date:, ssn:, gender:)
+      super
+      @ssn = ssn&.gsub(/\D/, '')
 
-  def uuid
-    SecureRandom.uuid
+      @mhv_icn = nil
+      @edipi = nil
+      @authn_context = nil
+      @idme_uuid = nil
+      @logingov_uuid =nil
+    end
+
+    def to_h
+      {
+        first_name:,
+        middle_name:,
+        last_name:,
+        birth_date:,
+        ssn:
+      }
+    end
+
+    def uuid
+      SecureRandom.uuid
+    end
   end
 end

--- a/lib/hca/user_attributes.rb
+++ b/lib/hca/user_attributes.rb
@@ -21,15 +21,9 @@ module HCA
     # They can be nil as they're not part of the HCA form
     attr_reader :mhv_icn, :edipi, :authn_context, :idme_uuid, :logingov_uuid
 
-    def initialize(first_name:, middle_name:, last_name:, birth_date:, ssn:, gender:)
+    def initialize(attributes = {})
       super
-      @ssn = ssn&.gsub(/\D/, '')
-
-      @mhv_icn = nil
-      @edipi = nil
-      @authn_context = nil
-      @idme_uuid = nil
-      @logingov_uuid =nil
+      @ssn = attributes[:ssn]&.gsub(/\D/, '')
     end
 
     def to_h


### PR DESCRIPTION
## Summary

- Remove virtus from HCA::UserAttributes
- Moved `gender` from `attr_reader` to `attr_accessor` because it is in the form

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93531

## Testing done

- [x] tests pass 

## Acceptance criteria

- [x] HCA::UserAttributes don't use the virtus gem
- [x] necessary Virtus features were replicated