### PR TITLE
[CST] Adding new feature toggle for evidence failure emails

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -212,6 +212,18 @@ features:
     actor_type: user
     description: When enabled, claims status tool uses the new claim phase designs
     enable_in_development: true
+  cst_include_ddl_5103_letters:
+    actor_type: user
+    description: When enabled, the Download Decision Letters feature includes 5103 letters
+    enable_in_development: true
+  cst_include_ddl_boa_letters:
+    actor_type: user
+    description: When enabled, the Download Decision Letters feature includes Board of Appeals decision letters
+    enable_in_development: true
+  cst_include_ddl_sqd_letters:
+    actor_type: user
+    description: When enabled, the Download Decision Letters feature includes Subsequent Development Letters
+    enable_in_development: true
   cst_use_lighthouse_5103:
     actor_type: user
     description: When enabled, claims status tool uses the Lighthouse API for the 5103 endpoint
@@ -224,26 +236,18 @@ features:
     actor_type: user
     description: When enabled, claims status tool uses the Lighthouse API for the show endpoint
     enable_in_development: true
-  cst_include_ddl_boa_letters:
+  cst_send_evidence_failure_emails:
     actor_type: user
-    description: When enabled, the Download Decision Letters feature includes Board of Appeals decision letters
+    description: When enabled, emails will be sent when evidence uploads from the CST fail
     enable_in_development: true
-  cst_include_ddl_5103_letters:
+  cst_synchronous_evidence_uploads:
     actor_type: user
-    description: When enabled, the Download Decision Letters feature includes 5103 letters
-    enable_in_development: true
-  cst_include_ddl_sqd_letters:
-    actor_type: user
-    description: When enabled, the Download Decision Letters feature includes Subsequent Development Letters
+    description: When enabled, claims status tool uses synchronous evidence uploads
     enable_in_development: true
   cst_use_dd_rum:
     actor_type: user
     description: When enabled, claims status tool uses DataDog's Real User Monitoring logging
     enable_in_development: false
-  cst_synchronous_evidence_uploads:
-    actor_type: user
-    description: When enabled, claims status tool uses synchronous evidence uploads
-    enable_in_development: true
   coe_access:
     actor_type: user
     description: Feature gates the certificate of eligibility application


### PR DESCRIPTION
## Summary
Adding a new feature toggle for sending evidence failures emails for evidence submissions from the Claim Status Tool that fail. Also alphabetized all of the existing feature toggles with the prefix `cst_`

## Testing done
N/A
- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
