### PR TITLE
Add redis sidekiq health checker to initializer

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -64,5 +64,5 @@ Rails.application.reloader.to_prepare do
   end
 
   Sidekiq.strict_args!(false)
-  RedisHealthChecker.sidekiq_redis_up
+  RedisHealthChecker.sidekiq_redis_up if Settings.vsp_environment != 'production'
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -64,4 +64,5 @@ Rails.application.reloader.to_prepare do
   end
 
   Sidekiq.strict_args!(false)
+  RedisHealthChecker.sidekiq_redis_up
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,6 +8,7 @@ require 'sidekiq/semantic_logging'
 require 'sidekiq/set_request_id'
 require 'sidekiq/set_request_attributes'
 require 'datadog/statsd' # gem 'dogstatsd-ruby'
+require 'admin/redis_health_checker'
 
 Rails.application.reloader.to_prepare do
   Sidekiq::Enterprise.unique! if Rails.env.production?


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*

Each time Sidekiq is initialized, [this checker](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/admin/redis_health_checker.rb#L38-L53) will be run. It logs an error if Sidekiq's Redis is NOT up. We have a Datadog monitor watching for that error: https://vagov.ddog-gov.com/monitors/284651

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93586

## Testing done
I confirmed the conditional will work. This is prod:
```
irb(main):001> Settings.vsp_environment
=> "production"
```
This is dev:
```
irb(main):001> Settings.vsp_environment
=> "development"
```

## What areas of the site does it impact?
Sidekiq initializer

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated https://vfs.atlassian.net/wiki/spaces/PPT/pages/3127246924/Steps+for+EKS+Upgrade+Test
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)