### PR TITLE
[DBX-18767] update Form526SubmissionRemediation model with type enum

### DIFF
--- a/app/models/form526_submission_remediation.rb
+++ b/app/models/form526_submission_remediation.rb
@@ -9,6 +9,8 @@ class Form526SubmissionRemediation < ApplicationRecord
 
   before_create :initialize_lifecycle
 
+  enum remediation_type: { manual: 0, ignored_as_duplicate: 1, email_notified: 2 }
+
   STATSD_KEY_PREFIX = 'form526_submission_remediation'
 
   def mark_as_unsuccessful(context)

--- a/spec/models/form526_submission_remediation_spec.rb
+++ b/spec/models/form526_submission_remediation_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe Form526SubmissionRemediation, type: :model do
   end
 
   describe 'validations' do
+    context 'remediation_type validation' do
+      it 'defines an enum for remediation type' do
+        enum_values = %i[manual ignored_as_duplicate email_notified]
+        expect(define_enum_for(:remediation_type).with_values(enum_values)).to be_truthy
+      end
+    end
+
     context 'lifecycle validation' do
       it 'is invalid without context on create' do
         expect(subject).not_to be_valid


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- add an enum for `remediation_type` to the `Form526SubmissionRemediation` model. This will replace the `ignored_as_duplicate` boolean in a subsequent PR  & data migration. More details are listed in the ticket
- [Follow up to this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18779)

## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=82453998&issue=department-of-veterans-affairs%7Cvets-api%7C18767)

## Testing done

- [x] *New code is covered by unit tests*
- To verify functionality, run a rails console in the branch and run `Form526SubmissionRemediation.new.remediation_type`. It will return `manual`

## What areas of the site does it impact?
Part of zero silent failure work on the 526 EZ form

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (see ticket)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected (n / a)
- [ ]  I added a screenshot of the developed feature (n/a)
