### PR TITLE
add conditional logs to confirm attachment functionality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1076,6 +1076,7 @@ rakelib/support/vic_load_test.rb @department-of-veterans-affairs/octo-identity
 rakelib/test_user_account.rake @department-of-veterans-affairs/octo-identity
 rakelib/vbms.rake @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 script/github-actions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/concerns/form_attachment_create_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/concerns/traceable_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/config/initializers/staccato_spec.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/application_controller_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -5,11 +5,28 @@ module FormAttachmentCreate
   include SentryLogging
 
   def create
+    debug_timestamp = Time.current.iso8601
+    if Flipper.enabled?(:hca_log_form_attachment_create)
+      log_message_to_sentry(
+        'begin form attachment creation',
+        :info,
+        file_data_present: filtered_params[:file_data].present?,
+        class_name: filtered_params[:file_data]&.class&.name,
+        debug_timestamp:
+      )
+    end
+
     validate_file_upload_class!
     save_attachment_to_cloud!
     save_attachment_to_db!
 
-    render json: serializer_klass.new(form_attachment)
+    serialized = serializer_klass.new(form_attachment)
+
+    if Flipper.enabled?(:hca_log_form_attachment_create)
+      log_message_to_sentry('finish form attachment creation', :info, serialized: serialized.present?, debug_timestamp:)
+    end
+
+    render json: serialized
   end
 
   private

--- a/config/features.yml
+++ b/config/features.yml
@@ -95,6 +95,9 @@ features:
   hca_use_facilities_API:
     actor_type: user
     description: Allow list of medical care facilites to be fetched by way of the Facilities API.
+  hca_log_form_attachment_create:
+    actor_type: user
+    description: Enable logging all successful-looking attachment creation calls to Sentry at info-level
   cg1010_oauth_2_enabled:
     actor_type: user
     description: Use OAuth 2.0 Authentication for 10-10CG Form Mulesoft integration.

--- a/spec/concerns/form_attachment_create_spec.rb
+++ b/spec/concerns/form_attachment_create_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FormAttachmentCreate, type: :controller do
+  shared_context 'stub controller' do
+    before do
+      stub_const('TestFormAttachmentCreate', controller_class)
+
+      Rails.application.routes.draw do
+        get 'test_form_attachment_create', to: 'test_form_attachment_create#create'
+      end
+
+      @controller = controller_class.new
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  describe '#create' do
+    context 'with Sentry logging enabled' do
+      let(:controller_class) do
+        Class.new(ApplicationController) do
+          include FormAttachmentCreate
+          service_tag 'healthcare-application'
+
+          skip_before_action :authenticate
+
+          def form_attachment_model
+            HCAAttachment
+          end
+
+          def serializer_klass
+            HCAAttachmentSerializer
+          end
+        end
+      end
+
+      controller_class::FORM_ATTACHMENT_MODEL = HCAAttachment
+
+      include_context 'stub controller'
+
+      it 'validates and saves attachment' do
+        file_data = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+
+        expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).twice.and_return(true)
+
+        expect(@controller).to receive(:log_message_to_sentry).with(
+          'begin form attachment creation',
+          :info,
+          file_data_present: true,
+          class_name: 'ActionDispatch::Http::UploadedFile',
+          debug_timestamp: anything
+        )
+        expect(@controller).to receive(:log_message_to_sentry).with(
+          'finish form attachment creation',
+          :info,
+          serialized: true,
+          debug_timestamp: anything
+        )
+
+        form_attachment = double(HCAAttachment)
+        expect(HCAAttachment).to receive(:new) { form_attachment }
+        expect(form_attachment).to receive(:set_file_data!)
+        expect(form_attachment).to receive(:save!)
+
+        post(:create, params: { hca_attachment: { file_data: } })
+      end
+
+      it 'logs validation failure when attachment is not a type of UploadedFile' do
+        file_data = 'foo'
+        expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).and_return(true)
+        expect(@controller).to receive(:log_message_to_sentry).with(
+          'begin form attachment creation',
+          :info,
+          file_data_present: true,
+          class_name: 'String',
+          debug_timestamp: anything
+        )
+        expect(@controller).to receive(:log_exception_to_sentry).twice
+        post(:create, params: { hca_attachment: { file_data: } })
+      end
+
+      it 'logs failure to save to cloud' do
+        file_data = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+
+        expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).and_return(true)
+
+        expect(@controller).to receive(:log_message_to_sentry).with(
+          'begin form attachment creation',
+          :info,
+          file_data_present: true,
+          class_name: 'ActionDispatch::Http::UploadedFile',
+          debug_timestamp: anything
+        )
+        expect(@controller).to receive(:log_exception_to_sentry).twice
+
+        form_attachment = double(HCAAttachment)
+        expect(HCAAttachment).to receive(:new) { form_attachment }
+        expect(form_attachment).to receive(:set_file_data!).and_raise(Common::Exceptions::UnprocessableEntity)
+
+        post(:create, params: { hca_attachment: { file_data: } })
+      end
+
+      it 'logs failure to save to db' do
+        file_data = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+
+        expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).and_return(true)
+
+        expect(@controller).to receive(:log_message_to_sentry).with(
+          'begin form attachment creation',
+          :info,
+          file_data_present: true,
+          class_name: 'ActionDispatch::Http::UploadedFile',
+          debug_timestamp: anything
+        )
+        expect(@controller).to receive(:log_exception_to_sentry)
+
+        form_attachment = double(HCAAttachment)
+        expect(HCAAttachment).to receive(:new) { form_attachment }
+        expect(form_attachment).to receive(:set_file_data!)
+        expect(form_attachment).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+
+        post(:create, params: { hca_attachment: { file_data: } })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* (`hca_log_form_attachment_create`)
- Add Sentry info logs before and after the attachment creation process, so we can check whether this actually happens in production.
- We expected the 403 errors to come from this code, but aren't seeing any logs in Sentry. This will affirmatively validate whether that's because something's wrong with the error logging/reporting/retrieval, or if we're actually not seeing errors there and need to look elsewhere.
- Health Enrollment 10-10EZ/CG team

## Related issue(s)

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/92139

## Testing done

I ran the app locally and confirmed that the upload process works, and we get the corresponding logs in the console; since this is a logging change only, there's no testing to add.

## What areas of the site does it impact?
- This affects Sentry logging for File Upload creation

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs