### PR TITLE
Add logging when we're about to send a failure email

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -25,6 +25,12 @@ class FormSubmissionAttempt < ApplicationRecord
 
     event :fail do
       after do
+        Rails.logger.info({
+                            message: 'Preparing to send Form Submission Attempt error email',
+                            form_submission_id:,
+                            benefits_intake_uuid: form_submission&.benefits_intake_uuid,
+                            form_type: form_submission&.form_type
+                          })
         enqueue_result_email(:error) if Flipper.enabled?(:simple_forms_email_notifications)
       end
 


### PR DESCRIPTION
## Summary
This PR adds some logging for when a Simple Forms submission fails in Central Mail and we send an email to the user to let them know.
