### PR TITLE
Disability benefits nb refactor document upload provider initialization 1

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
+++ b/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
@@ -9,6 +9,10 @@ module EVSS
 
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526_bdd_instructions'
 
+      # 'Other Correspondence' document type in the VA
+      BDD_INSTRUCTIONS_DOCUMENT_TYPE = 'L023'
+      BDD_INSTRUCTIONS_FILE_NAME = 'BDD_Instructions.pdf'
+
       # retry for one day
       sidekiq_options retry: 14
 
@@ -36,6 +40,12 @@ module EVSS
         )
 
         StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
+
+        if Flipper.enabled?(:disability_compensation_use_api_provider_for_bdd_instructions)
+          submission = Form526Submission.find(form526_submission_id)
+          # api_upload_provider(submission).log_upload_failure(STATSD_KEY_PREFIX, error_class, error_message)
+          api_upload_provider(submission).log_upload_failure(error_class, error_message)
+        end
 
         ::Rails.logger.warn(
           'Submit Form 526 Upload BDD Instructions Retries exhausted',
@@ -67,6 +77,25 @@ module EVSS
         }
       )
 
+      # # Returns the correct SupplementalDocumentUploadProvider based on the state of the
+      # # ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS feature flag for the current user
+      # #
+      # @return [EVSSSupplementalDocumentUploadProvider or LighthouseSupplementalDocumentUploadProvider]
+      def self.api_upload_provider(submission)
+        user = User.find(submission.user_uuid)
+
+        ApiProviderFactory.call(
+          type: ApiProviderFactory::FACTORIES[:supplemental_document_upload],
+          options: {
+            form526_submission: submission,
+            va_document_type: BDD_INSTRUCTIONS_DOCUMENT_TYPE,
+            statsd_metric_prefix: STATSD_KEY_PREFIX
+          },
+          current_user: user,
+          feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS
+        )
+      end
+
       # Submits a BDD instruction PDF in to EVSS
       #
       # @param submission_id [Integer] The {Form526Submission} id
@@ -88,20 +117,34 @@ module EVSS
 
       private
 
-      def upload_bdd_instructions
-        client.upload(file_body, document_data)
-      end
-
       def file_body
         @file_body ||= File.read('lib/evss/disability_compensation_form/bdd_instructions.pdf')
       end
 
-      def client
-        @client ||= if Flipper.enabled?(:disability_compensation_lighthouse_document_service_provider)
-                      # TODO: create client from lighthouse document service
-                    else
-                      EVSS::DocumentsService.new(submission.auth_headers)
-                    end
+      def upload_bdd_instructions
+        # NOTE: the ApiProviderFactory implements its own Flipper,
+        # ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS, which will be used to iteratively
+        # start sending more BDD Instructions to Lighthouse instead of EVSS
+        # However, since using this factory is new behavior, it is hidden behind this additional Flipper, which will act
+        # as a "kill switch" in the event there are problems with the ApiProviderFactory implementation, so we can
+        # revert back to using the EVSS::DocumentsService directly here
+        if Flipper.enabled?(:disability_compensation_use_api_provider_for_bdd_instructions)
+          upload_via_api_provider
+        else
+          EVSS::DocumentsService.new(submission.auth_headers).upload(file_body, document_data)
+        end
+      end
+
+      def upload_via_api_provider
+        document = upload_provider.generate_upload_document(
+          BDD_INSTRUCTIONS_FILE_NAME,
+          BDD_INSTRUCTIONS_DOCUMENT_TYPE
+        )
+        upload_provider.submit_upload_document(document, file_body)
+      end
+
+      def upload_provider
+        @upload_provider ||= EVSS::DisabilityCompensationForm::UploadBddInstructions.api_upload_provider(submission)
       end
 
       def retryable_error_handler(error)
@@ -112,10 +155,10 @@ module EVSS
       def document_data
         @document_data ||= EVSSClaimDocument.new(
           evss_claim_id: submission.submitted_claim_id,
-          file_name: 'BDD_Instructions.pdf',
+          file_name: BDD_INSTRUCTIONS_FILE_NAME,
           tracked_item_id: nil,
-          document_type: 'L023'
-        ) # 'Other Correspondence'
+          document_type: BDD_INSTRUCTIONS_DOCUMENT_TYPE
+        )
       end
     end
   end

--- a/lib/disability_compensation/factories/api_provider_factory.rb
+++ b/lib/disability_compensation/factories/api_provider_factory.rb
@@ -56,7 +56,7 @@ class ApiProviderFactory
   FEATURE_TOGGLE_BRD = 'disability_compensation_lighthouse_brd'
   FEATURE_TOGGLE_GENERATE_PDF = 'disability_compensation_lighthouse_generate_pdf'
 
-  FEATURE_TOGGLE_UPLOAD_SUPPLEMENTAL_DOCUMENT = 'disability_compensation_lighthouse_upload_supplemental_document'
+  FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS = 'disability_compensation_lighthouse_upload_bdd_instructions'
 
   attr_reader :type
 
@@ -187,11 +187,17 @@ class ApiProviderFactory
   end
 
   def supplemental_document_upload_service_provider
+    provider_options = [
+      @options[:form526_submission],
+      @options[:document_type],
+      @options[:statsd_metric_prefix]
+    ]
+
     case api_provider
     when API_PROVIDER[:evss]
-      EVSSSupplementalDocumentUploadProvider.new(@options[:form526_submission])
+      EVSSSupplementalDocumentUploadProvider.new(*provider_options)
     when API_PROVIDER[:lighthouse]
-      LighthouseSupplementalDocumentUploadProvider.new(@options[:form526_submission])
+      LighthouseSupplementalDocumentUploadProvider.new(*provider_options)
     else
       raise NotImplementedError, 'No known Supplemental Document Upload Api Provider type provided'
     end

--- a/lib/disability_compensation/factories/api_provider_factory.rb
+++ b/lib/disability_compensation/factories/api_provider_factory.rb
@@ -56,7 +56,7 @@ class ApiProviderFactory
   FEATURE_TOGGLE_BRD = 'disability_compensation_lighthouse_brd'
   FEATURE_TOGGLE_GENERATE_PDF = 'disability_compensation_lighthouse_generate_pdf'
 
-  FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS = 'disability_compensation_lighthouse_upload_bdd_instructions'
+  FEATURE_TOGGLE_UPLOAD_SUPPLEMENTAL_DOCUMENT = 'disability_compensation_lighthouse_upload_supplemental_document'
 
   attr_reader :type
 

--- a/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
@@ -8,14 +8,8 @@ class EVSSSupplementalDocumentUploadProvider
   STATSD_PROVIDER_METRIC = 'evss_supplemental_document_upload_provider'
 
   # @param form526_submission [Form526Submission]
-  #
-  # @param va_document_type [String] The VA document code, which corresponds to
-  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
-  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
-  #
-  # @param statsd_metric_prefix [String] the metrics prefix the job calling this provider wants us to use when logging
-  # (e.g. 'worker.evss.submit_form526_bdd_instructions' for the UploadBddInstructions job)
-  #
+  # @param va_document_type [String] VA document code; see LighthouseDocument::DOCUMENT_TYPES
+  # @param statsd_metric_prefix [String] prefix, e.g. 'worker.evss.submit_form526_bdd_instructions' from including job
   def initialize(form526_submission, va_document_type, statsd_metric_prefix)
     @form526_submission = form526_submission
     @va_document_type = va_document_type
@@ -28,10 +22,6 @@ class EVSSSupplementalDocumentUploadProvider
   # an assembly of file-related EVSS metadata, not the actual uploaded file itself
   #
   # @param file_name [String] The name of the file we want to appear in EVSS
-  # @param document_type [String] The VA document code, which corresponds to
-  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
-  # These types are mapped in EVSSClaimDocument[DOCUMENT_TYPES]
-  #
   # @return [EVSSClaimDocument]
   def generate_upload_document(file_name)
     EVSSClaimDocument.new(

--- a/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider.rb
@@ -8,8 +8,18 @@ class EVSSSupplementalDocumentUploadProvider
   STATSD_PROVIDER_METRIC = 'evss_supplemental_document_upload_provider'
 
   # @param form526_submission [Form526Submission]
-  def initialize(form526_submission)
+  #
+  # @param va_document_type [String] The VA document code, which corresponds to
+  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
+  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
+  #
+  # @param statsd_metric_prefix [String] the metrics prefix the job calling this provider wants us to use when logging
+  # (e.g. 'worker.evss.submit_form526_bdd_instructions' for the UploadBddInstructions job)
+  #
+  def initialize(form526_submission, va_document_type, statsd_metric_prefix)
     @form526_submission = form526_submission
+    @va_document_type = va_document_type
+    @statsd_metric_prefix = statsd_metric_prefix
   end
 
   # Uploads to EVSS via the EVSS::DocumentsService require both the file body and an instance
@@ -23,11 +33,11 @@ class EVSSSupplementalDocumentUploadProvider
   # These types are mapped in EVSSClaimDocument[DOCUMENT_TYPES]
   #
   # @return [EVSSClaimDocument]
-  def generate_upload_document(file_name, document_type)
+  def generate_upload_document(file_name)
     EVSSClaimDocument.new(
       evss_claim_id: @form526_submission.submitted_claim_id,
-      file_name:,
-      document_type:
+      document_type: @va_document_type,
+      file_name:
     )
   end
 
@@ -49,14 +59,12 @@ class EVSSSupplementalDocumentUploadProvider
   def submit_upload_document(evss_claim_document, file_body)
     client = EVSS::DocumentsService.new(@form526_submission.auth_headers)
     client.upload(file_body, evss_claim_document)
+
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
   end
 
-  def log_upload_success(uploading_class_prefix)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
-  end
-
-  def log_upload_failure(uploading_class_prefix, error_class, error_message)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
+  def log_upload_failure(error_class, error_message)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
 
     Rails.logger.error(
       'EVSSSupplementalDocumentUploadProvider upload failure',

--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -16,13 +16,8 @@ class LighthouseSupplementalDocumentUploadProvider
 
   # @param form526_submission [Form526Submission]
   #
-  # @param va_document_type [String] The VA document code, which corresponds to
-  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
-  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
-  #
-  # @param statsd_metric_prefix [String] the metrics prefix the job calling this provider wants us to use when logging
-  # (e.g. 'worker.evss.submit_form526_bdd_instructions' for the UploadBddInstructions job)
-  #
+  # @param va_document_type [String] VA document code, see LighthouseDocument::DOCUMENT_TYPES
+  # @param statsd_metric_prefix [String] prefix, e.g. 'worker.evss.submit_form526_bdd_instructions' from including job
   def initialize(form526_submission, va_document_type, statsd_metric_prefix)
     @form526_submission = form526_submission
     @va_document_type = va_document_type
@@ -81,9 +76,6 @@ class LighthouseSupplementalDocumentUploadProvider
 
   private
 
-  # Processes the response from Lighthouse and logs accordingly. If the upload is successful, creates
-  # a polling record so we can check on the status of the document after Lighthouse has receieved it
-  #
   # @param api_response [Faraday::Response] Lighthouse API response returned from the UploadSupplementalDocumentService
   def handle_lighthouse_response(api_response)
     response_body = api_response.body['data']

--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -8,9 +8,25 @@ class LighthouseSupplementalDocumentUploadProvider
 
   STATSD_PROVIDER_METRIC = 'lighthouse_supplemental_document_upload_provider'
 
+  # Maps VA's internal Document Types to the correct document_type attribute for a Lighthouse526DocumentUpload polling
+  # record. We need this to create a valid polling record
+  POLLING_DOCUMENT_TYPES = {
+    'L023' => Lighthouse526DocumentUpload::BDD_INSTRUCTIONS_DOCUMENT_TYPE
+  }.freeze
+
   # @param form526_submission [Form526Submission]
-  def initialize(form526_submission)
+  #
+  # @param va_document_type [String] The VA document code, which corresponds to
+  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
+  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
+  #
+  # @param statsd_metric_prefix [String] the metrics prefix the job calling this provider wants us to use when logging
+  # (e.g. 'worker.evss.submit_form526_bdd_instructions' for the UploadBddInstructions job)
+  #
+  def initialize(form526_submission, va_document_type, statsd_metric_prefix)
     @form526_submission = form526_submission
+    @va_document_type = va_document_type
+    @statsd_metric_prefix = statsd_metric_prefix
   end
 
   # Uploads to Lighthouse require both the file body and an instance
@@ -19,16 +35,16 @@ class LighthouseSupplementalDocumentUploadProvider
   # an assembly of file-related Lighthouse metadata, not the actual uploaded file itself
   #
   # @param file_name [String] The name of the file we want to appear in Lighthouse
-  # @param document_type [String] The VA document code, which corresponds to
-  # the type of document being uploaded ('Buddy/Lay Statement', 'Disability Benefits Questionnaire (DBQ)' etc.)
-  # These types are mapped in LighthouseDocument::DOCUMENT_TYPES
   #
   # @return [LighthouseDocument]
-  def generate_upload_document(file_name, document_type)
+  def generate_upload_document(file_name)
+    user = User.find(@form526_submission.user_uuid)
+
     LighthouseDocument.new(
-      evss_claim_id: @form526_submission.submitted_claim_id,
-      file_name:,
-      document_type:
+      claim_id: @form526_submission.submitted_claim_id,
+      participant_id: user.participant_id,
+      document_type: @va_document_type,
+      file_name:
     )
   end
 
@@ -45,19 +61,13 @@ class LighthouseSupplementalDocumentUploadProvider
   #
   # @param lighthouse_document [LighthouseDocument]
   # @param file_body [String]
-  #
-  # return [Faraday::Response] BenefitsDocuments::WorkerService makes http
-  # calls with the Faraday gem under the hood
   def submit_upload_document(lighthouse_document, file_body)
-    BenefitsDocuments::Form526::UploadSupplementalDocumentService.call(file_body, lighthouse_document)
+    api_response = BenefitsDocuments::Form526::UploadSupplementalDocumentService.call(file_body, lighthouse_document)
+    handle_lighthouse_response(api_response)
   end
 
-  def log_upload_success(uploading_class_prefix)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
-  end
-
-  def log_upload_failure(uploading_class_prefix, error_class, error_message)
-    StatsD.increment("#{uploading_class_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
+  def log_upload_failure(error_class, error_message)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
 
     Rails.logger.error(
       'LighthouseSupplementalDocumentUploadProvider upload failure',
@@ -66,6 +76,34 @@ class LighthouseSupplementalDocumentUploadProvider
         error_class:,
         error_message:
       }
+    )
+  end
+
+  private
+
+  # Processes the response from Lighthouse and logs accordingly. If the upload is successful, creates
+  # a polling record so we can check on the status of the document after Lighthouse has receieved it
+  #
+  # @param api_response [Faraday::Response] Lighthouse API response returned from the UploadSupplementalDocumentService
+  def handle_lighthouse_response(api_response)
+    response_body = api_response.body['data']
+
+    if response_body['success'] == true && response_body['requestId']
+      create_lighthouse_polling_record(response_body['requestId'])
+      StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
+    end
+  end
+
+  # Creates a Lighthouse526DocumentUpload polling record
+  #
+  # @param lighthouse_request_id [String] unique ID Lighthouse provides us in the API response after we
+  # upload a document. We use this ID in the Form526DocumentUploadPollingJob chron job to check the status
+  # of the document after Lighthouse has received it.
+  def create_lighthouse_polling_record(lighthouse_request_id)
+    Lighthouse526DocumentUpload.create!(
+      form526_submission: @form526_submission,
+      document_type: POLLING_DOCUMENT_TYPES[@va_document_type],
+      lighthouse_document_request_id: lighthouse_request_id
     )
   end
 end

--- a/spec/lib/disability_compensation/factories/api_provider_factory_spec.rb
+++ b/spec/lib/disability_compensation/factories/api_provider_factory_spec.rb
@@ -272,29 +272,6 @@ RSpec.describe ApiProviderFactory do
       expect(provider(:lighthouse).class).to equal(LighthouseSupplementalDocumentUploadProvider)
     end
 
-    context 'for BDD instruction uploads' do
-      def provider
-        ApiProviderFactory.call(
-          type: ApiProviderFactory::FACTORIES[:supplemental_document_upload],
-          options: {
-            form526_submission: submission,
-            document_type: va_document_type,
-            statsd_metric_prefix: 'my_stats_metric_prefix'
-          },
-          current_user:,
-          feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS
-        )
-      end
-
-      it 'provides a SupplementalDocumentUploadProvider based on a Flipper' do
-        Flipper.enable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS)
-        expect(provider.class).to equal(LighthouseSupplementalDocumentUploadProvider)
-
-        Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS)
-        expect(provider.class).to equal(EVSSSupplementalDocumentUploadProvider)
-      end
-    end
-
     it 'throw error if provider unknown' do
       expect do
         provider(:random)

--- a/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
@@ -8,7 +8,16 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
   let(:submission) { create(:form526_submission) }
   let(:file_body) { File.read(fixture_file_upload('doctors-note.pdf', 'application/pdf')) }
   let(:file_name) { Faker::File.file_name }
-  let(:provider) { EVSSSupplementalDocumentUploadProvider.new(submission) }
+
+  let(:va_document_type) { 'L023' }
+
+  let(:provider) do
+    EVSSSupplementalDocumentUploadProvider.new(
+      submission,
+      va_document_type,
+      'my_upload_job_prefix'
+    )
+  end
 
   let(:evss_claim_document) do
     EVSSClaimDocument.new(
@@ -23,16 +32,14 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
   describe '#generate_upload_document' do
     it 'generates an EVSSClaimDocument' do
       file_name = Faker::File.file_name
-      document_type = 'L023'
-
-      upload_document = provider.generate_upload_document(file_name, document_type)
+      upload_document = provider.generate_upload_document(file_name)
 
       expect(upload_document).to be_an_instance_of(EVSSClaimDocument)
       expect(upload_document).to have_attributes(
         {
           evss_claim_id: submission.submitted_claim_id,
           file_name:,
-          document_type:
+          document_type: va_document_type
         }
       )
     end
@@ -55,14 +62,25 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
 
   describe '#submit_upload_document' do
     context 'for a valid payload' do
-      let(:faraday_response) { instance_double(Faraday::Response) }
+      it 'submits the document via the EVSSDocumentService' do
+        expect_any_instance_of(EVSS::DocumentsService).to receive(:upload)
+          .with(file_body, evss_claim_document)
 
-      it 'submits the document via the EVSSDocumentService and returns the API response' do
+        provider.submit_upload_document(evss_claim_document, file_body)
+      end
+
+      it 'increments a StatsD success metric' do
+        faraday_response = instance_double(Faraday::Response)
+
         allow_any_instance_of(EVSS::DocumentsService).to receive(:upload)
           .with(file_body, evss_claim_document)
           .and_return(faraday_response)
 
-        expect(provider.submit_upload_document(evss_claim_document, file_body)).to eq(faraday_response)
+        expect(StatsD).to receive(:increment).with(
+          'my_upload_job_prefix.evss_supplemental_document_upload_provider.success'
+        )
+
+        provider.submit_upload_document(evss_claim_document, file_body)
       end
     end
   end
@@ -72,15 +90,12 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
     # since submissions have callbacks that log to StatsD and we need to test
     # only the metrics in this class
     let(:submission) { instance_double(Form526Submission) }
-    let(:provider) { EVSSSupplementalDocumentUploadProvider.new(submission) }
-
-    describe 'log_upload_success' do
-      it 'increments a StatsD success metric' do
-        expect(StatsD).to receive(:increment).with(
-          'my_upload_job_prefix.evss_supplemental_document_upload_provider.success'
-        )
-        provider.log_upload_success('my_upload_job_prefix')
-      end
+    let(:provider) do
+      EVSSSupplementalDocumentUploadProvider.new(
+        submission,
+        va_document_type,
+        'my_upload_job_prefix'
+      )
     end
 
     describe 'log_upload_failure' do
@@ -91,7 +106,7 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
         expect(StatsD).to receive(:increment).with(
           'my_upload_job_prefix.evss_supplemental_document_upload_provider.failed'
         )
-        provider.log_upload_failure('my_upload_job_prefix', error_class, error_message)
+        provider.log_upload_failure(error_class, error_message)
       end
 
       it 'logs to the Rails logger' do
@@ -104,7 +119,7 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
           }
         )
 
-        provider.log_upload_failure('my_upload_job_prefix', error_class, error_message)
+        provider.log_upload_failure(error_class, error_message)
       end
     end
   end

--- a/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
+++ b/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 shared_examples 'supplemental document upload provider' do
-  subject { described_class.new(submission, 'My Document Type', 'my_metrics_prefix' ) }
+  subject { described_class.new(submission, 'My Document Type', 'my_metrics_prefix') }
 
   let(:submission) { create(:form526_submission) }
 

--- a/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
+++ b/spec/support/disability_compensation_form/shared_examples/supplemental_document_upload_provider.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 shared_examples 'supplemental document upload provider' do
-  subject { described_class.new(submission) }
+  subject { described_class.new(submission, 'My Document Type', 'my_metrics_prefix' ) }
 
   let(:submission) { create(:form526_submission) }
 


### PR DESCRIPTION

**NOTE: these changes were originally PRed in https://github.com/department-of-veterans-affairs/vets-api/pull/18695, but had to be extracted from other improvements because of exceeding the line count limit**


## Summary

Overhauls the shared "API Provider" code we will use to migrate Form 526 ancillary document upload jobs from uploading to EVSS to uploading to Lighthouse instead, and adds behavior to allow us to poll for the status of documents we send to Lighthouse. The purpose of these changes is to better encapsulate logic in the providers so the upload job using them doesn't have to know too much.

Updates the constructor signatures of both the EVSSSupplementalDocumentUploadProvider and LighthouseSupplementalDocumentUploadProviders to make better use of the freely customizable `options` hash provided by the [APIProviderFactory](https://github.com/department-of-veterans-affairs/vets-api/blob/benefits-disability-nb-refactor-supplemental-document-upload-providers/lib/disability_compensation/factories/api_provider_factory.rb#L87)

Also adds the creation of the record we use to poll Lighthouse for document status after upload, Form526DocumentUpload, when we successfully submit a document to the Lighthouse Benefits Documents API

- *This work is behind a feature toggle (flipper): NO, this code is not used yet

## Related issue(s)
- There was no issue created for this, it is a blocker to migrating the Form 526 document upload jobs because we will be using this shared code there.

## Testing done

- [X] *New code is covered by unit tests*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (inline documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (not yet)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [ ]  I added a screenshot of the developed feature N/A
