### PR TITLE
Rename Vets spec dummy classes to prevent naming conflicts

### DIFF
--- a/app/models/preneeds/base.rb
+++ b/app/models/preneeds/base.rb
@@ -80,7 +80,7 @@ module Preneeds
             end
           end
 
-          value = ActiveModel::Type::Boolean.new.cast(value) if klass == Boolean
+          value = ActiveModel::Type::Boolean.new.cast(value) if klass == Bool
 
           value = klass.new(value) if value.is_a?(Hash)
 

--- a/app/models/preneeds/base.rb
+++ b/app/models/preneeds/base.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # This will be moved after virtus is removed
-module Boolean; end
-class TrueClass; include Boolean; end
-class FalseClass; include Boolean; end
+module Bool; end
+class TrueClass; include Bool; end
+class FalseClass; include Bool; end
 
 # Parent class for other Preneeds Burial form related models
 # Should not be initialized directly

--- a/app/models/preneeds/race.rb
+++ b/app/models/preneeds/race.rb
@@ -13,7 +13,7 @@ module Preneeds
     }.freeze
 
     ATTRIBUTE_MAPPING.each_value do |attr|
-      attribute(attr, Boolean, default: false)
+      attribute(attr, Bool, default: false)
     end
 
     def as_eoas

--- a/lib/vets/attributes/value.rb
+++ b/lib/vets/attributes/value.rb
@@ -15,7 +15,7 @@ module Vets
 
       def setter_value(value)
         validate_array(value) if @array
-        value = cast_boolean(value) if @klass == Boolean
+        value = cast_boolean(value) if @klass == Bool
         value = coerce_to_class(value)
         validate_type(value)
         value

--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -3,9 +3,9 @@
 require 'vets/attributes'
 
 # This will be moved after virtus is removed
-module Boolean; end
-class TrueClass; include Boolean; end
-class FalseClass; include Boolean; end
+module Bool; end
+class TrueClass; include Bool; end
+class FalseClass; include Bool; end
 
 module Vets
   class Model

--- a/spec/lib/vets/attributes/value_spec.rb
+++ b/spec/lib/vets/attributes/value_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 require 'vets/attributes/value'
 require 'vets/attributes'
-require 'vets/model' # temporarily needed for Boolean
+require 'vets/model' # temporarily needed for Bool
 
-class DoubleClass
+class FakeClass
   attr_reader :attr
 
   def initialize(attrs)
@@ -30,33 +30,33 @@ RSpec.describe Vets::Attributes::Value do
   describe '#setter_value' do
     context 'when value is a scalar type (e.g., Integer or String)' do
       it 'returns a value for a valid type' do
-        attribute_value = described_class.new(:test_name, Boolean)
+        attribute_value = described_class.new(:test_name, Bool)
         setter_value = attribute_value.setter_value('test_value')
         expect(setter_value).to be_truthy
       end
     end
 
-    context 'when value is a Boolean' do
-      it 'coerces a non-falsey, non-empty String to a true Boolean' do
-        attribute_value = described_class.new(:test_name, Boolean)
+    context 'when value is a Bool' do
+      it 'coerces a non-falsey, non-empty String to a true Bool' do
+        attribute_value = described_class.new(:test_name, Bool)
         setter_value = attribute_value.setter_value('test')
         expect(setter_value).to be_truthy
       end
 
-      it 'casts 0 (Integer) to a false Boolean' do
-        attribute_value = described_class.new(:test_name, Boolean)
+      it 'casts 0 (Integer) to a false Bool' do
+        attribute_value = described_class.new(:test_name, Bool)
         setter_value = attribute_value.setter_value(0)
         expect(setter_value).to be_falsey
       end
 
-      it 'casts "falsey" string to a false Boolean' do
-        attribute_value = described_class.new(:test_name, Boolean)
+      it 'casts "falsey" string to a false Bool' do
+        attribute_value = described_class.new(:test_name, Bool)
         setter_value = attribute_value.setter_value('f')
         expect(setter_value).to be_falsey
       end
 
       it 'coerces a empty String to nil' do
-        attribute_value = described_class.new(:test_name, Boolean)
+        attribute_value = described_class.new(:test_name, Bool)
         setter_value = attribute_value.setter_value('')
         expect(setter_value).to be_nil
       end
@@ -64,8 +64,8 @@ RSpec.describe Vets::Attributes::Value do
 
     context 'when value is a complex Object' do
       it 'returns the same complex Object when' do
-        attribute_value = described_class.new(:test_name, DoubleClass)
-        double_class = DoubleClass.new(attr: 'Steven')
+        attribute_value = described_class.new(:test_name, FakeClass)
+        double_class = FakeClass.new(attr: 'Steven')
         setter_value = attribute_value.setter_value(double_class)
         expect(setter_value).to eq(double_class)
       end
@@ -74,10 +74,10 @@ RSpec.describe Vets::Attributes::Value do
     context 'when value is a Hash' do
       context 'when klass is a Hash' do
         it 'returns a complex Object with given attributes' do
-          attribute_value = described_class.new(:test_name, DoubleClass)
+          attribute_value = described_class.new(:test_name, FakeClass)
           hash_params = { attr: 'Steven' }
           setter_value = attribute_value.setter_value(hash_params)
-          expect(setter_value.class).to eq(DoubleClass)
+          expect(setter_value.class).to eq(FakeClass)
           expect(setter_value.attr).to eq(hash_params[:attr])
         end
       end
@@ -96,36 +96,36 @@ RSpec.describe Vets::Attributes::Value do
     context 'when value is an Array' do
       context 'when elements of value are hashes' do
         it 'coerces elements to klass' do
-          attribute_value = described_class.new(:test_array, DoubleClass, array: true)
+          attribute_value = described_class.new(:test_array, FakeClass, array: true)
           setter_value = attribute_value.setter_value([{ attr: 'value' }, { attr: 'value2' }])
-          expect(setter_value).to all(be_an(DoubleClass))
+          expect(setter_value).to all(be_an(FakeClass))
           expect(setter_value.first.attr).to eq('value')
         end
       end
 
       context 'when elements of value are complex Object' do
         it 'returns the same array' do
-          attribute_value = described_class.new(:test_array, DoubleClass, array: true)
-          double1 = DoubleClass.new(attr: 'value')
-          double2 = DoubleClass.new(attr: 'value1')
+          attribute_value = described_class.new(:test_array, FakeClass, array: true)
+          double1 = FakeClass.new(attr: 'value')
+          double2 = FakeClass.new(attr: 'value1')
           setter_value = attribute_value.setter_value([double1, double2])
-          expect(setter_value).to all(be_an(DoubleClass))
+          expect(setter_value).to all(be_an(FakeClass))
           expect(setter_value.first.attr).to eq('value')
         end
       end
 
       it 'raises TypeError if value is not an Array' do
         expect do
-          attribute_value = described_class.new(:test_array, DoubleClass, array: true)
+          attribute_value = described_class.new(:test_array, FakeClass, array: true)
           attribute_value.setter_value('not_an_array')
         end.to raise_error(TypeError, 'test_array must be an Array')
       end
 
       it 'raises TypeError if elements are of incorrect type' do
         expect do
-          attribute_value = described_class.new(:test_array, DoubleClass, array: true)
+          attribute_value = described_class.new(:test_array, FakeClass, array: true)
           attribute_value.setter_value(%w[wrong_type also_wrong_type])
-        end.to raise_error(TypeError, "All elements of test_array must be of type #{DoubleClass}")
+        end.to raise_error(TypeError, "All elements of test_array must be of type #{FakeClass}")
       end
     end
   end

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 require 'vets/attributes'
-require 'vets/model' # temporarily needed for Bool
+require 'vets/model' # temporarily needed for Boolean
 
 class FakeCategory
   include Vets::Attributes
@@ -10,7 +10,7 @@ class FakeCategory
   attribute :name, String, default: 'test'
 end
 
-class TestModel
+class DummyModel
   include Vets::Attributes
 
   attribute :name, String, default: 'Unknown'
@@ -25,7 +25,7 @@ class TestModel
 end
 
 RSpec.describe Vets::Attributes do
-  let(:model) { TestModel.new }
+  let(:model) { DummyModel.new }
 
   describe '.attribute' do
     it 'defines the setters and getters' do
@@ -38,7 +38,7 @@ RSpec.describe Vets::Attributes do
     end
 
     it 'defines the defaults' do
-      no_name = TestModel.new
+      no_name = DummyModel.new
       expect(no_name.name).to eq('Unknown')
       expect(model.categories).to be_nil
     end
@@ -58,14 +58,14 @@ RSpec.describe Vets::Attributes do
         categories: { type: FakeCategory, default: nil, array: true },
         created_at: { type: DateTime, default: :current_time, array: false }
       }
-      expect(TestModel.attributes).to eq(expected_attributes)
+      expect(DummyModel.attributes).to eq(expected_attributes)
     end
   end
 
   describe '.attribute_set' do
     it 'returns an array of the attribute names' do
       expected_attribute_set = %i[name age tags categories created_at]
-      expect(TestModel.attribute_set).to eq(expected_attribute_set)
+      expect(DummyModel.attribute_set).to eq(expected_attribute_set)
     end
   end
 end

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 require 'vets/attributes'
-require 'vets/model' # temporarily needed for Boolean
+require 'vets/model' # temporarily needed for Bool
 
-class Category
+class FakeCategory
   include Vets::Attributes
 
   attribute :name, String, default: 'test'
@@ -16,7 +16,7 @@ class TestModel
   attribute :name, String, default: 'Unknown'
   attribute :age, Integer, array: false
   attribute :tags, String, array: true
-  attribute :categories, Category, array: true
+  attribute :categories, FakeCategory, array: true
   attribute :created_at, DateTime, default: :current_time
 
   def current_time
@@ -55,7 +55,7 @@ RSpec.describe Vets::Attributes do
         name: { type: String, default: 'Unknown', array: false },
         age: { type: Integer, default: nil, array: false },
         tags: { type: String, default: nil, array: true },
-        categories: { type: Category, default: nil, array: true },
+        categories: { type: FakeCategory, default: nil, array: true },
         created_at: { type: DateTime, default: :current_time, array: false }
       }
       expect(TestModel.attributes).to eq(expected_attributes)

--- a/spec/lib/vets/model_spec.rb
+++ b/spec/lib/vets/model_spec.rb
@@ -15,7 +15,7 @@ class FakeAddress < Vets::Model
   attribute :country, String
   attribute :state, String
   attribute :postal_code, String
-  attribute :apartment, Apartment
+  attribute :apartment, FakeApartment
 end
 
 RSpec.describe Vets::Model do
@@ -44,12 +44,12 @@ RSpec.describe Vets::Model do
 
   describe '#initialize' do
     it 'initializes the model with provided params' do
-      address = Address.new(street: '456 Elm St')
+      address = FakeAddress.new(street: '456 Elm St')
       expect(address.instance_variable_get('@street')).to eq('456 Elm St')
     end
 
     it 'initializes the model with objects' do
-      address = Address.new(apartment:)
+      address = FakeAddress.new(apartment:)
       expect(address.instance_variable_get('@apartment')).to eq(apartment)
     end
 

--- a/spec/lib/vets/model_spec.rb
+++ b/spec/lib/vets/model_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 require 'vets/model'
 
-class Apartment < Vets::Model
+class FakeApartment < Vets::Model
   attribute :unit_number, Integer
   attribute :building_number, Integer
 end
 
-class Address < Vets::Model
+class FakeAddress < Vets::Model
   attribute :street, String
   attribute :street2, String
   attribute :city, String
@@ -39,8 +39,8 @@ RSpec.describe Vets::Model do
       }
     }
   end
-  let(:address) { Address.new(address_params) }
-  let(:apartment) { Apartment.new(apartment_params) }
+  let(:address) { FakeAddress.new(address_params) }
+  let(:apartment) { FakeApartment.new(apartment_params) }
 
   describe '#initialize' do
     it 'initializes the model with provided params' do


### PR DESCRIPTION
## Summary

- Rename Rspec dummy classes e.g., `Apartment` -> `FakeApartment`
- Long-term solution will be implemented at a later time
- `Boolean` defined in `Vets::Model` is renamed to `Bool`
- Preneeds classes that used the `Vets::Model` predecessor Boolean was renamed too

## Related issue(s)

- n/a

## Testing done

- [ ] manual testing

## Acceptance criteria

- [ ] Class names don't conflict with other class names