### PR TITLE
Update bin/setup native for PostGIS check 

### DIFF
--- a/bin/lib/vets-api/setups/native.rb
+++ b/bin/lib/vets-api/setups/native.rb
@@ -16,7 +16,7 @@ module VetsApi
         if RbConfig::CONFIG['host_os'] =~ /darwin/i
           install_postgres
           run_brewfile
-          pex_install_postgis
+          validate_postgis_installed
           configuring_clamav_antivirus
           install_pdftk
         else
@@ -70,8 +70,9 @@ module VetsApi
         puts 'Done'
       end
 
-      def pex_install_postgis
-        return if ShellCommand.run("psql -U postgres -d vets-api -c 'SELECT PostGIS_Version();' | grep -q '(1 row)'")
+      def validate_postgis_installed
+        ShellCommand.run_quiet("psql -U postgres -d postgres -c 'CREATE EXTENSION IF NOT EXISTS postgis;'")
+        return if ShellCommand.run("psql -U postgres -d postgres -c 'SELECT PostGIS_Version();' | grep -q '(1 row)'")
 
         g_cppflags = '-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H -I/usr/local/include'
         cflags = '-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H -I/usr/local/include'


### PR DESCRIPTION
## Summary

- Creates Extension if it doesn't exists 
- Validates PostGIS on postgres DB instead of vets-api (which might not be installed)


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94234

## Testing done

- Deleted vets-api and re-ran bin/setup 

## Acceptance criteria

- [x] bin/setup completes
- [x] vets-api postgres database is created