### PR TITLE
10-10CG - Updated Redis key to utilize redis-namespace for SubmissionJob

### DIFF
--- a/app/models/form1010cg/submission_job_claim.rb
+++ b/app/models/form1010cg/submission_job_claim.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'common/models/redis_store'
+
+module Form1010cg
+  class SubmissionJobClaim < Common::RedisStore
+    redis_store REDIS_CONFIG[:form_1010_cg_submission_job_claim][:namespace]
+    redis_ttl REDIS_CONFIG[:form_1010_cg_submission_job_claim][:each_ttl]
+    redis_key :claim_id
+
+    attribute :claim_id
+    validates :claim_id, presence: true
+
+    def self.set_claim_key(claim_id)
+      redis_namespace.set(claim_id, 't') unless redis_namespace.exists?(claim_id)
+    end
+  end
+end

--- a/app/models/form1010cg/submission_job_claim.rb
+++ b/app/models/form1010cg/submission_job_claim.rb
@@ -11,7 +11,7 @@ module Form1010cg
     attribute :claim_id
     validates :claim_id, presence: true
 
-    def self.set_claim_key(claim_id)
+    def self.set_key(claim_id)
       redis_namespace.set(claim_id, 't') unless redis_namespace.exists?(claim_id)
     end
   end

--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -51,7 +51,7 @@ module Form1010cg
 
       StatsD.increment("#{STATSD_KEY_PREFIX}applications_retried")
 
-      Form1010cg::SubmissionJobClaim.set_claim_key(claim_id)
+      Form1010cg::SubmissionJobClaim.set_key(claim_id)
     end
   end
 end

--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -47,12 +47,11 @@ module Form1010cg
     private
 
     def increment_applications_retried(claim_id)
-      redis_key = "Form1010cg::SubmissionJob:#{claim_id}"
-      return if $redis.get(redis_key).present?
+      return if Form1010cg::SubmissionJobClaim.exists?(claim_id)
 
       StatsD.increment("#{STATSD_KEY_PREFIX}applications_retried")
 
-      $redis.set(redis_key, 't')
+      Form1010cg::SubmissionJobClaim.set_claim_key(claim_id)
     end
   end
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -208,6 +208,9 @@ development: &defaults
   travel_pay_store:
     namespace: travel-pay-store
     each_ttl: 3300 # 55 minutes
+  form_1010_cg_submission_job_claim:
+    namespace: Form1010cg::SubmissionJob
+    each_ttl: 1000000 # persisted for at least 22 sidekiq retries
 test:
   <<: *defaults
   redis:

--- a/spec/models/form1010cg/submission_job_claim_spec.rb
+++ b/spec/models/form1010cg/submission_job_claim_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Form1010cg::SubmissionJobClaim, type: :model do
   let(:claim_id) { SecureRandom.uuid }
   let(:full_key) { "#{namespace}:#{claim_id}" }
 
-  describe '.set_claim_key' do
+  describe '.set_key' do
     subject do
-      described_class.set_claim_key(claim_id)
+      described_class.set_key(claim_id)
     end
 
     context 'when the key does not exist' do

--- a/spec/models/form1010cg/submission_job_claim_spec.rb
+++ b/spec/models/form1010cg/submission_job_claim_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Form1010cg::SubmissionJobClaim, type: :model do
+  let(:namespace) { REDIS_CONFIG[:form_1010_cg_submission_job_claim][:namespace] }
+  let(:claim_id) { SecureRandom.uuid }
+  let(:full_key) { "#{namespace}:#{claim_id}" }
+
+  describe '.set_claim_key' do
+    subject do
+      described_class.set_claim_key(claim_id)
+    end
+
+    context 'when the key does not exist' do
+      it 'sets the claim key in Redis' do
+        expect($redis).not_to exist(full_key)
+
+        subject
+
+        expect($redis).to exist(full_key)
+        expect($redis.get(full_key)).to eq('t')
+      end
+    end
+
+    context 'when the key already exists' do
+      it 'does not overwrite the existing key' do
+        $redis.set(full_key, 'existing_value')
+        expect($redis.get(full_key)).to eq('existing_value')
+        subject
+        expect($redis.get(full_key)).to eq('existing_value')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Added new class that extends `Common::RedisStore` to use for the redis key that is being used in the SubmissionJob to increment the applications that have been retried. 
- It is currently being directly created in redis, and no ttl is being set. The new redis namespace has a ttl defined in the `redis.yml` file. 
- This change will keep the key name for the existing redis values. We may want to consider removing any older than `n` days at some point to ensure the old ones have been cleaned up. Going forward, the ttl will cause them to be deleted automatically. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93615

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
- 10-10CG. It is only used to increment a StatsD value. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
