### PR TITLE
Adding nbf field to SiS STS access token which describes the start time the token should be considered valid

### DIFF
--- a/app/services/sign_in/service_account_access_token_jwt_encoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_encoder.rb
@@ -26,6 +26,7 @@ module SignIn
         sub: service_account_access_token.user_identifier,
         exp: service_account_access_token.expiration_time.to_i,
         iat: service_account_access_token.created_time.to_i,
+        nbf: service_account_access_token.created_time.to_i,
         version: service_account_access_token.version,
         scopes: service_account_access_token.scopes,
         service_account_id: service_account_access_token.service_account_id,

--- a/spec/services/sign_in/service_account_access_token_jwt_encoder_spec.rb
+++ b/spec/services/sign_in/service_account_access_token_jwt_encoder_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SignIn::ServiceAccountAccessTokenJwtEncoder do
       let(:expected_sub) { service_account_access_token.user_identifier }
       let(:expected_exp) { service_account_access_token.expiration_time.to_i }
       let(:expected_iat) { service_account_access_token.created_time.to_i }
+      let(:expected_nbf) { service_account_access_token.created_time.to_i }
       let(:expected_version) { service_account_access_token.version }
       let(:expected_scopes) { service_account_access_token.scopes }
       let(:expected_service_account_id) { service_account_access_token.service_account_id }
@@ -32,6 +33,7 @@ RSpec.describe SignIn::ServiceAccountAccessTokenJwtEncoder do
         expect(decoded_jwt.sub).to eq expected_sub
         expect(decoded_jwt.exp).to eq expected_exp
         expect(decoded_jwt.iat).to eq expected_iat
+        expect(decoded_jwt.nbf).to eq expected_nbf
         expect(decoded_jwt.version).to eq expected_version
         expect(decoded_jwt.scopes).to eq expected_scopes
         expect(decoded_jwt.service_account_id).to eq expected_service_account_id


### PR DESCRIPTION
## Summary

- This PR adds the `nbf` (not before) field to the SiS STS access token. This is essentially the same as the `iat` field, so is just an alias to that field

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-538

## Testing done

- [ ] Created a SiS STS token request
- [ ] Confirmed the created access token had an `nbf` field

## What areas of the site does it impact?
STS Authentication

## Acceptance criteria

- [ ]  Using any Sign in Service Service Account Configuration, send a request assertion for an access token
- [ ] Confirm the access token has the `nbf` field, and that it matches the `iat` value
