### PR TITLE
Ask va api adding profile to submit inquiry

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/attachments/uploader.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/attachments/uploader.rb
@@ -48,7 +48,7 @@ module AskVAApi
         return response[:Data] if response.is_a?(Hash)
 
         error = JSON.parse(response.body, symbolize_names: true)
-        raise(AttachmentsUploaderError, error.fetch(:Message, 'Unknown error occurred'))
+        raise(AttachmentsUploaderError, error)
       end
     end
   end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
@@ -13,8 +13,9 @@ module AskVAApi
         @service = service || default_service
       end
 
-      def call(payload:)
-        post_data(payload:)
+      def call(inquiry_params:)
+        payload = build_payload(inquiry_params)
+        post_data(payload)
       rescue => e
         ErrorHandler.handle_service_error(e)
       end
@@ -25,18 +26,25 @@ module AskVAApi
         Crm::Service.new(icn:)
       end
 
-      def post_data(payload: {})
+      def build_payload(inquiry_params)
+        translated_payload = params_translator(inquiry_params).call
+        translated_payload[:VeteranICN] = icn
+        translated_payload
+      end
+
+      def post_data(payload)
         response = service.call(endpoint: ENDPOINT, method: :put, payload:)
         handle_response_data(response)
       end
 
       def handle_response_data(response)
-        case response
-        when Hash
-          response[:Data]
-        else
-          raise(InquiriesCreatorError, response.body)
-        end
+        return response[:Data] if response.is_a?(Hash)
+
+        raise InquiriesCreatorError, response.body
+      end
+
+      def params_translator(inquiry_params)
+        Translator.new(inquiry_params:)
       end
     end
   end

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/attachments/uploader_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/attachments/uploader_spec.rb
@@ -64,7 +64,7 @@ module AskVAApi
 
           context 'CRM response with a 400' do
             it 'raise an error' do
-              expect { subject }.to raise_error(AttachmentsUploaderError, 'Data Validation: No Inquiries found')
+              expect { subject }.to raise_error(AttachmentsUploaderError)
             end
           end
 

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/creator_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/creator_spec.rb
@@ -6,32 +6,290 @@ RSpec.describe AskVAApi::Inquiries::Creator do
   let(:icn) { '123456' }
   let(:service) { instance_double(Crm::Service) }
   let(:creator) { described_class.new(icn:, service:) }
-  let(:payload) { { FirstName: 'Fake', YourLastName: 'Smith' } }
+  let(:file_path) { 'modules/ask_va_api/config/locales/get_inquiries_mock_data.json' }
+  let(:base64_encoded_file) { Base64.strict_encode64(File.read(file_path)) }
+  let(:file) { "data:image/png;base64,#{base64_encoded_file}" }
+  let(:inquiry_params) do
+    { 'are_you_the_dependent' => 'false',
+      'attachment_present' => 'true',
+      'branch_of_service' => '722310000',
+      'city' => 'Dallas',
+      'contact_method' => '722310000',
+      'country' => '722310186',
+      'daytime_phone' => '(989)898-9898',
+      'dependant_city' => nil,
+      'dependant_country' => '722310000',
+      'dependant_dob' => nil,
+      'dependant_email' => nil,
+      'dependant_first_name' => nil,
+      'dependant_gender' => nil,
+      'dependant_last_name' => nil,
+      'dependant_middle_name' => nil,
+      'dependant_province' => '722310005',
+      'dependant_relationship' => '722310006',
+      'dependant_ssn' => nil,
+      'dependant_state' => nil,
+      'dependant_street_address' => nil,
+      'dependant_zip_code' => nil,
+      'email_address' => 'vets.gov.user+119@gmail.com',
+      'email_confirmation' => 'vets.gov.user+119@gmail.com',
+      'first_name' => 'Glen',
+      'gender' => 'M',
+      'inquiry_about' => '722310000',
+      'inquiry_category' => '5c524deb-d864-eb11-bb24-000d3a579c45',
+      'inquiry_source' => '722310004',
+      'inquiry_subtopic' => '932a8586-e764-eb11-bb23-000d3a579c3f',
+      'inquiry_summary' => 'string',
+      'inquiry_topic' => '932a8586-e764-eb11-bb23-000d3a579c3f',
+      'inquiry_type' => '722310001',
+      'is_va_employee' => 'true',
+      'is_veteran' => 'true',
+      'is_veteran_an_employee' => 'true',
+      'is_veteran_deceased' => 'false',
+      'level_of_authentication' => '722310001',
+      'medical_center' => '07a51029-6816-e611-9436-0050568d743d',
+      'middle_name' => 'Lee',
+      'preferred_name' => nil,
+      'pronouns' => 'He/Him',
+      'street_address2' => nil,
+      'submitter' => '42cc2a0a-2ebf-e711-9495-0050568d63d9',
+      'submitter_dependent' => '722310000',
+      'submitter_dob' => '1971-12-08',
+      'submitter_gender' => 'M',
+      'submitter_province' => '722310008',
+      'submitter_question' => 'I would like to know more about my claims',
+      'submitters_dod_id_edipi_number' => '987654321',
+      'submitter_ssn' => '796231077',
+      'submitter_state' => 'TX',
+      'submitter_state_of_residency' => 'TX',
+      'submitter_state_of_school' => 'TX',
+      'submitter_state_property' => 'TX',
+      'submitter_street_address' => '4343 Rosemeade Pkwy',
+      'submitter_vet_center' => '200ESR',
+      'submitter_zip_code_of_residency' => '75287-2950',
+      'suffix' => '722310001',
+      'supervisor_flag' => 'true',
+      'va_employee_time_stamp' => nil,
+      'veteran_city' => 'Dallas',
+      'veteran_claim_number' => nil,
+      'veteran_country' => '722310186',
+      'veteran_date_of_death' => nil,
+      'veteran_dob' => '1971-12-08',
+      'veteran_dod_id_edipi_number' => '987654321',
+      'veteran_email' => 'vets.gov.user+119@gmail.com',
+      'veteran_email_confirmation' => 'vets.gov.user+119@gmail.com',
+      'veteran_enrolled' => 'true',
+      'veteran_first_name' => 'Glen',
+      'veteran_icn' => nil,
+      'veteran_last_name' => 'Wells',
+      'veteran_middle_name' => 'Lee',
+      'veteran_phone' => '(989)898-9898',
+      'veteran_prefered_name' => nil,
+      'veteran_pronouns' => 'He/Him',
+      'veteran_province' => '722310005',
+      'veteran_relationship' => '722310003',
+      'veteran_service_end_date' => '01/01/2000',
+      'veteran_service_number' => nil,
+      'veteran_service_start_date' => nil,
+      'veteran_ssn' => '123456799',
+      'veterans_state' => '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
+      'veteran_street_address' => '4343 Rosemeade Pkwy',
+      'veteran_suffix' => '722310001',
+      'veteran_suite_apt_other' => nil,
+      'veteran_zip_code' => '75287-2950',
+      'who_was_their_counselor' => nil,
+      'your_last_name' => 'Wells',
+      'zip_code' => '75287-2950',
+      'profile' =>
+       { 'first_name' => 'Glen',
+         'middle_name' => 'M',
+         'last_name' => 'Wells',
+         'preferred_name' => nil,
+         'suffix' => '722310001',
+         'gender' => 'M',
+         'pronouns' => 'He/Him',
+         'country' => '722310186',
+         'street' => '4343 Rosemeade Pkwy',
+         'city' => 'Dallas',
+         'state' => 'TX',
+         'zip_code' => '75287-2950',
+         'province' => nil,
+         'business_phone' => '(989)898-9898',
+         'personal_phone' => '(989)898-9898',
+         'personal_email' => 'vets.gov.user+119@gmail.com',
+         'business_email' => 'vets.gov.user+119@gmail.com',
+         'school_state' => 'TX',
+         'school_facility_code' => '1000000898',
+         'service_number' => nil,
+         'claim_number' => nil,
+         'veteran_service_state_date' => nil,
+         'date_of_birth' => '1971-12-08',
+         'edipi' => nil },
+      'school_obj' =>
+       { 'city' => 'Dallas',
+         'institution_name' => "Kyle's Institution",
+         'regional_office' => '669cbc60-b58d-eb11-b1ac-001dd8309d89',
+         'school_facility_code' => '1000000898',
+         'state_abbreviation' => '80b9d1e0-d488-eb11-b1ac-001dd8309d89' },
+      'attachments' =>
+       [{ 'file_name' => 'testfile.pdf',
+          'file_content' => file }] }
+  end
   let(:endpoint) { AskVAApi::Inquiries::Creator::ENDPOINT }
+  let(:translator) { instance_double(AskVAApi::Translator) }
+  let(:translated_payload) do
+    { AreYouTheDependent: 'false',
+      AttachmentPresent: 'true',
+      BranchOfService: '722310000',
+      City: 'Dallas',
+      ContactMethod: '722310000',
+      Country: '722310186',
+      DaytimePhone: '(989)898-9898',
+      DependantCity: nil,
+      DependantCountry: '722310000',
+      DependantDOB: nil,
+      DependantEmail: nil,
+      DependantFirstName: nil,
+      DependantGender: nil,
+      DependantLastName: nil,
+      DependantMiddleName: nil,
+      DependantProvince: '722310005',
+      DependantRelationship: 722_310_005,
+      DependantSSN: nil,
+      DependantState: nil,
+      DependantStreetAddress: nil,
+      DependantZipCode: nil,
+      EmailAddress: 'vets.gov.user+119@gmail.com',
+      EmailConfirmation: 'vets.gov.user+119@gmail.com',
+      FirstName: 'Glen',
+      Gender: 'M',
+      InquiryAbout: 722_310_003,
+      InquiryCategory: '5c524deb-d864-eb11-bb24-000d3a579c45',
+      InquirySource: 722_310_000,
+      InquirySubtopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
+      InquirySummary: 'string',
+      InquiryTopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
+      InquiryType: 722_310_001,
+      IsVAEmployee: 'true',
+      IsVeteran: 'true',
+      IsVeteranAnEmployee: 'true',
+      IsVeteranDeceased: 'false',
+      LevelOfAuthentication: 722_310_001,
+      MedicalCenter: '07a51029-6816-e611-9436-0050568d743d',
+      MiddleName: 'Lee',
+      PreferredName: nil,
+      Pronouns: 'He/Him',
+      ResponseType: 722_310_000,
+      StreetAddress2: nil,
+      Submitter: '42cc2a0a-2ebf-e711-9495-0050568d63d9',
+      SubmitterDependent: '722310000',
+      SubmitterDOB: '1971-12-08',
+      SubmitterGender: 'M',
+      SubmitterProvince: '722310008',
+      SubmitterQuestion: 'I would like to know more about my claims',
+      SubmittersDodIdEdipiNumber: '987654321',
+      SubmitterSSN: '796231077',
+      SubmitterState: 'TX',
+      SubmitterStateOfResidency: 'TX',
+      SubmitterStateOfSchool: 'TX',
+      SubmitterStateProperty: 'TX',
+      SubmitterStreetAddress: '4343 Rosemeade Pkwy',
+      SubmitterVetCenter: '200ESR',
+      SubmitterZipCodeOfResidency: '75287-2950',
+      Suffix: 722_310_000,
+      SupervisorFlag: 'true',
+      VaEmployeeTimeStamp: nil,
+      VeteranCity: 'Dallas',
+      VeteranClaimNumber: nil,
+      VeteranCountry: '722310186',
+      VeteranDateOfDeath: nil,
+      VeteranDOB: '1971-12-08',
+      VeteranDodIdEdipiNumber: '987654321',
+      VeteranEmail: 'vets.gov.user+119@gmail.com',
+      VeteranEmailConfirmation: 'vets.gov.user+119@gmail.com',
+      VeteranEnrolled: 'true',
+      VeteranFirstName: 'Glen',
+      VeteranICN: nil,
+      VeteranLastName: 'Wells',
+      VeteranMiddleName: 'Lee',
+      VeteranPhone: '(989)898-9898',
+      VeteranPreferedName: nil,
+      VeteranPronouns: 'He/Him',
+      VeteranProvince: '722310005',
+      VeteranRelationship: 722_310_019,
+      VeteranServiceEndDate: '01/01/2000',
+      VeteranServiceNumber: nil,
+      VeteranServiceStartDate: nil,
+      VeteranSSN: '123456799',
+      VeteransState: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
+      VeteranStreetAddress: '4343 Rosemeade Pkwy',
+      VeteranSuffix: '722310001',
+      VeteranSuiteAptOther: nil,
+      VeteranZipCode: '75287-2950',
+      WhoWasTheirCounselor: nil,
+      YourLastName: 'Wells',
+      ZipCode: '75287-2950',
+      Profile: { firstName: 'Glen',
+                 middleName: 'M',
+                 lastName: 'Wells',
+                 preferredName: nil,
+                 suffix: '722310001',
+                 gender: 'M',
+                 pronouns: 'He/Him',
+                 country: '722310186',
+                 street: '4343 Rosemeade Pkwy',
+                 city: 'Dallas',
+                 state: 'TX',
+                 zipCode: '75287-2950',
+                 province: nil,
+                 businessPhone: '(989)898-9898',
+                 personalPhone: '(989)898-9898',
+                 personalEmail: 'vets.gov.user+119@gmail.com',
+                 businessEmail: 'vets.gov.user+119@gmail.com',
+                 schoolState: 'TX',
+                 schoolFacilityCode: '1000000898',
+                 serviceNumber: nil,
+                 claimNumber: nil,
+                 veteranServiceStateDate: nil,
+                 dateOfBirth: '1971-12-08',
+                 edipi: nil },
+      SchoolObj: { City: 'Dallas',
+                   InstitutionName: "Kyle's Institution",
+                   RegionalOffice: '669cbc60-b58d-eb11-b1ac-001dd8309d89',
+                   SchoolFacilityCode: '1000000898',
+                   StateAbbreviation: '80b9d1e0-d488-eb11-b1ac-001dd8309d89' },
+      ListOfAttachments: [{ fileName: 'testfile.pdf',
+                            fileContent: 'base64 string' }] }
+  end
 
   before do
     allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
+    allow(AskVAApi::Translator).to receive(:new).with(inquiry_params:).and_return(translator)
+    allow(translator).to receive(:call).and_return(translated_payload)
   end
 
   describe '#call' do
     context 'when the API call is successful' do
       before do
-        allow(service).to receive(:call).with(endpoint:, method: :put,
-                                              payload:).and_return({
-                                                                     Data: {
-                                                                       InquiryNumber: '530d56a8-affd-ee11' \
-                                                                                      '-a1fe-001dd8094ff1'
-                                                                     },
-                                                                     Message: '',
-                                                                     ExceptionOccurred: false,
-                                                                     ExceptionMessage: '',
-                                                                     MessageId: 'b8ebd8e7-3bbf-49c5' \
-                                                                                '-aff0-99503e50ee27'
-                                                                   })
+        allow(service).to receive(:call).and_return({
+                                                      Data: {
+                                                        InquiryNumber: '530d56a8-affd-ee11-a1fe-001dd8094ff1'
+                                                      },
+                                                      Message: '',
+                                                      ExceptionOccurred: false,
+                                                      ExceptionMessage: '',
+                                                      MessageId: 'b8ebd8e7-3bbf-49c5-aff0-99503e50ee27'
+                                                    })
       end
 
-      it 'posts data to the service and returns the response' do
-        expect(creator.call(payload:)).to eq({ InquiryNumber: '530d56a8-affd-ee11-a1fe-001dd8094ff1' })
+      it 'assigns VeteranICN and posts data to the service' do
+        response = creator.call(inquiry_params:)
+
+        expect(service).to have_received(:call) do |params|
+          expect(params[:payload][:VeteranICN]).to eq(icn)
+        end
+
+        expect(response).to eq({ InquiryNumber: '530d56a8-affd-ee11-a1fe-001dd8094ff1' })
       end
     end
 
@@ -48,7 +306,7 @@ RSpec.describe AskVAApi::Inquiries::Creator do
       end
 
       it 'raise InquiriesCreatorError' do
-        expect { creator.call(payload:) }.to raise_error(ErrorHandler::ServiceError)
+        expect { creator.call(inquiry_params:) }.to raise_error(ErrorHandler::ServiceError)
       end
     end
   end

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/translator_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/translator_spec.rb
@@ -323,7 +323,6 @@ RSpec.describe AskVAApi::Translator do
         }[option]
       end
     end
-    let(:result) { subject.call }
 
     before do
       allow(Crm::CacheData).to receive(:new).and_return(cache_data_service)
@@ -358,7 +357,6 @@ RSpec.describe AskVAApi::Translator do
   end
 
   context 'when an error occurs' do
-    let(:result) { subject.call }
     let(:body) do
       '{"Data":null,"Message":"Data Validation: Invalid OptionSet Name iris_inquiryabou, valid' \
         ' values are iris_inquiryabout, iris_inquirysource, iris_inquirytype, iris_levelofauthentication,' \

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
@@ -22,9 +22,6 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
     allow(span).to receive(:set_tag)
     allow(Rails.logger).to receive(:error)
     allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
-    allow_any_instance_of(AskVAApi::RedisClient).to receive(:fetch)
-      .with('categories_topics_subtopics')
-      .and_return(cache_data)
   end
 
   shared_examples_for 'common error handling' do |status, action, error_message|
@@ -145,6 +142,12 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
             'veteran_relationship' => 'self' } } }
     end
 
+    before do
+      allow_any_instance_of(AskVAApi::RedisClient).to receive(:fetch)
+        .with('categories_topics_subtopics')
+        .and_return(cache_data)
+    end
+
     context 'when user is signed in' do
       context 'when mock is given' do
         before do
@@ -167,7 +170,7 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
             InquiryNumber: 'A-123456',
             InquiryStatus: 'In Progress',
             InquiryTopic: 'Cemetery Debt',
-            LastUpdate: '1/1/1900',
+            LastUpdate: '8/5/2024 4:51:52 PM',
             QueueId: '9876t54',
             QueueName: 'Debt Management Center',
             SchoolFacilityCode: '0123',
@@ -205,7 +208,7 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
                 'has_been_split' => true,
                 'inquiry_topic' => 'Cemetery Debt',
                 'level_of_authentication' => 'Personal',
-                'last_update' => '1/1/1900',
+                'last_update' => '8/5/2024 4:51:52 PM',
                 'queue_id' => '9876t54',
                 'queue_name' => 'Debt Management Center',
                 'status' => 'In Progress',
@@ -394,351 +397,319 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
     end
   end
 
-  describe 'POST #create' do
+  describe 'when creating an inquiry' do
+    let(:file_path) { 'modules/ask_va_api/config/locales/get_inquiries_mock_data.json' }
+    let(:base64_encoded_file) { Base64.strict_encode64(File.read(file_path)) }
+    let(:file) { "data:image/png;base64,#{base64_encoded_file}" }
     let(:payload) do
       {
-        inquiry_category: '5c524deb-d864-eb11-bb24-000d3a579c45',
-        inquiry_source: 722_310_004,
-        inquiry_subtopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
-        inquiry_topic: '932a8586-e764-eb11-bb23-000d3a579c3f',
-        submitter_question: 'test',
-        are_you_the_dependent: true,
-        attachment_present: false,
-        branch_of_service: 722_310_000,
-        city: 'Queens',
-        contact_method: 722_310_001,
-        country: 722_310_000,
-        daytime_phone: '1235559090',
-        dependant_city: 'Morrilton',
-        dependant_country: 722_310_000,
-        dependant_day_time_phone: '1235559090',
-        dependant_dob: '01/01/2000',
-        dependant_email: 'test@email.com',
-        dependant_first_name: 'Peter',
-        dependant_gender: 'M',
-        dependant_last_name: 'Parker',
-        dependant_middle_name: 'B',
-        dependant_province: 722_310_008,
-        dependant_relationship: 722_310_007,
-        dependant_ssn: '123456789',
-        dependant_state: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        dependant_street_address: 'TEST',
-        dependant_zip_code: '72156',
-        email_address: 'test@email.com',
-        email_confirmation: 'test@email.com',
-        first_name: 'Pete',
+        are_you_the_dependent: 'false',
+        attachment_present: 'true',
+        branch_of_service: '722310000',
+        city: 'Dallas',
+        contact_method: '722310000',
+        country: '722310186',
+        daytime_phone: '(989)898-9898',
+        dependant_city: nil,
+        dependant_country: '722310000',
+        dependant_dob: nil,
+        dependant_email: nil,
+        dependant_first_name: nil,
+        dependant_gender: nil,
+        dependant_last_name: nil,
+        dependant_middle_name: nil,
+        dependant_province: '722310005',
+        dependant_relationship: '722310006',
+        dependant_ssn: nil,
+        dependant_state: nil,
+        dependant_street_address: nil,
+        dependant_zip_code: nil,
+        email_address: 'vets.gov.user+119@gmail.com',
+        email_confirmation: 'vets.gov.user+119@gmail.com',
+        first_name: 'Glen',
         gender: 'M',
-        inquiry_about: 722_310_003,
+        inquiry_about: '722310000',
+        inquiry_category: '5c524deb-d864-eb11-bb24-000d3a579c45',
+        inquiry_source: '722310004',
+        inquiry_subtopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
         inquiry_summary: 'string',
-        inquiry_type: 722_310_001,
-        is_va_employee: true,
-        is_veteran: true,
-        is_veteran_an_employee: true,
-        is_veteran_deceased: true,
-        level_of_authentication: 722_310_001,
+        inquiry_topic: '932a8586-e764-eb11-bb23-000d3a579c3f',
+        inquiry_type: '722310001',
+        is_va_employee: 'true',
+        is_veteran: 'true',
+        is_veteran_an_employee: 'true',
+        is_veteran_deceased: 'false',
+        level_of_authentication: '722310001',
         medical_center: '07a51029-6816-e611-9436-0050568d743d',
-        middle_name: 'MiddleName',
-        preferred_name: 'Petey',
-        pronouns: 'string',
-        school_obj: {
-          school_facility_code: '1000000898',
-          institution_name: "Kyle's Institution",
-          city: 'Boston',
-          state_abbreviation: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-          regional_office: '669cbc60-b58d-eb11-b1ac-001dd8309d89'
-        },
-        street_address2: 'string',
+        middle_name: 'Lee',
+        preferred_name: nil,
+        pronouns: 'He/Him',
+        response_type: 'Email',
+        street_address2: nil,
         submitter: '42cc2a0a-2ebf-e711-9495-0050568d63d9',
-        submitter_dependent: 722_310_000,
-        submitter_dob: '01/01/2000',
+        submitter_dependent: '722310000',
+        submitter_dob: '1971-12-08',
         submitter_gender: 'M',
-        submitter_province: 722_310_008,
-        submitters_dod_id_edipi_number: 'string',
-        submitter_ssn: 'string',
-        submitter_state: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        submitter_state_of_residency: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        submitter_state_of_school: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        submitter_state_property: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        submitter_street_address: 'string',
-        submitter_vet_center: 'string',
-        submitter_zip_code_of_residency: 'e3df3e75-54a1-eb11-b1ac-001dd804abe6',
-        suffix: 722_310_001,
-        supervisor_flag: true,
-        va_employee_time_stamp: 'string',
-        veteran_city: 'string',
-        veteran_claim_number: 'string',
-        veteran_country: 722_310_186,
-        veteran_date_of_death: '01/01/2000',
-        veteran_dob: '01/01/2000',
-        veteran_dod_id_edipi_number: 'string',
-        veteran_email: 'string',
-        veteran_email_confirmation: 'string',
-        veteran_enrolled: true,
-        veteran_first_name: 'string',
-        veteran_icn: 'string',
-        veteran_last_name: 'string',
-        veteran_middle_name: 'string',
-        veteran_phone: 'string',
-        veteran_prefered_name: 'string',
-        veteran_pronouns: 'string',
-        veteran_province: 722_310_005,
-        veteran_relationship: 722_310_008,
+        submitter_province: '722310008',
+        submitter_question: 'I would like to know more about my claims',
+        submitters_dod_id_edipi_number: '987654321',
+        submitter_ssn: '796231077',
+        submitter_state: 'TX',
+        submitter_state_of_residency: 'TX',
+        submitter_state_of_school: 'TX',
+        submitter_state_property: 'TX',
+        submitter_street_address: '4343 Rosemeade Pkwy',
+        submitter_vet_center: '200ESR',
+        submitter_zip_code_of_residency: '75287-2950',
+        suffix: '722310001',
+        supervisor_flag: 'true',
+        va_employee_time_stamp: nil,
+        veteran_city: 'Dallas',
+        veteran_claim_number: nil,
+        veteran_country: '722310186',
+        veteran_date_of_death: nil,
+        veteran_dob: '1971-12-08',
+        veteran_dod_id_edipi_number: '987654321',
+        veteran_email: 'vets.gov.user+119@gmail.com',
+        veteran_email_confirmation: 'vets.gov.user+119@gmail.com',
+        veteran_enrolled: 'true',
+        veteran_first_name: 'Glen',
+        veteran_icn: nil,
+        veteran_last_name: 'Wells',
+        veteran_middle_name: 'Lee',
+        veteran_phone: '(989)898-9898',
+        veteran_prefered_name: nil,
+        veteran_pronouns: 'He/Him',
+        veteran_province: '722310005',
+        veteran_relationship: '722310003',
         veteran_service_end_date: '01/01/2000',
-        veteran_service_number: 'string',
-        veteran_service_start_date: '01/01/1960',
-        veteran_ssn: 'string',
+        veteran_service_number: nil,
+        veteran_service_start_date: nil,
+        veteran_ssn: '123456799',
         veterans_state: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        veteran_street_address: 'string',
-        veteran_suffix: 722_310_001,
-        veteran_suite_apt_other: 'string',
-        veteran_zip_code: 'string',
-        who_was_their_counselor: 'string',
-        your_last_name: 'string',
-        zip_code: 'string'
+        veteran_street_address: '4343 Rosemeade Pkwy',
+        veteran_suffix: '722310001',
+        veteran_suite_apt_other: nil,
+        veteran_zip_code: '75287-2950',
+        who_was_their_counselor: nil,
+        your_last_name: 'Wells',
+        zip_code: '75287-2950',
+        profile: {
+          first_name: 'Glen',
+          middle_name: 'M',
+          last_name: 'Wells',
+          preferred_name: nil,
+          suffix: '722310001',
+          gender: 'M',
+          pronouns: 'He/Him',
+          country: '722310186',
+          street: '4343 Rosemeade Pkwy',
+          city: 'Dallas',
+          state: 'TX',
+          zip_code: '75287-2950',
+          province: nil,
+          business_phone: '(989)898-9898',
+          personal_phone: '(989)898-9898',
+          personal_email: 'vets.gov.user+119@gmail.com',
+          business_email: 'vets.gov.user+119@gmail.com',
+          school_state: 'TX',
+          school_facility_code: '1000000898',
+          service_number: nil,
+          claim_number: nil,
+          veteran_service_state_date: nil,
+          date_of_birth: '1971-12-08',
+          edipi: nil
+        },
+        school_obj: {
+          city: 'Dallas',
+          institution_name: "Kyle's Institution",
+          regional_office: '669cbc60-b58d-eb11-b1ac-001dd8309d89',
+          school_facility_code: '1000000898',
+          state_abbreviation: '80b9d1e0-d488-eb11-b1ac-001dd8309d89'
+        },
+        attachments: [
+          {
+            file_name: 'testfile.pdf',
+            file_content: file
+          }
+        ]
       }
     end
-    let(:converted_payload) do
-      { AreYouTheDependent: 'true',
-        AttachmentPresent: 'false',
-        BranchOfService: '722310000',
-        City: 'Queens',
-        ContactMethod: '722310001',
-        Country: '722310000',
-        DaytimePhone: '1235559090',
-        DependantCity: 'Morrilton',
-        DependantCountry: '722310000',
-        DependantDOB: '01/01/2000',
-        DependantEmail: 'test@email.com',
-        DependantFirstName: 'Peter',
-        DependantGender: 'M',
-        DependantLastName: 'Parker',
-        DependantMiddleName: 'B',
-        DependantProvince: '722310008',
-        DependantRelationship: '722310007',
-        DependantSSN: '123456789',
-        DependantState: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        DependantStreetAddress: 'TEST',
-        DependantZipCode: '72156',
-        EmailAddress: 'test@email.com',
-        EmailConfirmation: 'test@email.com',
-        FirstName: 'Pete',
-        Gender: 'M',
-        InquiryAbout: '722310003',
-        InquiryCategory: '5c524deb-d864-eb11-bb24-000d3a579c45',
-        InquirySource: '722310004',
-        InquirySubtopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
-        InquirySummary: 'string',
-        InquiryTopic: '932a8586-e764-eb11-bb23-000d3a579c3f',
-        InquiryType: '722310001',
-        IsVAEmployee: 'true',
-        IsVeteran: 'true',
-        IsVeteranAnEmployee: 'true',
-        IsVeteranDeceased: 'true',
-        LevelOfAuthentication: '722310001',
-        MedicalCenter: '07a51029-6816-e611-9436-0050568d743d',
-        MiddleName: 'MiddleName',
-        PreferredName: 'Petey',
-        Pronouns: 'string',
-        StreetAddress2: 'string',
-        Submitter: '42cc2a0a-2ebf-e711-9495-0050568d63d9',
-        SubmitterDependent: '722310000',
-        SubmitterDOB: '01/01/2000',
-        SubmitterGender: 'M',
-        SubmitterProvince: '722310008',
-        SubmitterQuestion: 'test',
-        SubmittersDodIdEdipiNumber: 'string',
-        SubmitterSSN: 'string',
-        SubmitterState: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        SubmitterStateOfResidency: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        SubmitterStateOfSchool: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        SubmitterStateProperty: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        SubmitterStreetAddress: 'string',
-        SubmitterVetCenter: 'string',
-        SubmitterZipCodeOfResidency: 'e3df3e75-54a1-eb11-b1ac-001dd804abe6',
-        Suffix: '722310001',
-        SupervisorFlag: 'true',
-        VaEmployeeTimeStamp: 'string',
-        VeteranCity: 'string',
-        VeteranClaimNumber: 'string',
-        VeteranCountry: '722310186',
-        VeteranDateOfDeath: '01/01/2000',
-        VeteranDOB: '01/01/2000',
-        VeteranDodIdEdipiNumber: 'string',
-        VeteranEmail: 'string',
-        VeteranEmailConfirmation: 'string',
-        VeteranEnrolled: 'true',
-        VeteranFirstName: 'string',
-        VeteranICN: 'string',
-        VeteranLastName: 'string',
-        VeteranMiddleName: 'string',
-        VeteranPhone: 'string',
-        VeteranPreferedName: 'string',
-        VeteranPronouns: 'string',
-        VeteranProvince: '722310005',
-        VeteranRelationship: '722310008',
-        VeteranServiceEndDate: '01/01/2000',
-        VeteranServiceNumber: 'string',
-        VeteranServiceStartDate: '01/01/1960',
-        VeteranSSN: 'string',
-        VeteransState: '80b9d1e0-d488-eb11-b1ac-001dd8309d89',
-        VeteranStreetAddress: 'string',
-        VeteranSuffix: '722310001',
-        VeteranSuiteAptOther: 'string',
-        VeteranZipCode: 'string',
-        WhoWasTheirCounselor: 'string',
-        YourLastName: 'string',
-        ZipCode: 'string',
-        SchoolObj: { City: 'Boston',
-                     InstitutionName: "Kyle's Institution",
-                     RegionalOffice: '669cbc60-b58d-eb11-b1ac-001dd8309d89',
-                     SchoolFacilityCode: '1000000898',
-                     StateAbbreviation: '80b9d1e0-d488-eb11-b1ac-001dd8309d89' } }
-    end
     let(:endpoint) { AskVAApi::Inquiries::Creator::ENDPOINT }
-
-    context 'when successful' do
-      before do
-        allow_any_instance_of(Crm::Service).to receive(:call)
-          .with(endpoint:, method: :put,
-                payload: converted_payload).and_return({
-                                                         Data: {
-                                                           Id: '530d56a8-affd-ee11-a1fe-001dd8094ff1'
-                                                         },
-                                                         Message: '',
-                                                         ExceptionOccurred: false,
-                                                         ExceptionMessage: '',
-                                                         MessageId: 'b8ebd8e7-3bbf-49c5-aff0-99503e50ee27'
-                                                       })
-        sign_in(authorized_user)
-        post '/ask_va_api/v0/inquiries/auth', params: payload
+    let(:option_keys) do
+      %w[inquiryabout inquirysource inquirytype levelofauthentication suffix veteranrelationship
+         dependentrelationship responsetype]
+    end
+    let(:cache_data_service) { instance_double(Crm::CacheData) }
+    let(:cache_data) do
+      lambda do |option|
+        {
+          'inquiryabout' => { Data: [{ Id: 722_310_003, Name: 'A general question' },
+                                     { Id: 722_310_000, Name: 'About Me, the Veteran' },
+                                     { Id: 722_310_002, Name: 'For the dependent of a Veteran' },
+                                     { Id: 722_310_001, Name: 'On behalf of a Veteran' }] },
+          'inquirysource' => { Data: [{ Id: 722_310_005, Name: 'Phone' },
+                                      { Id: 722_310_004, Name: 'US Mail' },
+                                      { Id: 722_310_000, Name: 'AVA' },
+                                      { Id: 722_310_001, Name: 'Email' },
+                                      { Id: 722_310_002, Name: 'Facebook' }] },
+          'inquirytype' => { Data: [{ Id: 722_310_000, Name: 'Compliment' },
+                                    { Id: 722_310_001, Name: 'Question' },
+                                    { Id: 722_310_002, Name: 'Service Complaint' },
+                                    { Id: 722_310_006, Name: 'Suggestion' },
+                                    { Id: 722_310_004, Name: 'Other' }] },
+          'levelofauthentication' => { Data: [{ Id: 722_310_002, Name: 'Authenticated' },
+                                              { Id: 722_310_000, Name: 'Unauthenticated' },
+                                              { Id: 722_310_001, Name: 'Personal' },
+                                              { Id: 722_310_003, Name: 'Business' }] },
+          'suffix' => { Data: [{ Id: 722_310_000, Name: 'Jr' },
+                               { Id: 722_310_001, Name: 'Sr' },
+                               { Id: 722_310_003, Name: 'II' },
+                               { Id: 722_310_004, Name: 'III' },
+                               { Id: 722_310_006, Name: 'IV' },
+                               { Id: 722_310_002, Name: 'V' },
+                               { Id: 722_310_005, Name: 'VI' }] },
+          'veteranrelationship' => { Data: [{ Id: 722_310_007, Name: 'Child' },
+                                            { Id: 722_310_008, Name: 'Guardian' },
+                                            { Id: 722_310_005, Name: 'Parent' },
+                                            { Id: 722_310_012, Name: 'Sibling' },
+                                            { Id: 722_310_015, Name: 'Spouse/Surviving Spouse' },
+                                            { Id: 722_310_004, Name: 'Ex-spouse' },
+                                            { Id: 722_310_010, Name: 'GI Bill Beneficiary' },
+                                            { Id: 722_310_018, Name: 'Other (Personal)' },
+                                            { Id: 722_310_000, Name: 'Attorney' },
+                                            { Id: 722_310_001, Name: 'Authorized 3rd Party' },
+                                            { Id: 722_310_020, Name: 'Fiduciary' },
+                                            { Id: 722_310_006, Name: 'Funeral Director' },
+                                            { Id: 722_310_016, Name: 'OJT/Apprenticeship Supervisor' },
+                                            { Id: 722_310_013, Name: 'School Certifying Official' },
+                                            { Id: 722_310_019, Name: 'VA Employee' },
+                                            { Id: 722_310_017, Name: 'VSO' },
+                                            { Id: 722_310_014, Name: 'Work Study Site Supervisor' },
+                                            { Id: 722_310_011, Name: 'Other (Business)' },
+                                            { Id: 722_310_002, Name: 'School Official (DO NOT USE)' },
+                                            { Id: 722_310_009, Name: 'Helpless Child' },
+                                            { Id: 722_310_003, Name: 'Dependent Child' }] },
+          'dependentrelationship' => { Data: [{ Id: 722_310_006, Name: 'Child' },
+                                              { Id: 722_310_009, Name: 'Parent' },
+                                              { Id: 722_310_008, Name: 'Spouse' },
+                                              { Id: 722_310_010, Name: 'Stepchild' },
+                                              { Id: 722_310_005, Name: 'Other' }] },
+          'responsetype' => { Data: [{ Id: 722_310_000, Name: 'Email' }, { Id: 722_310_001, Name: 'Phone' },
+                                     { Id: 722_310_002, Name: 'US Mail' }] }
+        }[option]
       end
-
-      it { expect(response).to have_http_status(:created) }
     end
 
-    context 'when crm api fail' do
-      context 'when the API call fails' do
-        let(:payload) { { first_name: 'test' } }
-        let(:converted_payload) { { FirstName: 'test' } }
-        let(:body) do
-          '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
-            ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
-            'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
-        end
-        let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+    before do
+      allow(Crm::CacheData).to receive(:new).and_return(cache_data_service)
 
+      option_keys.each do |option|
+        allow(cache_data_service).to receive(:call).with(
+          endpoint: 'optionset',
+          cache_key: option,
+          payload: { name: "iris_#{option}" }
+        ).and_return(cache_data.call(option))
+      end
+    end
+
+    context 'POST #create' do
+      context 'when successful' do
         before do
           allow_any_instance_of(Crm::Service).to receive(:call)
-            .with(endpoint:, method: :put,
-                  payload: converted_payload).and_return(failure)
+            .and_return({
+                          Data: {
+                            Id: '530d56a8-affd-ee11-a1fe-001dd8094ff1'
+                          },
+                          Message: '',
+                          ExceptionOccurred: false,
+                          ExceptionMessage: '',
+                          MessageId: 'b8ebd8e7-3bbf-49c5-aff0-99503e50ee27'
+                        })
           sign_in(authorized_user)
           post '/ask_va_api/v0/inquiries/auth', params: payload
         end
 
-        it 'raise InquiriesCreatorError' do
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-
-        it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
-                        'AskVAApi::Inquiries::InquiriesCreatorError: {"Data":null,"Message":' \
-                        '"Data Validation: missing InquiryCategory"' \
-                        ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
-                        'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
-      end
-    end
-  end
-
-  describe 'POST #unauth_create' do
-    let(:payload) { { first_name: 'Fake', your_last_name: 'Smith' } }
-    let(:converted_payload) { { FirstName: 'Fake', YourLastName: 'Smith' } }
-    let(:endpoint) { AskVAApi::Inquiries::Creator::ENDPOINT }
-
-    context 'when successful' do
-      before do
-        allow_any_instance_of(Crm::Service).to receive(:call)
-          .with(endpoint:, method: :put,
-                payload: converted_payload).and_return({
-                                                         Data: {
-                                                           Id: '530d56a8-affd-ee11-a1fe-001dd8094ff1'
-                                                         },
-                                                         Message: '',
-                                                         ExceptionOccurred: false,
-                                                         ExceptionMessage: '',
-                                                         MessageId: 'b8ebd8e7-3bbf-49c5-aff0-99503e50ee27'
-                                                       })
-        post inquiry_path, params: payload
+        it { expect(response).to have_http_status(:created) }
       end
 
-      it { expect(response).to have_http_status(:created) }
+      context 'when crm api fail' do
+        context 'when the API call fails' do
+          let(:payload) { { first_name: 'test' } }
+          let(:body) do
+            '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
+              ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
+              'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
+          end
+          let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+
+          before do
+            allow_any_instance_of(Crm::Service).to receive(:call)
+              .and_return(failure)
+            sign_in(authorized_user)
+            post '/ask_va_api/v0/inquiries/auth', params: payload
+          end
+
+          it 'raise InquiriesCreatorError' do
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
+                          'AskVAApi::Inquiries::InquiriesCreatorError: {"Data":null,"Message":' \
+                          '"Data Validation: missing InquiryCategory"' \
+                          ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
+                          'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
+        end
+      end
     end
 
-    context 'when crm api fail' do
-      context 'when the API call fails' do
-        let(:payload) { { first_name: 'test' } }
-        let(:converted_payload) { { FirstName: 'test' } }
-        let(:body) do
-          '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
-            ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
-            'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
-        end
-        let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+    context 'POST #unauth_create' do
+      let(:icn) { nil }
 
+      context 'when successful' do
         before do
           allow_any_instance_of(Crm::Service).to receive(:call)
-            .with(endpoint:, method: :put,
-                  payload: converted_payload).and_return(failure)
-          post '/ask_va_api/v0/inquiries', params: payload
+            .and_return({
+                          Data: {
+                            Id: '530d56a8-affd-ee11-a1fe-001dd8094ff1'
+                          },
+                          Message: '',
+                          ExceptionOccurred: false,
+                          ExceptionMessage: '',
+                          MessageId: 'b8ebd8e7-3bbf-49c5-aff0-99503e50ee27'
+                        })
+          post inquiry_path, params: payload
         end
 
-        it 'raise InquiriesCreatorError' do
-          expect(response).to have_http_status(:unprocessable_entity)
+        it { expect(response).to have_http_status(:created) }
+      end
+
+      context 'when crm api fail' do
+        context 'when the API call fails' do
+          let(:payload) { { first_name: 'test' } }
+          let(:body) do
+            '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
+              ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
+              'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
+          end
+          let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+
+          before do
+            allow_any_instance_of(Crm::Service).to receive(:call)
+              .and_return(failure)
+            post '/ask_va_api/v0/inquiries', params: payload
+          end
+
+          it 'raise InquiriesCreatorError' do
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
+                          'AskVAApi::Inquiries::InquiriesCreatorError: ' \
+                          '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
+                          ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
+                          'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
         end
-
-        it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
-                        'AskVAApi::Inquiries::InquiriesCreatorError: ' \
-                        '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
-                        ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
-                        'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
-      end
-    end
-  end
-
-  describe 'POST #upload_attachment' do
-    let(:file_path) { 'modules/ask_va_api/config/locales/get_inquiries_mock_data.json' }
-    let(:base64_encoded_file) { Base64.strict_encode64(File.read(file_path)) }
-    let(:file) { "data:image/png;base64,#{base64_encoded_file}" }
-    let(:inquiry_id) { '1c1f5631-9edf-ee11-904d-001dd8306b36' }
-    let(:correspondence_id) { nil }
-    let(:params) do
-      {
-        file_name: 'testfile',
-        file_content: file,
-        inquiry_id:,
-        correspondence_id:
-      }
-    end
-
-    context 'when successful' do
-      let(:crm_response) do
-        { Data: {
-          Id: '1c1f5631-9edf-ee11-904d-001dd8306b36'
-        } }
-      end
-
-      before do
-        allow_any_instance_of(Crm::Service).to receive(:call)
-          .with(endpoint: 'attachment/new', payload: {
-                  inquiryId: params[:inquiry_id],
-                  fileName: params[:file_name],
-                  fileContent: file,
-                  correspondenceId: params[:correspondence_id]
-                }).and_return(crm_response)
-
-        post '/ask_va_api/v0/upload_attachment', params:
-      end
-
-      it 'returns http status :ok' do
-        expect(response).to have_http_status(:ok)
       end
     end
   end


### PR DESCRIPTION
## Summary

- **Feature Toggle (flipper)**: NO
- This pull request introduces several key updates and refactors across the `InquiriesController` and `Inquiries::Creator` to improve maintainability, streamline the payload structure, and delegate responsibilities to relevant classes. The changes impact how inquiry data, including attachments and key conversions, are handled.

### Key Changes:

1. **InquiriesController Updates**:
   - **Attachment Handling**: Removed the ability to upload attachments separately, as they are now included directly in the inquiry payload during the creation process.
   - **Key Conversion**: The responsibility for converting keys from `snake_case` to `camelCase` has been moved from the controller to the `Translator` class, improving separation of concerns and enhancing code maintainability.

2. **Inquiries::Creator Refactor**:
   - **Integration with Translator**: The `Translator` class is now used to convert inquiry parameter keys from `snake_case` to `camelCase` and translate optionset names to their corresponding IDs.
   - **Update Payload**: `Inquiry params` now accepts `profile` object as part of the payload.
   - **VeteranICN Handling**: The `Creator` now assigns `VeteranICN` directly to the payload, ensuring this critical piece of information is included in API requests to the CRM system.

- **Team Ownership**: These changes are owned by the Ask VA team, and we are responsible for the ongoing maintenance of the `ask_va_api`.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/1028

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
