### PR TITLE
Fix unique pending_verifications

### DIFF
--- a/modules/vye/app/controllers/vye/v1/verifications_controller.rb
+++ b/modules/vye/app/controllers/vye/v1/verifications_controller.rb
@@ -44,7 +44,7 @@ module Vye
 
       def matching_awards?
         given = award_ids.sort
-        actual = pending_verifications.pluck(:award_id).sort
+        actual = pending_verifications.pluck(:award_id).uniq.sort
         given == actual
       end
 


### PR DESCRIPTION
## Summary

- This spec is failing on the master branch
- `VerificationController#matching_awards?` was not matching when it should
- `actual` pending_verifications had a duplicate `id`

Reference:
```
Failures:

  1) Vye::V1::VerificationsController#create sets the transact date to the highest act_end of verifications
     Failure/Error: subject.create

     Vye::V1::VerificationsController::AwardsMismatch:
       Vye::V1::VerificationsController::AwardsMismatch
     # ./modules/vye/app/controllers/vye/v1/verifications_controller.rb:53:in `validate_award_ids!'
     # ./modules/vye/app/controllers/vye/v1/verifications_controller.rb:18:in `create'
     # ./modules/vye/spec/controllers/vye/v1/verifications_controller_spec.rb:46:in `block (3 levels) in <top (required)>'

rspec ./modules/vye/spec/controllers/vye/v1/verifications_controller_spec.rb:45 
    # Vye::V1::VerificationsController#create sets the transact date to the highest act_end of verifications
```

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  The test passes