### PR TITLE
Filter invalid service_branches values

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1474,6 +1474,7 @@ spec/lib/pdf_fill @department-of-veterans-affairs/backend-review-group
 spec/lib/pdf_info/metadata_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/pdf_utilities @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/pension_burial @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/pension21p527ez/pension_military_information_spec.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/rx @department-of-veterans-affairs/vfs-mhv-medications
 spec/lib/rx/client_request_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/mobile-api-team

--- a/lib/pension_21p527ez/pension_military_information.rb
+++ b/lib/pension_21p527ez/pension_military_information.rb
@@ -7,7 +7,7 @@ module Pension21p527ez
   ##
   # extends FormMilitaryInformation to add additional military information fields to Pension prefill.
   # @see app/models/form_profile.rb FormProfile::FormMilitaryInformation
-  class PensionFormMilitaryInformation < FormMilitaryInformation
+  class PensionFormMilitaryInformation < FormProfile::FormMilitaryInformation
     include Virtus.model
 
     attribute :first_uniformed_entry_date, String
@@ -58,10 +58,16 @@ module Pension21p527ez
 
     # @return [Hash] { army => true, navy => true, ... } in the format required for pensions.serviceBranch
     def service_branches_for_pensions
-      map_service_episodes_to_branches.uniq.index_with { true }
+      format_service_branches_for_pensions(map_service_episodes_to_branches)
     rescue => e
       Rails.logger.error("Error fetching service branches for Pension prefill: #{e}")
       {}
+    end
+
+    # @return [Hash] { army => true, navy => true, ... }
+    # Filters out any unknown branches
+    def format_service_branches_for_pensions(branches)
+      branches.uniq.compact_blank.index_with { true }
     end
 
     ##

--- a/spec/lib/pension21p527ez/pension_military_information_spec.rb
+++ b/spec/lib/pension21p527ez/pension_military_information_spec.rb
@@ -2,9 +2,20 @@
 
 require 'rails_helper'
 require 'pension_21p527ez/pension_military_information'
+require 'va_profile/military_personnel/service_history_response'
 
 RSpec.describe Pension21p527ez::PensionMilitaryInformation do
   let(:user) { build(:user, :loa3) }
+  let(:army_episode) do
+    VAProfile::Models::ServiceHistory.new(
+      branch_of_service: 'Army'
+    )
+  end
+  let(:unknown_episode) do
+    VAProfile::Models::ServiceHistory.new(
+      branch_of_service: 'Unknown'
+    )
+  end
 
   describe '#format_service_branches_for_pensions' do
     it 'returns an object of valid branches' do
@@ -33,6 +44,30 @@ RSpec.describe Pension21p527ez::PensionMilitaryInformation do
       expect(described_class.new(user).format_service_branches_for_pensions(['army', nil])).to eq({
                                                                                                     'army' => true
                                                                                                   })
+    end
+  end
+
+  describe '#service_branches_for_pensions' do
+    it 'returns an object of valid branches' do
+      military_personnel_stub = instance_double(VAProfile::MilitaryPersonnel::Service)
+
+      allow(VAProfile::MilitaryPersonnel::Service).to receive(:new) { military_personnel_stub }
+      allow(military_personnel_stub).to receive(:get_service_history).and_return(VAProfile::MilitaryPersonnel::ServiceHistoryResponse.new(
+                                                                                   200, episodes: [army_episode]
+                                                                                 ))
+      expect(described_class.new(user).service_branches_for_pensions).to eq({
+                                                                              'army' => true
+                                                                            })
+    end
+
+    it 'filters out invalid branches' do
+      military_personnel_stub = instance_double(VAProfile::MilitaryPersonnel::Service)
+
+      allow(VAProfile::MilitaryPersonnel::Service).to receive(:new) { military_personnel_stub }
+      allow(military_personnel_stub).to receive(:get_service_history).and_return(VAProfile::MilitaryPersonnel::ServiceHistoryResponse.new(
+                                                                                   200, episodes: [unknown_episode]
+                                                                                 ))
+      expect(described_class.new(user).service_branches_for_pensions).to eq({})
     end
   end
 end

--- a/spec/lib/pension21p527ez/pension_military_information_spec.rb
+++ b/spec/lib/pension21p527ez/pension_military_information_spec.rb
@@ -52,9 +52,11 @@ RSpec.describe Pension21p527ez::PensionMilitaryInformation do
       military_personnel_stub = instance_double(VAProfile::MilitaryPersonnel::Service)
 
       allow(VAProfile::MilitaryPersonnel::Service).to receive(:new) { military_personnel_stub }
-      allow(military_personnel_stub).to receive(:get_service_history).and_return(VAProfile::MilitaryPersonnel::ServiceHistoryResponse.new(
-                                                                                   200, episodes: [army_episode]
-                                                                                 ))
+      allow(military_personnel_stub).to receive(:get_service_history).and_return(
+        VAProfile::MilitaryPersonnel::ServiceHistoryResponse.new(
+          200, episodes: [army_episode]
+        )
+      )
       expect(described_class.new(user).service_branches_for_pensions).to eq({
                                                                               'army' => true
                                                                             })
@@ -64,9 +66,11 @@ RSpec.describe Pension21p527ez::PensionMilitaryInformation do
       military_personnel_stub = instance_double(VAProfile::MilitaryPersonnel::Service)
 
       allow(VAProfile::MilitaryPersonnel::Service).to receive(:new) { military_personnel_stub }
-      allow(military_personnel_stub).to receive(:get_service_history).and_return(VAProfile::MilitaryPersonnel::ServiceHistoryResponse.new(
-                                                                                   200, episodes: [unknown_episode]
-                                                                                 ))
+      allow(military_personnel_stub).to receive(:get_service_history).and_return(
+        VAProfile::MilitaryPersonnel::ServiceHistoryResponse.new(
+          200, episodes: [unknown_episode]
+        )
+      )
       expect(described_class.new(user).service_branches_for_pensions).to eq({})
     end
   end

--- a/spec/lib/pension21p527ez/pension_military_information_spec.rb
+++ b/spec/lib/pension21p527ez/pension_military_information_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pension_21p527ez/pension_military_information'
+
+RSpec.describe Pension21p527ez::PensionMilitaryInformation do
+  let(:user) { build(:user, :loa3) }
+
+  describe '#format_service_branches_for_pensions' do
+    it 'returns an object of valid branches' do
+      expect(described_class.new(user).format_service_branches_for_pensions(%w[
+                                                                              army
+                                                                              navy
+                                                                              airForce
+                                                                              coastGuard
+                                                                              marineCorps
+                                                                              spaceForce
+                                                                              usphs
+                                                                              noaa
+                                                                            ])).to eq({
+                                                                                        'army' => true,
+                                                                                        'navy' => true,
+                                                                                        'airForce' => true,
+                                                                                        'coastGuard' => true,
+                                                                                        'marineCorps' => true,
+                                                                                        'spaceForce' => true,
+                                                                                        'usphs' => true,
+                                                                                        'noaa' => true
+                                                                                      })
+    end
+
+    it 'filters out invalid branches' do
+      expect(described_class.new(user).format_service_branches_for_pensions(['army', nil])).to eq({
+                                                                                                    'army' => true
+                                                                                                  })
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Removes nil values from the service history branches for Pension prefill. An episode with `{ branch_of_service: 'Unknown' }` in Production set the service_branches to `{ nil: true }`; this will prevent that. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93779

## Testing done

- [x] *New code is covered by unit tests*
- [x] Additional tests include example replicating fixed error
- In production terminal, pulled the service history of the user whose prefill failed and manually ran it through both the previous code and the updated code

## What areas of the site does it impact?
Pensions

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

