### PR TITLE
[SIMPLE_FORMS] feat: form remediation solution streamlining, test coverage, and documentation - PART 4

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
@@ -32,7 +32,7 @@ module SimpleFormsApi
         FileUtils.mkdir_p(dir_path)
       end
 
-      def build_local_file_dir!(s3_key, dir_path, s3_dir_path)
+      def create_local_file_path(s3_key, dir_path, s3_dir_path)
         local_path = Pathname.new(s3_key).relative_path_from(Pathname.new(s3_dir_path))
         final_path = Pathname.new(dir_path).join(local_path)
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -81,7 +81,7 @@ module SimpleFormsApi
       end
 
       def local_file_path
-        @local_file_path ||= build_local_file_dir!(s3_upload_file_path, temp_directory_path, s3_directory_path)
+        @local_file_path ||= create_local_file_path(s3_upload_file_path, temp_directory_path, s3_directory_path)
       end
     end
   end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'fileutils'
+require 'simple_forms_api/form_remediation/configuration/base'
+
+# Built in accordance with the following documentation:
+# https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/practices/zero-silent-failures/remediation.md
+module SimpleFormsApi
+  module FormRemediation
+    class S3Client
+      include FileUtilities
+
+      class << self
+        def fetch_presigned_url(id, type: :submission)
+          new(id:).s3_generate_presigned_url(s3_upload_file_path, type:)
+        end
+      end
+
+      def initialize(config: Configuration::Base.new, type: :remediation, **options)
+        @upload_type = type
+        @config = config
+        @parent_dir = config.parent_dir
+        @presign_s3_url = config.presign_s3_url
+        @temp_directory_path = config.temp_directory_path
+
+        @file_path = options[:file_path]
+        @id = options[:id]
+
+        @archive_path = build_archive!(config:, type:, **options)
+      rescue => e
+        config.handle_error("#{self.class.name} initialization failed", e)
+      end
+
+      def upload
+        config.log_info("Uploading #{upload_type}: #{id} to S3 bucket")
+
+        upload_to_s3
+        cleanup(s3_upload_file_path)
+
+        presign_s3_url ? s3_generate_presigned_url(s3_get_presigned_path) : id
+      rescue => e
+        config.handle_error("Failed #{upload_type} upload: #{id}", e)
+      end
+
+      private
+
+      attr_reader :archive_path, :config, :id, :parent_dir, :presign_s3_url, :temp_directory_path, :upload_type
+
+      def build_archive!(**)
+        config.submission_archive_class.new(**).build!
+      end
+
+      def upload_to_s3
+        return if File.directory?(local_file_path)
+
+        File.open(local_file_path) do |file_obj|
+          sanitized_file = CarrierWave::SanitizedFile.new(file_obj)
+          s3_uploader.store!(sanitized_file)
+        end
+      end
+
+      def s3_uploader
+        @s3_uploader ||= config.uploader_class.new(config:, directory: s3_directory_path)
+      end
+
+      def s3_directory_path
+        @s3_directory_path ||= build_path(:dir, parent_dir, upload_type.to_s)
+      end
+
+      def s3_upload_file_path
+        @s3_upload_file_path ||= build_path(:file, s3_directory_path, "#{archive_path}.ext")
+      end
+
+      def s3_get_presigned_path
+        build_path(:file, s3_directory_path, local_file_path.split('/').last)
+      end
+
+      def s3_generate_presigned_url(s3_path)
+        config.uploader_class.get_s3_link(s3_path)
+      end
+
+      def local_file_path
+        @local_file_path ||= build_local_file_dir!(s3_upload_file_path, temp_directory_path, s3_directory_path)
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
+  let(:form_type) { '20-10207' }
+  let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
+  let(:form_data) { Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read }
+  let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
+  let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
+  let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+  let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
+  let(:metadata) do
+    {
+      'veteranFirstName' => 'John',
+      'veteranLastName' => 'Veteran',
+      'fileNumber' => '222773333',
+      'zipCode' => '12345',
+      'source' => 'VA Platform Digital Forms',
+      'docType' => form_type,
+      'businessLine' => 'CMP'
+    }
+  end
+  let(:submission_archive_instance) { instance_double(SimpleFormsApi::FormRemediation::SubmissionArchive) }
+  let(:temp_file_path) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
+  let(:submission_file_path) do
+    [Time.zone.today.strftime('%-m.%d.%y'), 'form', form_type, 'vagov', benefits_intake_uuid].join('_')
+  end
+  let(:uploader) { instance_double(SimpleFormsApi::FormRemediation::Uploader) }
+  let(:carrier_wave_file) { instance_double(CarrierWave::Storage::Fog::File) }
+
+  before do
+    allow(FileUtils).to receive(:mkdir_p).and_return(true)
+    allow(File).to receive(:directory?).and_return(true)
+    allow(SimpleFormsApi::FormRemediation::SubmissionArchive).to(receive(:new).and_return(submission_archive_instance))
+    allow(submission_archive_instance).to receive(:build!).and_return(
+      ["#{temp_file_path}/", submission, submission_file_path]
+    )
+    allow(SimpleFormsApi::FormRemediation::Uploader).to(
+      receive_messages(new: uploader, get_s3_link: '/s3_url/stuff.pdf')
+    )
+    allow(uploader).to receive_messages(store!: carrier_wave_file)
+    allow(Rails.logger).to receive(:info).and_call_original
+    allow(Rails.logger).to receive(:error).and_call_original
+  end
+
+  describe '#initialize' do
+    subject(:new) { described_class.new(id: benefits_intake_uuid) }
+
+    context 'when initialized with a valid benefits_intake_uuid' do
+      it 'successfully completes initialization' do
+        expect { new }.not_to raise_exception
+      end
+    end
+  end
+
+  describe '#upload' do
+    subject(:upload) { instance.upload }
+
+    let(:instance) { described_class.new(id: benefits_intake_uuid) }
+
+    context 'when no errors occur' do
+      it 'logs a notification upon starting' do
+        upload
+        expect(Rails.logger).to have_received(:info).with(
+          "Uploading remediation: #{benefits_intake_uuid} to S3 bucket", {}
+        )
+      end
+
+      it 'returns the s3 directory' do
+        expect(upload).to eq('/s3_url/stuff.pdf')
+      end
+
+      context 'when a different parent_dir is provided' do
+        let(:instance) { described_class.new(id: benefits_intake_uuid) }
+
+        it 'returns the s3 directory' do
+          expect(upload).to eq('/s3_url/stuff.pdf')
+        end
+      end
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(File).to receive(:directory?).and_return(false)
+      end
+
+      let(:instance) { described_class.new(benefits_intake_uuid:) }
+
+      it 'raises the error' do
+        expect { upload }.to raise_exception(Errno::ENOENT)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This solution is designed to remediate form submissions which have failed submission and are over two weeks old. It is composed of several Ruby on Rails service objects which interact with each other.

The primary use-case for this solution is for form remediation. This process consists of the following:

1. Accept a form submission identifier.
1. Generate an archive payload consisting of the original form submission data as well as remediation specific documentation:
    1. Hydrate the original form submission
    1. Hydrate any original attachments that were a part of this submission
    1. Generate a JSON file with the original metadata from the submission
    1. Generate a manifest file to be used in the remediation process
1. Upload the generated archive as a .zip file onto the configured S3 bucket
1. Optionally return a presigned URL for accessing this file

This solution also provides a means for storing and retrieving a single .pdf copy of the originally submitted form.

The following image depicts how this solution is architected:

![Error Remediation Architecture Diagram_2024-10-07_14-14-25](https://github.com/user-attachments/assets/99c8d0a5-ad65-4cbd-8c76-b59988483c8c)


- This work updates the form remediation solution to be configurable and usable by all other va.gov teams.
- This is part 4 of a larger PR which was too large and needed broken up. It includes the S3 Client.

## Related issue(s)

- [Form Submission Remediation - Genericize S3 bucket archiving solution for external team usage](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/1954)

## Testing done

- [x] New logic is covered by unit tests

## Requested Feedback

Any
