### PR TITLE
Check for confirmation_number before sending a NotificationEmail in ITF 21-0966

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -90,7 +90,7 @@ module SimpleFormsApi
         confirmation_number, expiration_date = intent_service.submit
         form.track_user_identity(confirmation_number)
 
-        if Flipper.enabled?(:simple_forms_email_confirmations)
+        if confirmation_number && Flipper.enabled?(:simple_forms_email_confirmations)
           send_confirmation_email(parsed_form_data, get_form_id, confirmation_number)
         end
 

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -878,6 +878,24 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
             expect(VANotify::EmailJob).not_to have_received(:perform_async)
           end
         end
+
+        context 'no new intent to file added' do
+          before do
+            allow_any_instance_of(SimpleFormsApi::IntentToFile).to receive(:submit).and_return([nil, Time.zone.now])
+            allow_any_instance_of(SimpleFormsApi::IntentToFile)
+              .to receive(:existing_intents)
+              .and_return({ 'compensation' => {}, 'pension' => {}, 'survivor' => {} })
+          end
+
+          it 'does not send a confirmation email' do
+            data['preparer_identification'] = 'VETERAN'
+
+            post '/simple_forms_api/v1/simple_forms', params: data
+
+            expect(response).to have_http_status(:ok)
+            expect(VANotify::EmailJob).not_to have_received(:perform_async)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
This PR checks for `confirmation_code` before sending off a Notification Email for 21-0966 ITF. This can occur if the user already has all requested ITFs on file so no confirmation code is newly created.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1727
