### PR TITLE
Simple Forms NotificationEmail bugfix on getting first_name

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -141,7 +141,11 @@ module SimpleFormsApi
     def get_first_name
       if user_account
         mpi_profile = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
-        mpi_profile.first_name
+        if mpi_profile
+          raise mpi_profile.error if mpi_profile.error
+
+          mpi_profile.first_name
+        end
       elsif user
         user.first_name
       end

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -98,9 +98,7 @@ module SimpleFormsApi
     def enqueue_email(at, template_id, data)
       # async job and we have a UserAccount
       if user_account
-        mpi_profile = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
-        first_name = mpi_profile.first_name
-        data[:personalization]['first_name'] = first_name
+        data[:personalization]['first_name'] = get_first_name
         VANotify::UserAccountJob.perform_at(
           at,
           user_account.id,
@@ -140,6 +138,15 @@ module SimpleFormsApi
       end
     end
 
+    def get_first_name
+      if user_account
+        mpi_profile = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
+        mpi_profile.first_name
+      elsif user
+        user.first_name
+      end
+    end
+
     # rubocop:disable Metrics/MethodLength
     # email and personalization hash
     def form_specific_data
@@ -162,7 +169,7 @@ module SimpleFormsApi
 
         {
           email: @user&.va_profile_email,
-          personalization: default_personalization(@user.first_name)
+          personalization: default_personalization(get_first_name)
             .merge(form21_0966_personalization)
         }
       when 'vba_21_0972'
@@ -226,7 +233,7 @@ module SimpleFormsApi
     def form20_10206_contact_info
       # email address not required and omitted
       if @form_data['email_address'].blank? && @user
-        [@user&.va_profile_email, @form_data.dig('full_name', 'first')]
+        [@user.va_profile_email, @form_data.dig('full_name', 'first')]
 
       # email address not required and optionally entered
       else
@@ -261,7 +268,7 @@ module SimpleFormsApi
     def form21_0845_contact_info
       # (vet && signed in)
       if @form_data['authorizer_type'] == 'veteran' && @user
-        [@user&.va_profile_email, @form_data.dig('veteran_full_name', 'first')]
+        [@user.va_profile_email, @form_data.dig('veteran_full_name', 'first')]
 
       # (non-vet && signed in) || (non-vet && anon)
       elsif @form_data['authorizer_type'] == 'nonVeteran'

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -143,10 +143,13 @@ module SimpleFormsApi
         mpi_profile = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
         if mpi_profile
           raise mpi_profile.error if mpi_profile.error
+          raise 'First name not found in MPI profile' unless mpi_profile.first_name
 
           mpi_profile.first_name
         end
       elsif user
+        raise 'First name not found in user profile' unless user.first_name
+
         user.first_name
       end
     end

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -112,7 +112,7 @@ describe SimpleFormsApi::NotificationEmail do
 
           it 'sends the email at the specified time' do
             time = double
-            mpi_profile = double(first_name: double)
+            mpi_profile = double(first_name: double, error: nil)
             allow(VANotify::UserAccountJob).to receive(:perform_at)
             allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(mpi_profile)
             subject = described_class.new(config, notification_type:, user_account:)


### PR DESCRIPTION
## Summary
This PR is necessary because, while the nightly job worked fine on staging, I just ran it on prod and it threw an error about calling `first_name` on `nil`. This was happening for a 21-0966 email.
