### PR TITLE
Add Attribute Inheritance to Vets::Model

### DIFF
--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -24,7 +24,8 @@ module Vets
       end
 
       def attribute_set
-        attributes.keys
+        # grabs attribute keys from parent classes
+        ancestors.select { |klass| klass.respond_to?(:attributes) }.flat_map { |klass| klass.attributes.keys }.uniq
       end
 
       private

--- a/lib/vets/attributes/value.rb
+++ b/lib/vets/attributes/value.rb
@@ -42,6 +42,14 @@ module Vets
       def coerce_to_class(value)
         return value if value.is_a?(@klass) || value.nil?
 
+        if @klass == DateTime
+          begin
+            value = DateTime.parse(value) if value.is_a?(String)
+          rescue ArgumentError
+            raise TypeError, "#{@name} could not be parsed into a Date"
+          end
+        end
+
         value.is_a?(Hash) ? @klass.new(value) : value
       end
 

--- a/lib/vets/attributes/value.rb
+++ b/lib/vets/attributes/value.rb
@@ -46,7 +46,7 @@ module Vets
           begin
             value = DateTime.parse(value) if value.is_a?(String)
           rescue ArgumentError
-            raise TypeError, "#{@name} could not be parsed into a Date"
+            raise TypeError, "#{@name} could not be parsed into a DateTime"
           end
         end
 

--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -15,6 +15,9 @@ module Vets
     include Vets::Attributes
 
     def initialize(params = {})
+      # Remove attributes that aren't defined in the class aka unknown
+      params.select! { |x| self.class.attribute_set.index(x.to_sym) }
+
       super
       # Ensure all attributes have a defined value (default to nil)
       self.class.attribute_set.each do |attr_name|

--- a/spec/lib/vets/attributes/value_spec.rb
+++ b/spec/lib/vets/attributes/value_spec.rb
@@ -80,12 +80,13 @@ RSpec.describe Vets::Attributes::Value do
           expect(setter_value).to eq(DateTime.parse(value).to_s)
         end
       end
+
       context 'when value is a non-parseable string' do
         it 'raises an TypeError' do
           expect do
             attribute_value = described_class.new(:test_name, DateTime)
-            setter_value = attribute_value.setter_value('bad-time')
-          end.to raise_error(TypeError, "test_name could not be parsed into a DateTime")
+            attribute_value.setter_value('bad-time')
+          end.to raise_error(TypeError, 'test_name could not be parsed into a DateTime')
         end
       end
     end

--- a/spec/lib/vets/attributes/value_spec.rb
+++ b/spec/lib/vets/attributes/value_spec.rb
@@ -71,6 +71,25 @@ RSpec.describe Vets::Attributes::Value do
       end
     end
 
+    context 'when klass is DateTime' do
+      context 'when value is a parseable string' do
+        it 'returns a DateTime' do
+          value = '2024-01-01T12:00:00+00:00'
+          attribute_value = described_class.new(:test_name, DateTime)
+          setter_value = attribute_value.setter_value(value)
+          expect(setter_value).to eq(DateTime.parse(value).to_s)
+        end
+      end
+      context 'when value is a non-parseable string' do
+        it 'raises an TypeError' do
+          expect do
+            attribute_value = described_class.new(:test_name, DateTime)
+            setter_value = attribute_value.setter_value('bad-time')
+          end.to raise_error(TypeError, "test_name could not be parsed into a DateTime")
+        end
+      end
+    end
+
     context 'when value is a Hash' do
       context 'when klass is a Hash' do
         it 'returns a complex Object with given attributes' do

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -10,7 +10,17 @@ class FakeCategory
   attribute :name, String, default: 'test'
 end
 
-class DummyModel
+class DummyParentModel
+  include Vets::Attributes
+
+  attribute :updated_at, DateTime, default: :current_time
+
+  def current_time
+    DateTime.new(2024, 9, 25, 10, 30, 0)
+  end
+end
+
+class DummyModel < DummyParentModel
   include Vets::Attributes
 
   attribute :name, String, default: 'Unknown'
@@ -63,9 +73,13 @@ RSpec.describe Vets::Attributes do
   end
 
   describe '.attribute_set' do
-    it 'returns an array of the attribute names' do
+    it 'returns an array of the attribute names from itself' do
       expected_attribute_set = %i[name age tags categories created_at]
-      expect(DummyModel.attribute_set).to eq(expected_attribute_set)
+      expect(DummyModel.attribute_set).to include(*expected_attribute_set)
+    end
+
+    it 'includes an array of attributes from ancestors' do
+      expect(DummyModel.attribute_set).to include(:updated_at)
     end
   end
 end

--- a/spec/lib/vets/model_spec.rb
+++ b/spec/lib/vets/model_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe Vets::Model do
     it 'sets missing parameters to nil' do
       expect(address.instance_variable_get('@street2')).to be_nil
     end
+
+    it 'rejects unknown attributes' do
+      address = FakeAddress.new(street9: '456 Elm St')
+      expect(address).not_to respond_to(:street9)
+    end
   end
 
   describe '#attributes' do


### PR DESCRIPTION
## Summary

- `Vets::Model` needed a way to reject unknown attributes
- `Vets::Model.attribute_set` includes ancestor's attributes
- Added `DateTime` parser to `Vets::Attributes::Value`
- These three issues were identified from a different ticket that will be linked soon

## Related issue(s)

- n/a 

## Testing done

- [ ] manually testing

## Acceptance criteria

- [x] `Vets::Model` subclasses can ignore unknown attributes
- [x] `Vets::Model` subclasses inherit attributes 
- [x] `Vets::Model` can coerce `Strings` to `DateTimes`