### PR TITLE
Add optional VPG routing to clinic requests

### DIFF
--- a/modules/mobile/spec/requests/mobile/v0/appointments/facilities/clinics_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appointments/facilities/clinics_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe 'Mobile::V0::Appointments::Facilities::Clinics', type: :request d
 
             expect(response).to have_http_status(:bad_request)
             expect(JSON.parse(response.parsed_body.dig('errors', 0, 'source',
-                                                       'vamfBody'))['message']).to eq('clinicalService: param is invalid')
+                                                       'vamfBody')) ['message'])
+              .to eq('clinicalService: param is invalid')
           end
         end
       end
@@ -108,7 +109,8 @@ RSpec.describe 'Mobile::V0::Appointments::Facilities::Clinics', type: :request d
 
             expect(response).to have_http_status(:bad_request)
             expect(JSON.parse(response.parsed_body.dig('errors', 0, 'source',
-                                                       'vamfBody'))['message']).to eq('clinicalService: param is invalid')
+                                                       'vamfBody'))['message'])
+              .to eq('clinicalService: param is invalid')
           end
         end
       end

--- a/modules/mobile/spec/requests/mobile/v0/appointments/facilities/clinics_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appointments/facilities/clinics_spec.rb
@@ -12,47 +12,104 @@ RSpec.describe 'Mobile::V0::Appointments::Facilities::Clinics', type: :request d
   end
 
   describe 'GET /mobile/v0/appointments/facilities/:facility_id/clinics', :aggregate_failures do
-    context 'when both facility id and service type is found' do
-      let(:facility_id) { '983' }
-      let(:params) { { service_type: 'audiology' } }
+    context 'using VAOS' do
+      before do
+        Flipper.disable(:va_online_scheduling_use_vpg)
+      end
 
-      it 'returns 200' do
-        VCR.use_cassette('mobile/appointments/get_facility_clinics_200', match_requests_on: %i[method uri]) do
-          get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+      context 'when both facility id and service type is found' do
+        let(:facility_id) { '983' }
+        let(:params) { { service_type: 'audiology' } }
 
-          expect(response).to have_http_status(:ok)
-          expect(response.body).to match_json_schema('clinic')
+        it 'returns 200' do
+          VCR.use_cassette('mobile/appointments/get_facility_clinics_200', match_requests_on: %i[method uri]) do
+            get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to match_json_schema('clinic')
+          end
+        end
+      end
+
+      context 'when facility id is not found' do
+        let(:facility_id) { '999AA' }
+        let(:params) { { service_type: 'audiology' } }
+
+        it 'returns 200 with empty response' do
+          VCR.use_cassette('mobile/appointments/get_facility_clinics_bad_facility_id_200',
+                           match_requests_on: %i[method uri]) do
+            get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['data']).to eq([])
+          end
+        end
+      end
+
+      context 'when service type is not found' do
+        let(:facility_id) { '983' }
+        let(:params) { { service_type: 'badservice' } }
+
+        it 'returns bad request' do
+          VCR.use_cassette('mobile/appointments/get_facility_clinics_bad_service_400',
+                           match_requests_on: %i[method uri]) do
+            get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+
+            expect(response).to have_http_status(:bad_request)
+            expect(JSON.parse(response.parsed_body.dig('errors', 0, 'source',
+                                                       'vamfBody'))['message']).to eq('clinicalService: param is invalid')
+          end
         end
       end
     end
 
-    context 'when facility id is not found' do
-      let(:facility_id) { '999AA' }
-      let(:params) { { service_type: 'audiology' } }
+    context 'using VPG' do
+      before do
+        Flipper.enable(:va_online_scheduling_use_vpg)
+      end
 
-      it 'returns 200 with empty response' do
-        VCR.use_cassette('mobile/appointments/get_facility_clinics_bad_facility_id_200',
-                         match_requests_on: %i[method uri]) do
-          get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+      context 'when both facility id and service type is found' do
+        let(:facility_id) { '983' }
+        let(:params) { { service_type: 'audiology' } }
 
-          expect(response).to have_http_status(:ok)
-          expect(response.parsed_body['data']).to eq([])
+        it 'returns 200' do
+          VCR.use_cassette('mobile/appointments/get_facility_clinics_200_vpg', match_requests_on: %i[method uri]) do
+            get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to match_json_schema('clinic')
+          end
         end
       end
-    end
 
-    context 'when service type is not found' do
-      let(:facility_id) { '983' }
-      let(:params) { { service_type: 'badservice' } }
+      context 'when facility id is not found' do
+        let(:facility_id) { '999AA' }
+        let(:params) { { service_type: 'audiology' } }
 
-      it 'returns bad request' do
-        VCR.use_cassette('mobile/appointments/get_facility_clinics_bad_service_400',
-                         match_requests_on: %i[method uri]) do
-          get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+        it 'returns 200 with empty response' do
+          VCR.use_cassette('mobile/appointments/get_facility_clinics_bad_facility_id_200_vpg',
+                           match_requests_on: %i[method uri]) do
+            get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
 
-          expect(response).to have_http_status(:bad_request)
-          expect(JSON.parse(response.parsed_body.dig('errors', 0, 'source',
-                                                     'vamfBody'))['message']).to eq('clinicalService: param is invalid')
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['data']).to eq([])
+          end
+        end
+      end
+
+      context 'when service type is not found' do
+        let(:facility_id) { '983' }
+        let(:params) { { service_type: 'badservice' } }
+
+        it 'returns bad request' do
+          VCR.use_cassette('mobile/appointments/get_facility_clinics_bad_service_400_vpg',
+                           match_requests_on: %i[method uri]) do
+            get "/mobile/v0/appointments/facilities/#{facility_id}/clinics", params:, headers: sis_headers
+
+            expect(response).to have_http_status(:bad_request)
+            expect(JSON.parse(response.parsed_body.dig('errors', 0, 'source',
+                                                       'vamfBody'))['message']).to eq('clinicalService: param is invalid')
+          end
         end
       end
     end

--- a/modules/vaos/app/services/vaos/v2/systems_service.rb
+++ b/modules/vaos/app/services/vaos/v2/systems_service.rb
@@ -9,20 +9,6 @@ module VAOS
                                page_size: nil,
                                page_number: nil)
         with_monitoring do
-          # page_size = 0 if page_size.nil? # 0 is the default for the VAOS service which means return all clinics
-          # url = "/vaos/v1/locations/#{location_id}/clinics"
-          # url_params = {
-          #   'patientIcn' => get_icn(clinical_service),
-          #   'clinicIds' => get_clinic_ids(clinic_ids),
-          #   'clinicalService' => clinical_service,
-          #   'pageSize' => page_size,
-          #   'pageNumber' => page_number
-          # }.compact
-          #
-          # #  'clinicalService' is used when retrieving clinics for appointment scheduling,
-          # #  triggering stop code filtering to avoid displaying unavailable clinics.
-          # url_params.merge!('enableStopCodeFilter' => true) if url_params['clinicalService'].present?
-
           response = get_clinics(location_id:, clinical_service:, clinic_ids:, page_size:, page_number:)
           response.body[:data].map { |clinic| OpenStruct.new(clinic) }
         end

--- a/modules/vaos/app/services/vaos/v2/systems_service.rb
+++ b/modules/vaos/app/services/vaos/v2/systems_service.rb
@@ -9,21 +9,21 @@ module VAOS
                                page_size: nil,
                                page_number: nil)
         with_monitoring do
-          page_size = 0 if page_size.nil? # 0 is the default for the VAOS service which means return all clinics
-          url = "/vaos/v1/locations/#{location_id}/clinics"
-          url_params = {
-            'patientIcn' => get_icn(clinical_service),
-            'clinicIds' => get_clinic_ids(clinic_ids),
-            'clinicalService' => clinical_service,
-            'pageSize' => page_size,
-            'pageNumber' => page_number
-          }.compact
+          # page_size = 0 if page_size.nil? # 0 is the default for the VAOS service which means return all clinics
+          # url = "/vaos/v1/locations/#{location_id}/clinics"
+          # url_params = {
+          #   'patientIcn' => get_icn(clinical_service),
+          #   'clinicIds' => get_clinic_ids(clinic_ids),
+          #   'clinicalService' => clinical_service,
+          #   'pageSize' => page_size,
+          #   'pageNumber' => page_number
+          # }.compact
+          #
+          # #  'clinicalService' is used when retrieving clinics for appointment scheduling,
+          # #  triggering stop code filtering to avoid displaying unavailable clinics.
+          # url_params.merge!('enableStopCodeFilter' => true) if url_params['clinicalService'].present?
 
-          #  'clinicalService' is used when retrieving clinics for appointment scheduling,
-          #  triggering stop code filtering to avoid displaying unavailable clinics.
-          url_params.merge!('enableStopCodeFilter' => true) if url_params['clinicalService'].present?
-
-          response = perform(:get, url, url_params, headers)
+          response = get_clinics(location_id:, clinical_service:, clinic_ids:, page_size:, page_number:)
           response.body[:data].map { |clinic| OpenStruct.new(clinic) }
         end
       end
@@ -42,6 +42,28 @@ module VAOS
       end
 
       private
+
+      def get_clinics(location_id:, clinical_service:, clinic_ids:, page_size:, page_number:)
+        page_size = 0 if page_size.nil? # 0 is the default for the VAOS service which means return all clinics
+        url = if Flipper.enabled?(:va_online_scheduling_use_vpg, user)
+                "/vpg/v1/locations/#{location_id}/clinics"
+              else
+                "/vaos/v1/locations/#{location_id}/clinics"
+              end
+
+        url_params = {
+          'patientIcn' => get_icn(clinical_service),
+          'clinicIds' => get_clinic_ids(clinic_ids),
+          'clinicalService' => clinical_service,
+          'pageSize' => page_size,
+          'pageNumber' => page_number
+        }.compact
+
+        #  'clinicalService' is used when retrieving clinics for appointment scheduling,
+        #  triggering stop code filtering to avoid displaying unavailable clinics.
+        url_params.merge!('enableStopCodeFilter' => true) if url_params['clinicalService'].present?
+        perform(:get, url, url_params, headers)
+      end
 
       # Patient icn is only valid if the clinical service is of type primary care.
       def get_icn(clinical_service)

--- a/modules/vaos/spec/requests/vaos/v2/locations/clinics_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/locations/clinics_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
 
         context 'on successful query for clinics given service type' do
           it 'returns a list of clinics' do
-            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg',
+                             match_requests_on: %i[method path query]) do
               get '/vaos/v2/locations/983/clinics?clinical_service=audiology', headers: inflection_header
               expect(response).to have_http_status(:ok)
               expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
@@ -118,7 +119,8 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
 
         context 'on successful query for clinics given csv clinic ids' do
           it 'returns a list of clinics' do
-            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg',
+                             match_requests_on: %i[method path query]) do
               get '/vaos/v2/locations/983/clinics?clinic_ids=570,945', headers: inflection_header
               expect(response).to have_http_status(:ok)
               expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
@@ -133,7 +135,8 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
 
         context 'on successful query for clinics given array clinic ids' do
           it 'returns a list of clinics' do
-            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg',
+                             match_requests_on: %i[method path query]) do
               get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinic_ids[]=945', headers: inflection_header
               expect(response).to have_http_status(:ok)
               expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
@@ -144,7 +147,8 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
 
         context 'on successful query for clinics given an array with a single clinic id' do
           it 'returns a single clinic' do
-            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg',
+                             match_requests_on: %i[method path query]) do
               get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
               expect(response).to have_http_status(:ok)
               expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
@@ -155,7 +159,8 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
 
         context 'on successful query for clinics given an array with a single clinic id when camel-inflected' do
           it 'returns a single clinic' do
-            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg',
+                             match_requests_on: %i[method path query]) do
               get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
               expect(response).to have_http_status(:ok)
               expect(JSON.parse(response.body)['data'].size).to eq(1)
@@ -166,7 +171,8 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
 
         context 'on sending a bad request to the VAOS Service' do
           it 'returns a 400 http status' do
-            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400_vpg', match_requests_on: %i[method path query]) do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400_vpg',
+                             match_requests_on: %i[method path query]) do
               get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinical_service=audiology'
               expect(response).to have_http_status(:bad_request)
               expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')

--- a/modules/vaos/spec/requests/vaos/v2/locations/clinics_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/locations/clinics_spec.rb
@@ -17,75 +17,160 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
     let(:user) { build(:user, :mhv) }
 
     describe 'GET facility clinics' do
-      context 'on successful query for clinics given service type' do
-        it 'returns a list of clinics' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
-            get '/vaos/v2/locations/983/clinics?clinical_service=audiology', headers: inflection_header
-            expect(response).to have_http_status(:ok)
-            expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
-            x = JSON.parse(response.body)
-            expect(x['data'].size).to eq(7)
-            expect(x['data'][0]['id']).to eq('570')
-            expect(x['data'][0]['type']).to eq('clinics')
-            expect(x['data'][0]['attributes']['serviceName']).to eq('CHY C&P AUDIO')
+      context 'using VAOS' do
+        before do
+          Flipper.disable(:va_online_scheduling_use_vpg)
+        end
+
+        context 'on successful query for clinics given service type' do
+          it 'returns a list of clinics' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinical_service=audiology', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              x = JSON.parse(response.body)
+              expect(x['data'].size).to eq(7)
+              expect(x['data'][0]['id']).to eq('570')
+              expect(x['data'][0]['type']).to eq('clinics')
+              expect(x['data'][0]['attributes']['serviceName']).to eq('CHY C&P AUDIO')
+            end
+          end
+        end
+
+        context 'on successful query for clinics given csv clinic ids' do
+          it 'returns a list of clinics' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids=570,945', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              x = JSON.parse(response.body)
+              expect(x['data'].size).to eq(2)
+              expect(x['data'][1]['id']).to eq('945')
+              expect(x['data'][1]['type']).to eq('clinics')
+              expect(x['data'][1]['attributes']['serviceName']).to eq('FTC C&P AUDIO BEV')
+            end
+          end
+        end
+
+        context 'on successful query for clinics given array clinic ids' do
+          it 'returns a list of clinics' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinic_ids[]=945', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              expect(JSON.parse(response.body)['data'].size).to eq(2)
+            end
+          end
+        end
+
+        context 'on successful query for clinics given an array with a single clinic id' do
+          it 'returns a single clinic' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              expect(JSON.parse(response.body)['data'].size).to eq(1)
+            end
+          end
+        end
+
+        context 'on successful query for clinics given an array with a single clinic id when camel-inflected' do
+          it 'returns a single clinic' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(JSON.parse(response.body)['data'].size).to eq(1)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics')
+            end
+          end
+        end
+
+        context 'on sending a bad request to the VAOS Service' do
+          it 'returns a 400 http status' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinical_service=audiology'
+              expect(response).to have_http_status(:bad_request)
+              expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')
+            end
           end
         end
       end
 
-      context 'on successful query for clinics given csv clinic ids' do
-        it 'returns a list of clinics' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
-            get '/vaos/v2/locations/983/clinics?clinic_ids=570,945', headers: inflection_header
-            expect(response).to have_http_status(:ok)
-            expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
-            x = JSON.parse(response.body)
-            expect(x['data'].size).to eq(2)
-            expect(x['data'][1]['id']).to eq('945')
-            expect(x['data'][1]['type']).to eq('clinics')
-            expect(x['data'][1]['attributes']['serviceName']).to eq('FTC C&P AUDIO BEV')
+      context 'using VPG' do
+        before do
+          Flipper.enable(:va_online_scheduling_use_vpg)
+        end
+
+        context 'on successful query for clinics given service type' do
+          it 'returns a list of clinics' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinical_service=audiology', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              x = JSON.parse(response.body)
+              expect(x['data'].size).to eq(7)
+              expect(x['data'][0]['id']).to eq('570')
+              expect(x['data'][0]['type']).to eq('clinics')
+              expect(x['data'][0]['attributes']['serviceName']).to eq('CHY C&P AUDIO')
+            end
           end
         end
-      end
 
-      context 'on successful query for clinics given array clinic ids' do
-        it 'returns a list of clinics' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
-            get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinic_ids[]=945', headers: inflection_header
-            expect(response).to have_http_status(:ok)
-            expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
-            expect(JSON.parse(response.body)['data'].size).to eq(2)
+        context 'on successful query for clinics given csv clinic ids' do
+          it 'returns a list of clinics' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids=570,945', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              x = JSON.parse(response.body)
+              expect(x['data'].size).to eq(2)
+              expect(x['data'][1]['id']).to eq('945')
+              expect(x['data'][1]['type']).to eq('clinics')
+              expect(x['data'][1]['attributes']['serviceName']).to eq('FTC C&P AUDIO BEV')
+            end
           end
         end
-      end
 
-      context 'on successful query for clinics given an array with a single clinic id' do
-        it 'returns a single clinic' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
-            get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
-            expect(response).to have_http_status(:ok)
-            expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
-            expect(JSON.parse(response.body)['data'].size).to eq(1)
+        context 'on successful query for clinics given array clinic ids' do
+          it 'returns a list of clinics' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinic_ids[]=945', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              expect(JSON.parse(response.body)['data'].size).to eq(2)
+            end
           end
         end
-      end
 
-      context 'on successful query for clinics given an array with a single clinic id when camel-inflected' do
-        it 'returns a single clinic' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
-            get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
-            expect(response).to have_http_status(:ok)
-            expect(JSON.parse(response.body)['data'].size).to eq(1)
-            expect(response.body).to match_camelized_schema('vaos/v2/clinics')
+        context 'on successful query for clinics given an array with a single clinic id' do
+          it 'returns a single clinic' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
+              expect(JSON.parse(response.body)['data'].size).to eq(1)
+            end
           end
         end
-      end
 
-      context 'on sending a bad request to the VAOS Service' do
-        it 'returns a 400 http status' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
-            get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinical_service=audiology'
-            expect(response).to have_http_status(:bad_request)
-            expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')
+        context 'on successful query for clinics given an array with a single clinic id when camel-inflected' do
+          it 'returns a single clinic' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
+              expect(response).to have_http_status(:ok)
+              expect(JSON.parse(response.body)['data'].size).to eq(1)
+              expect(response.body).to match_camelized_schema('vaos/v2/clinics')
+            end
+          end
+        end
+
+        context 'on sending a bad request to the VAOS Service' do
+          it 'returns a 400 http status' do
+            VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400_vpg', match_requests_on: %i[method path query]) do
+              get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinical_service=audiology'
+              expect(response).to have_http_status(:bad_request)
+              expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')
+            end
           end
         end
       end
@@ -113,7 +198,7 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
           end
         end
 
-        context 'on unccessful query for latest appointment within look back limit' do
+        context 'on unsuccessful query for latest appointment within look back limit' do
           it 'returns a 404 http status' do
             expect_any_instance_of(VAOS::V2::AppointmentsService)
               .to receive(:get_most_recent_visited_clinic_appointment)

--- a/modules/vaos/spec/services/v2/systems_service_spec.rb
+++ b/modules/vaos/spec/services/v2/systems_service_spec.rb
@@ -10,22 +10,60 @@ describe VAOS::V2::SystemsService do
   before { allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token') }
 
   describe '#get_facility_clinics' do
-    context 'with 7 clinics' do
-      it 'returns an array of size 7' do
-        VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
-          response = subject.get_facility_clinics(location_id: '983', clinical_service: 'audiology')
-          expect(response.size).to eq(7)
-          expect(response[0][:id]).to eq('570')
+    context 'using VAOS' do
+      before do
+        Flipper.disable(:va_online_scheduling_use_vpg)
+      end
+
+      context 'with 7 clinics' do
+        it 'returns an array of size 7' do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
+            response = subject.get_facility_clinics(location_id: '983', clinical_service: 'audiology')
+            expect(response.size).to eq(7)
+            expect(response[0][:id]).to eq('570')
+          end
+        end
+      end
+
+      context 'when the upstream server returns a 400' do
+        before do
+          Flipper.disable(:va_online_scheduling_use_vpg)
+        end
+        it 'raises a backend exception' do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
+            expect do
+              subject.get_facility_clinics(location_id: '983', clinic_ids: '570', clinical_service: 'audiology')
+            end.to raise_error(Common::Exceptions::BackendServiceException, /VAOS_400/)
+          end
         end
       end
     end
 
-    context 'when the upstream server returns a 400' do
-      it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
-          expect do
-            subject.get_facility_clinics(location_id: '983', clinic_ids: '570', clinical_service: 'audiology')
-          end.to raise_error(Common::Exceptions::BackendServiceException, /VAOS_400/)
+    context 'using VPG' do
+      before do
+        Flipper.enable(:va_online_scheduling_use_vpg)
+      end
+
+      context 'with 7 clinics' do
+        it 'returns an array of size 7' do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200_vpg', match_requests_on: %i[method path query]) do
+            response = subject.get_facility_clinics(location_id: '983', clinical_service: 'audiology')
+            expect(response.size).to eq(7)
+            expect(response[0][:id]).to eq('570')
+          end
+        end
+      end
+
+      context 'when the upstream server returns a 400' do
+        before do
+          Flipper.disable(:va_online_scheduling_use_vpg)
+        end
+        it 'raises a backend exception' do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
+            expect do
+              subject.get_facility_clinics(location_id: '983', clinic_ids: '570', clinical_service: 'audiology')
+            end.to raise_error(Common::Exceptions::BackendServiceException, /VAOS_400/)
+          end
         end
       end
     end

--- a/modules/vaos/spec/services/v2/systems_service_spec.rb
+++ b/modules/vaos/spec/services/v2/systems_service_spec.rb
@@ -29,6 +29,7 @@ describe VAOS::V2::SystemsService do
         before do
           Flipper.disable(:va_online_scheduling_use_vpg)
         end
+
         it 'raises a backend exception' do
           VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
             expect do
@@ -58,6 +59,7 @@ describe VAOS::V2::SystemsService do
         before do
           Flipper.disable(:va_online_scheduling_use_vpg)
         end
+
         it 'raises a backend exception' do
           VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
             expect do

--- a/spec/support/vcr_cassettes/mobile/appointments/get_facility_clinics_200_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/get_facility_clinics_200_vpg.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/locations/983/clinics?clinicalService=audiology&enableStopCodeFilter=true&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 08 Oct 2021 17:16:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2066'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.10.0
+      B3:
+      - d59a397d6ff313e3-0534a9f1c0bcf50e-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 58ec2e2
+      X-Vamf-Timestamp:
+      - '2021-08-18T13:44:12+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"vistaSite":983,"id":"570","serviceName":"CHY C&P AUDIO","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS","patientDirectScheduling":false,"patientDisplay":true},{"vistaSite":983,"id":"945","serviceName":"FTC
+        C&P AUDIO BEV","physicalLocation":"FORT COLLINS AUDIO","stationId":"983GC","stationName":"CHYSHR-Fort
+        Collins VA Clinic","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS","patientDirectScheduling":true,"patientDisplay":true},{"vistaSite":983,"id":"947","serviceName":"CHY
+        C&P AUDIO JAN","physicalLocation":"C&P OFFICE","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS"},{"vistaSite":983,"id":"1014","serviceName":"CHY AUDIOLOGY","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","patientDirectScheduling":true,"patientDisplay":true},{"vistaSite":983,"id":"1020","serviceName":"WHT
+        AUDIO VAR2","physicalLocation":"WHEATLAND","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCodeName":"*Missing*","patientDirectScheduling":true,"patientDisplay":true},{"vistaSite":983,"id":"1022","serviceName":"TOR
+        C&P LORI","stationId":"983","stationName":"CHYSHR-Cheyenne VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS"},{"vistaSite":983,"id":"1072","serviceName":"WHT HEARING
+        AID LORI","physicalLocation":"WHEATLAND","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":449,"secondaryStopCodeName":"FITTING
+        & ADJSTMNTS 2ND ONLY"}]}'
+  recorded_at: Fri, 08 Oct 2021 17:16:25 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/get_facility_clinics_bad_facility_id_200_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/get_facility_clinics_bad_facility_id_200_vpg.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://veteran.apps.va.gov/vpg/v1/locations/999AA/clinics?clinicalService=audiology&enableStopCodeFilter=true&pageSize=0
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://review-instance.va.gov
+        X-Vamf-Jwt:
+          - stubbed_token
+        X-Request-Id:
+          - ''
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Fri, 08 Oct 2021 17:16:25 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '2066'
+        Server:
+          - openresty
+        X-Vamf-Version:
+          - 1.10.0
+        B3:
+          - d59a397d6ff313e3-0534a9f1c0bcf50e-1
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        X-Vamf-Build:
+          - 58ec2e2
+        X-Vamf-Timestamp:
+          - '2021-08-18T13:44:12+0000'
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - '3600'
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: '{"data": []}'
+    recorded_at: Fri, 08 Oct 2021 17:16:25 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/mobile/appointments/get_facility_clinics_bad_service_400_vpg.yml
+++ b/spec/support/vcr_cassettes/mobile/appointments/get_facility_clinics_bad_service_400_vpg.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/locations/983/clinics?clinicalService=badservice&enableStopCodeFilter=true&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Fri, 08 Oct 2021 17:16:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '64'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.10.0
+      B3:
+      - 94e118652ec116aa-39b8b9a2242919c3-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 58ec2e2
+      X-Vamf-Timestamp:
+      - '2021-08-18T13:44:12+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+    body:
+      encoding: UTF-8
+      string: '{"message":"clinicalService: param is invalid"}'
+  recorded_at: Fri, 08 Oct 2021 17:16:24 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/vaos/v2/systems/get_facility_clinics_200_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/systems/get_facility_clinics_200_vpg.yml
@@ -1,0 +1,194 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/locations/983/clinics?clinicalService=audiology&enableStopCodeFilter=true&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 08 Oct 2021 17:16:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2066'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.10.0
+      B3:
+      - d59a397d6ff313e3-0534a9f1c0bcf50e-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 58ec2e2
+      X-Vamf-Timestamp:
+      - '2021-08-18T13:44:12+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"vistaSite":983,"id":"570","serviceName":"CHY C&P AUDIO","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS","patientDirectScheduling":false,"patientDisplay":true},{"vistaSite":983,"id":"945","serviceName":"FTC
+        C&P AUDIO BEV","physicalLocation":"FORT COLLINS AUDIO","stationId":"983GC","stationName":"CHYSHR-Fort
+        Collins VA Clinic","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS","patientDirectScheduling":true,"patientDisplay":true},{"vistaSite":983,"id":"947","serviceName":"CHY
+        C&P AUDIO JAN","physicalLocation":"C&P OFFICE","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS"},{"vistaSite":983,"id":"1014","serviceName":"CHY AUDIOLOGY","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","patientDirectScheduling":true,"patientDisplay":true},{"vistaSite":983,"id":"1020","serviceName":"WHT
+        AUDIO VAR2","physicalLocation":"WHEATLAND","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCodeName":"*Missing*","patientDirectScheduling":true,"patientDisplay":true},{"vistaSite":983,"id":"1022","serviceName":"TOR
+        C&P LORI","stationId":"983","stationName":"CHYSHR-Cheyenne VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS"},{"vistaSite":983,"id":"1072","serviceName":"WHT HEARING
+        AID LORI","physicalLocation":"WHEATLAND","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":449,"secondaryStopCodeName":"FITTING
+        & ADJSTMNTS 2ND ONLY"}]}'
+  recorded_at: Fri, 08 Oct 2021 17:16:25 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/locations/983/clinics?clinicIds=570&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 08 Oct 2021 18:39:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '321'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.10.0
+      B3:
+      - fb526a32c61e30ea-13c8646788450d07-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 58ec2e2
+      X-Vamf-Timestamp:
+      - '2021-08-18T13:44:12+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"vistaSite":983,"id":"570","serviceName":"CHY C&P AUDIO","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS","patientDirectScheduling":false,"patientDisplay":true}]}'
+  recorded_at: Fri, 08 Oct 2021 18:39:57 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/locations/983/clinics?clinicIds=570,945&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 08 Oct 2021 18:43:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '673'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.10.0
+      B3:
+      - '08b731bfc160b666-23723de99bd8a7c2-1'
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 58ec2e2
+      X-Vamf-Timestamp:
+      - '2021-08-18T13:44:12+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"vistaSite":983,"id":"570","serviceName":"CHY C&P AUDIO","stationId":"983","stationName":"CHYSHR-Cheyenne
+        VA Medical Center","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS","patientDirectScheduling":false,"patientDisplay":true},{"vistaSite":983,"id":"945","serviceName":"FTC
+        C&P AUDIO BEV","physicalLocation":"FORT COLLINS AUDIO","stationId":"983GC","stationName":"CHYSHR-Fort
+        Collins VA Clinic","primaryStopCode":203,"primaryStopCodeName":"AUDIOLOGY","secondaryStopCode":450,"secondaryStopCodeName":"COMP
+        & PENS (C&P) EXAMS","patientDirectScheduling":true,"patientDisplay":true}]}'
+  recorded_at: Fri, 08 Oct 2021 18:43:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/vaos/v2/systems/get_facility_clinics_400_vpg.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/systems/get_facility_clinics_400_vpg.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/vpg/v1/locations/983/clinics?clinicIds=570&clinicalService=audiology&enableStopCodeFilter=true&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Fri, 08 Oct 2021 17:16:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '64'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 1.10.0
+      B3:
+      - 94e118652ec116aa-39b8b9a2242919c3-1
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 58ec2e2
+      X-Vamf-Timestamp:
+      - '2021-08-18T13:44:12+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+    body:
+      encoding: UTF-8
+      string: '{"message":"clinicalService: mutually exclusive with clinicIds"}'
+  recorded_at: Fri, 08 Oct 2021 17:16:24 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Update the `locations/{locationId/clinics` endpoint to route requests to the `vetsapi-patient-gateway` service if the va_online_scheduling_use_vpg feature flag is enabled.

## Related issue(s)
https://app.zenhub.com/workspaces/appointments-oracle-health-integration-65a6e99ea522640e4d09393b/issues/gh/department-of-veterans-affairs/va.gov-team/93475

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Clinic searches in the VAOS module will optionally be routed to the `vetsapi-patient-gateway` service, enabling Oracle Health support.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
