### PR TITLE
dbex/92496: modify transactionId to LH Submit request bodies

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -78,6 +78,13 @@ class Form526Submission < ApplicationRecord
   # plus 1 week to accomodate for edge cases and our sidekiq jobs
   MAX_PENDING_TIME = 3.weeks
 
+  # used to track in APMs between systems such as Lighthouse
+  # example: can be used as a search parameter in Datadog
+  # TODO: follow-up in ticket #93563 to make this more robust, i.e. attempts of jobs, etc.
+  def system_transaction_id
+    "Form526Submission_#{id}"
+  end
+
   # Called when the DisabilityCompensation form controller is ready to hand off to the backend
   # submission process. Currently this passes directly to the retryable EVSS workflow, but if any
   # one-time setup or workflow redirection (e.g. for Claims Fast-Tracking) needs to happen, it should

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -148,7 +148,7 @@ module EVSS
       def send_submission_data_to_lighthouse(submission, icn)
         # 1. transform submission data to LH format
         transform_service = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
-        transaction_id = submission.auth_headers['va_eauth_service_transaction_id']
+        transaction_id = submission.system_transaction_id
         body = transform_service.transform(submission.form['form526'])
         # 2. send transformed submission data to LH endpoint
         benefits_claims_service = BenefitsClaims::Service.new(icn)

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -181,7 +181,7 @@ module BenefitsClaims
 
     def prepare_submission_body(body, transaction_id)
       # if we're coming straight from the transformation service without
-      # making this a jsonapi request body first ({data: {type:, attributes}}),
+      # making this a jsonapi request body first ({data: {type:, attributes}, meta: {transactionId:}}),
       # this will put it in the correct format for transmission
       body = build_request_body(body, transaction_id)
 

--- a/lib/sidekiq/form526_backup_submission_process/processor.rb
+++ b/lib/sidekiq/form526_backup_submission_process/processor.rb
@@ -332,7 +332,9 @@ module Sidekiq
 
         form_version = submission.saved_claim.parsed_form['startedFormVersion']
         if form_version.present?
-          resp = get_form_from_external_api(headers, ApiProviderFactory::API_PROVIDER[:lighthouse], form_json.to_json)
+          transaction_id = submission.system_transaction_id
+          resp = get_form_from_external_api(headers, ApiProviderFactory::API_PROVIDER[:lighthouse], form_json.to_json,
+                                            transaction_id)
           content = resp.env.response_body
         else
           resp = get_form_from_external_api(headers, ApiProviderFactory::API_PROVIDER[:evss], form_json.to_json)
@@ -344,10 +346,13 @@ module Sidekiq
       end
 
       # 82245 - Adding provider to method. this should be removed when toxic exposure flipper is removed
-      def get_form_from_external_api(headers, provider, form_json)
+      # @param headers auth headers for evss transmission
+      # @param provider which provider is desired? :evss or :lighthouse
+      # @param form_json the request body as a hash
+      # @param transaction_id for lighthouse provider only: to track submission's journey in APM(s) across systems
+      def get_form_from_external_api(headers, provider, form_json, transaction_id = nil)
         # get the "breakered" version
         service = choose_provider(headers, provider, breakered: true)
-        transaction_id = headers['va_eauth_service_transaction_id']
         service.generate_526_pdf(form_json, transaction_id)
       end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- modified what is sent to Lighthouse in the meta.transactionId field for Form526 submission

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#92496

## Testing done

- [x] *New code is covered by unit tests*
- we were sending a random guid before. now we are sending the submission id for better tracking

## Screenshots
n/a

## What areas of the site does it impact?
send the form526 submission id for easier tracking in downstream systems

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

