### PR TITLE
Capitalize first_name instead of upcase in NotificationEmail

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -177,7 +177,7 @@ module SimpleFormsApi
     # personalization hash shared by all simple form confirmation emails
     def default_personalization(first_name)
       {
-        'first_name' => first_name&.capitalize,
+        'first_name' => first_name&.titleize,
         'date_submitted' => date_submitted,
         'confirmation_number' => confirmation_number,
         'lighthouse_updated_at' => lighthouse_updated_at

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -177,7 +177,7 @@ module SimpleFormsApi
     # personalization hash shared by all simple form confirmation emails
     def default_personalization(first_name)
       {
-        'first_name' => first_name&.upcase,
+        'first_name' => first_name&.capitalize,
         'date_submitted' => date_submitted,
         'confirmation_number' => confirmation_number,
         'lighthouse_updated_at' => lighthouse_updated_at

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-third-party-veteran.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-third-party-veteran.json
@@ -1,7 +1,7 @@
 {
   "preparer_type": "third-party-veteran",
   "third_party_full_name": {
-    "first": "Joe",
+    "first": "Joey Jo",
     "last": "Rep-Veteran"
   },
   "third_party_type": "representative",

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -643,7 +643,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           'veteran.surname@address.com',
           'form21_4142_confirmation_email_template_id',
           {
-            'first_name' => 'VETERAN',
+            'first_name' => 'Veteran',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil
@@ -685,7 +685,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           'my.long.email.address@email.com',
           'form21_10210_confirmation_email_template_id',
           {
-            'first_name' => 'JACK',
+            'first_name' => 'Jack',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil
@@ -733,7 +733,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           'preparer_address@email.com',
           'form21p_0847_confirmation_email_template_id',
           {
-            'first_name' => 'ARTHUR',
+            'first_name' => 'Arthur',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil
@@ -776,7 +776,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
           'preparer@email.com',
           'form21_0972_confirmation_email_template_id',
           {
-            'first_name' => 'PREPARE',
+            'first_name' => 'Prepare',
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil
@@ -832,7 +832,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
               'abraham.lincoln@vets.gov',
               'form21_0966_confirmation_email_template_id',
               {
-                'first_name' => 'ABRAHAM',
+                'first_name' => 'Abraham',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => confirmation_number,
                 'lighthouse_updated_at' => nil,
@@ -856,7 +856,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
               'abraham.lincoln@vets.gov',
               'form21_0966_confirmation_email_template_id',
               {
-                'first_name' => 'ABRAHAM',
+                'first_name' => 'Abraham',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => confirmation_number,
                 'lighthouse_updated_at' => nil,

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -497,7 +497,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form21_0966_confirmation_email_template_id',
             {
-              'first_name' => user.first_name,
+              'first_name' => user.first_name.capitalize,
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil,

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -151,7 +151,7 @@ describe SimpleFormsApi::NotificationEmail do
                 email,
                 "form21_10210_#{notification_type}_email_template_id",
                 {
-                  'first_name' => 'JOHN',
+                  'first_name' => 'John',
                   'date_submitted' => date_submitted,
                   'confirmation_number' => 'confirmation_number',
                   'lighthouse_updated_at' => nil
@@ -174,7 +174,7 @@ describe SimpleFormsApi::NotificationEmail do
                 'veteran.longemail@email.com',
                 "form21_10210_#{notification_type}_email_template_id",
                 {
-                  'first_name' => 'JOHN',
+                  'first_name' => 'John',
                   'date_submitted' => date_submitted,
                   'confirmation_number' => 'confirmation_number',
                   'lighthouse_updated_at' => nil
@@ -201,7 +201,7 @@ describe SimpleFormsApi::NotificationEmail do
                   email,
                   "form21_10210_#{notification_type}_email_template_id",
                   {
-                    'first_name' => 'JOE',
+                    'first_name' => 'Joe',
                     'date_submitted' => date_submitted,
                     'confirmation_number' => 'confirmation_number',
                     'lighthouse_updated_at' => nil
@@ -224,7 +224,7 @@ describe SimpleFormsApi::NotificationEmail do
                   'claimant.long@address.com',
                   "form21_10210_#{notification_type}_email_template_id",
                   {
-                    'first_name' => 'JOE',
+                    'first_name' => 'Joe',
                     'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                     'confirmation_number' => 'confirmation_number',
                     'lighthouse_updated_at' => nil
@@ -251,7 +251,7 @@ describe SimpleFormsApi::NotificationEmail do
               'my.long.email.address@email.com',
               "form21_10210_#{notification_type}_email_template_id",
               {
-                'first_name' => 'JACK',
+                'first_name' => 'Jack',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => 'confirmation_number',
                 'lighthouse_updated_at' => nil
@@ -274,7 +274,7 @@ describe SimpleFormsApi::NotificationEmail do
               'my.long.email.address@email.com',
               "form21_10210_#{notification_type}_email_template_id",
               {
-                'first_name' => 'JACK',
+                'first_name' => 'Jack',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => 'confirmation_number',
                 'lighthouse_updated_at' => nil
@@ -312,7 +312,7 @@ describe SimpleFormsApi::NotificationEmail do
               'a@b.com',
               'form40_0247_confirmation_email_template_id',
               {
-                'first_name' => 'JOE',
+                'first_name' => 'Joe',
                 'date_submitted' => date_submitted,
                 'confirmation_number' => 'confirmation_number',
                 'lighthouse_updated_at' => nil
@@ -404,7 +404,7 @@ describe SimpleFormsApi::NotificationEmail do
             'authorizer_email@example.com',
             'form21_0845_confirmation_email_template_id',
             {
-              'first_name' => 'JACK',
+              'first_name' => 'Jack',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil
@@ -426,7 +426,7 @@ describe SimpleFormsApi::NotificationEmail do
             'abraham.lincoln@vets.gov',
             'form21_0845_confirmation_email_template_id',
             {
-              'first_name' => 'JOHN',
+              'first_name' => 'John',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil
@@ -449,7 +449,7 @@ describe SimpleFormsApi::NotificationEmail do
             'authorizer_email@example.com',
             'form21_0845_confirmation_email_template_id',
             {
-              'first_name' => 'JACK',
+              'first_name' => 'Jack',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil
@@ -551,7 +551,7 @@ describe SimpleFormsApi::NotificationEmail do
           'jv@example.com',
           'form20_10206_confirmation_email_template_id',
           {
-            'first_name' => 'JOHN',
+            'first_name' => 'John',
             'date_submitted' => date_submitted,
             'confirmation_number' => 'confirmation_number',
             'lighthouse_updated_at' => nil
@@ -587,7 +587,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form20_10207_confirmation_email_template_id',
             {
-              'first_name' => 'JOHN',
+              'first_name' => 'John',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil
@@ -616,7 +616,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form20_10207_confirmation_email_template_id',
             {
-              'first_name' => 'JOE',
+              'first_name' => 'Joe',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil
@@ -645,7 +645,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form20_10207_confirmation_email_template_id',
             {
-              'first_name' => 'JOHN',
+              'first_name' => 'John',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil
@@ -674,7 +674,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form20_10207_confirmation_email_template_id',
             {
-              'first_name' => 'JOE',
+              'first_name' => 'Joe',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -497,7 +497,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form21_0966_confirmation_email_template_id',
             {
-              'first_name' => user.first_name.capitalize,
+              'first_name' => user.first_name.titleize,
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil,
@@ -616,7 +616,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form20_10207_confirmation_email_template_id',
             {
-              'first_name' => 'Joe',
+              'first_name' => 'Joey Jo',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -497,7 +497,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form21_0966_confirmation_email_template_id',
             {
-              'first_name' => user.first_name.upcase,
+              'first_name' => user.first_name,
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil,


### PR DESCRIPTION
## Summary
This PR changes the email we send from SimpleForms such that first names are capitalized (`John`) instead of upcased (`JOHN`).