### PR TITLE
[Disability Benefits] Add missing dispatch logging to Form 526 ancillary document upload failure emails

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
@@ -80,7 +80,7 @@ module EVSS
             }
           )
 
-          StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
+          log_mailer_dispatch(form526_submission_id)
         end
       rescue => e
         retryable_error_handler(e)
@@ -93,6 +93,18 @@ module EVSS
         # which is included near the top of this job's inheritance tree in EVSS::DisabilityCompensationForm::JobStatus
         super(error)
         raise error
+      end
+
+      def log_mailer_dispatch(form526_submission_id)
+        Rails.logger.info(
+          'Form0781DocumentUploadFailureEmail notification dispatched',
+          {
+            form526_submission_id:,
+            timestamp: Time.now.utc
+          }
+        )
+
+        StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
       end
 
       def mailer_template_id

--- a/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
@@ -80,7 +80,7 @@ module EVSS
             }
           )
 
-          StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
+          log_mailer_dispatch(form526_submission_id)
         end
       rescue => e
         retryable_error_handler(e)
@@ -93,6 +93,18 @@ module EVSS
         # which is included near the top of this job's inheritance tree in EVSS::DisabilityCompensationForm::JobStatus
         super(error)
         raise error
+      end
+
+      def log_mailer_dispatch(form526_submission_id)
+        Rails.logger.info(
+          'Form4142DocumentUploadFailureEmail notification dispatched',
+          {
+            form526_submission_id:,
+            timestamp: Time.now.utc
+          }
+        )
+
+        StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
       end
 
       def mailer_template_id

--- a/spec/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email_spec.rb
@@ -38,9 +38,11 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form4142DocumentUploadFailureEm
   end
 
   describe 'logging' do
-    it 'increments a Statsd metric' do
+    before do
       allow(notification_client).to receive(:send_email)
+    end
 
+    it 'increments a Statsd metric' do
       expect do
         subject.perform_async(form526_submission.id)
         subject.drain
@@ -49,9 +51,25 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form4142DocumentUploadFailureEm
       )
     end
 
-    it 'creates a Form526JobStatus' do
-      allow(notification_client).to receive(:send_email)
+    it 'logs to the Rails logger' do
+      allow(Rails.logger).to receive(:info)
+      exhaustion_time = Time.new(1985, 10, 26).utc
 
+      Timecop.freeze(exhaustion_time) do
+        subject.perform_async(form526_submission.id)
+        subject.drain
+
+        expect(Rails.logger).to have_received(:info).with(
+          'Form4142DocumentUploadFailureEmail notification dispatched',
+          {
+            form526_submission_id: form526_submission.id,
+            timestamp: exhaustion_time
+          }
+        )
+      end
+    end
+
+    it 'creates a Form526JobStatus' do
       expect do
         subject.perform_async(form526_submission.id)
         subject.drain


### PR DESCRIPTION

## Summary

The Form0781DocumentUploadFailureEmail and Form4142DocumentUploadFailureEmail jobs are used to send VA Notify emails to Veterans when those respective forms fail to upload to EVSS so they can get instructions on a manual workaround.

These jobs were missing a logging statement for dispatching the email, which we want to use in DataDog to monitor the frequency and success rate of sending these emails


- *This work is behind a feature toggle (flipper): Yes and no, the Form 4142 mailer is live, the Form 0781 mailer will live soon (fixing this logging is required before launch


## Testing done

- [X] *New code is covered by unit tests*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) N/A
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [ ]  I added a screenshot of the developed feature N/A