### PR TITLE
[10-10CG] Update specs to get 100% coverage per simple-cov

### DIFF
--- a/spec/lib/carma/client/mule_soft_auth_token_configuration_spec.rb
+++ b/spec/lib/carma/client/mule_soft_auth_token_configuration_spec.rb
@@ -12,12 +12,27 @@ describe CARMA::Client::MuleSoftAuthTokenConfiguration do
     allow(Settings.form_10_10cg.carma.mulesoft.auth).to receive(:token_url).and_return(token_url)
   end
 
-  it 'sets base_path on connection' do
-    expect(Faraday).to receive(:new).with("#{token_url}/")
-    subject.connection
+  describe 'connection' do
+    let(:faraday) { double('Faraday::Connection') }
+
+    it 'creates a new Faraday connection with the correct base path' do
+      expect(Faraday).to receive(:new).with("#{token_url}/")
+      subject.connection
+    end
+
+    it 'creates the connection' do
+      allow(Faraday).to receive(:new).and_yield(faraday)
+
+      expect(faraday).to receive(:use).once.with(:breakers)
+      expect(faraday).to receive(:request).once.with(:instrumentation,
+                                                     { name: 'CARMA::Client::MuleSoftAuthTokenConfiguration' })
+      expect(faraday).to receive(:adapter).once.with(Faraday.default_adapter)
+
+      subject.connection
+    end
   end
 
-  it 'returns class name' do
+  it 'service_name returns class name' do
     expect(subject.service_name).to eq('CARMA::Client::MuleSoftAuthTokenConfiguration')
   end
 

--- a/spec/lib/carma/client/mule_soft_configuration_spec.rb
+++ b/spec/lib/carma/client/mule_soft_configuration_spec.rb
@@ -6,6 +6,28 @@ require 'carma/client/mule_soft_configuration'
 describe CARMA::Client::MuleSoftConfiguration do
   subject { described_class.instance }
 
+  let(:host) { 'https://www.somesite.gov' }
+
+  describe 'connection' do
+    let(:faraday) { double('Faraday::Connection') }
+
+    it 'creates a new Faraday connection with the correct base path' do
+      allow(Settings.form_10_10cg.carma.mulesoft).to receive(:host).and_return(host)
+      expect(Faraday).to receive(:new).with("#{host}/va-carma-caregiver-papi/api/")
+      subject.connection
+    end
+
+    it 'creates the connection' do
+      allow(Faraday).to receive(:new).and_yield(faraday)
+
+      expect(faraday).to receive(:use).once.with(:breakers)
+      expect(faraday).to receive(:request).once.with(:instrumentation, { name: 'CARMA::Client::MuleSoftConfiguration' })
+      expect(faraday).to receive(:adapter).once.with(Faraday.default_adapter)
+
+      subject.connection
+    end
+  end
+
   describe 'id and secret' do
     before do
       allow(Settings.form_10_10cg.carma.mulesoft).to receive_messages(client_id: fake_id, client_secret: fake_secret)
@@ -24,6 +46,10 @@ describe CARMA::Client::MuleSoftConfiguration do
         end
       end
     end
+  end
+
+  it 'returns class name as service_name' do
+    expect(subject.service_name).to eq('CARMA::Client::MuleSoftConfiguration')
   end
 
   describe 'timeout' do
@@ -63,8 +89,6 @@ describe CARMA::Client::MuleSoftConfiguration do
   end
 
   describe 'base_path' do
-    let(:host) { 'https://www.somesite.gov' }
-
     before do
       allow(Settings.form_10_10cg.carma.mulesoft).to receive(:host).and_return(host)
     end


### PR DESCRIPTION


## Summary

- This work is behind a feature toggle (flipper): NO
- Added some new specs to get coverage of two class to 100% per simple-cov gem. 
- 1010 Health Apps

## Testing done

- [x] *New code is covered by unit tests*
- This is only updating specs.  No implementation code was changed. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10CG spec coverage. No implementation code was changed. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

