### PR TITLE
Handle user_account in NotificationEmail

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -84,7 +84,7 @@ class FormSubmissionAttempt < ApplicationRecord
     SimpleFormsApi::NotificationEmail.new(
       config,
       notification_type:,
-      user: user_account
+      user_account:
     ).send(at: time_to_send)
   end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -2,7 +2,8 @@
 
 module SimpleFormsApi
   class NotificationEmail
-    attr_reader :form_number, :confirmation_number, :date_submitted, :lighthouse_updated_at, :notification_type, :user
+    attr_reader :form_number, :confirmation_number, :date_submitted, :lighthouse_updated_at, :notification_type, :user,
+                :user_account
 
     TEMPLATE_IDS = {
       'vba_21_0845' => {
@@ -53,7 +54,7 @@ module SimpleFormsApi
     }.freeze
     SUPPORTED_FORMS = TEMPLATE_IDS.keys
 
-    def initialize(config, notification_type: :confirmation, user: nil)
+    def initialize(config, notification_type: :confirmation, user: nil, user_account: nil)
       check_missing_keys(config)
 
       @form_data = config[:form_data]
@@ -68,13 +69,14 @@ module SimpleFormsApi
       @lighthouse_updated_at = config[:lighthouse_updated_at]
       @notification_type = notification_type
       @user = user
+      @user_account = user_account
     end
 
     def send(at: nil)
       return unless SUPPORTED_FORMS.include?(form_number)
 
       data = form_specific_data || empty_form_specific_data
-      return if data[:email].blank? || data[:personalization]['first_name'].blank?
+      return if data[:personalization]['first_name'].blank?
 
       template_id = TEMPLATE_IDS[form_number][notification_type]
       return unless template_id
@@ -95,15 +97,20 @@ module SimpleFormsApi
 
     def enqueue_email(at, template_id, data)
       # async job and we have a UserAccount
-      if user
+      if user_account
+        mpi_profile = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
+        first_name = mpi_profile.first_name
+        data[:personalization]['first_name'] = first_name
         VANotify::UserAccountJob.perform_at(
           at,
-          user.uuid,
+          user_account.id,
           template_id,
           data[:personalization]
         )
       # async job and we don't have a UserAccount but form data should include email
       else
+        return if data[:email].blank?
+
         VANotify::EmailJob.perform_at(
           at,
           data[:email],
@@ -114,12 +121,23 @@ module SimpleFormsApi
     end
 
     def send_email_now(template_id, data)
+      # sync job and we have a User
+      if user
+        VANotify::EmailJob.perform_async(
+          user.va_profile_email,
+          template_id,
+          data[:personalization]
+        )
       # sync job and form data should include email
-      VANotify::EmailJob.perform_async(
-        data[:email],
-        template_id,
-        data[:personalization]
-      )
+      else
+        return if data[:email].blank?
+
+        VANotify::EmailJob.perform_async(
+          data[:email],
+          template_id,
+          data[:personalization]
+        )
+      end
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -143,7 +161,7 @@ module SimpleFormsApi
         return unless Flipper.enabled?(:form21_0966_confirmation_email)
 
         {
-          email: @user.va_profile_email,
+          email: @user&.va_profile_email,
           personalization: default_personalization(@user.first_name)
             .merge(form21_0966_personalization)
         }
@@ -208,7 +226,7 @@ module SimpleFormsApi
     def form20_10206_contact_info
       # email address not required and omitted
       if @form_data['email_address'].blank? && @user
-        [@user.va_profile_email, @form_data.dig('full_name', 'first')]
+        [@user&.va_profile_email, @form_data.dig('full_name', 'first')]
 
       # email address not required and optionally entered
       else
@@ -222,7 +240,7 @@ module SimpleFormsApi
 
       return unless preparer_types.include?(@form_data['preparer_type'])
 
-      email_and_first_name = [@user.va_profile_email]
+      email_and_first_name = [@user&.va_profile_email]
       # veteran
       email_and_first_name << if @form_data['preparer_type'] == 'veteran'
                                 @form_data['veteran_full_name']['first']
@@ -243,7 +261,7 @@ module SimpleFormsApi
     def form21_0845_contact_info
       # (vet && signed in)
       if @form_data['authorizer_type'] == 'veteran' && @user
-        [@user.va_profile_email, @form_data.dig('veteran_full_name', 'first')]
+        [@user&.va_profile_email, @form_data.dig('veteran_full_name', 'first')]
 
       # (non-vet && signed in) || (non-vet && anon)
       elsif @form_data['authorizer_type'] == 'nonVeteran'
@@ -260,13 +278,13 @@ module SimpleFormsApi
       # user's own claim
       # user is a veteran
       if @form_data['claim_ownership'] == 'self' && @form_data['claimant_type'] == 'veteran'
-        email = user&.email || @form_data['veteran_email']
+        email = user&.va_profile_email || @form_data['veteran_email']
         [email, @form_data.dig('veteran_full_name', 'first')]
 
       # user's own claim
       # user is not a veteran
       elsif @form_data['claim_ownership'] == 'self' && @form_data['claimant_type'] == 'non-veteran'
-        email = user&.email || @form_data['claimant_email']
+        email = user&.va_profile_email || @form_data['claimant_email']
         [email, @form_data.dig('claimant_full_name', 'first')]
 
       # someone else's claim

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -616,11 +616,12 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
   end
 
   describe 'email confirmations' do
-    before do
-      sign_in
-    end
-
     let(:confirmation_number) { 'some_confirmation_number' }
+    let(:user) { build(:user) }
+
+    before do
+      sign_in(user)
+    end
 
     describe '21_4142' do
       let(:data) do
@@ -640,7 +641,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'veteran.surname@address.com',
+          user.va_profile_email,
           'form21_4142_confirmation_email_template_id',
           {
             'first_name' => 'VETERAN',
@@ -682,7 +683,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'my.long.email.address@email.com',
+          user.va_profile_email,
           'form21_10210_confirmation_email_template_id',
           {
             'first_name' => 'JACK',
@@ -730,7 +731,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'preparer_address@email.com',
+          user.va_profile_email,
           'form21p_0847_confirmation_email_template_id',
           {
             'first_name' => 'ARTHUR',
@@ -773,7 +774,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          'preparer@email.com',
+          user.va_profile_email,
           'form21_0972_confirmation_email_template_id',
           {
             'first_name' => 'PREPARE',

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -107,22 +107,24 @@ describe SimpleFormsApi::NotificationEmail do
       end
 
       context 'send at time is specified' do
-        context 'user is passed in' do
-          let(:email) { 'email@fromrecord.com' }
-          let(:user) { create(:user, { email: }) }
+        context 'user_account is passed in' do
+          let(:user_account) { create(:user_account) }
 
           it 'sends the email at the specified time' do
             time = double
+            mpi_profile = double(first_name: double)
             allow(VANotify::UserAccountJob).to receive(:perform_at)
-            subject = described_class.new(config, notification_type:, user:)
+            allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(mpi_profile)
+            subject = described_class.new(config, notification_type:, user_account:)
 
             subject.send(at: time)
 
-            expect(VANotify::UserAccountJob).to have_received(:perform_at).with(time, user.uuid, anything, anything)
+            expect(VANotify::UserAccountJob).to have_received(:perform_at).with(time, user_account.id, anything,
+                                                                                anything)
           end
         end
 
-        context 'user is not passed in' do
+        context 'user and user_account are not passed in' do
           it 'sends the email at the specified time' do
             time = double
             allow(VANotify::EmailJob).to receive(:perform_at)
@@ -152,8 +154,7 @@ describe SimpleFormsApi::NotificationEmail do
       context 'users own claim' do
         context 'is a veteran' do
           context 'user is passed in' do
-            let(:email) { 'email@fromrecord.com' }
-            let(:user) { build(:user, { email: }) }
+            let(:user) { build(:user) }
 
             it 'calls VANotify::EmailJob with user record email' do
               allow(VANotify::EmailJob).to receive(:perform_async)
@@ -165,7 +166,7 @@ describe SimpleFormsApi::NotificationEmail do
               subject.send
 
               expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                email,
+                user.va_profile_email,
                 "form21_10210_#{notification_type}_email_template_id",
                 {
                   'first_name' => 'JOHN',
@@ -202,8 +203,7 @@ describe SimpleFormsApi::NotificationEmail do
 
           context 'is not a veteran' do
             context 'user is passed in' do
-              let(:email) { 'email@fromrecord.com' }
-              let(:user) { build(:user, { email: }) }
+              let(:user) { build(:user) }
 
               it 'calls VANotify::EmailJob with user record email' do
                 allow(VANotify::EmailJob).to receive(:perform_async)
@@ -215,7 +215,7 @@ describe SimpleFormsApi::NotificationEmail do
                 subject.send
 
                 expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                  email,
+                  user.va_profile_email,
                   "form21_10210_#{notification_type}_email_template_id",
                   {
                     'first_name' => 'JOE',
@@ -409,16 +409,18 @@ describe SimpleFormsApi::NotificationEmail do
       end
 
       describe 'signed in user' do
+        let(:user) { create(:user) }
+
         it 'non-veteran authorizer' do
           allow(VANotify::EmailJob).to receive(:perform_async)
           data['authorizer_email'] = 'authorizer_email@example.com'
 
-          subject = described_class.new(config, user: create(:user))
+          subject = described_class.new(config, user:)
 
           subject.send
 
           expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            'authorizer_email@example.com',
+            user.va_profile_email,
             'form21_0845_confirmation_email_template_id',
             {
               'first_name' => 'JACK',

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe FormSubmissionAttempt, type: :model do
         allow(SimpleFormsApi::NotificationEmail).to receive(:new).with(
           config,
           notification_type:,
-          user: anything
+          user_account: anything
         ).and_return(notification_email)
         form_submission_attempt = create(:form_submission_attempt)
 
@@ -67,7 +67,7 @@ RSpec.describe FormSubmissionAttempt, type: :model do
         allow(SimpleFormsApi::NotificationEmail).to receive(:new).with(
           config,
           notification_type:,
-          user: anything
+          user_account: anything
         ).and_return(notification_email)
         form_submission_attempt = create(:form_submission_attempt)
 


### PR DESCRIPTION
## Summary
This PR is another attempt to handle `UserAccount`s in the `NotificationEmail`s that Simple Forms sends. I desperately want to refactor the `NotificationEmail` class but this needs to get out sooner than later. That tech debt will have to remain until zero silent failures is handled.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1709
