### PR TITLE
86426: Add logic to Sidekiq job to avoid duplicating logic if pending…

### DIFF
--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -54,4 +54,8 @@ class FormSubmission < ApplicationRecord
   def latest_pending_attempt
     form_submission_attempts.where(aasm_state: 'pending').order(created_at: :asc).last
   end
+
+  def non_failure_attempt
+    form_submission_attempts.where(aasm_state: %w[pending success]).first
+  end
 end

--- a/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
+++ b/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
@@ -105,11 +105,9 @@ module Pensions
     # or there are no matching FormSubmissionAttempt aasm_states
     #
     def form_submission_pending_or_success
-      form_submission = @claim&.form_submissions&.find do |submission|
-        submission.benefits_intake_uuid == @intake_service.uuid
-      end
-
-      form_submission&.non_failure_attempt.present? || false
+      @claim&.form_submissions&.any? do |form_submission|
+        form_submission.non_failure_attempt.present?
+      end || false
     end
 
     ##

--- a/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
+++ b/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
@@ -101,8 +101,8 @@ module Pensions
     ##
     # Check FormSubmissionAttempts for record with 'pending' or 'success'
     #
-    # @return false if unable to find a FormSubmission, matching the intake.uuid
-    # or there are no matching FormSubmissionAttempt aasm_states
+    # @return true if FormSubmissionAttempt has 'pending' or 'success'
+    # @return false if unable to find a FormSubmission or FormSubmissionAttempt not 'pending' or 'success'
     #
     def form_submission_pending_or_success
       @claim&.form_submissions&.any? do |form_submission|

--- a/modules/pensions/spec/factories/pension_claim.rb
+++ b/modules/pensions/spec/factories/pension_claim.rb
@@ -30,6 +30,12 @@ FactoryBot.define do
       end
     end
 
+    trait :success do
+      after(:create) do |pension_claim|
+        create(:form_submission, :success, saved_claim_id: pension_claim.id)
+      end
+    end
+
     trait :failure do
       after(:create) do |pension_claim|
         create(:form_submission, :failure, saved_claim_id: pension_claim.id)

--- a/modules/pensions/spec/factories/pension_claim.rb
+++ b/modules/pensions/spec/factories/pension_claim.rb
@@ -23,5 +23,17 @@ FactoryBot.define do
         statementOfTruthSignature: 'Test User'
       }.to_json
     end
+
+    trait :pending do
+      after(:create) do |pension_claim|
+        create(:form_submission, :pending, saved_claim_id: pension_claim.id)
+      end
+    end
+
+    trait :failure do
+      after(:create) do |pension_claim|
+        create(:form_submission, :failure, saved_claim_id: pension_claim.id)
+      end
+    end
   end
 end

--- a/modules/pensions/spec/sidekiq/pensions/pension_benefit_intake_job_spec.rb
+++ b/modules/pensions/spec/sidekiq/pensions/pension_benefit_intake_job_spec.rb
@@ -88,14 +88,11 @@ RSpec.describe Pensions::PensionBenefitIntakeJob, :uploader_helpers do
     before do
       job.instance_variable_set(:@claim, claim)
       allow(Pensions::SavedClaim).to receive(:find).and_return(claim)
-
-      job.instance_variable_set(:@intake_service, service)
-      allow(BenefitsIntake::Service).to receive(:new).and_return(service)
     end
 
     context 'with no form submissions' do
       it 'returns false' do
-        expect(job.send(:form_submission_pending_or_success)).to eq(false)
+        expect(job.send(:form_submission_pending_or_success)).to eq(false).or be_nil
       end
     end
 
@@ -103,8 +100,14 @@ RSpec.describe Pensions::PensionBenefitIntakeJob, :uploader_helpers do
       let(:claim) { create(:pensions_module_pension_claim, :pending) }
 
       it 'return true' do
-        allow(service).to receive(:uuid).and_return(claim.form_submissions.first.benefits_intake_uuid)
+        expect(job.send(:form_submission_pending_or_success)).to eq(true)
+      end
+    end
 
+    context 'with success form submission attempt' do
+      let(:claim) { create(:pensions_module_pension_claim, :success) }
+
+      it 'return true' do
         expect(job.send(:form_submission_pending_or_success)).to eq(true)
       end
     end
@@ -113,8 +116,6 @@ RSpec.describe Pensions::PensionBenefitIntakeJob, :uploader_helpers do
       let(:claim) { create(:pensions_module_pension_claim, :failure) }
 
       it 'return false' do
-        allow(service).to receive(:uuid).and_return(claim.form_submissions.first.benefits_intake_uuid)
-
         expect(job.send(:form_submission_pending_or_success)).to eq(false)
       end
     end

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -86,5 +86,21 @@ RSpec.describe FormSubmission, type: :model do
         expect(results.count).to eq(3)
       end
     end
+
+    context 'latest_pending_attempt' do
+      it 'returns db record' do
+        form_submission = FormSubmission.with_form_types(nil).first
+
+        expect(form_submission.latest_pending_attempt).not_to be_nil
+      end
+    end
+
+    context 'non_failure_attempt' do
+      it 'returns db record' do
+        form_submission = FormSubmission.with_form_types(nil).first
+
+        expect(form_submission.non_failure_attempt).not_to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
When we upload the claim to Lighthouse within the PensionBenefitsIntakeJob, if the job fails after we submit, there's no way to 'undo' this step, and we don't have any checks in place to see if the claim has already been submitted, so this step could get run more than once.

Update the Sidekiq job to check whether a copy of the claim has been successfully submitted to Lighthouse before attempting to submit the claim.

## Summary

- This work is behind a feature toggle (flipper): NO
- Add guard statement to `PensionBenefitIntakeJob` to return if there are pending or successful `FormSubmissionAttempts`
- Update `FactoryBot` for Pensions to allow mocking nested logic
- Update/Add Sidekiq job specs
- Add new method to `FormSubmission` model
- Add new `FormSubmission` spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86426

## Testing done

- [x] New code is covered by unit tests

## Acceptance criteria

- [x]  If a SavedClaim has FormSubmissions and at least one FormSubmissionAttempt that has the aasm_state of :pending or :success, then skip the rest of the retry.
