### PR TITLE
Fetch email from logged-in user where available on 21-10210

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -240,7 +240,8 @@ module SimpleFormsApi
       # user's own claim
       # user is a veteran
       if @form_data['claim_ownership'] == 'self' && @form_data['claimant_type'] == 'veteran'
-        [@form_data['veteran_email'], @form_data.dig('veteran_full_name', 'first')]
+        email = user&.email || @form_data['veteran_email']
+        [email, @form_data.dig('veteran_full_name', 'first')]
 
       # user's own claim
       # user is not a veteran

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -246,7 +246,8 @@ module SimpleFormsApi
       # user's own claim
       # user is not a veteran
       elsif @form_data['claim_ownership'] == 'self' && @form_data['claimant_type'] == 'non-veteran'
-        [@form_data['claimant_email'], @form_data.dig('claimant_full_name', 'first')]
+        email = user&.email || @form_data['claimant_email']
+        [email, @form_data.dig('claimant_full_name', 'first')]
 
       # someone else's claim
       # claimant (aka someone else) is a veteran


### PR DESCRIPTION
## Summary
This PR gets the email address from the logged-in Veteran if available instead of relying on form data for the email. It will allow emails to be sent in these cases, since the form data will not contain their email address.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1684

## Testing done
I've also slightly refactored the tests.
