### PR TITLE
[API-40614] halt v2 526 synchronous submission if pdf empty

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
@@ -103,9 +103,9 @@ module ClaimsApi
           auto_claim = shared_submit_methods
 
           unless claims_load_testing # || sandbox_request(request)
-            pdf_generation_service.generate(auto_claim&.id, veteran_middle_initial) unless mocking
-            docker_container_service.upload(auto_claim&.id)
-            queue_flash_updater(auto_claim.flashes, auto_claim&.id)
+            generate_pdf_from_service!(auto_claim.id, veteran_middle_initial) unless mocking
+            docker_container_service.upload(auto_claim.id)
+            queue_flash_updater(auto_claim.flashes, auto_claim.id)
             start_bd_uploader_job(auto_claim) if auto_claim.status != errored_state_value
             auto_claim.reload
           end
@@ -114,6 +114,8 @@ module ClaimsApi
             auto_claim, async: false
           ), status: :accepted, location: url_for(controller: 'claims', action: 'show', id: auto_claim.id)
         end
+
+        private
 
         def shared_submit_methods
           auto_claim = ClaimsApi::AutoEstablishedClaim.create(
@@ -136,7 +138,15 @@ module ClaimsApi
           auto_claim
         end
 
-        private
+        def generate_pdf_from_service!(auto_claim_id, veteran_middle_initial)
+          claim_status = pdf_generation_service.generate(auto_claim_id, veteran_middle_initial)
+
+          if claim_status == ClaimsApi::AutoEstablishedClaim::ERRORED
+            raise ::ClaimsApi::Common::Exceptions::Lighthouse::UnprocessableEntity.new(
+              detail: 'Failed to generate PDF'
+            )
+          end
+        end
 
         def generate_pdf_mapper_service(form_data, pdf_data_wrapper, auth_headers, middle_initial, created_at)
           ClaimsApi::V2::DisabilityCompensationPdfMapper.new(

--- a/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service.rb
@@ -46,7 +46,7 @@ module ClaimsApi
 
         log_job_progress(auto_claim.id, '526EZ PDF generator job finished', auto_claim.transaction_id)
 
-        auto_claim.id
+        auto_claim.status
       end
 
       def generate_mapped_claim(auto_claim, middle_initial)

--- a/modules/claims_api/spec/services/disability_compensation/pdf_generation_service_spec.rb
+++ b/modules/claims_api/spec/services/disability_compensation/pdf_generation_service_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../rails_helper'
 require './modules/claims_api/app/services/claims_api/disability_compensation/pdf_generation_service'
 
 describe ClaimsApi::DisabilityCompensation::PdfGenerationService do
-  let(:pdf_generation_service) { ClaimsApi::DisabilityCompensation::PdfGenerationService.new }
+  let(:pdf_generation_service) { described_class.new }
   let(:user) { FactoryBot.create(:user, :loa3) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
@@ -35,12 +35,12 @@ describe ClaimsApi::DisabilityCompensation::PdfGenerationService do
   end
 
   describe '#generate' do
-    it 'has a generate method that returns a claim id' do
+    it 'returns the claim status' do
       VCR.use_cassette('claims_api/pdf_client') do
         allow(pdf_generation_service).to receive(:generate_mapped_claim).with(claim,
                                                                               middle_initial).and_return(mapped_claim)
 
-        expect(pdf_generation_service.send(:generate, claim.id, middle_initial)).to be_a(String)
+        expect(pdf_generation_service.send(:generate, claim.id, middle_initial)).to eq('pending')
       end
     end
 
@@ -51,6 +51,20 @@ describe ClaimsApi::DisabilityCompensation::PdfGenerationService do
                                                                               middle_initial).and_return(mapped_claim)
         pdf_generation_service.send(:generate, claim.id, middle_initial)
         expect(Rails.logger).to have_received(:info).with(/#{claim.transaction_id}/).at_least(:once)
+      end
+    end
+
+    context 'when the pdf string is empty' do
+      before do
+        allow(pdf_generation_service).to receive(:generate_mapped_claim).with(claim,
+                                                                              middle_initial).and_return(mapped_claim)
+        allow(pdf_generation_service).to receive(:generate_526_pdf).with(mapped_claim).and_return('')
+      end
+
+      it 'returns the errored claim status' do
+        VCR.use_cassette('claims_api/pdf_client') do
+          expect(pdf_generation_service.send(:generate, claim.id, middle_initial)).to eq('errored')
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- In v2 526 synchronous submission, if the pdf string is empty, raise an exception and stop processing the claim.

## Related issue(s)

- [API-40614](https://jira.devops.va.gov/browse/API-40614)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

disability compensation v2 controller and pdf generation service

## Acceptance criteria

- [x]  I updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
