### PR TITLE
Fix nested_attributes Mistake

### DIFF
--- a/app/models/preneeds/base.rb
+++ b/app/models/preneeds/base.rb
@@ -125,7 +125,7 @@ module Preneeds
     # @return [Hash] nested attributes
     def nested_attributes(values)
       values.transform_values do |value|
-        if value.respond_to?(:instance_values)
+        if value.respond_to?(:attributes)
           nested_attributes(value.instance_values)
         else
           value


### PR DESCRIPTION
## Summary

- String and other scalar values respond to instance_values, which caused an error
- This PR fixes that issue

```
# before 
{"applicant_email"=>{},
 "applicant_phone_number"=>{},
 "applicant_relationship_to_claimant"=>{},
 "completing_reason"=>{},
 "name"=>{"last"=>{}, "first"=>{}, "middle"=>{}, "maiden"=>{}, "suffix"=>{}},
 "mailing_address"=>{"street"=>{}, "street2"=>{}, "city"=>{}, "state"=>{}, "country"=>{}, "postal_code"=>{}}}
```
```
# after
{"applicant_email"=>"hg@hotmail.com",
 "applicant_phone_number"=>"555-555-5555 - 234",
 "applicant_relationship_to_claimant"=>"Self",
 "completing_reason"=>"I don't know",
 "name"=>{"last"=>"last 1", "first"=>"first 1", "middle"=>"middle 1", "maiden"=>"maiden 1", "suffix"=>"Jr."},
 "mailing_address"=>{"street"=>"street 1", "street2"=>"street2 1", "city"=>"NY", "state"=>"NY", "country"=>"USA", "postal_code"=>"10000"}}
```

## Testing done

- [ ] manual testing to confirm #attributes produced the correct values

## Acceptance criteria

- [ ]  #attributes has scalar values for nested attributes 

