### PR TITLE
Handle nil in form_data properly for Form Submission Attempts

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -79,8 +79,10 @@ class FormSubmissionAttempt < ApplicationRecord
   private
 
   def enqueue_result_email(notification_type)
+    raw_form_data = form_submission.form_data || '{}'
+    form_data = JSON.parse(raw_form_data)
     config = {
-      form_data: JSON.parse(form_submission.form_data),
+      form_data:,
       form_number: form_submission.form_type,
       confirmation_number: form_submission.benefits_intake_uuid,
       date_submitted: created_at.strftime('%B %d, %Y'),

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -75,6 +75,34 @@ RSpec.describe FormSubmissionAttempt, type: :model do
 
         expect(notification_email).to have_received(:send)
       end
+
+      context 'form_data is nil' do
+        let(:config) do
+          {
+            form_data: nil,
+            form_number: anything,
+            date_submitted: anything,
+            lighthouse_updated_at: anything,
+            confirmation_number: anything
+          }
+        end
+
+        it 'gracefully handles the nil form_data' do
+          notification_email = double
+          allow(JSON).to receive(:parse)
+          allow(SimpleFormsApi::NotificationEmail).to receive(:new).with(
+            config,
+            notification_type:,
+            user_account: anything
+          ).and_return(notification_email)
+          allow(notification_email).to receive(:send)
+          form_submission_attempt = create(:form_submission_attempt)
+
+          form_submission_attempt.vbms!
+
+          expect(JSON).to have_received(:parse).with('{}')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
This PR handles `nil` form_data in a non-destructive way ([see the revert](https://github.com/department-of-veterans-affairs/vets-api/pull/18773)).
