### PR TITLE
[VI-506] Invalidate MPI cache when user logs in with Sign in Service or SSOe

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@ class User < Common::RedisStore
   attribute :fingerprint, String
   attribute :needs_accepted_terms_of_use, Boolean
   attribute :credential_lock, Boolean
+  attribute :session_handle, String
 
   def account
     @account ||= Identity::AccountCreator.new(self).call

--- a/app/services/sign_in/user_loader.rb
+++ b/app/services/sign_in/user_loader.rb
@@ -17,7 +17,9 @@ module SignIn
 
     def find_valid_user
       user = User.find(access_token.user_uuid)
-      user&.identity ? user : nil
+      return unless user&.identity && user&.session_handle == access_token.session_handle
+
+      user
     end
 
     def reload_user
@@ -26,7 +28,9 @@ module SignIn
       current_user.uuid = access_token.user_uuid
       current_user.last_signed_in = session.created_at
       current_user.fingerprint = request_ip
+      current_user.session_handle = access_token.session_handle
       current_user.save && user_identity.save
+      current_user.invalidate_mpi_cache
       current_user
     end
 

--- a/modules/mobile/spec/support/helpers/sis_session_helper.rb
+++ b/modules/mobile/spec/support/helpers/sis_session_helper.rb
@@ -22,7 +22,8 @@ module SISSessionHelper
         arg.is_a? Symbol
       end
 
-      user_attributes = { uuid: sis_access_token.user_uuid }.merge(*attributes)
+      user_attributes = { uuid: sis_access_token.user_uuid,
+                          session_handle: sis_access_token.session_handle }.merge(*attributes)
       traits |= [:api_auth]
       create(:user, *traits, **user_attributes)
     end

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -95,7 +95,9 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       end
 
       context 'user.fingerprint does not match request IP' do
-        let!(:user) { create(:user, :loa3, uuid: access_token_object.user_uuid) }
+        let!(:user) do
+          create(:user, :loa3, uuid: access_token_object.user_uuid, session_handle: access_token_object.session_handle)
+        end
         let(:expected_error) { '[SignIn][Authentication] fingerprint mismatch' }
         let(:log_context) { { request_ip: request.remote_ip, fingerprint: user.fingerprint } }
 
@@ -156,7 +158,11 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
           let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
           let(:expected_error) { SignIn::Errors::AccessTokenMalformedJWTError.to_s }
           let!(:user) do
-            create(:user, :loa3, uuid: access_token_object.user_uuid, fingerprint: request.remote_ip)
+            create(:user,
+                   :loa3,
+                   uuid: access_token_object.user_uuid,
+                   fingerprint: request.remote_ip,
+                   session_handle: access_token_object.session_handle)
           end
           let(:user_serializer) { SignIn::IntrospectSerializer.new(user) }
           let(:expected_introspect_response) { JSON.parse(user_serializer.to_json) }
@@ -240,7 +246,9 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       end
 
       context 'user.fingerprint does not match request IP' do
-        let!(:user) { create(:user, :loa3, uuid: access_token_object.user_uuid) }
+        let!(:user) do
+          create(:user, :loa3, uuid: access_token_object.user_uuid, session_handle: access_token_object.session_handle)
+        end
         let(:expected_error) { '[SignIn][Authentication] fingerprint mismatch' }
         let(:log_context) { { request_ip: request.remote_ip, fingerprint: user.fingerprint } }
 

--- a/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
+++ b/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe V0::TermsOfUseAgreementsController, type: :controller do
     end
 
     context 'when user is authenticated with a sign in service cookie' do
-      let(:access_token_object) { create(:access_token, user_uuid: user.uuid) }
+      let(:access_token_object) { create(:access_token, user_uuid: user.uuid, session_handle: user.session_handle) }
       let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
 
       before do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     uuid { 'b2fab2b5-6af0-45e1-a9e2-394347af91ef' }
     last_signed_in { Time.now.utc }
     fingerprint { '111.111.1.1' }
+    session_handle { SecureRandom.hex }
     transient do
       authn_context { LOA::IDME_LOA1_VETS }
       email { 'abraham.lincoln@vets.gov' }


### PR DESCRIPTION
## Summary

- This PR adds a mechanism for the `User` model to store the current session handle/token so that we can tell when a new session is reloading the user. This allows us to invalidate the MPI cache when a user is logging in with a new authenticated session

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-506

## Testing done

- [ ] Authenticated with a user, confirmed MPI was being called during authentication
- [ ] Logged out, then back in, confirmed MPI was being called again during re-authentication
- [ ] Above process was performed for Sign in Service and SSOe

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Authenticate with SiS/SSOe
- [ ] After authenticating, go into Rails Console and confirm an attribute on the MPI record (for example, `User.find('uuid of user you logged in with').mhv_ids`)
- [ ] In mockdata repo, change the relevant attribute on the mocked MPI record
- [ ] Log out then log back in with the same user
- [ ] After authenticating, go into Rails Console and confirm that the given attribute has successfully changed (for example, `User.find('uuid of user you logged in with').mhv_ids`)
