### PR TITLE
[VI-530] Update MHV account creation parsing

### DIFF
--- a/lib/mhv/account_creation/service.rb
+++ b/lib/mhv/account_creation/service.rb
@@ -54,9 +54,9 @@ module MHV
 
       def normalize_response_body(response_body)
         {
-          user_profile_id: response_body['mhv_userprofileid'],
+          user_profile_id: response_body['mhv_userProfileId'],
           premium: response_body['isPremium'],
-          champ_va: response_body['isChampVA'],
+          champ_va: response_body['isChampVABeneficiary'],
           patient: response_body['isPatient'],
           sm_account_created: response_body['isSMAccountCreated'],
           message: response_body['message']

--- a/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_200_response.yml
+++ b/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_200_response.yml
@@ -104,6 +104,6 @@ http_interactions:
       - '14658'
     body:
       encoding: UTF-8
-      string: '{"mhv_userprofileid":"12345678","isPremium":true,"isChampVA":true,"isPatient":true,"isSMAccountCreated":true,"message":"Existing MHV Account Found for ICN"}'
+      string: '{"mhv_userProfileId":"12345678","isPremium":true,"isChampVABeneficiary":true,"isPatient":true,"isSMAccountCreated":true,"message":"Existing MHV Account Found for ICN"}'
   recorded_at: Wed, 28 Aug 2024 19:56:07 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION

# Summary
- MHV changed some fields in their response body:
  -  `mhv_userprofileid` -> `mhv_userProfileId`
  - `isChampVA` -> `isChampVABeneficiary`
  
## Related issue(s)
- https://jira.devops.va.gov/browse/VI-530

## Testing done
- updated specs
- need to test on staging and update betamocks

## What areas of the site does it impact?
MHV account creation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
