### PR TITLE
Travel Pay/Update query path builder for appointments client

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/appointments_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/appointments_client.rb
@@ -23,7 +23,11 @@ module TravelPay
       correlation_id = SecureRandom.uuid
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      query_path = URI::HTTPS.build(path: '/api/v1.1/appointments', query: params.to_query)
+      query_path = if params.empty?
+                     '/api/v1.1/appointments'
+                   else
+                     "/api/v1.1/appointments?#{params.to_query}"
+                   end
 
       connection(server_url: btsss_url).get(query_path) do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"

--- a/modules/travel_pay/app/services/travel_pay/appointments_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/appointments_client.rb
@@ -24,9 +24,9 @@ module TravelPay
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
       query_path = if params.empty?
-                     '/api/v1.1/appointments'
+                     'api/v1.1/appointments'
                    else
-                     "/api/v1.1/appointments?#{params.to_query}"
+                     "api/v1.1/appointments?#{params.to_query}"
                    end
 
       connection(server_url: btsss_url).get(query_path) do |req|


### PR DESCRIPTION

## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*
The URI::HTTPS builder was adding unnecessary things to the query path when building. The PR removes that URI::HTTPS.build step and just builds it manually.

- *(Which team do you work for, does your team own the maintenance of this component?)*
- Travel Pay


## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
-  [#92293](https://app.zenhub.com/workspaces/beneficiary-travel-btsss-65147e21930cd900223d8e64/issues/gh/department-of-veterans-affairs/va.gov-team/92293)
- *Link to previous change of the code/bug (if applicable)*
- #18548 


## Testing done

- *Describe what the old behavior was prior to the change*
- ArgoCD Terminal tests showed Connection Refused errors due to the URL path not being build properly
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Tests must be run in the ArgoCD terminal


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Travel Pay Module

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

