### PR TITLE
Remove authorization policy to allow access for LOA1 users

### DIFF
--- a/app/controllers/v0/my_va/submission_statuses_controller.rb
+++ b/app/controllers/v0/my_va/submission_statuses_controller.rb
@@ -7,7 +7,6 @@ module V0
     class SubmissionStatusesController < ApplicationController
       service_tag 'form-submission-statuses'
       before_action :controller_enabled?
-      before_action { authorize :lighthouse, :access? }
 
       def show
         report = Forms::SubmissionStatuses::Report.new(

--- a/spec/requests/v0/my_va/submission_statuses_spec.rb
+++ b/spec/requests/v0/my_va/submission_statuses_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'forms/submission_statuses/gateway'
 
 RSpec.describe 'V0::MyVA::SubmissionStatuses', type: :request do
-  let(:user) { build(:user, :loa3, :with_terms_of_use_agreement) }
+  let(:user) { build(:user, :loa1) }
 
   before do
     sign_in_as(user)


### PR DESCRIPTION
## Summary
The My VA should allow LOA1 and LOA3 users to view their form submission statuses.  The existing authorization policy on the `V0::MyVA::SubmissionStatusesController` was to strict and was not allowing LOA1 users access.  The policy has been removed.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93723

## Testing done
Updated request spec to use LOA1 user.