### PR TITLE
Add support for alternate vaos-service route

### DIFF
--- a/modules/vaos/app/services/vaos/base_service.rb
+++ b/modules/vaos/app/services/vaos/base_service.rb
@@ -28,5 +28,13 @@ module VAOS
         'https://review-instance.va.gov' # VAMF rejects Referer that is not valid; such as those of review instances
       end
     end
+
+    def base_vaos_route
+      if Flipper.enabled?(:va_online_scheduling_vaos_alternate_route, user)
+        'vaos-alt/v1'
+      else
+        'vaos/v1'
+      end
+    end
   end
 end

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -727,7 +727,7 @@ module VAOS
       end
 
       def appointments_base_path_vaos
-        "/vaos/v1/patients/#{user.icn}/appointments"
+        "/#{base_vaos_route}/patients/#{user.icn}/appointments"
       end
 
       def appointments_base_path_vpg
@@ -742,7 +742,7 @@ module VAOS
         if Flipper.enabled?(APPOINTMENTS_USE_VPG, user)
           "/vpg/v1/patients/#{user.icn}/appointments/#{appointment_id}"
         else
-          "/vaos/v1/patients/#{user.icn}/appointments/#{appointment_id}"
+          "/#{base_vaos_route}/patients/#{user.icn}/appointments/#{appointment_id}"
         end
       end
 
@@ -773,7 +773,7 @@ module VAOS
       end
 
       def update_appointment_vaos(appt_id, status)
-        url_path = "/vaos/v1/patients/#{user.icn}/appointments/#{appt_id}"
+        url_path = "/#{base_vaos_route}/patients/#{user.icn}/appointments/#{appt_id}"
         params = VAOS::V2::UpdateAppointmentForm.new(status:).params
         perform(:put, url_path, params, headers)
       end

--- a/modules/vaos/app/services/vaos/v2/mobile_facility_service.rb
+++ b/modules/vaos/app/services/vaos/v2/mobile_facility_service.rb
@@ -285,7 +285,7 @@ module VAOS
       end
 
       def clinic_url(station_id)
-        "/vaos/v1/locations/#{station_id}/clinics"
+        "/#{base_vaos_route}/locations/#{station_id}/clinics"
       end
 
       def scheduling_url

--- a/modules/vaos/app/services/vaos/v2/patients_service.rb
+++ b/modules/vaos/app/services/vaos/v2/patients_service.rb
@@ -29,7 +29,7 @@ module VAOS
           type:
         }
 
-        perform(:get, "/vaos/v1/patients/#{user.icn}/eligibility", params, headers)
+        perform(:get, "/#{base_vaos_route}/patients/#{user.icn}/eligibility", params, headers)
       end
 
       def get_patient_appointment_metadata_vpg(clinic_service_id, facility_id, type)

--- a/modules/vaos/app/services/vaos/v2/systems_service.rb
+++ b/modules/vaos/app/services/vaos/v2/systems_service.rb
@@ -10,7 +10,7 @@ module VAOS
                                page_number: nil)
         with_monitoring do
           page_size = 0 if page_size.nil? # 0 is the default for the VAOS service which means return all clinics
-          url = "/vaos/v1/locations/#{location_id}/clinics"
+          url = "/#{base_vaos_route}/locations/#{location_id}/clinics"
           url_params = {
             'patientIcn' => get_icn(clinical_service),
             'clinicIds' => get_clinic_ids(clinic_ids),
@@ -57,7 +57,7 @@ module VAOS
       end
 
       def get_slots_vaos(location_id:, clinic_id:, start_dt:, end_dt:)
-        url_path = "/vaos/v1/locations/#{location_id}/clinics/#{clinic_id}/slots"
+        url_path = "/#{base_vaos_route}/locations/#{location_id}/clinics/#{clinic_id}/slots"
         url_params = {
           'start' => start_dt,
           'end' => end_dt


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): YES*
- This work is behind the `va_online_scheduling_vaos_alternate_route` feature toggle.

This adds support for the future ability to set an alternate route for vaos-service that can be used by the vaos module. The alternate route isn't defined yet, and `vaos-alt` is a placeholder, which is why the flag is off by default.

## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-oracle-health-integration-65a6e99ea522640e4d09393b/issues/gh/department-of-veterans-affairs/va.gov-team/93478

## Testing done

- Future work that implements the alternate route will test functionality.

## Screenshots
N/A

## What areas of the site does it impact?
None

