### PR TITLE
[VI-470] Create MHVUserAccountsController with show action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,6 +134,7 @@ app/controllers/v0/terms_of_use_agreements_controller.rb @department-of-veterans
 app/controllers/v0/trackings_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/triage_teams_controller.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/upload_supporting_evidences_controller.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/v0/user @department-of-veterans-affairs/octo-identity
 app/controllers/v0/users_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/veteran_readiness_employment_claims_controller.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/virtual_agent @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -410,6 +411,7 @@ app/serializers/maintenance_window_serializer.rb @department-of-veterans-affairs
 app/serializers/message_serializer.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/messages_serializer.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/messaging_preference_serializer.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/serializers/mhv_user_account_serializer.rb @department-of-veterans-affairs/octo-identity
 app/serializers/onsite_notification_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/payment_history_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/serializers/persistent_attachment_serializer.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pensions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1118,6 +1120,7 @@ spec/controllers/v0/rated_disabilities_discrepancies_controller_spec.rb @departm
 spec/controllers/v0/sign_in_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/terms_of_use_agreements_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/upload_supporting_evidences_controller_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/controllers/v0/user @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/users_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/veteran_readiness_employment_claims_controller_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/veteran_onboardings_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
@@ -1748,6 +1751,7 @@ spec/serializers/maintenance_window_serializer_spec.rb @department-of-veterans-a
 spec/serializers/message_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/messages_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/messaging_preference_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/serializers/mhv_user_account_serializer_spec.rb @department-of-veterans-affairs/octo-identity
 spec/serializers/onsite_notification_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/payment_history_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/serializers/persistent_attachment_serializer_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pensions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/user/mhv_user_accounts_controller.rb
+++ b/app/controllers/v0/user/mhv_user_accounts_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module V0
+  module User
+    class MHVUserAccountsController < ApplicationController
+      service_tag 'identity'
+
+      before_action :set_mhv_user_account, only: :show
+      rescue_from MHV::UserAccount::Errors::UserAccountError, with: ->(e) { render_errors(e.message) }
+
+      def show
+        return render_errors('not_found', status: :not_found) if @mhv_user_account.blank?
+
+        log_result('success')
+        render json: MHVUserAccountSerializer.new(@mhv_user_account).serializable_hash, status: :ok
+      end
+
+      private
+
+      def set_mhv_user_account
+        @mhv_user_account = current_user.mhv_user_account
+      end
+
+      def render_errors(error_message, status: :unprocessable_entity)
+        log_result('error', error_message:)
+
+        errors = error_message.split(',').map { |m| { detail: m.strip } }
+        render json: { errors: }, status:
+      end
+
+      def log_result(result, **payload)
+        Rails.logger.info("[User][MHVUserAccountsController] #{action_name} #{result}", payload)
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,11 +151,12 @@ class User < Common::RedisStore
                             MHV::UserAccount::Creator.new(user_verification:).perform
                           else
                             log_mhv_user_account_error('User has no va_treatment_facility_ids')
+
                             nil
                           end
   rescue MHV::UserAccount::Errors::UserAccountError => e
     log_mhv_user_account_error(e.message)
-    nil
+    raise
   end
 
   def middle_name

--- a/app/serializers/mhv_user_account_serializer.rb
+++ b/app/serializers/mhv_user_account_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MHVUserAccountSerializer
+  include JSONAPI::Serializer
+
+  set_id(&:user_profile_id)
+
+  attributes :user_profile_id, :premium, :champ_va, :patient, :sm_account_created, :message
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,9 @@ Rails.application.routes.draw do
 
     resource :user, only: [:show] do
       get 'icn', to: 'users#icn'
+      resource :mhv_user_account, only: [:show], controller: 'user/mhv_user_accounts'
     end
+
     resource :veteran_onboarding, only: %i[show update]
 
     resource :education_benefits_claims, only: %i[create show] do

--- a/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
+++ b/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mhv/account_creation/service'
+
+describe V0::User::MHVUserAccountsController, type: :controller do
+  let(:user) { build(:user, :loa3, vha_facility_ids:, icn:) }
+  let(:vha_facility_ids) { %w[450MH] }
+  let(:icn) { '10101V964144' }
+
+  let!(:user_verification) do
+    create(:idme_user_verification, idme_uuid: user.idme_uuid, user_credential_email:, user_account:)
+  end
+  let(:user_credential_email) { create(:user_credential_email) }
+  let(:user_account) { create(:user_account, icn:) }
+  let!(:terms_of_use_agreement) { create(:terms_of_use_agreement, user_account:, response: terms_of_use_response) }
+  let(:terms_of_use_response) { 'accepted' }
+
+  let(:mhv_account_creator) { MHV::UserAccount::Creator.new(user_verification:) }
+  let(:mhv_client) { instance_double(MHV::AccountCreation::Service) }
+  let(:mhv_response) do
+    {
+      user_profile_id: '12345678',
+      premium: true,
+      champ_va: true,
+      patient: true,
+      sm_account_created: true,
+      message: 'some-message'
+    }
+  end
+
+  before do
+    sign_in_as(user)
+    allow(MHV::AccountCreation::Service).to receive(:new).and_return(mhv_client)
+
+    allow(Rails.logger).to receive(:info)
+  end
+
+  describe '#show' do
+    context 'when the user has an MHV account and the call is successful' do
+      before do
+        allow(mhv_client).to receive(:create_account).and_return(mhv_response)
+      end
+
+      it 'returns the MHV account' do
+        get :show
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['data']['attributes']).to eq(mhv_response.with_indifferent_access)
+      end
+    end
+
+    context 'when the user does not have an MHV account' do
+      let(:vha_facility_ids) { [] }
+
+      it 'returns a 404' do
+        get :show
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when there is an error retrieving the MHV account' do
+      shared_examples 'an unprocessable entity' do
+        let(:expected_log_payload) { { error_message: expected_error_message } }
+        let(:expected_log_message) { '[User][MHVUserAccountsController] show error' }
+        let(:expected_response_body) do
+          {
+            errors: expected_error_message.split(',').map { |m| { detail: m.strip } }
+          }.as_json
+        end
+
+        it 'returns an unprocessable entity' do
+          get :show
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(JSON.parse(response.body)).to eq(expected_response_body)
+        end
+
+        it 'logs the error' do
+          get :show
+
+          expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+        end
+      end
+
+      context 'when there is an MHV client error' do
+        let(:expected_error_message) { 'some client error' }
+
+        before do
+          allow(mhv_client).to receive(:create_account).and_raise(Common::Client::Errors::ClientError,
+                                                                  expected_error_message)
+        end
+
+        it_behaves_like 'an unprocessable entity'
+      end
+
+      context 'when the user does not have an ICN' do
+        let(:icn) { nil }
+        let(:expected_error_message) { 'ICN must be present' }
+
+        it_behaves_like 'an unprocessable entity'
+      end
+
+      context 'when the user does not have an email' do
+        let(:user_credential_email) { nil }
+        let(:expected_error_message) { 'Email must be present' }
+
+        it_behaves_like 'an unprocessable entity'
+      end
+
+      context 'when the user does not have a terms of use agreement' do
+        let(:terms_of_use_agreement) { nil }
+        let(:expected_error_message) do
+          "Current terms of use agreement must be present, Current terms of use agreement must be 'accepted'"
+        end
+
+        it_behaves_like 'an unprocessable entity'
+      end
+
+      context 'when the user has not accepted the terms of use agreement' do
+        let(:terms_of_use_response) { 'declined' }
+        let(:expected_error_message) { "Current terms of use agreement must be 'accepted'" }
+
+        it_behaves_like 'an unprocessable entity'
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1290,8 +1290,8 @@ RSpec.describe User, type: :model do
           let(:expected_log_message) { '[User] mhv_user_account error' }
           let(:expected_log_payload) { { error_message: /#{expected_error_message}/, icn: user.icn } }
 
-          it 'logs an error and returns nil' do
-            expect(user.mhv_user_account).to be_nil
+          it 'logs and re-raises the error' do
+            expect { user.mhv_user_account }.to raise_error(MHV::UserAccount::Errors::UserAccountError)
             expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
           end
         end

--- a/spec/serializers/mhv_user_account_serializer_spec.rb
+++ b/spec/serializers/mhv_user_account_serializer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MHVUserAccountSerializer, type: :serializer do
+  subject { serialize(mhv_user_account, serializer_class: described_class) }
+
+  let(:mhv_user_account) { MHVUserAccount.new(mhv_response) }
+  let(:mhv_response) do
+    {
+      user_profile_id: '123456',
+      premium: true,
+      champ_va: true,
+      patient: true,
+      sm_account_created: true,
+      message: 'some-message'
+    }
+  end
+
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  it 'includes :id' do
+    expect(data['id']).to eq mhv_response[:user_profile_id]
+  end
+
+  it 'includes :user_profile_id' do
+    expect(attributes['user_profile_id']).to eq mhv_response[:user_profile_id]
+  end
+
+  it 'includes :premium' do
+    expect(attributes['premium']).to eq mhv_response[:premium]
+  end
+
+  it 'includes :champ_va' do
+    expect(attributes['champ_va']).to eq mhv_response[:champ_va]
+  end
+
+  it 'includes :patient' do
+    expect(attributes['patient']).to eq mhv_response[:patient]
+  end
+
+  it 'includes :sm_account_created' do
+    expect(attributes['sm_account_created']).to eq mhv_response[:sm_account_created]
+  end
+
+  it 'includes :message' do
+    expect(attributes['message']).to eq mhv_response[:message]
+  end
+end


### PR DESCRIPTION
## Summary
- create `V0::User::MHVUserAccountsController` with show action
- route: `v0/user/mhv_user_account`
- returns `404` if the user does not have a MHVUserAccount
- returns `422` if there was an error with creating the MHVUserAccount
- if the user has an mhv_user_account it returns the serialized account


## Related issue(s)

- https://jira.devops.va.gov/browse/VI-470

## Testing 
- betamocks ticket is being worked on so we'll need to mock the response"
 in [lib/mhv_account_creation/service.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/mhv/account_creation/service.rb#L14) change `response =` to
   ```ruby
   response = { mhv_userprofileid: '12345678', isPremium: true, isChampVA: true, isPatient: true,
                       isSMAccountCreated: true, message: 'Existing MHV Account Found for ICN' }.as_json
   ```

- start `vets-api` and `vets-website`
- sign in http://localhost:3001/?next=loginModal&oauth=true
- got to http://localhost:3000/v0/user/mhv_user_account
- if your user meets all the requirements you should get a response like:
     ```json
     {
    "data": {
        "id": "12345678",
        "type": "mhv_user_account",
        "attributes": {
          "user_profile_id": "12345678",
          "premium": true,
          "champ_va": true,
          "patient": true,
          "sm_account_created": true,
          "message": "Existing MHV Account Found for ICN"
        }
      }
    }
   ```
- if your user doesn't you should get a 404 and (or you can `return nil` [here](https://github.com/department-of-veterans-affairs/vets-api/blob/57e1eb8efcfb096886d450bbb6791701215d5ade/app/models/user.rb#L149)):
   ```json
     {
      "errors": [
        {
          "detail": "not_found"
        }
      ]
    }
   ```
- If there are other validation errors it will return 422, e.g. if your dont have an accepted tou agreement:
   ```json
     {
      "errors": [
        {
          "detail": "Current terms of use agreement must be 'accepted'"
        }
      ]
    }
   ```

## What areas of the site does it impact?
MHV user accounts

