### PR TITLE
[DBX-18617] refactor accepted_to_primary 526 scope

### DIFF
--- a/app/sidekiq/form526_submission_processing_report_job.rb
+++ b/app/sidekiq/form526_submission_processing_report_job.rb
@@ -58,12 +58,6 @@ class Form526SubmissionProcessingReportJob
     @sub_arel ||= Form526Submission.arel_table
   end
 
-  def backup_submissions
-    @backup_submissions ||= timeboxed_submissions
-                            .joins(:form526_job_statuses)
-                            .where(form526_job_statuses: { job_class: 'BackupSubmission', status: 'success' })
-  end
-
   def timeboxed_submissions
     @timeboxed_submissions ||= Form526Submission
                                .where(sub_arel_created_at.gt(start_date))

--- a/lib/scopes/form526_submission_state.rb
+++ b/lib/scopes/form526_submission_state.rb
@@ -24,7 +24,9 @@ module Scopes
       }
 
       scope :accepted_to_primary_path, lambda {
-        accepted_to_lighthouse_primary_path.or(accepted_to_evss_primary_path)
+        lh = accepted_to_lighthouse_primary_path.pluck(:id)
+        evss = accepted_to_evss_primary_path.pluck(:id)
+        where(id: lh + evss)
       }
       scope :accepted_to_evss_primary_path, lambda {
         where.not(submitted_claim_id: nil)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- refactor our form 526 `accepted_to_primary_path` scope
  - fixes a bug caused by `.or` returning extra rows
  - shortens DB interaction by processing array join in memory
- remove unused method from Report logging job
  
## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=81066319)
- [Doc](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/engineering_research/526_scopes.md)

## Testing done

- [x] *New code is covered by unit tests*
- new scope count is correct in production using new logic

## What areas of the site does it impact?
526 form submission logging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (see abo ve)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature (n/a)

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
