### PR TITLE
Handle nil form_data with a sensible default, needed for JSON parsing

### DIFF
--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -51,6 +51,10 @@ class FormSubmission < ApplicationRecord
     end
   end
 
+  def form_data
+    super || '{}'
+  end
+
   def latest_pending_attempt
     form_submission_attempts.where(aasm_state: 'pending').order(created_at: :asc).last
   end

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe FormSubmission, type: :model do
     it { is_expected.to validate_presence_of(:form_type) }
   end
 
+  describe '#form_data' do
+    it 'defaults to an empty hash in a string' do
+      form_submission = create(:form_submission, form_data: nil)
+
+      expect(form_submission.form_data).to eq '{}'
+    end
+  end
+
   describe 'user form submission statuses' do
     before do
       @fsa, @fsb, @fsc = create_list(:form_submission, 3, user_account:)


### PR DESCRIPTION
## Summary
This PR handles when `form_data` is `nil` in a `FormSubmission`. If we allow it to remain `nil`, then it will break in our nightly job when we try to run `JSON.parse(form_data)`. If we can default it to `'{}'` then it won't error out when trying to JSON parse.
