### PR TITLE
[DR-76676] Remove version number logging from NOD requests

### DIFF
--- a/app/controllers/v1/notice_of_disagreements_controller.rb
+++ b/app/controllers/v1/notice_of_disagreements_controller.rb
@@ -18,7 +18,6 @@ module V1
         current_user: @current_user,
         request_body_hash:,
         decision_review_service:,
-        version_number:
       )
 
       render json: nod_response_body
@@ -34,10 +33,6 @@ module V1
 
     def error_class(method:, exception_class:)
       "#{self.class.name}##{method} exception #{exception_class} (NOD_V1)"
-    end
-
-    def version_number
-      'v2'
     end
 
     def handle_personal_info_error(e)

--- a/app/controllers/v1/notice_of_disagreements_controller.rb
+++ b/app/controllers/v1/notice_of_disagreements_controller.rb
@@ -17,7 +17,7 @@ module V1
       nod_response_body = AppealSubmission.submit_nod(
         current_user: @current_user,
         request_body_hash:,
-        decision_review_service:,
+        decision_review_service:
       )
 
       render json: nod_response_body

--- a/lib/decision_review/service.rb
+++ b/lib/decision_review/service.rb
@@ -61,10 +61,7 @@ module DecisionReview
           key: :overall_claim_submission,
           form_id: '10182',
           user_uuid: user.uuid,
-          downstream_system: 'Lighthouse',
-          params: {
-            version_number: 'v1'
-          }
+          downstream_system: 'Lighthouse'
         }
         begin
           response = perform :post, 'notice_of_disagreements', request_body, headers

--- a/lib/decision_review_v1/service.rb
+++ b/lib/decision_review_v1/service.rb
@@ -144,10 +144,7 @@ module DecisionReviewV1
           key: :overall_claim_submission,
           form_id: '10182',
           user_uuid: user.uuid,
-          downstream_system: 'Lighthouse',
-          params: {
-            version_number: 'v2'
-          }
+          downstream_system: 'Lighthouse'
         }
         begin
           response = perform :post, 'notice_of_disagreements', request_body, headers

--- a/spec/requests/v1/notice_of_disagreements_spec.rb
+++ b/spec/requests/v1/notice_of_disagreements_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe 'V1::NoticeOfDisagreements', type: :request do
       http: {
         status_code: 422,
         body: response_error_body
-      },
-      version_number: 'v2'
+      }
     }
   end
 
@@ -80,12 +79,10 @@ RSpec.describe 'V1::NoticeOfDisagreements', type: :request do
                                                       http: {
                                                         status_code: 200,
                                                         body: '[Redacted]'
-                                                      },
-                                                      version_number: 'v2'
+                                                      }
                                                     })
         allow(StatsD).to receive(:increment)
         expect(StatsD).to receive(:increment).with('decision_review.form_10182.overall_claim_submission.success')
-        expect(StatsD).to receive(:increment).with('nod_evidence_upload.v2.queued')
         previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
         # Create an InProgressForm
         in_progress_form = create(:in_progress_form, user_uuid: user.uuid, form_id: '10182')


### PR DESCRIPTION
## Summary
Since we've released NOD v2 at 100% for a few months now, we want to clean up any logging we used to differentiate between v1 and v2 requests. Basically reverts https://github.com/department-of-veterans-affairs/vets-api/pull/15503/. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/76676

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Decision Reviews backend

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

