### PR TITLE
[VI-534] Properly passing along hashed_device_secret in refreshed access token for sessions that are device_sso enabled

### DIFF
--- a/app/services/sign_in/session_refresher.rb
+++ b/app/services/sign_in/session_refresher.rb
@@ -92,7 +92,8 @@ module SignIn
         parent_refresh_token_hash: refresh_token_hash,
         anti_csrf_token: updated_anti_csrf_token,
         last_regeneration_time:,
-        user_attributes: session.user_attributes_hash
+        user_attributes: session.user_attributes_hash,
+        device_secret_hash: session.hashed_device_secret
       )
     end
 
@@ -150,6 +151,12 @@ module SignIn
 
     def access_token
       @access_token ||= create_access_token
+    end
+
+    def hashed_device_secret
+      return unless validated_credential.device_sso
+
+      @hashed_device_secret ||= get_hash(device_secret)
     end
   end
 end

--- a/spec/services/sign_in/session_refresher_spec.rb
+++ b/spec/services/sign_in/session_refresher_spec.rb
@@ -247,6 +247,7 @@ RSpec.describe SignIn::SessionRefresher do
                   expect(container.access_token.parent_refresh_token_hash).to eq(expected_parent_refresh_token_hash)
                   expect(container.access_token.refresh_token_hash).to eq(expected_refresh_token_hash)
                   expect(container.access_token.last_regeneration_time).to eq(expected_last_regeneration_time)
+                  expect(container.access_token.device_secret_hash).to eq(session.hashed_device_secret)
                 end
               end
             end


### PR DESCRIPTION
## Summary

- This PR updates the rotated access token during a sign in service session refresh so that it includes the hashed `device_secret`. This is necessary for Sign in Service SSO enabled apps to be able to spawn new sessions even if the original access token has been refreshed

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-534

## Testing done

- [ ] Created SIS authentication with `device_sso` enabled
- [ ] Confirmed `hashed_device_sso` was a field on the access token
- [ ] Refreshed the set of authentication tokens
- [ ] Confirmed `hashed_device_sso` was still a field on the access token

## What areas of the site does it impact?
SSO Authentication

## Acceptance criteria

- [ ] Authenticate with a Sign in Service client that is SSO enabled, using the `scope=device_sso` field
- [ ] Confirm `hashed_device_sso` was a field on the access token
- [ ] Refresh the set of authentication tokens
- [ ] Confirm `hashed_device_sso` was still a field on the access token

