### PR TITLE
Simple Forms - add callbacks endpoint for VANotify email notifications

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -669,6 +669,10 @@ features:
     actor_type: user
     description: Enables form email notifications upon certain state changes (error and received)
     enable_in_development: true
+  simple_forms_callbacks_endpoint:
+    actor_type: user
+    description: Simple Forms API VANotify notification callbacks endpoint
+    enable_in_development: true
   form2010206:
     actor_type: user
     description: If enabled shows the digital form experience for form 20-10206

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -430,6 +430,9 @@ ask_va:
 nod_vanotify_status_callback:
   bearer_token: bearer_token_secret
 
+simple_forms_vanotify_status_callback:
+  bearer_token: bearer_token_secret
+
 travel_pay:
   veis:
     client_id: 'client_id'

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/callbacks_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/callbacks_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module SimpleFormsApi
+  module V1
+    class CallbacksController < ApplicationController
+      include ActionController::HttpAuthentication::Token::ControllerMethods
+
+      skip_before_action :verify_authenticity_token, only: [:create]
+      skip_before_action :authenticate, only: [:create]
+      skip_after_action :set_csrf_header, only: [:create]
+      before_action :authenticate_header, only: [:create]
+
+      def create
+        return render json: nil, status: :not_found unless Flipper.enabled? :simple_forms_callbacks_endpoint
+
+        status = params[:status]
+        status_reason = params[:status_reason]
+        notification_type = params[:notification_type]
+
+        Rails.logger.info(
+          'Simple forms api - VANotify callback received',
+          { status:, status_reason:, notification_type: }
+        )
+
+        head :ok
+      end
+
+      private
+
+      def authenticate_header
+        authenticate_user_with_token || authenticity_error
+      end
+
+      def authenticate_user_with_token
+        Rails.logger.info('nod-callbacks-74832 - Received request, authenticating')
+        authenticate_with_http_token do |token|
+          return false if bearer_token_secret.nil?
+
+          token == bearer_token_secret
+        end
+      end
+
+      def authenticity_error
+        Rails.logger.info('nod-callbacks-74832 - Failed to authenticate request')
+        render json: { message: 'Invalid credentials' }, status: :unauthorized
+      end
+
+      def bearer_token_secret
+        Settings.dig(:simple_forms_vanotify_status_callback, :bearer_token)
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/config/routes.rb
+++ b/modules/simple_forms_api/config/routes.rb
@@ -8,5 +8,9 @@ SimpleFormsApi::Engine.routes.draw do
 
     post '/submit_scanned_form', to: 'scanned_form_uploads#submit'
     post '/scanned_form_upload', to: 'scanned_form_uploads#upload_scanned_form'
+
+    scope format: false do
+      resources :callbacks, only: [:create]
+    end
   end
 end

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/callbacks_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/callbacks_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'SimpleFormsApi::V1::Callbacks', type: :request do
+  let(:params) do
+    {
+      id: SecureRandom.uuid,
+      reference: nil,
+      to: 'test@test.com',
+      status: 'delivered',
+      created_at: '2023-01-10T00:04:25.273410Z',
+      completed_at: '2023-01-10T00:05:33.255911Z',
+      sent_at: '2023-01-10T00:04:25.775363Z',
+      notification_type: 'email',
+      status_reason: '',
+      provider: 'sendgrid'
+    }
+  end
+
+  describe '#create' do
+    let(:headers) do
+      { 'Authorization' => "Bearer #{Settings.simple_forms_vanotify_status_callback.bearer_token}" }
+    end
+
+    context 'with payload' do
+      context 'Flipper for simple_forms_callbacks_endpoint' do
+        after { Flipper.disable(:simple_forms_callbacks_endpoint) }
+
+        context 'when flipped on' do
+          before { Flipper.enable(:simple_forms_callbacks_endpoint) }
+
+          it 'returns success' do
+            post('/simple_forms_api/v1/callbacks', params:, headers:)
+
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context 'when flipped off' do
+          before { Flipper.disable(:simple_forms_callbacks_endpoint) }
+
+          it 'returns 500' do
+            post('/simple_forms_api/v1/callbacks', params:, headers:)
+
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'authentication' do
+    context 'with missing Authorization header' do
+      let(:headers) { {} }
+
+      it 'returns 401' do
+        post('/simple_forms_api/v1/callbacks', params:, headers:)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with invalid Authorization header' do
+      let(:headers) { { 'Authorization' => 'Bearer rawr rawr' } }
+
+      it 'returns 401' do
+        post('/simple_forms_api/v1/callbacks', params:, headers:)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR (heavily inspired by [this NOD PR](https://github.com/department-of-veterans-affairs/vets-api/pull/15436)) adds an endpoint for receiving webhooks from VANotify. After this, I think the remaining steps are:
1. Populate the bearer token in staging and prod
2. Communicate the endpoint (`simple_forms_api/v1/callbacks`) to VANotify.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1702
