### PR TITLE
sidekiq job for MHV Account Creation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -645,6 +645,7 @@ app/sidekiq/lighthouse/create_intent_to_file_job.rb @department-of-veterans-affa
 app/sidekiq/lighthouse/income_and_assets_intake_job.rb @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
 app/sidekiq/load_average_days_for_claim_completion_job.rb @department-of-veterans-affairs/benefits-microservices @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/mhv @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/mhv/account_creator_job.rb @department-of-veterans-affairs/octo-identity
 app/sidekiq/pager_duty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/schema_contract @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1341,6 +1342,7 @@ spec/sidekiq/kms_key_rotation @department-of-veterans-affairs/va-api-engineers @
 spec/sidekiq/lighthouse @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/load_average_days_for_claim_completion_job_spec.rb @department-of-veterans-affairs/benefits-microservices @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/mhv @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/mhv/account_creator_job_spec.rb @department-of-veterans-affairs/octo-identity
 spec/sidekiq/pager_duty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/schema_contract @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/sidekiq/mhv/account_creator_job.rb
+++ b/app/sidekiq/mhv/account_creator_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'mhv/user_account/creator'
+
+module MHV
+  class AccountCreatorJob
+    include Sidekiq::Job
+
+    sidekiq_options retry: false
+
+    def perform(id, break_cache: false)
+      user_verification = UserVerification.find(id)
+      MHV::UserAccount::Creator.new(user_verification:, break_cache:).perform
+    rescue ActiveRecord::RecordNotFound
+      Rails.logger.error("MHV AccountCreatorJob failed: UserVerification not found for id #{id}")
+    end
+  end
+end

--- a/spec/sidekiq/mhv/account_creator_job_spec.rb
+++ b/spec/sidekiq/mhv/account_creator_job_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+require 'vcr'
+
+RSpec.describe MHV::AccountCreatorJob, type: :job do
+  let(:user_account) { create(:user_account, icn:) }
+  let(:user_verification) { create(:user_verification, user_account:, user_credential_email:) }
+  let(:user_credential_email) { create(:user_credential_email, credential_email: email) }
+  let!(:terms_of_use_agreement) { create(:terms_of_use_agreement, user_account:) }
+  let(:icn) { '10101V964144' }
+  let(:email) { 'some-email@email.com' }
+  let(:break_cache) { false }
+  let(:job) { described_class.new }
+
+  before do
+    Sidekiq::Testing.inline!
+  end
+
+  describe '#perform' do
+    context 'when a UserVerification exists' do
+      let(:mhv_redis_key) { "mhv_account_creation_#{icn}" }
+
+      context 'when break_cache is false and a cached MHV account exists' do
+        before do
+          Rails.cache.write(mhv_redis_key, {})
+        end
+
+        it 'does not update the cached MHV account' do
+          VCR.use_cassette('mhv/account_creation/account_creation_service_200_response',
+                           match_requests_on: %i[method path]) do
+            expect(MHV::UserAccount::Creator).to receive(:new)
+              .with(user_verification:, break_cache:).and_call_original
+            expect(Rails.cache).to receive(:fetch)
+              .with(mhv_redis_key, force: false, expires_in: 1.day).and_call_original
+            job.perform(user_verification.id, break_cache: false)
+          end
+        end
+      end
+
+      context 'when break_cache is true' do
+        let(:break_cache) { true }
+
+        it 'updates the cached MHV account' do
+          VCR.use_cassette('mhv/account_creation/account_creation_service_200_response',
+                           match_requests_on: %i[method path]) do
+            expect(MHV::UserAccount::Creator).to receive(:new)
+              .with(user_verification:, break_cache:).and_call_original
+            expect(Rails.cache).to receive(:fetch)
+              .with(mhv_redis_key, force: true, expires_in: 1.day).and_call_original
+            job.perform(user_verification.id, break_cache: true)
+          end
+        end
+      end
+
+      it 'calls the MHV::UserAccount::Creator service class and returns the created MHVUserAccount instance' do
+        VCR.use_cassette('mhv/account_creation/account_creation_service_200_response',
+                         match_requests_on: %i[method path]) do
+          expect(MHV::UserAccount::Creator).to receive(:new).with(user_verification:, break_cache:).and_call_original
+          job.perform(user_verification.id)
+        end
+      end
+
+      context 'when the MHV API call is successful' do
+        it 'creates & returns a new MHVUserAccount instance' do
+          VCR.use_cassette('mhv/account_creation/account_creation_service_200_response',
+                           match_requests_on: %i[method path]) do
+            response = job.perform(user_verification.id)
+            expect(response).to be_an_instance_of(MHVUserAccount)
+          end
+        end
+      end
+    end
+
+    context 'when a UserVerification does not exist' do
+      let(:expected_error_id) { 999 }
+      let(:expected_error_message) do
+        "MHV AccountCreatorJob failed: UserVerification not found for id #{expected_error_id}"
+      end
+
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:error).with(expected_error_message)
+        job.perform(expected_error_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Followup PR to #18479 , this adds the Sidekiq job that will be called during SiS & SSOe auth to invoke the MHV::UserAccount::Creator service

## Related issue(s)

- VI-471

## Testing done

- [x] *New code is covered by unit tests*
-  This is difficult to test without being on staging but the validations and object creation with a dummy response can be tested.
    - in the [mhv_account_creation_response](https://github.com/department-of-veterans-affairs/vets-api/blob/2ee69f5120ccb4789f931a08e9832691341f800e/app/services/mhv/user_account/creator.rb#L35-L38) method add a dummy response
     ```ruby
      def mhv_account_creation_response
        {
          user_profile_id: '12345678',
          premium: true,
          champ_va: true,
          patient: true,
          sm_account_created: true,
          message: 'some message'
        }
      end
     ````
- in rails console test the Sidekiq job by passing a `user_verification.id` you have locally
  - a `user_verification.user_account.terms_of_use_agreements` needs to exist & be accepted
      ```
      > mhv_account = MHV::AccountCreatorJob.new.perform(5)
         => #<MHVUserAccount:0x00007213e4c3f950 @attributes=...>
      > mhv_account.attributes
         => {"user_profile_id"=>"12345678", "premium"=>true, "champ_va"=>true, "patient"=>true, "sm_account_created"=>true, "message"=>"some message"
      ```
   - test the error response with a bad user_verification id
       ```
       > mhv_account = MHV::AccountCreatorJob.new.perform(55555)
       Rails -- MHV AccountCreatorJob failed: UserVerification not found for id 55555
      ```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution