### PR TITLE
Set timezone to US Eastern for Simple Forms email sends

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -95,7 +95,7 @@ class FormSubmissionAttempt < ApplicationRecord
   end
 
   def time_to_send
-    now = Time.zone.now
+    now = Time.now.in_time_zone('Eastern Time (US & Canada)')
     if now.hour < HOUR_TO_SEND_NOTIFICATIONS
       now.change(hour: HOUR_TO_SEND_NOTIFICATIONS,
                  min: 0)


### PR DESCRIPTION
## Summary
This PR updates the timezone for sending daily emails about received and errored submissions for Simple Forms forms from UTC to US Eastern.
