### PR TITLE
Overhaul Lighthouse API Upload Provider logging

### DIFF
--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -57,33 +57,103 @@ class LighthouseSupplementalDocumentUploadProvider
   # @param lighthouse_document [LighthouseDocument]
   # @param file_body [String]
   def submit_upload_document(lighthouse_document, file_body)
+    log_upload_attempt
     api_response = BenefitsDocuments::Form526::UploadSupplementalDocumentService.call(file_body, lighthouse_document)
     handle_lighthouse_response(api_response)
   end
 
-  def log_upload_failure(error_class, error_message)
-    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
-
+  # To call in the sidekiq_retries_exhausted block of the including job
+  # This is meant to log an upload attempt that was retried and eventually given up on,
+  # so we can investigate the failure in Datadog
+  #
+  # @param uploading_job_class [String] the job where we are uploading the Lighthouse Document
+  # (e.g. UploadBDDInstructions)
+  # @param error_class [String] the Error class of the exception that exhausted the upload job
+  # @param error_message [String] the message in the exception that exhausted the upload job
+  def log_uploading_job_failure(uploading_job_class, error_class, error_message)
     Rails.logger.error(
-      'LighthouseSupplementalDocumentUploadProvider upload failure',
+      "#{uploading_job_class} LighthouseSupplementalDocumentUploadProvider Failure",
       {
-        class: 'LighthouseSupplementalDocumentUploadProvider',
+        **base_logging_info,
+        uploading_job_class:,
         error_class:,
         error_message:
       }
     )
+
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STASTD_UPLOAD_JOB_FAILED_METRIC}")
   end
 
   private
 
+  def base_logging_info
+    {
+      class: 'LighthouseSupplementalDocumentUploadProvider',
+      submission_id: @form526_submission.submitted_claim_id,
+      user_uuid: @form526_submission.user_uuid,
+      va_document_type_code: @va_document_type,
+      primary_form: 'Form526'
+    }
+  end
+
+  def log_upload_attempt
+    Rails.logger.info('LighthouseSupplementalDocumentUploadProvider upload attempted', base_logging_info)
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_ATTEMPT_METRIC}")
+  end
+
+  def log_upload_success(lighthouse_request_id)
+    Rails.logger.info(
+      'LighthouseSupplementalDocumentUploadProvider upload successful',
+      {
+        **base_logging_info,
+        lighthouse_request_id:
+      }
+    )
+
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
+  end
+
+  # For logging an error response from the Lighthouse Benefits Document API
+  #
+  # @param lighthouse_error_response [Hash] parsed JSON response from the Lighthouse API
+  # this will be an array of errors
+  def log_upload_failure(lighthouse_error_response)
+    Rails.logger.error(
+      'LighthouseSupplementalDocumentUploadProvider upload failed',
+      {
+        **base_logging_info,
+        lighthouse_error_response:
+      }
+    )
+
+    StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_FAILED_METRIC}")
+  end
+
+  # Processes the response from Lighthouse and logs accordingly. If the upload is successful, creates
+  # a polling record so we can check on the status of the document after Lighthouse has receieved it
+  #
   # @param api_response [Faraday::Response] Lighthouse API response returned from the UploadSupplementalDocumentService
   def handle_lighthouse_response(api_response)
-    response_body = api_response.body['data']
+    response_body = api_response.body
 
-    if response_body['success'] == true && response_body['requestId']
-      create_lighthouse_polling_record(response_body['requestId'])
-      StatsD.increment("#{@statsd_metric_prefix}.#{STATSD_PROVIDER_METRIC}.#{STATSD_SUCCESS_METRIC}")
+    if lighthouse_success_response?(response_body)
+      lighthouse_request_id = response_body.dig('data', 'requestId')
+      create_lighthouse_polling_record(lighthouse_request_id)
+      log_upload_success(lighthouse_request_id)
+    else
+      log_upload_failure(response_body)
     end
+  end
+
+  # Parses a response from the Lighthouse Benefits Document API
+  # If there is a problem with the upload, Lighthouse provides an array of error hashes
+  # (See spec/support/vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
+  # for an example).
+  #
+  # If the upload succeeds, we get success metadata nested under a 'data' key, a success flag and a requestId
+  # we can use to poll Lighthouse for the document's status later
+  def lighthouse_success_response?(response_body)
+    !response_body['errors'] && response_body.dig('data', 'success') && response_body.dig('data', 'requestId')
   end
 
   # Creates a Lighthouse526DocumentUpload polling record

--- a/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/supplemental_document_upload_provider.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 module SupplementalDocumentUploadProvider
-  STATSD_SUCCESS_METRIC = 'success'
-  STATSD_RETRIED_METRIC = 'retried'
-  STATSD_FAILED_METRIC = 'failed'
+  STATSD_ATTEMPT_METRIC = 'upload_attempt'
+  STATSD_SUCCESS_METRIC = 'upload_success'
+  STATSD_FAILED_METRIC = 'upload_failure'
+  STASTD_UPLOAD_JOB_FAILED_METRIC = 'upload_job_failed'
 
   def self.raise_not_implemented_error
     raise NotImplementedError, 'Do not use base module methods. Override this method in implementation class.'

--- a/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/evss_supplemental_document_upload_provider_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
           .and_return(faraday_response)
 
         expect(StatsD).to receive(:increment).with(
-          'my_upload_job_prefix.evss_supplemental_document_upload_provider.success'
+          'my_upload_job_prefix.evss_supplemental_document_upload_provider.upload_success'
         )
 
         provider.submit_upload_document(evss_claim_document, file_body)
@@ -104,7 +104,7 @@ RSpec.describe EVSSSupplementalDocumentUploadProvider do
 
       it 'increments a StatsD failure metric' do
         expect(StatsD).to receive(:increment).with(
-          'my_upload_job_prefix.evss_supplemental_document_upload_provider.failed'
+          'my_upload_job_prefix.evss_supplemental_document_upload_provider.upload_failure'
         )
         provider.log_upload_failure(error_class, error_message)
       end

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
     )
   end
 
+  let(:faraday_response) { instance_double(Faraday::Response) }
+  let(:lighthouse_request_id) { Faker::Number.number(digits: 8) }
+
+  # Mock Lighthouse API response
+  before do
+    allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+      .with(file_body, lighthouse_document)
+      .and_return(faraday_response)
+
+    allow(faraday_response).to receive(:body).and_return(
+      {
+        'data' => {
+          'success' => true,
+          'requestId' => lighthouse_request_id
+        }
+      }
+    )
+  end
+
   it_behaves_like 'supplemental document upload provider'
 
   describe 'generate_upload_document' do
@@ -68,35 +87,9 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
   end
 
   describe 'submit_upload_document' do
-    let(:faraday_response) { instance_double(Faraday::Response) }
-    let(:lighthouse_request_id) { Faker::Number.number(digits: 8) }
-
-    before do
-      allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
-        .with(file_body, lighthouse_document)
-        .and_return(faraday_response)
-
-      allow(faraday_response).to receive(:body).and_return(
-        {
-          'data' => {
-            'success' => true,
-            'requestId' => lighthouse_request_id
-          }
-        }
-      )
-    end
-
     it 'uploads the document via the UploadSupplementalDocumentService' do
       expect(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
         .with(file_body, lighthouse_document)
-
-      provider.submit_upload_document(lighthouse_document, file_body)
-    end
-
-    it 'increments a StatsD success metric' do
-      expect(StatsD).to receive(:increment).with(
-        'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.success'
-      )
 
       provider.submit_upload_document(lighthouse_document, file_body)
     end
@@ -116,42 +109,149 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
     end
   end
 
-  describe 'logging methods' do
-    # We don't want to generate an actual submission for these tests,
-    # since submissions have callbacks that log to StatsD and we need to test
-    # only the metrics in this class
-    let(:submission) { instance_double(Form526Submission) }
+  describe 'events logging' do
+    context 'when attempting to upload a document' do
+      before do
+        allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+        allow(provider).to receive(:handle_lighthouse_response)
+      end
 
-    let(:provider) do
-      LighthouseSupplementalDocumentUploadProvider.new(
-        submission,
-        'MyUploadingClass',
-        'my_stats_metric_prefix'
-      )
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:info).with(
+          'LighthouseSupplementalDocumentUploadProvider upload attempted',
+          {
+            class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526'
+          }
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+
+      it 'increments a StatsD attempt metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_attempt'
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
     end
 
-    describe 'log_upload_failure' do
-      let(:error_class) { 'StandardError' }
-      let(:error_message) { 'Something broke' }
+    context 'when an upload is successfull' do
+      before do
+        # Skip upload attempt logging
+        allow(provider).to receive(:log_upload_attempt)
+      end
 
-      it 'increments a StatsD failure metric' do
-        expect(StatsD).to receive(:increment).with(
-          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.failed'
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:info).with(
+          'LighthouseSupplementalDocumentUploadProvider upload successful',
+          {
+            class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526',
+            lighthouse_request_id:
+          }
         )
-        provider.log_upload_failure(error_class, error_message)
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+
+      it 'increments a StatsD success metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_success'
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+    end
+
+    context 'when we get a non-200 response from Lighthouse' do
+      let(:error_response_body) do
+        # Based on error response Lighthouse returned saved in VCR cassette:
+        # spec/support/vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
+        {
+          'errors' => [
+            {
+              'detail' => 'Something broke',
+              'status' => 400,
+              'title' => 'Bad Request',
+              'instance' => Faker::Internet.uuid
+            }
+          ]
+        }
+      end
+
+      before do
+        # Skip upload attempt logging
+        allow(provider).to receive(:log_upload_attempt)
+
+        allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+          .with(file_body, lighthouse_document)
+          .and_return(faraday_response)
+
+        allow(faraday_response).to receive(:body).and_return(error_response_body)
       end
 
       it 'logs to the Rails logger' do
         expect(Rails.logger).to receive(:error).with(
-          'LighthouseSupplementalDocumentUploadProvider upload failure',
+          'LighthouseSupplementalDocumentUploadProvider upload failed',
           {
             class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526',
+            lighthouse_error_response: error_response_body
+          }
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+
+      it 'increments a StatsD metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_failure'
+        )
+
+        provider.submit_upload_document(lighthouse_document, file_body)
+      end
+    end
+
+    # Will be called in the sidekiq_retries_exhausted block of the including job
+    context 'uploading job failure' do
+      let(:uploading_job_class) { 'MyUploadJob' }
+      let(:error_class) { 'StandardError' }
+      let(:error_message) { 'Something broke' }
+
+      it 'logs to the Rails logger' do
+        expect(Rails.logger).to receive(:error).with(
+          "#{uploading_job_class} LighthouseSupplementalDocumentUploadProvider Failure",
+          {
+            class: 'LighthouseSupplementalDocumentUploadProvider',
+            submission_id: submission.submitted_claim_id,
+            user_uuid: submission.user_uuid,
+            va_document_type_code: va_document_type,
+            primary_form: 'Form526',
+            uploading_job_class:,
             error_class:,
             error_message:
           }
         )
 
-        provider.log_upload_failure(error_class, error_message)
+        provider.log_uploading_job_failure(uploading_job_class, error_class, error_message)
+      end
+
+      it 'increments a StatsD failure metric' do
+        expect(StatsD).to receive(:increment).with(
+          'my_stats_metric_prefix.lighthouse_supplemental_document_upload_provider.upload_job_failed'
+        )
+        provider.log_uploading_job_failure(uploading_job_class, error_class, error_message)
       end
     end
   end

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -173,8 +173,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
 
     context 'when we get a non-200 response from Lighthouse' do
       let(:error_response_body) do
-        # Based on error response Lighthouse returned saved in VCR cassette:
-        # spec/support/vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
+        # Based on spec/support/vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
         {
           'errors' => [
             {
@@ -223,7 +222,6 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
       end
     end
 
-    # Will be called in the sidekiq_retries_exhausted block of the including job
     context 'uploading job failure' do
       let(:uploading_job_class) { 'MyUploadJob' }
       let(:error_class) { 'StandardError' }

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
       end
     end
 
-    context 'when an upload is successfull' do
+    context 'when an upload is successful' do
       before do
         # Skip upload attempt logging
         allow(provider).to receive(:log_upload_attempt)

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
 
     context 'when we get a non-200 response from Lighthouse' do
       let(:error_response_body) do
-        # Based on spec/support/vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
+        # From vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
         {
           'errors' => [
             {


### PR DESCRIPTION
Adds more robust logging for documenting uploads via the LighthouseSupplementalDocumentUploadProvider. This will track all of the important events during an upload and allow us to easily query and make dashboards in DataDog

## Summary

- *This work is behind a feature toggle (flipper): NO but it will be, this code is unused currently

- *(Which team do you work for, does your team own the maintenance of this component?)*
Benefits Disability

## Testing done

- [C] *New code is covered by unit tests*


## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable) NOT YET but it will

