### PR TITLE
[SIMPLE_FORMS] fix: update size range for uploader

### DIFF
--- a/app/uploaders/veteran_facing_forms_remediation_uploader.rb
+++ b/app/uploaders/veteran_facing_forms_remediation_uploader.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class VeteranFacingFormsRemediationUploader < CarrierWave::Uploader::Base
-  include SetAWSConfig
   include UploaderVirusScan
 
   class << self
@@ -22,7 +21,7 @@ class VeteranFacingFormsRemediationUploader < CarrierWave::Uploader::Base
   end
 
   def size_range
-    (1.byte)..(100.megabytes)
+    (1.byte)...(150.megabytes)
   end
 
   # Allowed file types, including those specific to benefits intake


### PR DESCRIPTION
## Summary

- This work increases a file size limitation on the remediation file uploader

## Related issue(s)

- [Form Submission Remediation - Test remediation process and make updates in accordance with findings](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/1956)

## Testing done

- [x] This new logic is covered by unit test coverage

## Requested Feedback

Any
