### PR TITLE
[VI-476]  updates mhv account creation betamocks path

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -126,7 +126,7 @@
   :endpoints:
   - :method: :post
     :path: '/v1/usermgmt/account-service/account'
-    :file_path: 'mhv/account_creation/create_account'
+    :file_path: 'mhv/account_creation/create_account/default'
 
 - :name: 'MHV_Rx'
   :base_uri: <%= "#{URI(Settings.mhv.rx.host).host}:#{URI(Settings.mhv.rx.host).port}" %>


### PR DESCRIPTION
## Summary

- Updates the betamocks path for MHV Account Creation to correctly point to `/mhv/account_creation/create_account/default`

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-476
- https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/542