### PR TITLE
rename uploaded file class data to avoid filtering

### DIFF
--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -11,7 +11,7 @@ module FormAttachmentCreate
         'begin form attachment creation',
         :info,
         file_data_present: filtered_params[:file_data].present?,
-        class_name: filtered_params[:file_data]&.class&.name,
+        klass: filtered_params[:file_data]&.class&.name,
         debug_timestamp:
       )
     end

--- a/spec/concerns/form_attachment_create_spec.rb
+++ b/spec/concerns/form_attachment_create_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe FormAttachmentCreate, type: :controller do
           'begin form attachment creation',
           :info,
           file_data_present: true,
-          class_name: 'ActionDispatch::Http::UploadedFile',
+          klass: 'ActionDispatch::Http::UploadedFile',
           debug_timestamp: anything
         )
         expect(@controller).to receive(:log_message_to_sentry).with(
@@ -76,7 +76,7 @@ RSpec.describe FormAttachmentCreate, type: :controller do
           'begin form attachment creation',
           :info,
           file_data_present: true,
-          class_name: 'String',
+          klass: 'String',
           debug_timestamp: anything
         )
         expect(@controller).to receive(:log_exception_to_sentry).twice
@@ -92,7 +92,7 @@ RSpec.describe FormAttachmentCreate, type: :controller do
           'begin form attachment creation',
           :info,
           file_data_present: true,
-          class_name: 'ActionDispatch::Http::UploadedFile',
+          klass: 'ActionDispatch::Http::UploadedFile',
           debug_timestamp: anything
         )
         expect(@controller).to receive(:log_exception_to_sentry).twice
@@ -113,7 +113,7 @@ RSpec.describe FormAttachmentCreate, type: :controller do
           'begin form attachment creation',
           :info,
           file_data_present: true,
-          class_name: 'ActionDispatch::Http::UploadedFile',
+          klass: 'ActionDispatch::Http::UploadedFile',
           debug_timestamp: anything
         )
         expect(@controller).to receive(:log_exception_to_sentry)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* (`hca_log_form_attachment_create`)
- Update the logging so we can actually see the class name
- I didn't realize that naming the extra_context entry `class_name` would cause its contents to be filtered out to `FILTERED-CLIENTSIDE`; renaming to adjust
- Health Enrollment 10-10EZ/CG team

## Related issue(s)

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/92139

## Testing done

I ran the app locally and confirmed that the upload process works, and we get the corresponding logs in the console.

## What areas of the site does it impact?
- This affects Sentry logging for File Upload creation

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs