### PR TITLE
93214: Fix error logging for DR SavedClaim status updater jobs

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -105,13 +105,16 @@ module DecisionReview
         status = upload['status']
         result = false unless UPLOAD_SUCCESSFUL_STATUS.include? status
 
-        upload_id = upload['id']
-        # Increment StatsD and log only for new errors
-        unless old_uploads_metadata.dig(upload_id, 'status') == ERROR_STATUS
-          StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])
+        if status == ERROR_STATUS
+          upload_id = upload['id']
+          # Increment StatsD and log only for new errors
+          next if old_uploads_metadata.dig(upload_id, 'status') == ERROR_STATUS
+
           Rails.logger.info('DecisionReview::SavedClaimNodStatusUpdaterJob evidence status error',
                             { guid: nod.guid, lighthouse_upload_id: upload_id, detail: upload['detail'] })
         end
+
+        StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])
       end
 
       result

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -105,13 +105,15 @@ module DecisionReview
         status = upload['status']
         result = false unless UPLOAD_SUCCESSFUL_STATUS.include? status
 
-        upload_id = upload['id']
-        # Increment StatsD and log only for new errors
-        unless old_uploads_metadata.dig(upload_id, 'status') == ERROR_STATUS
-          StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])
+        if status == ERROR_STATUS
+          upload_id = upload['id']
+          # Increment StatsD and log only for new errors
+          next if old_uploads_metadata.dig(upload_id, 'status') == ERROR_STATUS
+
           Rails.logger.info('DecisionReview::SavedClaimScStatusUpdaterJob evidence status error',
                             { guid: sc.guid, lighthouse_upload_id: upload_id, detail: upload['detail'] })
         end
+        StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])
       end
 
       result

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -107,6 +107,8 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
         let(:upload_id4) { SecureRandom.uuid }
 
         before do
+          allow(Rails.logger).to receive(:info)
+
           SavedClaim::NoticeOfDisagreement.create(guid: guid1, form: '{}')
           SavedClaim::NoticeOfDisagreement.create(guid: guid2, form: '{}')
           SavedClaim::NoticeOfDisagreement.create(guid: guid3, form: '{}')
@@ -177,6 +179,8 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.saved_claim_nod_status_updater_upload.status', tags: ['status:processing'])
             .exactly(2).times
+          expect(Rails.logger).not_to have_received(:info)
+            .with('DecisionReview::SavedClaimNodStatusUpdaterJob evidence status error', anything)
         end
       end
 

--- a/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_sc_status_updater_job_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
         let(:upload_id4) { SecureRandom.uuid }
 
         before do
+          allow(Rails.logger).to receive(:info)
           SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}')
           SavedClaim::SupplementalClaim.create(guid: guid2, form: '{}')
           SavedClaim::SupplementalClaim.create(guid: guid3, form: '{}')
@@ -177,6 +178,8 @@ RSpec.describe DecisionReview::SavedClaimScStatusUpdaterJob, type: :job do
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.saved_claim_sc_status_updater_upload.status', tags: ['status:processing'])
             .exactly(2).times
+          expect(Rails.logger).not_to have_received(:info)
+            .with('DecisionReview::SavedClaimScStatusUpdaterJob evidence status error', anything)
         end
       end
 


### PR DESCRIPTION
## Summary
This fixes an erroneous log message for non-error evidence statuses in the DR SavedClaim status updater jobs.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93214
https://github.com/department-of-veterans-affairs/va.gov-team/issues/90103

## Testing done
Tested locally and spec tests
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
This impacts Rails logs and the SavedClaim status updater jobs.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature