### PR TITLE
[Lighthouse Document Upload Migration] Overhaul shared API Provider code for better encapsulation and logging

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
+++ b/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
@@ -9,6 +9,10 @@ module EVSS
 
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526_bdd_instructions'
 
+      # 'Other Correspondence' document type in the VA
+      BDD_INSTRUCTIONS_DOCUMENT_TYPE = 'L023'
+      BDD_INSTRUCTIONS_FILE_NAME = 'BDD_Instructions.pdf'
+
       # retry for one day
       sidekiq_options retry: 14
 
@@ -36,6 +40,12 @@ module EVSS
         )
 
         StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
+
+        if Flipper.enabled?(:disability_compensation_use_api_provider_for_bdd_instructions)
+          submission = Form526Submission.find(form526_submission_id)
+          # api_upload_provider(submission).log_upload_failure(STATSD_KEY_PREFIX, error_class, error_message)
+          api_upload_provider(submission).log_upload_failure(error_class, error_message)
+        end
 
         ::Rails.logger.warn(
           'Submit Form 526 Upload BDD Instructions Retries exhausted',
@@ -67,6 +77,25 @@ module EVSS
         }
       )
 
+      # # Returns the correct SupplementalDocumentUploadProvider based on the state of the
+      # # ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS feature flag for the current user
+      # #
+      # @return [EVSSSupplementalDocumentUploadProvider or LighthouseSupplementalDocumentUploadProvider]
+      def self.api_upload_provider(submission)
+        user = User.find(submission.user_uuid)
+
+        ApiProviderFactory.call(
+          type: ApiProviderFactory::FACTORIES[:supplemental_document_upload],
+          options: {
+            form526_submission: submission,
+            va_document_type: BDD_INSTRUCTIONS_DOCUMENT_TYPE,
+            statsd_metric_prefix: STATSD_KEY_PREFIX
+          },
+          current_user: user,
+          feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS
+        )
+      end
+
       # Submits a BDD instruction PDF in to EVSS
       #
       # @param submission_id [Integer] The {Form526Submission} id
@@ -88,20 +117,34 @@ module EVSS
 
       private
 
-      def upload_bdd_instructions
-        client.upload(file_body, document_data)
-      end
-
       def file_body
         @file_body ||= File.read('lib/evss/disability_compensation_form/bdd_instructions.pdf')
       end
 
-      def client
-        @client ||= if Flipper.enabled?(:disability_compensation_lighthouse_document_service_provider)
-                      # TODO: create client from lighthouse document service
-                    else
-                      EVSS::DocumentsService.new(submission.auth_headers)
-                    end
+      def upload_bdd_instructions
+        # NOTE: the ApiProviderFactory implements its own Flipper,
+        # ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS, which will be used to iteratively
+        # start sending more BDD Instructions to Lighthouse instead of EVSS
+        # However, since using this factory is new behavior, it is hidden behind this additional Flipper, which will act
+        # as a "kill switch" in the event there are problems with the ApiProviderFactory implementation, so we can
+        # revert back to using the EVSS::DocumentsService directly here
+        if Flipper.enabled?(:disability_compensation_use_api_provider_for_bdd_instructions)
+          upload_via_api_provider
+        else
+          EVSS::DocumentsService.new(submission.auth_headers).upload(file_body, document_data)
+        end
+      end
+
+      def upload_via_api_provider
+        document = upload_provider.generate_upload_document(
+          BDD_INSTRUCTIONS_FILE_NAME,
+          BDD_INSTRUCTIONS_DOCUMENT_TYPE
+        )
+        upload_provider.submit_upload_document(document, file_body)
+      end
+
+      def upload_provider
+        @upload_provider ||= EVSS::DisabilityCompensationForm::UploadBddInstructions.api_upload_provider(submission)
       end
 
       def retryable_error_handler(error)
@@ -112,10 +155,10 @@ module EVSS
       def document_data
         @document_data ||= EVSSClaimDocument.new(
           evss_claim_id: submission.submitted_claim_id,
-          file_name: 'BDD_Instructions.pdf',
+          file_name: BDD_INSTRUCTIONS_FILE_NAME,
           tracked_item_id: nil,
-          document_type: 'L023'
-        ) # 'Other Correspondence'
+          document_type: BDD_INSTRUCTIONS_DOCUMENT_TYPE
+        )
       end
     end
   end

--- a/lib/disability_compensation/factories/api_provider_factory.rb
+++ b/lib/disability_compensation/factories/api_provider_factory.rb
@@ -56,7 +56,7 @@ class ApiProviderFactory
   FEATURE_TOGGLE_BRD = 'disability_compensation_lighthouse_brd'
   FEATURE_TOGGLE_GENERATE_PDF = 'disability_compensation_lighthouse_generate_pdf'
 
-  FEATURE_TOGGLE_UPLOAD_SUPPLEMENTAL_DOCUMENT = 'disability_compensation_lighthouse_upload_supplemental_document'
+  FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS = 'disability_compensation_lighthouse_upload_bdd_instructions'
 
   attr_reader :type
 
@@ -187,11 +187,17 @@ class ApiProviderFactory
   end
 
   def supplemental_document_upload_service_provider
+    provider_options = [
+      @options[:form526_submission],
+      @options[:document_type],
+      @options[:statsd_metric_prefix]
+    ]
+
     case api_provider
     when API_PROVIDER[:evss]
-      EVSSSupplementalDocumentUploadProvider.new(@options[:form526_submission])
+      EVSSSupplementalDocumentUploadProvider.new(*provider_options)
     when API_PROVIDER[:lighthouse]
-      LighthouseSupplementalDocumentUploadProvider.new(@options[:form526_submission])
+      LighthouseSupplementalDocumentUploadProvider.new(*provider_options)
     else
       raise NotImplementedError, 'No known Supplemental Document Upload Api Provider type provided'
     end

--- a/lib/disability_compensation/factories/api_provider_factory.rb
+++ b/lib/disability_compensation/factories/api_provider_factory.rb
@@ -56,7 +56,7 @@ class ApiProviderFactory
   FEATURE_TOGGLE_BRD = 'disability_compensation_lighthouse_brd'
   FEATURE_TOGGLE_GENERATE_PDF = 'disability_compensation_lighthouse_generate_pdf'
 
-  FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS = 'disability_compensation_lighthouse_upload_bdd_instructions'
+  FEATURE_TOGGLE_UPLOAD_SUPPLEMENTAL_DOCUMENT = 'disability_compensation_lighthouse_upload_supplemental_document'
 
   attr_reader :type
 

--- a/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
@@ -57,22 +57,66 @@ class EVSSSupplementalDocumentUploadProvider
   #
   # @return [Faraday::Response] The EVSS::DocumentsService API calls are implemented with Faraday
   def submit_upload_document(evss_claim_document, file_body)
+    log_upload_attempt
+
     client = EVSS::DocumentsService.new(@form526_submission.auth_headers)
     client.upload(file_body, evss_claim_document)
 
-    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
+    # EVSS::DocumentsService uploads throw a EVSS::ErrorMiddleware::EVSSError if they fail
+    # If no exception is raised, log a success response
+    log_upload_success
+  rescue EVSS::ErrorMiddleware::EVSSError => e
+    # If exception is raised, log and re-raise the error
+    log_upload_failure
+    raise e
   end
 
-  def log_upload_failure(error_class, error_message)
-    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
-
+  # To call in the sidekiq_retries_exhausted block of the including job
+  # This is meant to log an upload attempt that was retried and eventually given up on,
+  # so we can investigate the failure in Datadog
+  #
+  # @param uploading_job_class [String] the job where we are uploading the EVSSClaimDocument
+  # (e.g. UploadBDDInstructions)
+  # @param error_class [String] the Error class of the exception that exhausted the upload job
+  # @param error_message [String] the message in the exception that exhausted the upload job
+  def log_uploading_job_failure(uploading_job_class, error_class, error_message)
     Rails.logger.error(
-      'EVSSSupplementalDocumentUploadProvider upload failure',
+      "#{uploading_job_class} EVSSSupplementalDocumentUploadProvider Failure",
       {
-        class: 'EVSSSupplementalDocumentUploadProvider',
+        **base_logging_info,
+        uploading_job_class:,
         error_class:,
         error_message:
       }
     )
+
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STASTD_UPLOAD_JOB_FAILED_METRIC}")
+  end
+
+  private
+
+  def base_logging_info
+    {
+      class: 'EVSSSupplementalDocumentUploadProvider',
+      submission_id: @form526_submission.submitted_claim_id,
+      user_uuid: @form526_submission.user_uuid,
+      va_document_type_code: @va_document_type,
+      primary_form: 'Form526'
+    }
+  end
+
+  def log_upload_attempt
+    Rails.logger.info('EVSSSupplementalDocumentUploadProvider upload attempted', base_logging_info)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_ATTEMPT_METRIC}")
+  end
+
+  def log_upload_success
+    Rails.logger.info('EVSSSupplementalDocumentUploadProvider upload successful', base_logging_info)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
+  end
+
+  def log_upload_failure
+    Rails.logger.error('EVSSSupplementalDocumentUploadProvider upload failed', base_logging_info)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
   end
 end

--- a/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
@@ -8,8 +8,18 @@ class EVSSSupplementalDocumentUploadProvider
   STATSD_PROVIDER_METRIC = 'evss_supplemental_document_upload_provider'
 
   # @param form526_submission [Form526Submission]
-  def initialize(form526_submission)
+  #
+  # @param va_document_type [String] The VA document code, which corresponds to
+  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
+  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
+  #
+  # @param statsd_metric_prefix [String] the metrics prefix the job calling this provider wants us to use when logging
+  # (e.g. 'worker.evss.submit_form526_bdd_instructions' for the UploadBddInstructions job)
+  #
+  def initialize(form526_submission, va_document_type, statsd_metric_prefix)
     @form526_submission = form526_submission
+    @va_document_type = va_document_type
+    @statsd_metric_prefix = statsd_metric_prefix
   end
 
   # Uploads to EVSS via the EVSS::DocumentsService require both the file body and an instance
@@ -23,11 +33,11 @@ class EVSSSupplementalDocumentUploadProvider
   # These types are mapped in EVSSClaimDocument[DOCUMENT_TYPES]
   #
   # @return [EVSSClaimDocument]
-  def generate_upload_document(file_name, document_type)
+  def generate_upload_document(file_name)
     EVSSClaimDocument.new(
       evss_claim_id: @form526_submission.submitted_claim_id,
-      file_name:,
-      document_type:
+      document_type: @va_document_type,
+      file_name:
     )
   end
 
@@ -49,14 +59,12 @@ class EVSSSupplementalDocumentUploadProvider
   def submit_upload_document(evss_claim_document, file_body)
     client = EVSS::DocumentsService.new(@form526_submission.auth_headers)
     client.upload(file_body, evss_claim_document)
+
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
   end
 
-  def log_upload_success(uploading_class_prefix)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
-  end
-
-  def log_upload_failure(uploading_class_prefix, error_class, error_message)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
+  def log_upload_failure(error_class, error_message)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
 
     Rails.logger.error(
       'EVSSSupplementalDocumentUploadProvider upload failure',

--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -8,9 +8,25 @@ class LighthouseSupplementalDocumentUploadProvider
 
   STATSD_PROVIDER_METRIC = 'lighthouse_supplemental_document_upload_provider'
 
+  # Maps VA's internal Document Types to the correct document_type attribute for a Lighthouse526DocumentUpload polling
+  # record. We need this to create a valid polling record
+  POLLING_DOCUMENT_TYPES = {
+    'L023' => Lighthouse526DocumentUpload::BDD_INSTRUCTIONS_DOCUMENT_TYPE
+  }.freeze
+
   # @param form526_submission [Form526Submission]
-  def initialize(form526_submission)
+  #
+  # @param va_document_type [String] The VA document code, which corresponds to
+  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
+  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
+  #
+  # @param statsd_metric_prefix [String] the metrics prefix the job calling this provider wants us to use when logging
+  # (e.g. 'worker.evss.submit_form526_bdd_instructions' for the UploadBddInstructions job)
+  #
+  def initialize(form526_submission, va_document_type, statsd_metric_prefix)
     @form526_submission = form526_submission
+    @va_document_type = va_document_type
+    @statsd_metric_prefix = statsd_metric_prefix
   end
 
   # Uploads to Lighthouse require both the file body and an instance
@@ -19,16 +35,16 @@ class LighthouseSupplementalDocumentUploadProvider
   # an assembly of file-related Lighthouse metadata, not the actual uploaded file itself
   #
   # @param file_name [String] The name of the file we want to appear in Lighthouse
-  # @param document_type [String] The VA document code, which corresponds to
-  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
-  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
   #
   # @return [LighthouseDocument]
-  def generate_upload_document(file_name, document_type)
+  def generate_upload_document(file_name)
+    user = User.find(@form526_submission.user_uuid)
+
     LighthouseDocument.new(
-      evss_claim_id: @form526_submission.submitted_claim_id,
-      file_name:,
-      document_type:
+      claim_id: @form526_submission.submitted_claim_id,
+      participant_id: user.participant_id,
+      document_type: @va_document_type,
+      file_name:
     )
   end
 
@@ -45,19 +61,13 @@ class LighthouseSupplementalDocumentUploadProvider
   #
   # @param lighthouse_document [LighthouseDocument]
   # @param file_body [String]
-  #
-  # return [Faraday::Response] BenefitsDocuments::WorkerService makes http
-  # calls with the Faraday gem under the hood
   def submit_upload_document(lighthouse_document, file_body)
-    BenefitsDocuments::Form526::UploadSupplementalDocumentService.call(file_body, lighthouse_document)
+    api_response = BenefitsDocuments::Form526::UploadSupplementalDocumentService.call(file_body, lighthouse_document)
+    handle_lighthouse_response(api_response)
   end
 
-  def log_upload_success(uploading_class_prefix)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
-  end
-
-  def log_upload_failure(uploading_class_prefix, error_class, error_message)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
+  def log_upload_failure(error_class, error_message)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
 
     Rails.logger.error(
       'LighthouseSupplementalDocumentUploadProvider upload failure',
@@ -66,6 +76,34 @@ class LighthouseSupplementalDocumentUploadProvider
         error_class:,
         error_message:
       }
+    )
+  end
+
+  private
+
+  # Processes the response from Lighthouse and logs accordingly. If the upload is successful, creates
+  # a polling record so we can check on the status of the document after Lighthouse has receieved it
+  #
+  # @param api_response [Faraday::Response] Lighthouse API response returned from the UploadSupplementalDocumentService
+  def handle_lighthouse_response(api_response)
+    response_body = api_response.body['data']
+
+    if response_body['success'] == true && response_body['requestId']
+      create_lighthouse_polling_record(response_body['requestId'])
+      StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
+    end
+  end
+
+  # Creates a Lighthouse526DocumentUpload polling record
+  #
+  # @param lighthouse_request_id [String] unique ID Lighthouse provides us in the API response after we
+  # upload a document. We use this ID in the Form526DocumentUploadPollingJob chron job to check the status
+  # of the document after Lighthouse has received it.
+  def create_lighthouse_polling_record(lighthouse_request_id)
+    Lighthouse526DocumentUpload.create!(
+      form526_submission: @form526_submission,
+      document_type: POLLING_DOCUMENT_TYPES[@va_document_type],
+      lighthouse_document_request_id: lighthouse_request_id
     )
   end
 end

--- a/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 module SupplementalDocumentUploadProvider
-  STATSD_SUCCESS_METRIC = 'success'
-  STATSD_RETRIED_METRIC = 'retried'
-  STATSD_FAILED_METRIC = 'failed'
+  STATSD_ATTEMPT_METRIC = 'upload_attempt'
+  STATSD_SUCCESS_METRIC = 'upload_success'
+  STATSD_FAILED_METRIC = 'upload_failure'
+  STASTD_UPLOAD_JOB_FAILED_METRIC = 'upload_job_failed'
 
   def self.raise_not_implemented_error
     raise NotImplementedError, 'Do not use base module methods. Override this method in implementation class.'

--- a/spec/lib/disability_compensation/factories/api_provider_factory_spec.rb
+++ b/spec/lib/disability_compensation/factories/api_provider_factory_spec.rb
@@ -271,34 +271,5 @@ RSpec.describe ApiProviderFactory do
     it 'provides a Lighthouse upload_supplemental_document provider' do
       expect(provider(:lighthouse).class).to equal(LighthouseSupplementalDocumentUploadProvider)
     end
-
-    context 'for BDD instruction uploads' do
-      def provider
-        ApiProviderFactory.call(
-          type: ApiProviderFactory::FACTORIES[:supplemental_document_upload],
-          options: {
-            form526_submission: submission,
-            document_type: va_document_type,
-            statsd_metric_prefix: 'my_stats_metric_prefix'
-          },
-          current_user:,
-          feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS
-        )
-      end
-
-      it 'provides a SupplementalDocumentUploadProvider based on a Flipper' do
-        Flipper.enable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS)
-        expect(provider.class).to equal(LighthouseSupplementalDocumentUploadProvider)
-
-        Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS)
-        expect(provider.class).to equal(EVSSSupplementalDocumentUploadProvider)
-      end
-    end
-
-    it 'throw error if provider unknown' do
-      expect do
-        provider(:random)
-      end.to raise_error NotImplementedError
-    end
   end
 end

--- a/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
@@ -5,17 +5,17 @@ require 'disability_compensation/providers/document_upload/evss_supplemental_doc
 require 'support/disability_compensation_form/shared_examples/supplemental_document_upload_provider'
 
 RSpec.describe EVSSSupplementalDocumentUploadProvider do
-  let(:submission) { create(:form526_submission) }
+  let(:submission) { create(:form526_submission, :with_submitted_claim_id) }
   let(:file_body) { File.read(fixture_file_upload('doctors-note.pdf', 'application/pdf')) }
   let(:file_name) { Faker::File.file_name }
 
   let(:va_document_type) { 'L023' }
 
-  let(:provider) do
+  let!(:provider) do
     EVSSSupplementalDocumentUploadProvider.new(
       submission,
       va_document_type,
-      'my_upload_job_prefix'
+      'my_stats_metric_prefix'
     )
   end
 
@@ -25,6 +25,11 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
       document_type: 'L023',
       file_name:
     )
+  end
+
+  before do
+    # Disallow actual API calls
+    allow_any_instance_of(EVSS::DocumentsService).to receive(:upload)
   end
 
   it_behaves_like 'supplemental document upload provider'
@@ -68,58 +73,136 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
 
         provider.submit_upload_document(evss_claim_document, file_body)
       end
+    end
+  end
 
-      it 'increments a StatsD success metric' do
-        faraday_response = instance_double(Faraday::Response)
+  describe 'events logging' do
+    context 'when attempting to upload a document' do
+      before do
+        # Skip success logging
+        allow(provider).to receive(:log_upload_success)
+      end
 
-        allow_any_instance_of(EVSS::DocumentsService).to receive(:upload)
-          .with(file_body, evss_claim_document)
-          .and_return(faraday_response)
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:info).with(
+          'EVSSSupplementalDocumentUploadProvider upload attempted',
+          {
+            class: 'EVSSSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526'
+          }
+        )
 
+        provider.submit_upload_document(evss_claim_document, file_body)
+      end
+
+      it 'increments a StatsD attempt metric' do
         expect(StatsD).to receive(:increment).with(
-          'my_upload_job_prefix.evss_supplemental_document_upload_provider.success'
+          'my_stats_metric_prefix.evss_supplemental_document_upload_provider.upload_attempt'
         )
 
         provider.submit_upload_document(evss_claim_document, file_body)
       end
     end
-  end
 
-  describe 'logging methods' do
-    # We don't want to generate an actual submission for these tests,
-    # since submissions have callbacks that log to StatsD and we need to test
-    # only the metrics in this class
-    let(:submission) { instance_double(Form526Submission) }
-    let(:provider) do
-      EVSSSupplementalDocumentUploadProvider.new(
-        submission,
-        va_document_type,
-        'my_upload_job_prefix'
-      )
-    end
-
-    describe 'log_upload_failure' do
-      let(:error_class) { 'StandardError' }
-      let(:error_message) { 'Something broke' }
-
-      it 'increments a StatsD failure metric' do
-        expect(StatsD).to receive(:increment).with(
-          'my_upload_job_prefix.evss_supplemental_document_upload_provider.failed'
-        )
-        provider.log_upload_failure(error_class, error_message)
+    context 'when an upload is successfull' do
+      before do
+        # Skip upload attempt logging
+        allow(provider).to receive(:log_upload_attempt)
       end
 
       it 'logs to the Rails logger' do
-        expect(Rails.logger).to receive(:error).with(
-          'EVSSSupplementalDocumentUploadProvider upload failure',
+        expect(Rails.logger).to receive(:info).with(
+          'EVSSSupplementalDocumentUploadProvider upload successful',
           {
             class: 'EVSSSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526'
+          }
+        )
+
+        provider.submit_upload_document(evss_claim_document, file_body)
+      end
+
+      it 'increments a StatsD success metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.evss_supplemental_document_upload_provider.upload_success'
+        )
+
+        provider.submit_upload_document(evss_claim_document, file_body)
+      end
+    end
+
+    # The EVSS::DocumentsService client we used in this API provider has custom exception logic
+    # for unsucessful upload responses from EVSS (which still have a 200 response code)
+    # We want to preserve this behavior while logging the event for tracking purposes
+    context 'when an upload raises an EVSS response error' do
+      before do
+        # Skip upload attempt logging
+        allow(provider).to receive(:log_upload_attempt)
+        allow_any_instance_of(EVSS::DocumentsService).to receive(:upload).and_raise(EVSS::ErrorMiddleware::EVSSError)
+      end
+
+      it 'logs to the Rails logger, increments a StatsD failure metric, and re-raises the error' do
+        expect(Rails.logger).to receive(:error).with(
+          'EVSSSupplementalDocumentUploadProvider upload failed',
+          {
+            class: 'EVSSSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526'
+          }
+        )
+
+        # Ensure we don't increment the success metric
+        expect(StatsD).not_to receive(:increment).with(
+          'my_stats_metric_prefix.evss_supplemental_document_upload_provider.upload_success'
+        )
+
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.evss_supplemental_document_upload_provider.upload_failure'
+        )
+
+        expect { provider.submit_upload_document(evss_claim_document, file_body) }.to raise_exception(
+          EVSS::ErrorMiddleware::EVSSError
+        )
+      end
+    end
+
+    # Will be called in the sidekiq_retries_exhausted block of the including job
+    context 'uploading job failure' do
+      let(:uploading_job_class) { 'MyUploadJob' }
+      let(:error_class) { 'StandardError' }
+      let(:error_message) { 'Something broke' }
+
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:error).with(
+          "#{uploading_job_class} EVSSSupplementalDocumentUploadProvider Failure",
+          {
+            class: 'EVSSSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526',
+            uploading_job_class:,
             error_class:,
             error_message:
           }
         )
 
-        provider.log_upload_failure(error_class, error_message)
+        provider.log_uploading_job_failure(uploading_job_class, error_class, error_message)
+      end
+
+      it 'increments a StatsD failure metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.evss_supplemental_document_upload_provider.upload_job_failed'
+        )
+        provider.log_uploading_job_failure(uploading_job_class, error_class, error_message)
       end
     end
   end

--- a/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
@@ -8,7 +8,16 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
   let(:submission) { create(:form526_submission) }
   let(:file_body) { File.read(fixture_file_upload('doctors-note.pdf', 'application/pdf')) }
   let(:file_name) { Faker::File.file_name }
-  let(:provider) { EVSSSupplementalDocumentUploadProvider.new(submission) }
+
+  let(:va_document_type) { 'L023' }
+
+  let(:provider) do
+    EVSSSupplementalDocumentUploadProvider.new(
+      submission,
+      va_document_type,
+      'my_upload_job_prefix'
+    )
+  end
 
   let(:evss_claim_document) do
     EVSSClaimDocument.new(
@@ -23,16 +32,14 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
   describe '#generate_upload_document' do
     it 'generates an EVSSClaimDocument' do
       file_name = Faker::File.file_name
-      document_type = 'L023'
-
-      upload_document = provider.generate_upload_document(file_name, document_type)
+      upload_document = provider.generate_upload_document(file_name)
 
       expect(upload_document).to be_an_instance_of(EVSSClaimDocument)
       expect(upload_document).to have_attributes(
         {
           evss_claim_id: submission.submitted_claim_id,
           file_name:,
-          document_type:
+          document_type: va_document_type
         }
       )
     end
@@ -55,14 +62,25 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
 
   describe '#submit_upload_document' do
     context 'for a valid payload' do
-      let(:faraday_response) { instance_double(Faraday::Response) }
+      it 'submits the document via the EVSSDocumentService' do
+        expect_any_instance_of(EVSS::DocumentsService).to receive(:upload)
+          .with(file_body, evss_claim_document)
 
-      it 'submits the document via the EVSSDocumentService and returns the API response' do
+        provider.submit_upload_document(evss_claim_document, file_body)
+      end
+
+      it 'increments a StatsD success metric' do
+        faraday_response = instance_double(Faraday::Response)
+
         allow_any_instance_of(EVSS::DocumentsService).to receive(:upload)
           .with(file_body, evss_claim_document)
           .and_return(faraday_response)
 
-        expect(provider.submit_upload_document(evss_claim_document, file_body)).to eq(faraday_response)
+        expect(StatsD).to receive(:increment).with(
+          'my_upload_job_prefix.evss_supplemental_document_upload_provider.success'
+        )
+
+        provider.submit_upload_document(evss_claim_document, file_body)
       end
     end
   end
@@ -72,15 +90,12 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
     # since submissions have callbacks that log to StatsD and we need to test
     # only the metrics in this class
     let(:submission) { instance_double(Form526Submission) }
-    let(:provider) { EVSSSupplementalDocumentUploadProvider.new(submission) }
-
-    describe 'log_upload_success' do
-      it 'increments a StatsD success metric' do
-        expect(StatsD).to receive(:increment).with(
-          'my_upload_job_prefix.evss_supplemental_document_upload_provider.success'
-        )
-        provider.log_upload_success('my_upload_job_prefix')
-      end
+    let(:provider) do
+      EVSSSupplementalDocumentUploadProvider.new(
+        submission,
+        va_document_type,
+        'my_upload_job_prefix'
+      )
     end
 
     describe 'log_upload_failure' do
@@ -91,7 +106,7 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
         expect(StatsD).to receive(:increment).with(
           'my_upload_job_prefix.evss_supplemental_document_upload_provider.failed'
         )
-        provider.log_upload_failure('my_upload_job_prefix', error_class, error_message)
+        provider.log_upload_failure(error_class, error_message)
       end
 
       it 'logs to the Rails logger' do
@@ -104,7 +119,7 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
           }
         )
 
-        provider.log_upload_failure('my_upload_job_prefix', error_class, error_message)
+        provider.log_upload_failure(error_class, error_message)
       end
     end
   end

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
     )
   end
 
+  let(:faraday_response) { instance_double(Faraday::Response) }
+  let(:lighthouse_request_id) { Faker::Number.number(digits: 8) }
+
+  # Mock Lighthouse API response
+  before do
+    allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+      .with(file_body, lighthouse_document)
+      .and_return(faraday_response)
+
+    allow(faraday_response).to receive(:body).and_return(
+      {
+        'data' => {
+          'success' => true,
+          'requestId' => lighthouse_request_id
+        }
+      }
+    )
+  end
+
   it_behaves_like 'supplemental document upload provider'
 
   describe 'generate_upload_document' do
@@ -68,35 +87,9 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
   end
 
   describe 'submit_upload_document' do
-    let(:faraday_response) { instance_double(Faraday::Response) }
-    let(:lighthouse_request_id) { Faker::Number.number(digits: 8) }
-
-    before do
-      allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
-        .with(file_body, lighthouse_document)
-        .and_return(faraday_response)
-
-      allow(faraday_response).to receive(:body).and_return(
-        {
-          'data' => {
-            'success' => true,
-            'requestId' => lighthouse_request_id
-          }
-        }
-      )
-    end
-
     it 'uploads the document via the UploadSupplementalDocumentService' do
       expect(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
         .with(file_body, lighthouse_document)
-
-      provider.submit_upload_document(lighthouse_document, file_body)
-    end
-
-    it 'increments a StatsD success metric' do
-      expect(StatsD).to receive(:increment).with(
-        'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.success'
-      )
 
       provider.submit_upload_document(lighthouse_document, file_body)
     end
@@ -116,42 +109,149 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
     end
   end
 
-  describe 'logging methods' do
-    # We don't want to generate an actual submission for these tests,
-    # since submissions have callbacks that log to StatsD and we need to test
-    # only the metrics in this class
-    let(:submission) { instance_double(Form526Submission) }
+  describe 'events logging' do
+    context 'when attempting to upload a document' do
+      before do
+        allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+        allow(provider).to receive(:handle_lighthouse_response)
+      end
 
-    let(:provider) do
-      LighthouseSupplementalDocumentUploadProvider.new(
-        submission,
-        'MyUploadingClass',
-        'my_stats_metric_prefix'
-      )
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:info).with(
+          'LighthouseSupplementalDocumentUploadProvider upload attempted',
+          {
+            class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526'
+          }
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+
+      it 'increments a StatsD attempt metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_attempt'
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
     end
 
-    describe 'log_upload_failure' do
-      let(:error_class) { 'StandardError' }
-      let(:error_message) { 'Something broke' }
+    context 'when an upload is successfull' do
+      before do
+        # Skip upload attempt logging
+        allow(provider).to receive(:log_upload_attempt)
+      end
 
-      it 'increments a StatsD failure metric' do
-        expect(StatsD).to receive(:increment).with(
-          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.failed'
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:info).with(
+          'LighthouseSupplementalDocumentUploadProvider upload successful',
+          {
+            class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526',
+            lighthouse_request_id:
+          }
         )
-        provider.log_upload_failure(error_class, error_message)
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+
+      it 'increments a StatsD success metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_success'
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+    end
+
+    context 'when we get a non-200 response from Lighthouse' do
+      let(:error_response_body) do
+        # Based on error response Lighthouse returned saved in VCR cassette:
+        # spec/support/vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
+        {
+          'errors' => [
+            {
+              'detail' => 'Something broke',
+              'status' => 400,
+              'title' => 'Bad Request',
+              'instance' => Faker::Internet.uuid
+            }
+          ]
+        }
+      end
+
+      before do
+        # Skip upload attempt logging
+        allow(provider).to receive(:log_upload_attempt)
+
+        allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+          .with(file_body, lighthouse_document)
+          .and_return(faraday_response)
+
+        allow(faraday_response).to receive(:body).and_return(error_response_body)
       end
 
       it 'logs to the Rails logger' do
         expect(Rails.logger).to receive(:error).with(
-          'LighthouseSupplementalDocumentUploadProvider upload failure',
+          'LighthouseSupplementalDocumentUploadProvider upload failed',
           {
             class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526',
+            lighthouse_error_response: error_response_body
+          }
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+
+      it 'increments a StatsD metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_failure'
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+    end
+
+    # Will be called in the sidekiq_retries_exhausted block of the including job
+    context 'uploading job failure' do
+      let(:uploading_job_class) { 'MyUploadJob' }
+      let(:error_class) { 'StandardError' }
+      let(:error_message) { 'Something broke' }
+
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:error).with(
+          "#{uploading_job_class} LighthouseSupplementalDocumentUploadProvider Failure",
+          {
+            class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526',
+            uploading_job_class:,
             error_class:,
             error_message:
           }
         )
 
-        provider.log_upload_failure(error_class, error_message)
+        provider.log_uploading_job_failure(uploading_job_class, error_class, error_message)
+      end
+
+      it 'increments a StatsD failure metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_job_failed'
+        )
+        provider.log_uploading_job_failure(uploading_job_class, error_class, error_message)
       end
     end
   end

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
   # BDD Document Type
   let(:va_document_type) { 'L023' }
 
-  let(:provider) do
+  let!(:provider) do
     LighthouseSupplementalDocumentUploadProvider.new(
       submission,
       va_document_type,

--- a/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
+++ b/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 shared_examples 'supplemental document upload provider' do
-  subject { described_class.new(submission, 'My Document Type', 'my_metrics_prefix' ) }
+  subject { described_class.new(submission, 'My Document Type', 'my_metrics_prefix') }
 
   let(:submission) { create(:form526_submission) }
 

--- a/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
+++ b/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 shared_examples 'supplemental document upload provider' do
-  subject { described_class.new(submission) }
+  subject { described_class.new(submission, 'My Document Type', 'my_metrics_prefix' ) }
 
   let(:submission) { create(:form526_submission) }
 


### PR DESCRIPTION
**FOR PLATFORM REVIEWER: Apologies for the high line count on this PR, there are a lot of tests related to the logging we are adding here and I'm documenting things extensively. Our tech lead @kylesoskin has reviewed this so we are fairly confident in it, if you need to take a closer look and this is just too much I can try and split this up into smaller chunks thank you**

## Summary


Overhauls the shared "API Provider" code we will use to migrate Form 526 ancillary document upload jobs from uploading to EVSS to uploading to Lighthouse instead. This was based on my [initial attempt](https://github.com/department-of-veterans-affairs/vets-api/pull/18347) to use the new providers in the UploadBDDInstructions job, which exposed some of the issues with my original provider implementation, especially with regards to keeping upload behavior out of the job using the provider, and limited logging.

The overhaul was guided by the following principles:
1. As much of the upload, logging and polling as possible should be hidden from the including document upload job (e.g. UploadBDDInstructions) and encapsulated in the API Providers
2. It should be as quick and easy as possible to drop in a few methods into the uploading job 
3. It should log every major event with as much non-PII detail as possible, so we have a lot of freedom in how we build a dashboard and monitor the migraiton in DataDog

The overhaul encompasses
1. Updating the constructor signatures of both the EVSSSupplementalDocumentUploadProvider and LighthouseSupplementalDocumentUploadProviders to make better use of the freely customizable `options` hash provided by the [APIProviderFactory](https://github.com/department-of-veterans-affairs/vets-api/blob/benefits-disability-nb-refactor-supplemental-document-upload-providers/lib/disability_compensation/factories/api_provider_factory.rb#L87)
2. Using those options to better hide behavior in the provider
3. Adding the creation of the record we use to poll Lighthouse for document status after upload, Form526DocumentUpload, when we successfully submit a document to the Lighthouse Benefits Documents API
4. Add Rails logging statements and StatsD metrics increments for the following events: upload attempts, upload sucesses, upload failures, and failures of the upload which cause it to exhaust and enter a `sidekiq_retries_exhausted` block.

- *This work is behind a feature toggle (flipper): NO, this code is not used yet

## Related issue(s)
- There was no issue created for this, it is a blocker to migrating the Form 526 document upload jobs because we will be using this shared code there.

## Testing done

- [X] *New code is covered by unit tests*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (inline documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (not yet)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [ ]  I added a screenshot of the developed feature N/A

## Requested Feedback

See my comments for an explanation of a question I had around the EVSS response logging
