### PR TITLE
[SIMPLE_FORMS] feat: form remediation solution streamlining, test coverage, and documentation - PART 3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2088,7 +2088,7 @@ spec/uploaders/form1010cg/poa_uploader_spec.rb @department-of-veterans-affairs/v
 spec/uploaders/supporting_evidence_attachment_uploader_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/uploader_virus_scan_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/validate_pdf_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/uploaders/veteran_facing_forms_remediation_uploader_spec.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/uploaders/simple_forms_api/ @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/prescription_details.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/backend-review-group
 modules/my_health/app/controllers/my_health/v1/prescriptions_controller.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/backend-review-group
 modules/my_health/spec/request/v1/prescriptions_request_spec.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/backend-review-group

--- a/app/uploaders/simple_forms_api/form_remediation/uploader.rb
+++ b/app/uploaders/simple_forms_api/form_remediation/uploader.rb
@@ -36,6 +36,7 @@ module SimpleFormsApi
 
       def initialize(directory:, config: Configuration::Base.new)
         raise 'The S3 directory is missing.' if directory.blank?
+        raise 'The configuration is missing.' unless config
 
         @config = config
         @directory = directory

--- a/app/uploaders/simple_forms_api/form_remediation/uploader.rb
+++ b/app/uploaders/simple_forms_api/form_remediation/uploader.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'simple_forms_api/form_remediation/configuration/base'
+
+module SimpleFormsApi
+  module FormRemediation
+    class Uploader < CarrierWave::Uploader::Base
+      include UploaderVirusScan
+
+      class << self
+        def s3_settings
+          config = Configuration::Base.new
+          config.s3_settings
+        end
+
+        def new_s3_resource
+          client = Aws::S3::Client.new(region: s3_settings.region)
+          Aws::S3::Resource.new(client:)
+        end
+
+        def get_s3_link(file_path)
+          new_s3_resource.bucket(s3_settings.bucket)
+                         .object(file_path)
+                         .presigned_url(:get, expires_in: 30.minutes.to_i)
+        end
+      end
+
+      def size_range
+        (1.byte)...(150.megabytes)
+      end
+
+      # Allowed file types, including those specific to benefits intake
+      def extension_allowlist
+        %w[bmp csv gif jpeg jpg json pdf png tif tiff txt zip]
+      end
+
+      def initialize(directory:, config: Configuration::Base.new)
+        raise 'The S3 directory is missing.' if directory.blank?
+
+        @config = config
+        @directory = directory
+
+        super()
+        set_storage_options!
+      end
+
+      def store_dir
+        @directory
+      end
+
+      private
+
+      def set_storage_options!
+        settings = @config.s3_settings
+
+        self.aws_credentials = { region: settings.region }
+        self.aws_acl = 'private'
+        self.aws_bucket = settings.bucket
+        self.aws_attributes = { server_side_encryption: 'AES256' }
+        self.class.storage = :aws
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -14,8 +14,8 @@ module SimpleFormsApi
       def initialize(config: Configuration::Base.new, **options)
         @config = config
         @temp_directory_path = config.temp_directory_path
-        @include_manifest = config.include_manifest || true
-        @include_metadata = config.include_metadata || true
+        @include_manifest = config.include_manifest
+        @include_metadata = config.include_metadata
 
         assign_defaults(options)
         hydrate_submission_data unless submission_already_hydrated?

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'fileutils'
+require 'simple_forms_api/form_remediation/configuration/base'
+
+# Built in accordance with the following documentation:
+# https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/practices/zero-silent-failures/remediation.md
+module SimpleFormsApi
+  module FormRemediation
+    class SubmissionArchive
+      include FileUtilities
+
+      def initialize(config: Configuration::Base.new, **options)
+        @config = config
+        @temp_directory_path = config.temp_directory_path
+        @include_manifest = config.include_manifest || true
+        @include_metadata = config.include_metadata || true
+
+        assign_defaults(options)
+        hydrate_submission_data unless submission_already_hydrated?
+
+        @form_number = JSON.parse(submission&.form_data)['form_number']
+      rescue => e
+        config.handle_error("#{self.class.name} initialization failed", e)
+      end
+
+      def build!
+        create_temp_directory!(temp_directory_path)
+        process_submission_files
+
+        return "#{submission_file_path}.pdf" if archive_type == :submission
+
+        zip_directory!(config.parent_dir, temp_directory_path)
+      rescue => e
+        config.handle_error("Failed building submission: #{id}", e)
+      end
+
+      private
+
+      attr_reader :archive_type, :attachments, :config, :file_path, :form_number, :id, :include_manifest,
+                  :include_metadata, :metadata, :submission, :temp_directory_path
+
+      def assign_defaults(options)
+        # The file paths of any hydrated attachments which were originally included in the submission
+        @attachments = options[:attachments]
+        # The local path where the submission PDF is stored
+        @file_path = options[:file_path]
+        # The FormSubmission object representing the original data payload submitted
+        @submission = options[:submission]
+        # The UUID returned from the Benefits Intake API upon original submission
+        @id = @submission&.send(config.id_type) || options[:id]
+        # Data appended to the original submission headers
+        @metadata = options[:metadata]
+        # The type of archive to be created (:submission or :remediation)
+        @archive_type = options[:type] || :remediation
+      end
+
+      def submission_already_hydrated?
+        submission && file_path && attachments && metadata
+      end
+
+      def hydrate_submission_data
+        raise "No #{config.id_type} was provided" unless id
+
+        built_submission = config.remediation_data_class.new(id:).hydrate!
+        # The local path where the submission PDF is stored
+        @file_path = built_submission.file_path
+        # The FormSubmission object representing the original data payload submitted
+        @submission = built_submission.submission
+        # The UUID returned from the Benefits Intake API upon original submission
+        @id = submission&.send(config.id_type)
+        # The file paths of any hydrated attachments which were originally included in the submission
+        @attachments = built_submission.attachments || []
+        # Data appended to the original submission headers
+        @metadata = built_submission.metadata
+      end
+
+      def process_submission_files
+        [
+          -> { write_pdf },
+          -> { write_attachments if attachments&.any? },
+          -> { write_manifest if include_manifest },
+          -> { write_metadata if include_metadata }
+        ].each do |task|
+          safely_execute_task(task)
+        end
+      end
+
+      def safely_execute_task(task)
+        task.call
+      rescue => e
+        config.handle_error("Error during processing task: #{task.source_location}", e)
+      end
+
+      def write_pdf
+        create_file("#{submission_file_path}.pdf", File.read(file_path), 'submission pdf')
+      end
+
+      def write_metadata
+        create_file("metadata_#{submission_file_path}.json", metadata.to_json, 'metadata')
+      end
+
+      def write_attachments
+        config.log_info("Processing #{attachments.count} attachments")
+        attachments.each_with_index { |attachment, i| process_attachment(i + 1, attachment) }
+      end
+
+      def process_attachment(attachment_number, file_path)
+        config.log_info("Processing attachment ##{attachment_number}: #{file_path}")
+        create_file("attachment_#{attachment_number}__#{submission_file_path}.pdf", File.read(file_path), 'attachment')
+      end
+
+      def write_manifest
+        file_name = "manifest_#{submission_file_path}.csv"
+        manifest_path = File.join(temp_directory_path, file_name)
+
+        CSV.open(manifest_path, 'wb') do |csv|
+          csv << %w[SubmissionDateTime FormType VAGovID VeteranID FirstName LastName]
+          csv << [
+            submission.created_at,
+            form_number,
+            id,
+            metadata['fileNumber'],
+            metadata['veteranFirstName'],
+            metadata['veteranLastName']
+          ]
+        end
+      rescue => e
+        config.handle_error("Failed writing manifest for submission: #{id}", e)
+      end
+
+      def create_file(file_name, payload, file_description, dir_path = config.temp_directory_path)
+        write_file(dir_path, file_name, payload)
+      rescue => e
+        config.handle_error("Failed writing #{file_description} file #{file_name} for submission: #{id}", e)
+      end
+
+      def submission_file_path
+        @submission_file_path ||= unique_file_path(form_number, id)
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -99,12 +99,6 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
       it 'writes the manifest file' do
         expect(CSV).to have_received(:open).with("#{temp_file_path}/manifest_#{submission_file_path}.csv", 'wb')
       end
-
-      it 'writes the metadata json file' do
-        expect(File).to have_received(:write).with(
-          "#{temp_file_path}/metadata_#{submission_file_path}.json", metadata.to_json
-        )
-      end
     end
   end
 end

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
+  let(:form_type) { '20-10207' }
+  let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
+  let(:form_data) { Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read }
+  let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
+  let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
+  let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+  let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
+  let(:metadata) do
+    {
+      veteranFirstName: 'John',
+      veteranLastName: 'Veteran',
+      fileNumber: '321540987',
+      zipCode: '12345',
+      source: 'VA Platform Digital Forms',
+      docType: '20-10207',
+      businessLine: 'CMP'
+    }
+  end
+  let(:submission_file_path) do
+    [Time.zone.today.strftime('%-m.%d.%y'), 'form', form_type, 'vagov', benefits_intake_uuid].join('_')
+  end
+  let(:new_submission_instance) { instance_double(SimpleFormsApi::FormRemediation::SubmissionRemediationData) }
+  let(:hydrated_submission_instance) do
+    instance_double(
+      SimpleFormsApi::FormRemediation::SubmissionRemediationData, submission:, file_path:, attachments:, metadata:
+    )
+  end
+  let(:submission_archive_instance) { described_class.new(id: benefits_intake_uuid) }
+
+  before do
+    allow(FormSubmission).to receive(:find_by).and_return(submission)
+    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+    allow(SimpleFormsApi::FormRemediation::SubmissionRemediationData).to(
+      receive(:new).and_return(new_submission_instance)
+    )
+    allow(new_submission_instance).to receive_messages(hydrate!: hydrated_submission_instance)
+    allow(File).to receive_messages(write: true, directory?: true)
+    allow(CSV).to receive(:open).and_return(true)
+    allow(FileUtils).to receive(:mkdir_p).and_return(true)
+    allow(submission_archive_instance).to receive(:zip_directory!) { |_, dir| dir }
+  end
+
+  describe '#initialize' do
+    subject(:new) { submission_archive_instance }
+
+    context 'when initialized with a valid benefits_intake_uuid' do
+      it 'successfully completes initialization' do
+        expect { new }.not_to raise_exception
+      end
+    end
+
+    context 'when initialized with valid hydrated submission data' do
+      let(:submission_archive_instance) { described_class.new(submission:, file_path:, attachments:, metadata:) }
+
+      it 'successfully completes initialization' do
+        expect { new }.not_to raise_exception
+      end
+    end
+
+    context 'when no valid parameters are passed' do
+      it 'raises an exception' do
+        expect { described_class.new(id: nil) }.to raise_exception('No benefits_intake_uuid was provided')
+      end
+    end
+  end
+
+  describe '#build!' do
+    subject(:build_archive) { submission_archive_instance.build! }
+
+    let(:temp_file_path) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
+
+    before { build_archive }
+
+    context 'when properly initialized' do
+      it 'completes successfully' do
+        expect(build_archive).to include(temp_file_path)
+      end
+
+      it 'writes the submission pdf file' do
+        expect(File).to have_received(:write).with(
+          "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+        )
+      end
+
+      it 'writes the attachment files' do
+        attachments.each_with_index do |_, i|
+          expect(File).to have_received(:write).with(
+            "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+          )
+        end
+      end
+
+      it 'writes the manifest file' do
+        expect(CSV).to have_received(:open).with("#{temp_file_path}/manifest_#{submission_file_path}.csv", 'wb')
+      end
+
+      it 'writes the metadata json file' do
+        expect(File).to have_received(:write).with(
+          "#{temp_file_path}/metadata_#{submission_file_path}.json", metadata.to_json
+        )
+      end
+    end
+  end
+end

--- a/spec/uploaders/simple_forms_api/form_remediation/uploader_spec.rb
+++ b/spec/uploaders/simple_forms_api/form_remediation/uploader_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+require 'simple_forms_api/form_remediation/configuration/vff_config'
+
+module SimpleFormsApi
+  module FormRemediation
+    RSpec.describe Uploader do
+      describe '#initialize' do
+        subject(:new) { described_class.new(directory:, config:) }
+
+        before do
+          allow(Settings.vff_simple_forms).to(
+            receive(:aws).and_return(OpenStruct.new(region: 'region', bucket: 'bucket'))
+          )
+        end
+
+        let(:config) { Configuration::VffConfig.new }
+        let(:directory) { '/some/path' }
+
+        it 'allows image, pdf, json, csv, and text files' do
+          expect(new.extension_allowlist).to match_array %w[bmp csv gif jpeg jpg json pdf png tif tiff txt zip]
+        end
+
+        it 'returns a store directory containing benefits_intake_uuid' do
+          expect(new.store_dir).to eq(directory)
+        end
+
+        describe 'when config is nil' do
+          let(:config) { nil }
+
+          it 'throws an error' do
+            expect { new }.to raise_exception(RuntimeError, 'The configuration is missing.')
+          end
+        end
+
+        describe 'when directory is nil' do
+          let(:directory) { nil }
+
+          it 'throws an error' do
+            expect { new }.to raise_exception(RuntimeError, 'The S3 directory is missing.')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary


This solution is designed to remediate form submissions which have failed submission and are over two weeks old. It is composed of several Ruby on Rails service objects which interact with each other.

The primary use-case for this solution is for form remediation. This process consists of the following:

1. Accept a form submission identifier.
1. Generate an archive payload consisting of the original form submission data as well as remediation specific documentation:
    1. Hydrate the original form submission
    1. Hydrate any original attachments that were a part of this submission
    1. Generate a JSON file with the original metadata from the submission
    1. Generate a manifest file to be used in the remediation process
1. Upload the generated archive as a .zip file onto the configured S3 bucket
1. Optionally return a presigned URL for accessing this file

This solution also provides a means for storing and retrieving a single .pdf copy of the originally submitted form.

The following image depicts how this solution is architected:

![Error Remediation Architecture Diagram_2024-10-07_14-14-25](https://github.com/user-attachments/assets/99c8d0a5-ad65-4cbd-8c76-b59988483c8c)


- This work updates the form remediation solution to be configurable and usable by all other va.gov teams.
- This is part 3 of a larger PR which was too large and needed broken up. It includes the uploader and archive data.

## Related issue(s)

- [Form Submission Remediation - Genericize S3 bucket archiving solution for external team usage](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/1954)

## Testing done

- [x] New logic is covered by unit tests

## Requested Feedback

Any
