### PR TITLE
[API-40517] Remove `otherLivingSituation` when blank

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -207,8 +207,7 @@ module ClaimsApi
       form_data['veteran']['homelessness']['homelessnessRisk']['homelessnessRiskSituationType'] =
         mapper.code_from_name(name)
 
-      if mapper.code_from_name(name) == 'OTHER' &&
-         form_data['veteran']['homelessness']['homelessnessRisk']['otherLivingSituation'].blank?
+      if form_data['veteran']['homelessness']['homelessnessRisk']['otherLivingSituation'].blank?
         # Remove to avoid EVSS requirements of minLength 1 when present
         form_data['veteran']['homelessness']['homelessnessRisk'].delete('otherLivingSituation')
       end

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -209,8 +209,8 @@ module ClaimsApi
 
       if mapper.code_from_name(name) == 'OTHER' &&
          form_data['veteran']['homelessness']['homelessnessRisk']['otherLivingSituation'].blank?
-        # Transform to meet EVSS requirements of minLength 1
-        form_data['veteran']['homelessness']['homelessnessRisk']['otherLivingSituation'] = ' '
+        # Remove to avoid EVSS requirements of minLength 1 when present
+        form_data['veteran']['homelessness']['homelessnessRisk'].delete('otherLivingSituation')
       end
     end
 

--- a/modules/claims_api/spec/models/auto_establish_claim_spec.rb
+++ b/modules/claims_api/spec/models/auto_establish_claim_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
     end
 
     context 'when homelessness risk situation type is "other" and "otherLivingSituation" is not provided' do
-      it 'tranforms "otherLivingSituation" to a string with a single whitespace to pass EVSS validations' do
+      it 'does not add "otherLivingSituation" to pass EVSS validation' do
         temp_form_data = pending_record.form_data
         temp_form_data['veteran']['homelessness'].delete('currentlyHomeless')
         temp_form_data['veteran']['homelessness']['homelessnessRisk'] = {
@@ -153,12 +153,12 @@ RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
         payload = JSON.parse(pending_record.to_internal)
         homelessness_risk = payload['form526']['veteran']['homelessness']['homelessnessRisk']
         expect(homelessness_risk['homelessnessRiskSituationType']).to eq('OTHER')
-        expect(homelessness_risk['otherLivingSituation']).to eq(' ')
+        expect(homelessness_risk).not_to have_key('otherLivingSituation')
       end
     end
 
     context 'when homelessness risk situation type is "other" and "otherLivingSituation" is an empty string' do
-      it 'tranforms "otherLivingSituation" to a string with a single whitespace to pass EVSS validations' do
+      it 'removes "otherLivingSituation" to pass EVSS validations' do
         temp_form_data = pending_record.form_data
         temp_form_data['veteran']['homelessness'].delete('currentlyHomeless')
         temp_form_data['veteran']['homelessness']['homelessnessRisk'] = {
@@ -169,7 +169,7 @@ RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
         payload = JSON.parse(pending_record.to_internal)
         homelessness_risk = payload['form526']['veteran']['homelessness']['homelessnessRisk']
         expect(homelessness_risk['homelessnessRiskSituationType']).to eq('OTHER')
-        expect(homelessness_risk['otherLivingSituation']).to eq(' ')
+        expect(homelessness_risk).not_to have_key('otherLivingSituation')
       end
     end
 

--- a/modules/claims_api/spec/models/auto_establish_claim_spec.rb
+++ b/modules/claims_api/spec/models/auto_establish_claim_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
       payload = JSON.parse(pending_record.to_internal)
       homelessness_risk = payload['form526']['veteran']['homelessness']['homelessnessRisk']
       expect(homelessness_risk['homelessnessRiskSituationType']).to eq('OTHER')
-      expect(homelessness_risk['otherLivingSituation']).to eq(' ')
+      expect(homelessness_risk).not_to have_key('otherLivingSituation')
     end
 
     it 'is case insensitive when the homelessSituationType is "OTHER"' do


### PR DESCRIPTION
## Summary

Remove homelessnessRisk=>otherLivingSituation when otherLivingSituation is nil or empty. Resolves an error with EVSS.

## Related issue(s)

[API-40517](https://jira.devops.va.gov/browse/API-40517)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?

AutoEstablishedClaim model

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

~There is also [another `otherLivingSituation`](https://github.com/department-of-veterans-affairs/vets-api/blob/494076973b6c3f0973baf1d94df6cbc52ebd1fb2/modules/claims_api/app/models/claims_api/auto_established_claim.rb#L192-L195) (under `currentlyHomeless`) that attempts to send an empty space (`' '`) to pass EVSS validation. Should we also delete that key if blank?~ _Never mind, the problem was we were only padding `homelessnessRisk=>otherLivingSituation` when the situation type was `OTHER`. This [change](https://github.com/department-of-veterans-affairs/vets-api/pull/18665/commits/4f5ba33a834054c871a21792d380487460812934) deletes the key when blank **regardless of situation type**._