### PR TITLE
Fix how we query MPI Profile for first name

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -99,6 +99,8 @@ module SimpleFormsApi
       # async job and we have a UserAccount
       if user_account
         data[:personalization]['first_name'] = get_first_name
+        return if data[:personalization]['first_name'].blank?
+
         VANotify::UserAccountJob.perform_at(
           at,
           user_account.id,
@@ -107,7 +109,7 @@ module SimpleFormsApi
         )
       # async job and we don't have a UserAccount but form data should include email
       else
-        return if data[:email].blank?
+        return if data[:email].blank? || data[:personalization]['first_name'].blank?
 
         VANotify::EmailJob.perform_at(
           at,
@@ -121,6 +123,8 @@ module SimpleFormsApi
     def send_email_now(template_id, data)
       # sync job and we have a User
       if user
+        return if data[:personalization]['first_name'].blank?
+
         VANotify::EmailJob.perform_async(
           user.va_profile_email,
           template_id,
@@ -128,7 +132,7 @@ module SimpleFormsApi
         )
       # sync job and form data should include email
       else
-        return if data[:email].blank?
+        return if data[:email].blank? || data[:personalization]['first_name'].blank?
 
         VANotify::EmailJob.perform_async(
           data[:email],
@@ -140,17 +144,21 @@ module SimpleFormsApi
 
     def get_first_name
       if user_account
-        mpi_profile = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
-        if mpi_profile
-          raise mpi_profile.error if mpi_profile.error
-          raise 'First name not found in MPI profile' unless mpi_profile.first_name
+        mpi_response = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
+        if mpi_response
+          error = mpi_response.error
+          Rails.logger.error('MPI response error', { error: }) if error
 
-          mpi_profile.first_name
+          first_name = mpi_response.profile&.given_names&.first
+          Rails.logger.error('MPI profile missing first_name') unless first_name
+
+          first_name
         end
       elsif user
-        raise 'First name not found in user profile' unless user.first_name
+        first_name = user.first_name
+        Rails.logger.error('First name not found in user profile') unless first_name
 
-        user.first_name
+        first_name
       end
     end
 

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -112,7 +112,8 @@ describe SimpleFormsApi::NotificationEmail do
 
           it 'sends the email at the specified time' do
             time = double
-            mpi_profile = double(first_name: double, error: nil)
+            profile = double(given_names: [double])
+            mpi_profile = double(profile:, error: nil)
             allow(VANotify::UserAccountJob).to receive(:perform_at)
             allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(mpi_profile)
             subject = described_class.new(config, notification_type:, user_account:)


### PR DESCRIPTION
## Summary
This PR fixes a mistake in how we get user profile info from MPI. I had previously thought it looked like this:
```ruby
MPI::Service.new.find_profile_by_identifier returns mpi_profile
mpi_profile = { first_name: 'Joe' }
```
but it is actually like this
```ruby
MPI::Service.new.find_profile_by_identifier returns mpi_response
mpi_response = { profile: { given_names: ['Joe'] } }
```
This PR adds even more defensive programming in case things go wrong so we can run the whole nightly job, even if some things are missing (logging them instead of throwing an exception).