### PR TITLE
[SIMPLE_FORMS] fix: update uploader to default to vets-api account role

### DIFF
--- a/app/uploaders/veteran_facing_forms_remediation_uploader.rb
+++ b/app/uploaders/veteran_facing_forms_remediation_uploader.rb
@@ -12,11 +12,8 @@ class VeteranFacingFormsRemediationUploader < CarrierWave::Uploader::Base
     end
 
     def new_s3_resource
-      Aws::S3::Resource.new(
-        region: s3_settings.region,
-        access_key_id: s3_settings.aws_access_key_id,
-        secret_access_key: s3_settings.aws_secret_access_key
-      )
+      client = Aws::S3::Client.new(region: s3_settings.region)
+      Aws::S3::Resource.new(client:)
     end
 
     def get_s3_link(file_path)
@@ -54,13 +51,11 @@ class VeteranFacingFormsRemediationUploader < CarrierWave::Uploader::Base
 
   def set_storage_options!
     settings = self.class.s3_settings
-    if settings.aws_access_key_id.present?
-      set_aws_config(
-        settings.aws_access_key_id,
-        settings.aws_secret_access_key,
-        settings.region,
-        settings.bucket
-      )
-    end
+
+    self.aws_credentials = { region: settings.region }
+    self.aws_acl = 'private'
+    self.aws_bucket = settings.bucket
+    self.aws_attributes = { server_side_encryption: 'AES256' }
+    self.class.storage = :aws
   end
 end


### PR DESCRIPTION
## Summary

- This work updates the file uploader to default to vets-api default credentials

## Related issue(s)

- [Form Submission Remediation - Test remediation process and make updates in accordance with findings](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1697)

## Testing done

- [x] Testing to come in the future!

## Requested Feedback

Any
