### PR TITLE
Add va_online_scheduling_vaos_alternate_route feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1307,6 +1307,10 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for tickets with the label vaos-v2-next will be behind this flag
+  va_online_scheduling_vaos_alternate_route:
+    actor_type: user
+    enable_in_development: false
+    description: Toggle for the vaos module to use an alternate vaos-service route
   va_online_scheduling_clinic_filter:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds a new feature flag, `va_online_scheduling_vaos_alternate_route`

## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-oracle-health-integration-65a6e99ea522640e4d09393b/issues/gh/department-of-veterans-affairs/va.gov-team/93478

