### PR TITLE
Fixing issue with invalidating an MPI record on a User object when the record is cached

### DIFF
--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -29,7 +29,6 @@ class UserSessionForm
     @user = User.new(uuid:)
     @user.session_handle = @session.token
     @user.instance_variable_set(:@identity, @user_identity)
-    @user.invalidate_mpi_cache
 
     if saml_user.changing_multifactor?
       last_signed_in = existing_user&.last_signed_in || Time.current.utc
@@ -100,6 +99,7 @@ class UserSessionForm
 
   def persist
     if save
+      user.invalidate_mpi_cache
       [user, session]
     else
       [nil, nil]

--- a/modules/claims_api/spec/requests/v1/claims_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require_relative '../../rails_helper'
+require 'bgs/power_of_attorney_verifier'
 
 RSpec.describe 'ClaimsApi::V1::Claims', type: :request do
   include SchemaMatchers

--- a/modules/vaos/spec/request/v2/relationships_request_spec.rb
+++ b/modules/vaos/spec/request/v2/relationships_request_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'relationships', :skip_mvi, type: :request do
   before do
     sign_in_as(current_user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
+    allow(Flipper).to receive(:enabled?).and_return(true)
   end
 
   let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }


### PR DESCRIPTION
## Summary

- This PR fixes an issue that occurs when invalidating an MPI record on a User object.
- The issue is that the User object needs to be persisted in order to use the `RedisStore` function to destroy an MPI object, so the logic to invalidate the MPI cached record had to be moved to a point after the user object was persisted

## Testing done

- Logged in with `localhost:3000/v1/sessions/idme_verified/new`
- Logged in again with this URL, confirmed I cannot be logged in
- Did the above with the changes in this PR, confirmed I am able to log in the second time the attempt is made

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- Log in with `localhost:3000/v1/sessions/idme_verified/new`
- Log in again with this URL, confirmed you are able to log in