### PR TITLE
Add .aider to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ staging.benefits_claims.pem
 
 # ignore Yardoc generation
 .yardoc/
+.aider*


### PR DESCRIPTION
Add .aider to gitignore. aider is a coding assist for VIM, similar to CoPiolot