### PR TITLE
Refactor NotificationEmail to use UserAccount in addition to @current_user

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -84,7 +84,7 @@ class FormSubmissionAttempt < ApplicationRecord
     SimpleFormsApi::NotificationEmail.new(
       config,
       notification_type:,
-      user: user_account
+      user_account:
     ).send(at: time_to_send)
   end
 

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -616,11 +616,12 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
   end
 
   describe 'email confirmations' do
-    before do
-      sign_in
-    end
-
     let(:confirmation_number) { 'some_confirmation_number' }
+    let(:user) { create(:user, :loa3) }
+
+    before do
+      sign_in(user)
+    end
 
     describe '21_4142' do
       let(:data) do
@@ -640,10 +641,10 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'veteran.surname@address.com',
+          user.va_profile_email,
           'form21_4142_confirmation_email_template_id',
           {
-            'first_name' => 'VETERAN',
+            'first_name' => user.first_name.upcase,
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil
@@ -682,10 +683,10 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'my.long.email.address@email.com',
+          user.va_profile_email,
           'form21_10210_confirmation_email_template_id',
           {
-            'first_name' => 'JACK',
+            'first_name' => user.first_name.upcase,
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil
@@ -730,10 +731,10 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'preparer_address@email.com',
+          user.va_profile_email,
           'form21p_0847_confirmation_email_template_id',
           {
-            'first_name' => 'ARTHUR',
+            'first_name' => user.first_name.upcase,
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil
@@ -773,10 +774,10 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'preparer@email.com',
+          user.va_profile_email,
           'form21_0972_confirmation_email_template_id',
           {
-            'first_name' => 'PREPARE',
+            'first_name' => user.first_name.upcase,
             'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
             'confirmation_number' => confirmation_number,
             'lighthouse_updated_at' => nil

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -641,7 +641,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          user.email,
           'form21_4142_confirmation_email_template_id',
           {
             'first_name' => user.first_name.upcase,
@@ -683,7 +683,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          user.email,
           'form21_10210_confirmation_email_template_id',
           {
             'first_name' => user.first_name.upcase,
@@ -731,7 +731,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          user.email,
           'form21p_0847_confirmation_email_template_id',
           {
             'first_name' => user.first_name.upcase,
@@ -774,7 +774,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          user.email,
           'form21_0972_confirmation_email_template_id',
           {
             'first_name' => user.first_name.upcase,

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -4,121 +4,123 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::NotificationEmail do
-  %i[confirmation error received].each do |notification_type|
-    describe '#initialize' do
-      context 'when all required arguments are passed in' do
-        let(:config) do
-          { form_data: {}, form_number: 'vba_21_10210', confirmation_number: 'confirmation_number',
-            date_submitted: Time.zone.today.strftime('%B %d, %Y') }
-        end
-
-        it 'succeeds' do
-          expect { described_class.new(config, notification_type:) }.not_to raise_error(ArgumentError)
-        end
+  describe '#initialize' do
+    context 'when all required arguments are passed in' do
+      let(:config) do
+        { form_data: {}, form_number: 'vba_21_10210', confirmation_number: 'confirmation_number',
+          date_submitted: Time.zone.today.strftime('%B %d, %Y') }
       end
 
-      context 'missing form_data' do
-        let(:config) do
-          { form_number: 'vba_21_10210', confirmation_number: 'confirmation_number',
-            date_submitted: Time.zone.today.strftime('%B %d, %Y') }
-        end
-
-        it 'fails' do
-          expect { described_class.new(config, notification_type:) }.to raise_error(ArgumentError)
-        end
-      end
-
-      context 'missing form_number' do
-        let(:config) do
-          { form_data: {}, confirmation_number: 'confirmation_number',
-            date_submitted: Time.zone.today.strftime('%B %d, %Y') }
-        end
-
-        it 'fails' do
-          expect { described_class.new(config, notification_type:) }.to raise_error(ArgumentError)
-        end
-      end
-
-      context 'missing confirmation_number' do
-        let(:config) do
-          { form_data: {}, form_number: 'vba_21_10210', date_submitted: Time.zone.today.strftime('%B %d, %Y') }
-        end
-
-        it 'fails' do
-          expect { described_class.new(config, notification_type:) }.to raise_error(ArgumentError)
-        end
-      end
-
-      context 'missing date_submitted' do
-        let(:config) do
-          { form_data: {}, form_number: 'vba_21_10210', confirmation_number: 'confirmation_number' }
-        end
-
-        it 'fails' do
-          expect { described_class.new(config, notification_type:) }.to raise_error(ArgumentError)
-        end
+      it 'succeeds' do
+        expect { described_class.new(config, notification_type: :confirmation) }.not_to raise_error(ArgumentError)
       end
     end
 
-    describe '#send' do
-      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
+    context 'missing form_data' do
       let(:config) do
-        { form_data: data, form_number: 'vba_21_10210',
-          confirmation_number: 'confirmation_number', date_submitted: }
+        { form_number: 'vba_21_10210', confirmation_number: 'confirmation_number',
+          date_submitted: Time.zone.today.strftime('%B %d, %Y') }
       end
 
-      context 'flipper is on' do
-        before do
-          allow(Flipper).to receive(:enabled?).and_return true
-        end
+      it 'fails' do
+        expect { described_class.new(config, notification_type: :confirmation) }.to raise_error(ArgumentError)
+      end
+    end
 
-        it 'sends the email' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          data['claim_ownership'] = 'self'
-          data['claimant_type'] = 'veteran'
-
-          subject = described_class.new(config, notification_type:)
-
-          subject.send
-
-          expect(VANotify::EmailJob).to have_received(:perform_async)
-        end
+    context 'missing form_number' do
+      let(:config) do
+        { form_data: {}, confirmation_number: 'confirmation_number',
+          date_submitted: Time.zone.today.strftime('%B %d, %Y') }
       end
 
-      context 'flipper is off' do
-        before do
-          allow(Flipper).to receive(:enabled?).and_return false
-        end
+      it 'fails' do
+        expect { described_class.new(config, notification_type: :confirmation) }.to raise_error(ArgumentError)
+      end
+    end
 
-        it 'does not send the email' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          subject = described_class.new(config, notification_type:)
-
-          subject.send
-
-          expect(VANotify::EmailJob).not_to have_received(:perform_async)
-        end
+    context 'missing confirmation_number' do
+      let(:config) do
+        { form_data: {}, form_number: 'vba_21_10210', date_submitted: Time.zone.today.strftime('%B %d, %Y') }
       end
 
-      context 'send at time is specified' do
+      it 'fails' do
+        expect { described_class.new(config, notification_type: :confirmation) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'missing date_submitted' do
+      let(:config) do
+        { form_data: {}, form_number: 'vba_21_10210', confirmation_number: 'confirmation_number' }
+      end
+
+      it 'fails' do
+        expect { described_class.new(config, notification_type: :confirmation) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#send' do
+    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    let(:data) do
+      fixture_path = Rails.root.join(
+        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210.json'
+      )
+      JSON.parse(fixture_path.read)
+    end
+    let(:config) do
+      { form_data: data, form_number: 'vba_21_10210',
+        confirmation_number: 'confirmation_number', date_submitted: }
+    end
+
+    context 'flipper is on' do
+      before do
+        allow(Flipper).to receive(:enabled?).and_return true
+      end
+
+      it 'sends the email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        data['claim_ownership'] = 'self'
+        data['claimant_type'] = 'veteran'
+
+        subject = described_class.new(config, notification_type: :confirmation)
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async)
+      end
+    end
+
+    context 'flipper is off' do
+      before do
+        allow(Flipper).to receive(:enabled?).and_return false
+      end
+
+      it 'does not send the email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        subject = described_class.new(config, notification_type: :confirmation)
+
+        subject.send
+
+        expect(VANotify::EmailJob).not_to have_received(:perform_async)
+      end
+    end
+
+    context 'send at time is specified' do
+      %i[error received].each do |notification_type|
         context 'user is passed in' do
-          let(:email) { 'email@fromrecord.com' }
-          let(:user) { create(:user, { email: }) }
+          let(:user_account) { create(:user_account) }
 
           it 'sends the email at the specified time' do
             time = double
+            mpi_profile = double(first_name: 'Joe')
             allow(VANotify::UserAccountJob).to receive(:perform_at)
-            subject = described_class.new(config, notification_type:, user:)
+            allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(mpi_profile)
+            subject = described_class.new(config, notification_type:, user_account:)
 
             subject.send(at: time)
 
-            expect(VANotify::UserAccountJob).to have_received(:perform_at).with(time, user.uuid, anything, anything)
+            expect(VANotify::UserAccountJob).to have_received(:perform_at).with(time, user_account.id, anything,
+                                                                                anything)
           end
         end
 
@@ -136,445 +138,165 @@ describe SimpleFormsApi::NotificationEmail do
       end
     end
 
-    describe '21_10210' do
-      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
+    context 'template_id is missing' do
       let(:config) do
-        { form_data: data, form_number: 'vba_21_10210',
-          confirmation_number: 'confirmation_number', date_submitted: }
-      end
-
-      context 'users own claim' do
-        context 'is a veteran' do
-          context 'user is passed in' do
-            let(:email) { 'email@fromrecord.com' }
-            let(:user) { build(:user) }
-
-            it 'calls VANotify::EmailJob with user record email' do
-              allow(VANotify::EmailJob).to receive(:perform_async)
-              data['claim_ownership'] = 'self'
-              data['claimant_type'] = 'veteran'
-              allow(user).to receive(:va_profile_email).and_return(email)
-
-              subject = described_class.new(config, notification_type:, user:)
-
-              subject.send
-
-              expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                email,
-                "form21_10210_#{notification_type}_email_template_id",
-                {
-                  'first_name' => user.first_name.upcase,
-                  'date_submitted' => date_submitted,
-                  'confirmation_number' => 'confirmation_number',
-                  'lighthouse_updated_at' => nil
-                }
-              )
-            end
-          end
-
-          context 'user is not passed in' do
-            it 'calls VANotify::EmailJob with user record email' do
-              allow(VANotify::EmailJob).to receive(:perform_async)
-              data['claim_ownership'] = 'self'
-              data['claimant_type'] = 'veteran'
-
-              subject = described_class.new(config, notification_type:)
-
-              subject.send
-
-              expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                'veteran.longemail@email.com',
-                "form21_10210_#{notification_type}_email_template_id",
-                {
-                  'first_name' => 'JOHN',
-                  'date_submitted' => date_submitted,
-                  'confirmation_number' => 'confirmation_number',
-                  'lighthouse_updated_at' => nil
-                }
-              )
-            end
-          end
-        end
-
-        context 'is not a veteran' do
-          context 'user is passed in' do
-            let(:email) { 'email@fromrecord.com' }
-            let(:user) { build(:user) }
-
-            it 'calls VANotify::EmailJob with user record email' do
-              allow(VANotify::EmailJob).to receive(:perform_async)
-              data['claim_ownership'] = 'self'
-              data['claimant_type'] = 'non-veteran'
-              allow(user).to receive(:va_profile_email).and_return(email)
-
-              subject = described_class.new(config, notification_type:, user:)
-
-              subject.send
-
-              expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                email,
-                "form21_10210_#{notification_type}_email_template_id",
-                {
-                  'first_name' => user.first_name.upcase,
-                  'date_submitted' => date_submitted,
-                  'confirmation_number' => 'confirmation_number',
-                  'lighthouse_updated_at' => nil
-                }
-              )
-            end
-          end
-
-          context 'user is not passed in' do
-            it 'calls VANotify::EmailJob' do
-              allow(VANotify::EmailJob).to receive(:perform_async)
-              data['claim_ownership'] = 'self'
-              data['claimant_type'] = 'non-veteran'
-
-              subject = described_class.new(config, notification_type:)
-
-              subject.send
-
-              expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                'claimant.long@address.com',
-                "form21_10210_#{notification_type}_email_template_id",
-                {
-                  'first_name' => 'JOE',
-                  'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-                  'confirmation_number' => 'confirmation_number',
-                  'lighthouse_updated_at' => nil
-                }
-              )
-            end
-          end
-        end
-      end
-
-      context 'someone elses claim' do
-        context 'claimant is a veteran' do
-          it 'calls VANotify::EmailJob' do
-            allow(VANotify::EmailJob).to receive(:perform_async)
-            data['claim_ownership'] = 'third-party'
-            data['claimant_type'] = 'veteran'
-
-            subject = described_class.new(config, notification_type:)
-
-            subject.send
-
-            expect(VANotify::EmailJob).to have_received(:perform_async).with(
-              'my.long.email.address@email.com',
-              "form21_10210_#{notification_type}_email_template_id",
-              {
-                'first_name' => 'JACK',
-                'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-                'confirmation_number' => 'confirmation_number',
-                'lighthouse_updated_at' => nil
-              }
-            )
-          end
-        end
-
-        context 'claimant is not a veteran' do
-          it 'calls VANotify::EmailJob' do
-            allow(VANotify::EmailJob).to receive(:perform_async)
-            data['claim_ownership'] = 'third-party'
-            data['claimant_type'] = 'non-veteran'
-
-            subject = described_class.new(config, notification_type:)
-
-            subject.send
-
-            expect(VANotify::EmailJob).to have_received(:perform_async).with(
-              'my.long.email.address@email.com',
-              "form21_10210_#{notification_type}_email_template_id",
-              {
-                'first_name' => 'JACK',
-                'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-                'confirmation_number' => 'confirmation_number',
-                'lighthouse_updated_at' => nil
-              }
-            )
-          end
-        end
-      end
-    end
-
-    describe '40_0247' do
-      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-      let(:config) do
-        { form_data: data, form_number: 'vba_40_0247',
-          confirmation_number: 'confirmation_number', date_submitted: }
-      end
-
-      context 'template_id is provided', if: notification_type == :confirmation do
-        context 'when email is entered' do
-          let(:data) do
-            fixture_path = Rails.root.join(
-              'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247.json'
-            )
-            JSON.parse(fixture_path.read)
-          end
-
-          it 'sends the confirmation email' do
-            allow(VANotify::EmailJob).to receive(:perform_async)
-
-            subject = described_class.new(config, notification_type:)
-
-            subject.send
-
-            expect(VANotify::EmailJob).to have_received(:perform_async).with(
-              'a@b.com',
-              'form40_0247_confirmation_email_template_id',
-              {
-                'first_name' => 'JOE',
-                'date_submitted' => date_submitted,
-                'confirmation_number' => 'confirmation_number',
-                'lighthouse_updated_at' => nil
-              }
-            )
-          end
-        end
-
-        context 'when email is omitted' do
-          let(:data) do
-            fixture_path = Rails.root.join(
-              'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247-min.json'
-            )
-            JSON.parse(fixture_path.read)
-          end
-
-          context 'when user is signed in' do
-            let(:user) { create(:user, :loa3) }
-
-            it 'does not send the confirmation email' do
-              allow(VANotify::EmailJob).to receive(:perform_async)
-              expect(data['applicant_email']).to be_nil
-
-              subject = described_class.new(config, notification_type:)
-
-              subject.send
-
-              expect(VANotify::EmailJob).not_to have_received(:perform_async)
-            end
-          end
-
-          context 'when user is not signed in' do
-            it 'does not send the confirmation email' do
-              allow(VANotify::EmailJob).to receive(:perform_async)
-              expect(data['applicant_email']).to be_nil
-
-              subject = described_class.new(config)
-
-              subject.send
-
-              expect(VANotify::EmailJob).not_to have_received(:perform_async)
-            end
-          end
-        end
-      end
-
-      context 'template_id is missing', if: notification_type != :confirmation do
-        let(:data) do
-          fixture_path = Rails.root.join(
-            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247.json'
-          )
-          JSON.parse(fixture_path.read)
-        end
-        let(:user) { create(:user, :loa3) }
-
-        it 'sends nothing' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          subject = described_class.new(config, notification_type:, user:)
-
-          subject.send
-
-          expect(VANotify::EmailJob).not_to have_received(:perform_async)
-        end
-      end
-    end
-
-    describe '21_0845' do
-      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0845.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
-      let(:config) do
-        { form_data: data, form_number: 'vba_21_0845', confirmation_number: 'confirmation_number', date_submitted: }
-      end
-
-      describe 'signed in user' do
-        let(:email) { 'authorizer_email@example.com' }
-        let(:first_name) { 'John' }
-        let(:user) { build(:user, first_name:) }
-
-        before { allow(user).to receive(:va_profile_email).and_return(email) }
-
-        it 'non-veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          data['authorizer_email'] = 'authorizer_email@example.com'
-
-          subject = described_class.new(config, user:)
-
-          subject.send
-
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            email,
-            'form21_0845_confirmation_email_template_id',
-            {
-              'first_name' => first_name.upcase,
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
-        end
-
-        it 'veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          data['authorizer_type'] = 'veteran'
-
-          subject = described_class.new(config, user:)
-
-          subject.send
-
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            email,
-            'form21_0845_confirmation_email_template_id',
-            {
-              'first_name' => first_name.upcase,
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
-        end
-      end
-
-      describe 'not signed in user' do
-        it 'non-veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          # form requires email
-          data['authorizer_email'] = 'authorizer_email@example.com'
-
-          subject = described_class.new(config)
-
-          subject.send
-
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            'authorizer_email@example.com',
-            'form21_0845_confirmation_email_template_id',
-            {
-              'first_name' => 'JACK',
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
-        end
-
-        it 'veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          # form does not require email
-          data['authorizer_type'] = 'veteran'
-
-          subject = described_class.new(config)
-
-          subject.send
-
-          expect(VANotify::EmailJob).not_to have_received(:perform_async)
-        end
-      end
-    end
-
-    describe '21_0966' do
-      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
-      let(:config) do
-        { form_data: data, form_number: 'vba_21_0966',
+        { form_data: {}, form_number: 'something_fake',
           confirmation_number: 'confirmation_number', date_submitted: }
       end
       let(:user) { create(:user, :loa3) }
 
-      context 'template_id is provided', if: notification_type == :confirmation do
-        it 'sends the confirmation email' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
+      it 'sends nothing' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        subject = described_class.new(config, notification_type: :confirmation, user:)
 
-          subject = described_class.new(config, user:)
+        subject.send
+
+        expect(VANotify::EmailJob).not_to have_received(:perform_async)
+      end
+    end
+  end
+
+  describe '21_10210' do
+    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    let(:data) do
+      fixture_path = Rails.root.join(
+        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210.json'
+      )
+      JSON.parse(fixture_path.read)
+    end
+    let(:config) do
+      { form_data: data, form_number: 'vba_21_10210',
+        confirmation_number: 'confirmation_number', date_submitted: }
+    end
+
+    context 'users own claim' do
+      context 'is a veteran' do
+        let(:user) { build(:user) }
+
+        it 'calls VANotify::EmailJob with user record email' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          data['claim_ownership'] = 'self'
+          data['claimant_type'] = 'veteran'
+
+          subject = described_class.new(config, notification_type: :confirmation, user:)
 
           subject.send
 
           expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.va_profile_email,
-            'form21_0966_confirmation_email_template_id',
+            user.email,
+            'form21_10210_confirmation_email_template_id',
             {
               'first_name' => user.first_name.upcase,
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil,
-              'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
-                                           ' (VA Form 21P-534 or VA Form 21P-534EZ)'
+              'lighthouse_updated_at' => nil
             }
           )
         end
       end
 
-      context 'template_id is missing', if: notification_type != :confirmation do
-        let(:data) do
-          fixture_path = Rails.root.join(
-            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'
-          )
-          JSON.parse(fixture_path.read)
-        end
+      context 'is not a veteran' do
+        let(:user) { build(:user) }
 
-        it 'sends nothing' do
+        it 'calls VANotify::EmailJob with user record email' do
           allow(VANotify::EmailJob).to receive(:perform_async)
-          subject = described_class.new(config, notification_type:, user:)
+          data['claim_ownership'] = 'self'
+          data['claimant_type'] = 'non-veteran'
+
+          subject = described_class.new(config, notification_type: :confirmation, user:)
 
           subject.send
 
-          expect(VANotify::EmailJob).not_to have_received(:perform_async)
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            user.email,
+            'form21_10210_confirmation_email_template_id',
+            {
+              'first_name' => user.first_name.upcase,
+              'date_submitted' => date_submitted,
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
         end
       end
     end
 
-    describe '20_10206' do
-      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    context 'someone elses claim' do
+      context 'claimant is a veteran' do
+        it 'calls VANotify::EmailJob' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          data['claim_ownership'] = 'third-party'
+          data['claimant_type'] = 'veteran'
+
+          subject = described_class.new(config, notification_type: :confirmation)
+
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            'my.long.email.address@email.com',
+            'form21_10210_confirmation_email_template_id',
+            {
+              'first_name' => 'JACK',
+              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
+      end
+
+      context 'claimant is not a veteran' do
+        it 'calls VANotify::EmailJob' do
+          allow(VANotify::EmailJob).to receive(:perform_async)
+          data['claim_ownership'] = 'third-party'
+          data['claimant_type'] = 'non-veteran'
+
+          subject = described_class.new(config, notification_type: :confirmation)
+
+          subject.send
+
+          expect(VANotify::EmailJob).to have_received(:perform_async).with(
+            'my.long.email.address@email.com',
+            'form21_10210_confirmation_email_template_id',
+            {
+              'first_name' => 'JACK',
+              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+              'confirmation_number' => 'confirmation_number',
+              'lighthouse_updated_at' => nil
+            }
+          )
+        end
+      end
+    end
+  end
+
+  describe '40_0247' do
+    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    let(:config) do
+      { form_data: data, form_number: 'vba_40_0247',
+        confirmation_number: 'confirmation_number', date_submitted: }
+    end
+
+    context 'when email is entered' do
       let(:data) do
         fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10206.json'
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247.json'
         )
         JSON.parse(fixture_path.read)
-      end
-      let(:config) do
-        { form_data: data, form_number: 'vba_20_10206',
-          confirmation_number: 'confirmation_number', date_submitted: }
       end
 
       it 'sends the confirmation email' do
         allow(VANotify::EmailJob).to receive(:perform_async)
 
-        subject = described_class.new(config)
+        subject = described_class.new(config, notification_type: :confirmation)
 
         subject.send
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'jv@example.com',
-          'form20_10206_confirmation_email_template_id',
+          'a@b.com',
+          'form40_0247_confirmation_email_template_id',
           {
-            'first_name' => 'JOHN',
+            'first_name' => 'JOE',
             'date_submitted' => date_submitted,
             'confirmation_number' => 'confirmation_number',
             'lighthouse_updated_at' => nil
@@ -583,133 +305,324 @@ describe SimpleFormsApi::NotificationEmail do
       end
     end
 
-    describe '20_10207' do
-      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-      let(:config) do
-        { form_data: data, form_number: 'vba_20_10207',
-          confirmation_number: 'confirmation_number', date_submitted: }
+    context 'when email is omitted' do
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_40_0247-min.json'
+        )
+        JSON.parse(fixture_path.read)
       end
 
-      context 'veteran' do
-        let(:data) do
-          fixture_path = Rails.root.join(
-            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-veteran.json'
-          )
-          JSON.parse(fixture_path.read)
-        end
-        let(:first_name) { 'Joe' }
-        let(:user) { create(:user, :loa3, first_name:) }
+      context 'when user is signed in' do
+        let(:user) { create(:user, :loa3) }
 
-        it 'sends the confirmation email' do
+        it 'does not send the confirmation email' do
           allow(VANotify::EmailJob).to receive(:perform_async)
+          expect(data['applicant_email']).to be_nil
 
-          subject = described_class.new(config, user:)
+          subject = described_class.new(config, notification_type: :confirmation)
 
           subject.send
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.va_profile_email,
-            'form20_10207_confirmation_email_template_id',
-            {
-              'first_name' => first_name.upcase,
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
+          expect(VANotify::EmailJob).not_to have_received(:perform_async)
         end
       end
 
-      context 'third-party-veteran' do
-        let(:data) do
-          fixture_path = Rails.root.join(
-            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-veteran.json'
-          )
-          JSON.parse(fixture_path.read)
-        end
-        let(:first_name) { 'Joe' }
-        let(:user) { create(:user, :loa3, first_name:) }
-
-        it 'sends the confirmation email' do
+      context 'when user is not signed in' do
+        it 'does not send the confirmation email' do
           allow(VANotify::EmailJob).to receive(:perform_async)
+          expect(data['applicant_email']).to be_nil
 
-          subject = described_class.new(config, user:)
+          subject = described_class.new(config)
 
           subject.send
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.va_profile_email,
-            'form20_10207_confirmation_email_template_id',
-            {
-              'first_name' => first_name.upcase,
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
+          expect(VANotify::EmailJob).not_to have_received(:perform_async)
         end
       end
+    end
+  end
 
-      context 'non-veteran' do
-        let(:data) do
-          fixture_path = Rails.root.join(
-            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-non-veteran.json'
-          )
-          JSON.parse(fixture_path.read)
-        end
-        let(:first_name) { 'Joe' }
-        let(:user) { create(:user, :loa3, first_name:) }
+  describe '21_0845' do
+    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    let(:data) do
+      fixture_path = Rails.root.join(
+        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0845.json'
+      )
+      JSON.parse(fixture_path.read)
+    end
+    let(:config) do
+      { form_data: data, form_number: 'vba_21_0845', confirmation_number: 'confirmation_number', date_submitted: }
+    end
 
-        it 'sends the confirmation email' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
+    describe 'signed in user' do
+      let(:user) { build(:user) }
 
-          subject = described_class.new(config, user:)
+      it 'non-veteran authorizer' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
 
-          subject.send
+        subject = described_class.new(config, user:)
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.va_profile_email,
-            'form20_10207_confirmation_email_template_id',
-            {
-              'first_name' => first_name.upcase,
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
-        end
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          user.email,
+          'form21_0845_confirmation_email_template_id',
+          {
+            'first_name' => user.first_name.upcase,
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil
+          }
+        )
       end
 
-      context 'third-party-non-veteran' do
-        let(:data) do
-          fixture_path = Rails.root.join(
-            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-non-veteran.json'
-          )
-          JSON.parse(fixture_path.read)
-        end
-        let(:email) { 'email@fromrecord.com' }
-        let(:first_name) { 'Joe' }
-        let(:user) { create(:user, :loa3, first_name:) }
+      it 'veteran authorizer' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        data['authorizer_type'] = 'veteran'
 
-        it 'sends the confirmation email' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          allow(user).to receive(:va_profile_email).and_return(email)
+        subject = described_class.new(config, user:)
 
-          subject = described_class.new(config, user:)
+        subject.send
 
-          subject.send
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          user.email,
+          'form21_0845_confirmation_email_template_id',
+          {
+            'first_name' => user.first_name.upcase,
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil
+          }
+        )
+      end
+    end
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            email,
-            'form20_10207_confirmation_email_template_id',
-            {
-              'first_name' => first_name.upcase,
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
-        end
+    describe 'not signed in user' do
+      it 'non-veteran authorizer' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        # form requires email
+        data['authorizer_email'] = 'authorizer_email@example.com'
+
+        subject = described_class.new(config)
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          'authorizer_email@example.com',
+          'form21_0845_confirmation_email_template_id',
+          {
+            'first_name' => 'JACK',
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil
+          }
+        )
+      end
+
+      it 'veteran authorizer' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+        # form does not require email
+        data['authorizer_type'] = 'veteran'
+
+        subject = described_class.new(config)
+
+        subject.send
+
+        expect(VANotify::EmailJob).not_to have_received(:perform_async)
+      end
+    end
+  end
+
+  describe '21_0966' do
+    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    let(:data) do
+      fixture_path = Rails.root.join(
+        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'
+      )
+      JSON.parse(fixture_path.read)
+    end
+    let(:config) do
+      { form_data: data, form_number: 'vba_21_0966',
+        confirmation_number: 'confirmation_number', date_submitted: }
+    end
+    let(:user) { create(:user, :loa3) }
+
+    it 'sends the confirmation email' do
+      allow(VANotify::EmailJob).to receive(:perform_async)
+
+      subject = described_class.new(config, user:)
+
+      subject.send
+
+      expect(VANotify::EmailJob).to have_received(:perform_async).with(
+        user.email,
+        'form21_0966_confirmation_email_template_id',
+        {
+          'first_name' => user.first_name.upcase,
+          'date_submitted' => date_submitted,
+          'confirmation_number' => 'confirmation_number',
+          'lighthouse_updated_at' => nil,
+          'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
+                                       ' (VA Form 21P-534 or VA Form 21P-534EZ)'
+        }
+      )
+    end
+  end
+
+  describe '20_10206' do
+    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    let(:data) do
+      fixture_path = Rails.root.join(
+        'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10206.json'
+      )
+      JSON.parse(fixture_path.read)
+    end
+    let(:config) do
+      { form_data: data, form_number: 'vba_20_10206',
+        confirmation_number: 'confirmation_number', date_submitted: }
+    end
+
+    it 'sends the confirmation email' do
+      allow(VANotify::EmailJob).to receive(:perform_async)
+
+      subject = described_class.new(config)
+
+      subject.send
+
+      expect(VANotify::EmailJob).to have_received(:perform_async).with(
+        'jv@example.com',
+        'form20_10206_confirmation_email_template_id',
+        {
+          'first_name' => 'JOHN',
+          'date_submitted' => date_submitted,
+          'confirmation_number' => 'confirmation_number',
+          'lighthouse_updated_at' => nil
+        }
+      )
+    end
+  end
+
+  describe '20_10207' do
+    let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+    let(:config) do
+      { form_data: data, form_number: 'vba_20_10207',
+        confirmation_number: 'confirmation_number', date_submitted: }
+    end
+
+    context 'veteran' do
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-veteran.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+      let(:user) { create(:user, :loa3) }
+
+      it 'sends the confirmation email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+
+        subject = described_class.new(config, user:)
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          user.email,
+          'form20_10207_confirmation_email_template_id',
+          {
+            'first_name' => user.first_name.upcase,
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil
+          }
+        )
+      end
+    end
+
+    context 'third-party-veteran' do
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-veteran.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+      let(:user) { create(:user, :loa3) }
+
+      it 'sends the confirmation email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+
+        subject = described_class.new(config, user:)
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          user.email,
+          'form20_10207_confirmation_email_template_id',
+          {
+            'first_name' => user.first_name.upcase,
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil
+          }
+        )
+      end
+    end
+
+    context 'non-veteran' do
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-non-veteran.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+      let(:user) { create(:user, :loa3) }
+
+      it 'sends the confirmation email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+
+        subject = described_class.new(config, user:)
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          user.email,
+          'form20_10207_confirmation_email_template_id',
+          {
+            'first_name' => user.first_name.upcase,
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil
+          }
+        )
+      end
+    end
+
+    context 'third-party-non-veteran' do
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_20_10207-third-party-non-veteran.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+      let(:user) { create(:user, :loa3) }
+
+      it 'sends the confirmation email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+
+        subject = described_class.new(config, user:)
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          user.email,
+          'form20_10207_confirmation_email_template_id',
+          {
+            'first_name' => user.first_name.upcase,
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil
+          }
+        )
       end
     end
   end

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe FormSubmissionAttempt, type: :model do
         allow(SimpleFormsApi::NotificationEmail).to receive(:new).with(
           config,
           notification_type:,
-          user: anything
+          user_account: anything
         ).and_return(notification_email)
         form_submission_attempt = create(:form_submission_attempt)
 
@@ -71,7 +71,7 @@ RSpec.describe FormSubmissionAttempt, type: :model do
         allow(SimpleFormsApi::NotificationEmail).to receive(:new).with(
           config,
           notification_type:,
-          user: anything
+          user_account: anything
         ).and_return(notification_email)
         form_submission_attempt = create(:form_submission_attempt)
 

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
       let(:notification_type) { :error }
 
       it 'transitions to a failure state' do
+        allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send)
+
         form_submission_attempt = create(:form_submission_attempt)
 
         expect(form_submission_attempt)
@@ -55,6 +57,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
       let(:notification_type) { :received }
 
       it 'transitions to a vbms state' do
+        allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send)
+
         form_submission_attempt = create(:form_submission_attempt)
 
         expect(form_submission_attempt)

--- a/spec/sidekiq/benefits_intake_status_job_spec.rb
+++ b/spec/sidekiq/benefits_intake_status_job_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe BenefitsIntakeStatusJob, type: :job do
 
     describe 'updating the form submission status' do
       it 'updates the status with vbms from the bulk status report endpoint' do
+        allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send)
+
         pending_form_submissions = create_list(:form_submission, 1, :pending)
         batch_uuids = pending_form_submissions.map(&:benefits_intake_uuid)
         data = batch_uuids.map { |id| { 'id' => id, 'attributes' => { 'status' => 'vbms' } } }
@@ -96,6 +98,8 @@ RSpec.describe BenefitsIntakeStatusJob, type: :job do
       end
 
       it 'updates the status with error from the bulk status report endpoint' do
+        allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send)
+
         pending_form_submissions = create_list(:form_submission, 1, :pending)
         batch_uuids = pending_form_submissions.map(&:benefits_intake_uuid)
         error_code = 'error-code'
@@ -121,6 +125,8 @@ RSpec.describe BenefitsIntakeStatusJob, type: :job do
       end
 
       it 'updates the status with expired from the bulk status report endpoint' do
+        allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send)
+
         pending_form_submissions = create_list(:form_submission, 1, :pending)
         batch_uuids = pending_form_submissions.map(&:benefits_intake_uuid)
         data = batch_uuids.map { |id| { 'id' => id, 'attributes' => { 'status' => 'expired' } } }


### PR DESCRIPTION
## Summary
This PR refactors the Simple Forms `NotificationEmail` such that it can handle when a user is passed in AND when one is not. Previously, a user must be passed in but now that we have asynchronous emails going out we will need to accommodate a different model, the `UserAccount`.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1709
