### PR TITLE
dbex/94369: Remove dates from LH submit request for unselected location/hazard options

### DIFF
--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -267,25 +267,39 @@ module EVSS
 
         # create an Array[Requests::MultipleExposures]
         multiple_exposures = []
-        if toxic_exposure_source['gulfWar1990Details'].present?
-          multiple_exposures += transform_multiple_exposures(toxic_exposure_source['gulfWar1990Details'])
+
+        gulf_war1990_details = toxic_exposure_source['gulfWar1990Details']
+        if gulf_war1990_details.present? && gulf_war1990.present?
+          filtered_gulf_war1990_details = filtered_details(gulf_war1990, gulf_war1990_details)
+          multiple_exposures += transform_multiple_exposures(filtered_gulf_war1990_details)
         end
-        if toxic_exposure_source['gulfWar2001Details'].present?
-          multiple_exposures += transform_multiple_exposures(toxic_exposure_source['gulfWar2001Details'])
+
+        gulf_war2001_details = toxic_exposure_source['gulfWar2001Details']
+        if gulf_war2001_details.present? && gulf_war2001.present?
+          filtered_gulf_war2001_details = filtered_details(gulf_war2001, gulf_war2001_details)
+          multiple_exposures += transform_multiple_exposures(filtered_gulf_war2001_details)
         end
-        if toxic_exposure_source['herbicideDetails'].present?
-          multiple_exposures += transform_multiple_exposures(toxic_exposure_source['herbicideDetails'],
+
+        herbicide_details = toxic_exposure_source['herbicideDetails']
+        if herbicide_details.present? && herbicide.present?
+          filtered_herbicide_details = filtered_details(herbicide, herbicide_details)
+          multiple_exposures += transform_multiple_exposures(filtered_herbicide_details,
                                                              MULTIPLE_EXPOSURES_TYPE[:herbicide])
         end
+
         if values_present(toxic_exposure_source['otherHerbicideLocations'])
           multiple_exposures +=
             transform_multiple_exposures_other_details(toxic_exposure_source['otherHerbicideLocations'],
                                                        MULTIPLE_EXPOSURES_TYPE[:herbicide])
         end
-        if toxic_exposure_source['otherExposuresDetails'].present?
-          multiple_exposures += transform_multiple_exposures(toxic_exposure_source['otherExposuresDetails'],
+
+        other_exposures_details = toxic_exposure_source['otherExposuresDetails']
+        if other_exposures_details.present? && other_exposures.present?
+          filtered_other_exposures_details = filtered_details(other_exposures, other_exposures_details)
+          multiple_exposures += transform_multiple_exposures(filtered_other_exposures_details,
                                                              MULTIPLE_EXPOSURES_TYPE[:hazard])
         end
+
         if values_present(toxic_exposure_source['specifyOtherExposures'])
           multiple_exposures +=
             transform_multiple_exposures_other_details(toxic_exposure_source['specifyOtherExposures'],
@@ -349,6 +363,35 @@ module EVSS
         end
 
         [obj]
+      end
+
+      # Filters a details object (i.e. gulfwar1990Details) of "false" or "unchecked" attributes from the source object
+      # example:
+      # {
+      #   "gulfWar1990": {
+      #     "afghanistan": true,
+      #     "bahrain": true,
+      #     "jordan": true,
+      #     "kuwait": true,
+      #     "iraq": true,
+      #     "qatar": false #<- this should be removed from the matching details object
+      #   },
+      #   "gulfWar1990Details": {
+      #     "iraq": {
+      #       "startDate": "1991-03-01",
+      #       "endDate": "1992-01-01"
+      #     },
+      #     "qatar": { #<- remove this
+      #                "startDate": "1991-02-12",
+      #                "endDate": "1991-06-01"
+      #     },
+      #     "kuwait": {
+      #       "startDate": "1991-03-15"
+      #     }
+      #   }
+      # }
+      def filtered_details(source, details)
+        details.select { |obj| source[obj].present? }
       end
 
       def transform_gulf_war(gulf_war1990, gulf_war2001)

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -402,61 +402,63 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       # data sample mimics if a user filled out date data for a toxic exposure item
       # and then went back and unselected the options
       deselected_multiple_exposures_details = data.merge({
-                                          'gulfWar1990' => {
-                                            'iraq' => false,
-                                            'kuwait' => false,
-                                            'qatar' => false
-                                          },
-                                          'gulfWar2001' => {
-                                            'iraq' => {'startDate'=>"1991-03-XX", 'endDate'=>"1992-01-01"},
-                                            'qatar' => {'startDate'=>"1991-03-01", 'endDate'=>"1992-01-01"},
-                                            'kuwait'=>{'startDate'=>"1991-03-15"}
-                                          },                                          
-                                          'herbicide' => {
-                                            'cambodia'=> false,
-                                            'guam'=> false,
-                                            'laos'=> false
-                                          },
-                                          'herbicideDetails'=> {
-                                            'cambodia'=> {
-                                              'startDate'=> '1991-03-01',
-                                              'endDate'=> '1992-01-01'
-                                            },
-                                            'guam'=> {
-                                              'startDate'=> '1991-02-12',
-                                              'endDate'=> '1991-06-01'
-                                            },
-                                            'laos'=> {
-                                              'startDate'=> '1991-03-15'
-                                            }
-                                          },
-                                          'otherExposures' => {
-                                            'asbestos'=> false,
-                                            'chemical'=> false,
-                                            'mos'=> false,
-                                            'mustardgas'=> false,
-                                            'radiation'=> false,
-                                            'water'=> false
-                                          },
-                                          'otherExposuresDetails'=> {
-                                            'asbestos'=> {
-                                              'startDate'=> '1991-03-01',
-                                              'endDate'=> '1992-01-01'
-                                            },
-                                            'radiation'=> {
-                                              'startDate'=> '1991-03-01',
-                                              'endDate'=> '1992-01-01'
-                                            },
-                                            'chemical'=> {
-                                              'startDate'=> '1991-03-01'
-                                            },
-                                            'mos'=> {
-                                              'endDate'=> '1991-03-01'
-                                            }
-                                          },
-                                          'otherHerbicideLocations'=> nil,
-                                          'specifyOtherExposures'=> nil
-                                        })
+                                                           'gulfWar1990' => {
+                                                             'iraq' => false,
+                                                             'kuwait' => false,
+                                                             'qatar' => false
+                                                           },
+                                                           'gulfWar2001' => {
+                                                             'iraq' => { 'startDate' => '1991-03-XX',
+                                                                         'endDate' => '1992-01-01' },
+                                                             'qatar' => { 'startDate' => '1991-03-01',
+                                                                          'endDate' => '1992-01-01' },
+                                                             'kuwait' => { 'startDate' => '1991-03-15' }
+                                                           },
+                                                           'herbicide' => {
+                                                             'cambodia' => false,
+                                                             'guam' => false,
+                                                             'laos' => false
+                                                           },
+                                                           'herbicideDetails' => {
+                                                             'cambodia' => {
+                                                               'startDate' => '1991-03-01',
+                                                               'endDate' => '1992-01-01'
+                                                             },
+                                                             'guam' => {
+                                                               'startDate' => '1991-02-12',
+                                                               'endDate' => '1991-06-01'
+                                                             },
+                                                             'laos' => {
+                                                               'startDate' => '1991-03-15'
+                                                             }
+                                                           },
+                                                           'otherExposures' => {
+                                                             'asbestos' => false,
+                                                             'chemical' => false,
+                                                             'mos' => false,
+                                                             'mustardgas' => false,
+                                                             'radiation' => false,
+                                                             'water' => false
+                                                           },
+                                                           'otherExposuresDetails' => {
+                                                             'asbestos' => {
+                                                               'startDate' => '1991-03-01',
+                                                               'endDate' => '1992-01-01'
+                                                             },
+                                                             'radiation' => {
+                                                               'startDate' => '1991-03-01',
+                                                               'endDate' => '1992-01-01'
+                                                             },
+                                                             'chemical' => {
+                                                               'startDate' => '1991-03-01'
+                                                             },
+                                                             'mos' => {
+                                                               'endDate' => '1991-03-01'
+                                                             }
+                                                           },
+                                                           'otherHerbicideLocations' => nil,
+                                                           'specifyOtherExposures' => nil
+                                                         })
       result = transformer.send(:transform_toxic_exposure, deselected_multiple_exposures_details)
       expect(result.multiple_exposures).to eq([])
     end

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -398,6 +398,69 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(result.gulf_war_hazard_service.served_in_gulf_war_hazard_locations).to eq('YES')
     end
 
+    it 'filters and transforms multiple exposure details correctly' do
+      # data sample mimics if a user filled out date data for a toxic exposure item
+      # and then went back and unselected the options
+      deselected_multiple_exposures_details = data.merge({
+                                          'gulfWar1990' => {
+                                            'iraq' => false,
+                                            'kuwait' => false,
+                                            'qatar' => false
+                                          },
+                                          'gulfWar2001' => {
+                                            'iraq' => {'startDate'=>"1991-03-XX", 'endDate'=>"1992-01-01"},
+                                            'qatar' => {'startDate'=>"1991-03-01", 'endDate'=>"1992-01-01"},
+                                            'kuwait'=>{'startDate'=>"1991-03-15"}
+                                          },                                          
+                                          'herbicide' => {
+                                            'cambodia'=> false,
+                                            'guam'=> false,
+                                            'laos'=> false
+                                          },
+                                          'herbicideDetails'=> {
+                                            'cambodia'=> {
+                                              'startDate'=> '1991-03-01',
+                                              'endDate'=> '1992-01-01'
+                                            },
+                                            'guam'=> {
+                                              'startDate'=> '1991-02-12',
+                                              'endDate'=> '1991-06-01'
+                                            },
+                                            'laos'=> {
+                                              'startDate'=> '1991-03-15'
+                                            }
+                                          },
+                                          'otherExposures' => {
+                                            'asbestos'=> false,
+                                            'chemical'=> false,
+                                            'mos'=> false,
+                                            'mustardgas'=> false,
+                                            'radiation'=> false,
+                                            'water'=> false
+                                          },
+                                          'otherExposuresDetails'=> {
+                                            'asbestos'=> {
+                                              'startDate'=> '1991-03-01',
+                                              'endDate'=> '1992-01-01'
+                                            },
+                                            'radiation'=> {
+                                              'startDate'=> '1991-03-01',
+                                              'endDate'=> '1992-01-01'
+                                            },
+                                            'chemical'=> {
+                                              'startDate'=> '1991-03-01'
+                                            },
+                                            'mos'=> {
+                                              'endDate'=> '1991-03-01'
+                                            }
+                                          },
+                                          'otherHerbicideLocations'=> nil,
+                                          'specifyOtherExposures'=> nil
+                                        })
+      result = transformer.send(:transform_toxic_exposure, deselected_multiple_exposures_details)
+      expect(result.multiple_exposures).to eq([])
+    end
+
     it 'transforms gulf war, herbicide and hazard multiple exposure dates' do
       result = transformer.send(:transform_multiple_exposures, data['gulfWar1990Details'])
       expect(result[0].exposure_dates.begin_date).to eq('1991-03')
@@ -644,6 +707,18 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       result = transformer.send(:transform_other_exposures, none_option_with_no_other['otherExposures'],
                                 none_option_with_no_other['specifyOtherExposures'])
       expect(result).to eq(nil)
+    end
+
+    it 'filters unselected items from details objects correctly' do
+      source = { 'afghanistan' => true, 'bahrain' => true, 'jordan' => true, 'kuwait' => true, 'iraq' => true,
+                 'qatar' => false }
+      details = { 'iraq' => { startDate: '1991-03-01', endDate: '1992-01-01' },
+                  'qatar' => { startDate: '1991-02-12', endDate: '1991-06-01' },
+                  'kuwait' => { startDate: '1991-03-15' } }
+      result = transformer.send(:filtered_details, source, details)
+
+      expect(result).to eq({ 'iraq' => { startDate: '1991-03-01', endDate: '1992-01-01' },
+                             'kuwait' => { startDate: '1991-03-15' } })
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- on the frontend, if the user selects a toxic exposure item, moves forward, fills out a date, moves backward, then deselects the toxic exposure item, the date data is left in the in progress form and is later transmitted to vets-api
- this filters the transmittal of the unselected date data in the request body to lighthouse

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#94369

## Testing done

- [x] *New code is covered by unit tests*
- different client to vets-api objects can be used to test this out.
- the screenshot below shows this snippet of an object tested using the lighthouse pdf generation endpoint:
```
"otherExposures": {
        "asbestos": false,
        "chemical": false,
        "mos": true,
        "mustardgas": true,
        "radiation": true,
        "water": true
      },
      "otherExposuresDetails": {
        "asbestos": {
          "startDate": "1991-03-01",
          "endDate": "1992-01-01"
        },
        "radiation": {
          "startDate": "1991-03-01",
          "endDate": "1992-01-01"
        },
        "chemical": {
          "startDate": "1991-03-01"
        },
        "mos": {
          "endDate": "1991-03-01"
        }
      },
```
it is expected here that "Asbestos" or "SHAD - Shipboard Hazard and Defense" does not appear in the pdf generation, as shown in the Before and After screenshots below.

## Screenshots
Before
![image](https://github.com/user-attachments/assets/60bda603-da03-4206-8125-67f1a704c473)

After
![image](https://github.com/user-attachments/assets/4fef6e0e-818f-4f71-926c-eedd9977ad02)


## What areas of the site does it impact?
vets-api Form526 to Lighthouse transmission

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
