### PR TITLE
93074 Update travel claims client to take in client_number as initialization parameter

### DIFF
--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -12,16 +12,17 @@ module TravelClaim
     CLAIMANT_ID_TYPE = 'icn'
     TRIP_TYPE = 'RoundTrip'
 
-    attr_reader :settings, :check_in
+    attr_reader :settings, :check_in, :client_number
 
     def_delegators :settings, :auth_url, :tenant_id, :client_id, :client_secret, :scope, :claims_url, :claims_base_path,
-                   :client_number, :subscription_key, :e_subscription_key, :s_subscription_key, :service_name
+                   :subscription_key, :e_subscription_key, :s_subscription_key, :service_name
 
     ##
     # Builds a Client instance
     #
     # @param opts [Hash] options to create a Client
     # @option opts [CheckIn::V2::Session] :check_in the check_in session object
+    # @option opts [String] :client_number the client number to use for the claim
     #
     # @return [TravelClaim::Client] an instance of this class
     #
@@ -32,6 +33,7 @@ module TravelClaim
     def initialize(opts)
       @settings = Settings.check_in.travel_reimbursement_api_v2
       @check_in = opts[:check_in]
+      @client_number = opts[:client_number] || settings.client_number
     end
 
     ##

--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -12,9 +12,9 @@ module TravelClaim
     CLAIMANT_ID_TYPE = 'icn'
     TRIP_TYPE = 'RoundTrip'
 
-    attr_reader :settings, :check_in, :client_id
+    attr_reader :settings, :check_in
 
-    def_delegators :settings, :auth_url, :tenant_id, :client_secret, :scope, :claims_url, :claims_base_path,
+    def_delegators :settings, :auth_url, :tenant_id, :client_id, :client_secret, :scope, :claims_url, :claims_base_path,
                    :client_number, :subscription_key, :e_subscription_key, :s_subscription_key, :service_name
 
     ##
@@ -32,7 +32,6 @@ module TravelClaim
     def initialize(opts)
       @settings = Settings.check_in.travel_reimbursement_api_v2
       @check_in = opts[:check_in]
-      @client_id = opts[:client_id] || settings.client_id
     end
 
     ##

--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -12,9 +12,9 @@ module TravelClaim
     CLAIMANT_ID_TYPE = 'icn'
     TRIP_TYPE = 'RoundTrip'
 
-    attr_reader :settings, :check_in
+    attr_reader :settings, :check_in, :client_id
 
-    def_delegators :settings, :auth_url, :tenant_id, :client_id, :client_secret, :scope, :claims_url, :claims_base_path,
+    def_delegators :settings, :auth_url, :tenant_id, :client_secret, :scope, :claims_url, :claims_base_path,
                    :client_number, :subscription_key, :e_subscription_key, :s_subscription_key, :service_name
 
     ##
@@ -32,6 +32,7 @@ module TravelClaim
     def initialize(opts)
       @settings = Settings.check_in.travel_reimbursement_api_v2
       @check_in = opts[:check_in]
+      @client_id = opts[:client_id] || settings.client_id
     end
 
     ##

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 describe TravelClaim::Client do
-  subject { described_class.build(check_in:) }
+  subject { described_class.build(check_in:, client_number:) }
 
   let(:uuid) { 'd602d9eb-9a31-484f-9637-13ab0b507e0d' }
   let(:check_in) { CheckIn::V2::Session.build(data: { uuid: }) }
+  let(:client_number) { 'test-client-number' }
 
   before do
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
@@ -31,6 +32,15 @@ describe TravelClaim::Client do
 
     it 'has a session' do
       expect(subject.check_in).to be_a(CheckIn::V2::Session)
+    end
+
+    it 'has the client_number it is initialized with' do
+      expect(subject.client_number).to eq(client_number)
+    end
+
+    it 'has default client_id if not initialized with it' do
+      cls = described_class.build(check_in:)
+      expect(cls.client_number).to eq(Settings.check_in.travel_reimbursement_api_v2.client_number)
     end
   end
 

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -3,11 +3,10 @@
 require 'rails_helper'
 
 describe TravelClaim::Client do
-  subject { described_class.build(check_in:, client_id:) }
+  subject { described_class.build(check_in:) }
 
   let(:uuid) { 'd602d9eb-9a31-484f-9637-13ab0b507e0d' }
   let(:check_in) { CheckIn::V2::Session.build(data: { uuid: }) }
-  let(:client_id) { 'test-client-id' }
 
   before do
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
@@ -32,15 +31,6 @@ describe TravelClaim::Client do
 
     it 'has a session' do
       expect(subject.check_in).to be_a(CheckIn::V2::Session)
-    end
-
-    it 'has the client_id it is initialized with' do
-      expect(subject.client_id).to eq(client_id)
-    end
-
-    it 'has default client_id if not initialized with it' do
-      cls = described_class.build(check_in:)
-      expect(cls.client_id).to eq(Settings.check_in.travel_reimbursement_api_v2.client_id)
     end
   end
 

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -38,7 +38,7 @@ describe TravelClaim::Client do
       expect(subject.client_number).to eq(client_number)
     end
 
-    it 'has default client_id if not initialized with it' do
+    it 'has default client_number if not initialized with it' do
       cls = described_class.build(check_in:)
       expect(cls.client_number).to eq(Settings.check_in.travel_reimbursement_api_v2.client_number)
     end

--- a/modules/check_in/spec/services/travel_claim/client_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/client_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 describe TravelClaim::Client do
-  subject { described_class.build(check_in:) }
+  subject { described_class.build(check_in:, client_id:) }
 
   let(:uuid) { 'd602d9eb-9a31-484f-9637-13ab0b507e0d' }
   let(:check_in) { CheckIn::V2::Session.build(data: { uuid: }) }
+  let(:client_id) { 'test-client-id' }
 
   before do
     allow(Flipper).to receive(:enabled?).with('check_in_experience_mock_enabled').and_return(false)
@@ -31,6 +32,15 @@ describe TravelClaim::Client do
 
     it 'has a session' do
       expect(subject.check_in).to be_a(CheckIn::V2::Session)
+    end
+
+    it 'has the client_id it is initialized with' do
+      expect(subject.client_id).to eq(client_id)
+    end
+
+    it 'has default client_id if not initialized with it' do
+      cls = described_class.build(check_in:)
+      expect(cls.client_id).to eq(Settings.check_in.travel_reimbursement_api_v2.client_id)
     end
   end
 


### PR DESCRIPTION
## Summary
We need to use a different BTSSS API client_number when filing travel claims for OH sites, as compared to VistA sites. This PR adds an initialization parameter to the client class, which the service class can use to initialize the client with a different client_number.

This is a backward compatible change and doesn't require a feature flag.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93074

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
* check_in experience and Oracle Health travel claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
