### PR TITLE
Add `10-7959f-1-FMP` to FE app names

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -33,6 +33,7 @@ class SourceAppMiddleware
     10206-pa
     10207-pp
     10210-lay-witness-statement
+    10-7959f-1-FMP
     1990-edu-benefits
     1990e-edu-benefits
     1990ez-edu-benefits


### PR DESCRIPTION
## Summary
Add `10-7959f-1-FMP` as a front end app name. Based on my [vets-website search](https://github.com/search?q=repo%3Adepartment-of-veterans-affairs%2Fvets-website%20%2210-7959f-1-FMP%22&type=code), it's a form.

This resolves the monitor, [vets-api source app monitor - un-mapped source app detected](https://vagov.ddog-gov.com/monitors/200229?from_ts=1727885589000&to_ts=1727886789000&event_id=7778315188203486323&source=monitor_notif&eval_ts=1727886789000).

## Testing done

- [ ] After merge, make sure datadog alert resolves. 