### PR TITLE
dbex/94369: Remove dates from LH submit request for unselected location/hazard options - "other" objects

### DIFF
--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -287,9 +287,9 @@ module EVSS
                                                              MULTIPLE_EXPOSURES_TYPE[:herbicide])
         end
 
-        if values_present(toxic_exposure_source['otherHerbicideLocations'])
+        if values_present(other_herbicide_locations) && other_herbicide_locations['description'].present?
           multiple_exposures +=
-            transform_multiple_exposures_other_details(toxic_exposure_source['otherHerbicideLocations'],
+            transform_multiple_exposures_other_details(other_herbicide_locations,
                                                        MULTIPLE_EXPOSURES_TYPE[:herbicide])
         end
 
@@ -300,9 +300,9 @@ module EVSS
                                                              MULTIPLE_EXPOSURES_TYPE[:hazard])
         end
 
-        if values_present(toxic_exposure_source['specifyOtherExposures'])
+        if values_present(specify_other_exposures) && specify_other_exposures['description'].present?
           multiple_exposures +=
-            transform_multiple_exposures_other_details(toxic_exposure_source['specifyOtherExposures'],
+            transform_multiple_exposures_other_details(specify_other_exposures,
                                                        MULTIPLE_EXPOSURES_TYPE[:hazard])
         end
 
@@ -410,7 +410,7 @@ module EVSS
       def transform_herbicide(herbicide, other_herbicide_locations)
         filtered_results_herbicide = herbicide&.filter { |k| k != 'notsure' }
         herbicide_value = (values_present(filtered_results_herbicide) ||
-                          values_present(other_herbicide_locations)) &&
+          (other_herbicide_locations.present? && other_herbicide_locations['description'].present?)) &&
                           !none_of_these(filtered_results_herbicide)
 
         herbicide_service = Requests::HerbicideHazardService.new
@@ -420,7 +420,10 @@ module EVSS
       end
 
       def transform_other_exposures(other_exposures, specify_other_exposures)
-        return nil if none_of_these(other_exposures) && !values_present(specify_other_exposures)
+        if none_of_these(other_exposures) &&
+           (specify_other_exposures.present? && specify_other_exposures['description'].blank?)
+          return nil
+        end
 
         filtered_results_other_exposures = other_exposures&.filter { |k, v| k != 'notsure' && v }
         additional_hazard_exposures_service = Requests::AdditionalHazardExposures.new
@@ -429,7 +432,9 @@ module EVSS
             HAZARDS_LH_ENUM[k.to_sym]
           end
         end
-        other = HAZARDS_LH_ENUM[:other] if values_present(specify_other_exposures)
+        if specify_other_exposures.present? && specify_other_exposures['description'].present?
+          other = HAZARDS_LH_ENUM[:other]
+        end
         additional_hazard_exposures_service.additional_exposures << other if other.present?
         return nil if additional_hazard_exposures_service.additional_exposures == []
 
@@ -743,6 +748,7 @@ module EVSS
 
         # somehow, partial dates with the 'XX' (i.e. "2020-01-XX or 2020-XX-XX") are getting past FE validation
         # fix here in the backend while a proper FE solution is found
+        return nil if year.downcase.include?('x')
         return year if month.blank? || month.upcase == 'XX'
         return "#{year}-#{month}" if day.blank? || day.upcase == 'XX'
 

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -96,6 +96,67 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
     end
   end
 
+  describe 'specifyOtherExposure and otherHerbicideLocations' do
+    let(:submission) { create(:form526_submission, :with_everything_toxic_exposure) }
+    let(:data) { submission.form['form526'] }
+
+    context 'multiple exposures' do
+      it 'is processed if descriptions are present' do
+        # specifyOtherExposure and otherHerbicideLocations should be processed if descriptions are present
+        data['form526']['toxicExposure'] = {
+          'gulfWar2001Details' => {},
+          'gulfWar1990Details' => {},
+          'herbicide' => {},
+          'herbicideDetails' => {},
+          'otherExposureDetails' => {},
+          'specifyOtherExposures' => {
+            'description' => 'specifyOtherExposures',
+            'startDate' => '1992-01-01',
+            'endDate' => '1993-01-01'
+          },
+          'otherHerbicideLocations' => {
+            'description' => 'otherHerbicideLocations',
+            'startDate' => '1992-01-01',
+            'endDate' => '1993-01-01'
+          }
+        }
+        result = transformer.transform(data)
+
+        # "other" objects should have been processed for MultipleExposures because the descriptions are there
+        expect(result.toxic_exposure.multiple_exposures.length).to eq(2)
+        expect(result.toxic_exposure.multiple_exposures.first.exposure_location).to eq('otherHerbicideLocations')
+        expect(result.toxic_exposure.multiple_exposures.first.hazard_exposed_to).to eq(nil)
+        expect(result.toxic_exposure.multiple_exposures.last.exposure_location).to eq(nil)
+        expect(result.toxic_exposure.multiple_exposures.last.hazard_exposed_to).to eq('specifyOtherExposures')
+      end
+
+      it 'is not processed if missing descriptions' do
+        # specifyOtherExposure and otherHerbicideLocations should not be processed if missing descriptions
+        data['form526']['toxicExposure'] = {
+          'gulfWar2001Details' => {},
+          'gulfWar1990Details' => {},
+          'herbicide' => {},
+          'herbicideDetails' => {},
+          'otherExposureDetails' => {},
+          'specifyOtherExposures' => {
+            'description' => ' ',
+            'startDate' => '1992-01-01',
+            'endDate' => '1993-01-01'
+          },
+          'otherHerbicideLocations' => {
+            'description' => ' ',
+            'startDate' => '1992-01-01',
+            'endDate' => '1993-01-01'
+          }
+        }
+        result = transformer.transform(data)
+        # nothing should have been processed for MultipleExposures because
+        # all of the details are missing and the descriptions are missing in the "other" objects
+        expect(result.toxic_exposure.multiple_exposures).to eq([])
+      end
+    end
+  end
+
   describe '#evss_claims_process_type' do
     let(:submission) { create(:form526_submission, :with_everything) }
     let(:data) { submission.form['form526'] }
@@ -534,6 +595,14 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       date = '2024'
       result = transformer.send(:convert_date_no_day, date)
       expect(result).to eq('2024')
+
+      date = 'XXXX'
+      result = transformer.send(:convert_date_no_day, date)
+      expect(result).to eq(nil)
+
+      date = 'XX-XX-XX'
+      result = transformer.send(:convert_date_no_day, date)
+      expect(result).to eq(nil)
     end
 
     it 'set served_in_herbicide_hazard_locations correctly' do
@@ -605,6 +674,31 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
                                                               })
       result = transformer.send(:transform_herbicide, other_herbicide_locations_has_blank_fields['herbicide'],
                                 other_herbicide_locations_has_blank_fields['otherHerbicideLocations'])
+      expect(result.served_in_herbicide_hazard_locations).to eq('NO')
+
+      # description must be in the otherHerbicideLocations object for it to be processed (blank string)
+      other_herbicide_locations_description_blank = data.merge({
+                                                                 'herbicide' => nil,
+                                                                 'otherHerbicideLocations' => {
+                                                                   'description' => '',
+                                                                   'startDate' => '1992-01-01',
+                                                                   'endDate' => '1992-01-01'
+                                                                 }
+                                                               })
+      result = transformer.send(:transform_herbicide, other_herbicide_locations_description_blank['herbicide'],
+                                other_herbicide_locations_description_blank['otherHerbicideLocations'])
+      expect(result.served_in_herbicide_hazard_locations).to eq('NO')
+
+      # description must be in the otherHerbicideLocations object for it to be processed (attribute missing)
+      other_herbicide_locations_description_missing = data.merge({
+                                                                   'herbicide' => nil,
+                                                                   'otherHerbicideLocations' => {
+                                                                     'startDate' => '1992-01-01',
+                                                                     'endDate' => '1992-01-01'
+                                                                   }
+                                                                 })
+      result = transformer.send(:transform_herbicide, other_herbicide_locations_description_missing['herbicide'],
+                                other_herbicide_locations_description_missing['otherHerbicideLocations'])
       expect(result.served_in_herbicide_hazard_locations).to eq('NO')
     end
 
@@ -708,6 +802,32 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
                                              })
       result = transformer.send(:transform_other_exposures, none_option_with_no_other['otherExposures'],
                                 none_option_with_no_other['specifyOtherExposures'])
+      expect(result).to eq(nil)
+
+      # description must be in the specifyOtherExposures object for it to be processed (blank string)
+      no_option_with_no_other_blank_string = data.merge({
+                                                          'otherExposures' => {},
+                                                          'specifyOtherExposures' => {
+                                                            'description' => '',
+                                                            'startDate' => '1991-03-01',
+                                                            'endDate' => '1992-01-01'
+                                                          }
+                                                        })
+      result = transformer.send(:transform_other_exposures, no_option_with_no_other_blank_string['otherExposures'],
+                                no_option_with_no_other_blank_string['specifyOtherExposures'])
+      expect(result).to eq(nil)
+
+      # description must be in the specifyOtherExposures object for it to be processed (missing attribute)
+      no_option_with_no_other_missing = data.merge({
+                                                     'otherExposures' => {},
+                                                     'specifyOtherExposures' => {
+                                                       'startDate' => '1991-03-01',
+                                                       'endDate' => '1992-01-01'
+                                                     }
+                                                   })
+      result = transformer.send(:transform_other_exposures, no_option_with_no_other_missing['otherExposures'],
+                                no_option_with_no_other_missing['specifyOtherExposures'])
+
       expect(result).to eq(nil)
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- removes dates from the "other" objects if the user deselected them in the front end

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#94369

## Testing done

- [x] *New code is covered by unit tests*
- additional hazard dates were being sent to the 526 pdf generation step even if the user removed their free-form text on the front end
1. a user:
2. types in text into the "other" free-form text fields
3. enters in dates for that item
4. clicks BACK
-- but leaves the dates in-tact
5. then they completely delete their "other" free-form text answers
sample data objects in the unit tests

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

