### PR TITLE
[SIMPLE_FORMS] feat: form remediation solution streamlining, test coverage, and documentation - PART 5

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1239,6 +1239,7 @@ spec/factories/va5495.rb @department-of-veterans-affairs/govcio-vfep-codereviewe
 spec/factories/va_profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/veteran_onboardings.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
+spec/factories/persistent_attachments.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/fixtures/ask @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/fixtures/ask/minimal.json @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/fixtures/bgs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/jobs/archive_batch_processing_job.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/jobs/archive_batch_processing_job.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module SimpleFormsApi
+  module FormRemediation
+    module Jobs
+      class ArchiveBatchProcessingJob
+        include Sidekiq::Worker
+        include FileUtilities
+
+        PROGRESS_FILE_PATH = '/tmp/submission_archive_progress.json'
+
+        def perform(ids:, config:, type: :remediation)
+          raise Common::Exceptions::ParameterMissing, 'ids' unless ids&.any?
+
+          @ids = ids
+          @config = config
+          @parent_dir = @config.parent_dir
+          @presigned_urls = []
+
+          begin
+            load_progress
+            presigned_urls = upload(type:)
+            cleanup(PROGRESS_FILE_PATH)
+            presigned_urls
+          rescue => e
+            @config.handle_error("#{self.class.name} execution failed", e)
+          end
+        end
+
+        private
+
+        attr_reader :config, :ids, :parent_dir, :presigned_urls, :type
+
+        def upload(type:)
+          @type = type
+
+          archive_individual_submissions
+          read_urls_from_file
+        rescue => e
+          config.handle_error("Archiving #{type} collection failed.", e)
+        end
+
+        def load_progress
+          if File.exist?(PROGRESS_FILE_PATH)
+            progress_data = JSON.parse(File.read(PROGRESS_FILE_PATH))
+            @processed_uuids = progress_data['uuids']
+            @presigned_urls = progress_data['urls']
+          else
+            @processed_uuids = []
+            @presigned_urls = []
+          end
+        end
+
+        def write_progress
+          progress_data = { uuids: @processed_uuids, urls: @presigned_urls }
+          File.write(PROGRESS_FILE_PATH, JSON.pretty_generate(progress_data))
+        end
+
+        def read_urls_from_file
+          return [] unless File.exist?(PROGRESS_FILE_PATH)
+
+          progress_data = JSON.parse(File.read(PROGRESS_FILE_PATH))
+          progress_data['urls']
+        end
+
+        def archive_individual_submissions
+          ids.each_with_index do |uuid, i|
+            next if @processed_uuids.include? uuid
+
+            config.log_info("Archiving #{type}: #{uuid} ##{i + 1} of #{ids.count} total submissions")
+            presigned_url = archive_submission(uuid)
+            @presigned_urls << presigned_url
+            @processed_uuids << uuid
+            write_progress
+          end
+        end
+
+        def archive_submission(id)
+          config.s3_client.new(id:, parent_dir:, type:).upload
+        end
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/lib/tasks/archive_forms_by_uuid.rake
+++ b/modules/simple_forms_api/lib/tasks/archive_forms_by_uuid.rake
@@ -1,31 +1,29 @@
 # frozen_string_literal: true
 
 # Invoke this as follows:
-#  Passing just UUIDs (will use default type and parent_dir):
+#  Passing just UUIDs (will use default type):
 #    bundle exec rails simple_forms_api:archive_forms_by_uuid[abc-123 def-456]
-#  Passing a custom type (and using default parent_dir):
+#  Passing a custom type:
 #    bundle exec rails simple_forms_api:archive_forms_by_uuid[abc-123 def-456,submission]
-#  Passing custom type and parent_dir:
-#    bundle exec rails simple_forms_api:archive_forms_by_uuid[abc-123 def-456,remediation,/custom/dir]
 namespace :simple_forms_api do
-  desc 'Kick off the SubmissionArchiveHandler to archive submissions to S3 and print presigned URLs'
-  task :archive_forms_by_uuid, %i[benefits_intake_uuids type parent_dir] => :environment do |_, args|
-    # Explicit handling of UUIDs, allowing space-separated or comma-separated values
+  desc 'Kick off the ArchiveBatchProcessingJob to archive submissions to S3 and print presigned URLs'
+  task :archive_forms_by_uuid, %i[benefits_intake_uuids type] => :environment do |_, args|
     benefits_intake_uuids = args[:benefits_intake_uuids].to_s.split(/[,\s]+/)
-    parent_dir = args[:parent_dir] || 'vff-simple-forms'
     type = args[:type] || :remediation
 
     begin
       validate_input!(benefits_intake_uuids)
 
-      Rails.logger.info("Starting SubmissionArchiveHandler for UUIDs: #{benefits_intake_uuids.join(', ')}")
-      Rails.logger.info("Using type: #{type} and parent_dir: #{parent_dir}")
+      Rails.logger.info(
+        "Starting ArchiveBatchProcessingJob for UUIDs: #{benefits_intake_uuids.join(', ')} using type: #{type}"
+      )
 
       # Call the service object synchronously and get the presigned URLs
-      handler = SimpleFormsApi::S3::SubmissionArchiveHandler.new(benefits_intake_uuids:, parent_dir:)
-      presigned_urls = handler.upload(type: type.to_sym)
+      config = SimpleFormsApi::FormRemediation::Configuration::VffConfig.new
+      job = SimpleFormsApi::FormRemediation::ArchiveBatchProcessingJob.new
+      presigned_urls = job.perform(ids: benefits_intake_uuids, config:, type: type.to_sym)
 
-      Rails.logger.info('SubmissionArchiveHandler completed successfully.')
+      Rails.logger.info('ArchiveBatchProcessingJob completed successfully.')
 
       # ArgoCD makes it impossible to download any files so
       # the URLs must be printed to the console.

--- a/modules/simple_forms_api/spec/services/form_remediation/jobs/archive_batch_processing_job_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/jobs/archive_batch_processing_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+require 'simple_forms_api/form_remediation/configuration/vff_config'
+
+module SimpleFormsApi
+  module FormRemediation
+    module Jobs
+      RSpec.describe ArchiveBatchProcessingJob, type: :job do
+        include FileUtilities
+
+        let(:form_type) { '21-10210' }
+        let(:form_data) do
+          File.read("modules/simple_forms_api/spec/fixtures/form_json/vba_#{form_type.tr('-', '_')}.json")
+        end
+        let(:submissions) do
+          create_list(:form_submission, 4, :pending, form_type:, form_data:) do |submission|
+            submission.update!(benefits_intake_uuid: SecureRandom.uuid)
+          end
+        end
+        let(:benefits_intake_uuids) { submissions.map(&:benefits_intake_uuid) }
+        let(:config) { Configuration::VffConfig.new }
+        let(:s3_client_double) { instance_double(S3Client) }
+
+        describe '#perform' do
+          subject(:perform) { described_class.new.perform(ids: benefits_intake_uuids, config:) }
+
+          before do
+            allow(S3Client).to receive(:new).and_return(s3_client_double)
+            allow(s3_client_double).to receive(:upload).and_return('/s3/presigned/url')
+            allow(File).to receive_messages(exist?: false, write: true)
+            allow(Rails.logger).to receive(:info).and_call_original
+          end
+
+          context 'with valid parameters' do
+            it 'processes all submissions and generates presigned URLs' do
+              perform
+              expect(Rails.logger).to have_received(:info).exactly(4).times
+              expect(File).to have_received(:write).exactly(4).times
+            end
+          end
+
+          context 'when ids are missing' do
+            let(:benefits_intake_uuids) { [] }
+
+            it 'raises a ParameterMissing error' do
+              expect { perform }.to raise_error(Common::Exceptions::ParameterMissing, 'Missing parameter')
+            end
+          end
+
+          context 'when an error occurs during archiving' do
+            before { allow(s3_client_double).to receive(:upload).and_raise(StandardError.new('oopsy')) }
+
+            it 'handles the error with the config handle_error method' do
+              expect { perform }.to raise_error(StandardError, 'oopsy')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/persistent_attachments.rb
+++ b/spec/factories/persistent_attachments.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :persistent_attachment do
+    guid { Faker::Internet.uuid }
+
+    after(:build) do |attachment|
+      file = Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf').open('rb')
+      uploaded_file = Shrine.upload(file, :store)
+      attachment.file_data = uploaded_file.to_json
+    end
+
+    factory :persistent_attachment_va_form, class: 'PersistentAttachments::VAForm' do
+      form_id { '20-10207' }
+
+      after(:build) do |attachment|
+        file = Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf').open('rb')
+        uploaded_file = Shrine.upload(file, :store)
+        attachment.file_data = uploaded_file.to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This solution is designed to remediate form submissions which have failed submission and are over two weeks old. It is composed of several Ruby on Rails service objects which interact with each other.

The primary use-case for this solution is for form remediation. This process consists of the following:

1. Accept a form submission identifier.
1. Generate an archive payload consisting of the original form submission data as well as remediation specific documentation:
    1. Hydrate the original form submission
    1. Hydrate any original attachments that were a part of this submission
    1. Generate a JSON file with the original metadata from the submission
    1. Generate a manifest file to be used in the remediation process
1. Upload the generated archive as a .zip file onto the configured S3 bucket
1. Optionally return a presigned URL for accessing this file

This solution also provides a means for storing and retrieving a single .pdf copy of the originally submitted form.

The following image depicts how this solution is architected:

![Error Remediation Architecture Diagram_2024-10-07_14-14-25](https://github.com/user-attachments/assets/99c8d0a5-ad65-4cbd-8c76-b59988483c8c)


- This work updates the form remediation solution to be configurable and usable by all other va.gov teams.
- This is part 5 of a larger PR which was too large and needed broken up. It includes the batch processing logic.

## Related issue(s)

- [Form Submission Remediation - Genericize S3 bucket archiving solution for external team usage](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/1954)

## Testing done

- [x] New logic is covered by unit tests

## Requested Feedback

Any
