### PR TITLE
Invalidating MPI cache when user authenticates

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -307,7 +307,7 @@ class User < Common::RedisStore
   # Other MPI
 
   def invalidate_mpi_cache
-    return unless mpi.mpi_response_is_cached?
+    return unless loa3? && mpi.mpi_response_is_cached? && mpi.mvi_response
 
     mpi.destroy
     @mpi = nil

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -29,6 +29,7 @@ class UserSessionForm
     @user = User.new(uuid:)
     @user.session_handle = @session.token
     @user.instance_variable_set(:@identity, @user_identity)
+    @user.invalidate_mpi_cache
 
     if saml_user.changing_multifactor?
       last_signed_in = existing_user&.last_signed_in || Time.current.utc

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 require 'mhv/account_creation/service'
 
 RSpec.describe User, type: :model do
-  subject { described_class.new(build(:user)) }
+  subject { described_class.new(build(:user, loa:)) }
 
+  let(:loa) { loa_one }
   let(:loa_one) { { current: LOA::ONE, highest: LOA::ONE } }
   let(:loa_three) { { current: LOA::THREE, highest: LOA::THREE } }
   let(:user) { build(:user, :loa3) }
@@ -230,23 +231,38 @@ RSpec.describe User, type: :model do
     end
 
     describe 'invalidate_mpi_cache' do
+      let(:cache_exists) { true }
+
       before { allow_any_instance_of(MPIData).to receive(:cached?).and_return(cache_exists) }
 
-      context 'when mpi object exists with cached mpi response' do
-        let(:cache_exists) { true }
-
-        it 'clears the user mpi cache' do
-          expect_any_instance_of(MPIData).to receive(:destroy)
-          subject.invalidate_mpi_cache
-        end
-      end
-
-      context 'when mpi object does not exist with cached mpi response' do
-        let(:cache_exists) { false }
+      context 'when user is not loa3' do
+        let(:loa) { loa_one }
 
         it 'does not attempt to clear the user mpi cache' do
           expect_any_instance_of(MPIData).not_to receive(:destroy)
           subject.invalidate_mpi_cache
+        end
+      end
+
+      context 'when user is loa3' do
+        let(:loa) { loa_three }
+
+        context 'and mpi object exists with cached mpi response' do
+          let(:cache_exists) { true }
+
+          it 'clears the user mpi cache' do
+            expect_any_instance_of(MPIData).to receive(:destroy)
+            subject.invalidate_mpi_cache
+          end
+        end
+
+        context 'and mpi object does not exist with cached mpi response' do
+          let(:cache_exists) { false }
+
+          it 'does not attempt to clear the user mpi cache' do
+            expect_any_instance_of(MPIData).not_to receive(:destroy)
+            subject.invalidate_mpi_cache
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary

- This PR invalidates the MPI cache when a user authenticates, so a fresh MPI record can be called during each authentication


## Testing done

- [ ] Authenticated with `localhost:3000/v1/sessions/idme_verified/new` multiple times
- [ ] Confirmed the user was able to log in
- [ ] Confirmed MPI was called every time

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] AC described in the 'testing done' section above

