### PR TITLE
s3_deleted will no longer be nilable, fix unit test

### DIFF
--- a/modules/vba_documents/spec/sidekiq/upload_remover_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/upload_remover_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe VBADocuments::UploadRemover, type: :job do
 
     describe 'when a record was manually removed from s3' do
       let(:upload_manually_removed) do
-        FactoryBot.create(:upload_submission_manually_removed, status: 'received', s3_deleted: nil,
+        FactoryBot.create(:upload_submission_manually_removed, status: 'received', s3_deleted: false,
                                                                created_at: 11.days.ago)
       end
       let(:upload_old) { FactoryBot.create(:upload_submission, status: 'received', created_at: 12.days.ago) }


### PR DESCRIPTION
## Summary

Due to a slow query, we are going to modify the s3_deleted bool column in our vba_documents_upload_submision table to not allow nils.  Before we run the migration, we need to fix a unit test that was attempting to set it to nil.

Team banana peels table, I'm on banana peels


## Related issue(s)

[API-39107](https://jira.devops.va.gov/browse/API-39107)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Benefits Intake unit test

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).


