### PR TITLE
Relaxed parameter matching requirement

### DIFF
--- a/app/swagger/swagger/requests/travel_pay.rb
+++ b/app/swagger/swagger/requests/travel_pay.rb
@@ -47,7 +47,7 @@ module Swagger
           parameter do
             key :name, 'id'
             key :in, :path
-            key :description, 'The non-PII/PHI id of a claim (UUIDv4)'
+            key :description, 'The non-PII/PHI id of a claim (UUID - any version)'
             key :required, true
             key :type, :string
           end

--- a/modules/travel_pay/app/services/travel_pay/claims_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_service.rb
@@ -17,11 +17,11 @@ module TravelPay
     end
 
     def get_claim_by_id(veis_token, btsss_token, claim_id)
-      # ensure claim ID is the right format
-      uuid_v4_format = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+      # ensure claim ID is the right format, allowing any version
+      uuid_all_version_format = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[89ABCD][0-9A-F]{3}-[0-9A-F]{12}$/i
 
-      unless uuid_v4_format.match?(claim_id)
-        raise ArgumentError, message: "Expected claim id to be a valid v4 UUID, got #{claim_id}."
+      unless uuid_all_version_format.match?(claim_id)
+        raise ArgumentError, message: "Expected claim id to be a valid UUID, got #{claim_id}."
       end
 
       claims_response = client.get_claims(veis_token, btsss_token)

--- a/modules/travel_pay/spec/services/claims_service_spec.rb
+++ b/modules/travel_pay/spec/services/claims_service_spec.rb
@@ -97,7 +97,7 @@ describe TravelPay::ClaimsService do
         service = TravelPay::ClaimsService.new
 
         expect { service.get_claim_by_id(*tokens, claim_id) }
-          .to raise_error(ArgumentError, /valid v4 UUID/i)
+          .to raise_error(ArgumentError, /valid UUID/i)
       end
     end
 


### PR DESCRIPTION
## Summary
This is to fix a bug where the GUIDs from the upstream MS Dynamics CRM don't match the expected UUID V4 version. They use a proprietary version.

## Work completed
Relaxed the version to account for any UUID version and relaxed the variant to accept all non-reserved types.

Related to department-of-veterans-affairs/va.gov-team#91011