### PR TITLE
API-40976: Fix Benefits Intake API Responses Modified by JSON Serializer Changes

### DIFF
--- a/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
@@ -11,13 +11,7 @@ module VBADocuments
     set_type :document_upload
     set_id :guid
 
-    attribute :guid
-
-    attribute :status do |object|
-      object.status == 'vbms' ? 'success' : object.status
-    end
-
-    attribute :code
+    attribute :guid, :status, :code
 
     attribute :detail do |object|
       detail = object.detail.to_s

--- a/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
@@ -11,25 +11,29 @@ module VBADocuments
     set_type :document_upload
     set_id :guid
 
-    attributes :guid, :code, :updated_at
+    attribute :guid
+
+    attribute :status do |object|
+      object.status == 'vbms' ? 'success' : object.status
+    end
+
+    attribute :code
 
     attribute :detail do |object|
       detail = object.detail.to_s
       detail.length > MAX_DETAIL_DISPLAY_LENGTH ? "#{detail[0..MAX_DETAIL_DISPLAY_LENGTH - 1]}..." : detail
     end
 
-    attribute :uploaded_pdf do |object|
-      scrub_unnecessary_keys(object.uploaded_pdf) if object.uploaded_pdf
-    end
-
-    attribute :status do |object|
-      object.status == 'vbms' ? 'success' : object.status
-    end
-
     attribute :location do |object, params|
       object.get_location if params[:render_location]
     rescue => e
       raise Common::Exceptions::InternalServerError, e
+    end
+
+    attribute :updated_at
+
+    attribute :uploaded_pdf do |object|
+      scrub_unnecessary_keys(object.uploaded_pdf) if object.uploaded_pdf
     end
 
     def self.scrub_unnecessary_keys(pdf_hash)

--- a/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
@@ -11,7 +11,7 @@ module VBADocuments
     set_type :document_upload
     set_id :guid
 
-    attribute :guid, :status, :code
+    attributes :guid, :status, :code
 
     attribute :detail do |object|
       detail = object.detail.to_s

--- a/modules/vba_documents/app/serializers/vba_documents/v1/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/v1/upload_serializer.rb
@@ -3,6 +3,8 @@
 module VBADocuments
   module V1
     class UploadSerializer < VBADocuments::UploadSerializer
+      set_type :document_upload
+
       attribute :status
     end
   end

--- a/modules/vba_documents/app/serializers/vba_documents/v1/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/v1/upload_serializer.rb
@@ -4,8 +4,6 @@ module VBADocuments
   module V1
     class UploadSerializer < VBADocuments::UploadSerializer
       set_type :document_upload
-
-      attribute :status
     end
   end
 end

--- a/modules/vba_documents/app/serializers/vba_documents/v2/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/v2/upload_serializer.rb
@@ -8,7 +8,6 @@ module VBADocuments
 
       attr_reader :observers
 
-      attribute :status
       attribute :location, if: proc { !Settings.vba_documents.v2_upload_endpoint_enabled } do |object, params|
         object.get_location if params[:render_location]
       rescue => e

--- a/modules/vba_documents/app/serializers/vba_documents/v2/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/v2/upload_serializer.rb
@@ -4,6 +4,8 @@ require './lib/webhooks/utilities'
 module VBADocuments
   module V2
     class UploadSerializer < VBADocuments::UploadSerializer
+      set_type :document_upload
+
       attr_reader :observers
 
       attribute :status

--- a/modules/vba_documents/spec/serializers/shared_examples_upload_serializer.rb
+++ b/modules/vba_documents/spec/serializers/shared_examples_upload_serializer.rb
@@ -7,8 +7,16 @@ RSpec.shared_examples 'VBADocuments::UploadSerializer' do
     expect(data['id']).to eq upload_submission.guid.to_s
   end
 
+  it 'includes :type' do
+    expect(data['type']).to eq 'document_upload'
+  end
+
   it 'includes :guid' do
     expect(attributes['guid']).to eq upload_submission.guid
+  end
+
+  it 'includes :status' do
+    expect(attributes['status']).to eq upload_submission.status
   end
 
   it 'includes :code' do
@@ -47,10 +55,6 @@ RSpec.shared_examples 'VBADocuments::UploadSerializer' do
     expect_time_eq(attributes['updated_at'], upload_submission.updated_at)
   end
 
-  it 'includes :uploaded_pdf' do
-    expect(attributes['uploaded_pdf']).to eq upload_submission.uploaded_pdf
-  end
-
   context 'when render_location is true' do
     before do
       allow(upload_submission).to receive(:get_location).and_return('http://another.fakesite.com/rewrittenpath')
@@ -81,5 +85,9 @@ RSpec.shared_examples 'VBADocuments::UploadSerializer' do
       expect { serialize(upload_submission, { serializer_class: described_class, params: { render_location: true } }) }
         .to raise_error(Common::Exceptions::InternalServerError, 'Internal server error')
     end
+  end
+
+  it 'includes :uploaded_pdf' do
+    expect(attributes['uploaded_pdf']).to eq upload_submission.uploaded_pdf
   end
 end

--- a/modules/vba_documents/spec/serializers/upload_serializer_spec.rb
+++ b/modules/vba_documents/spec/serializers/upload_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative 'shared_upload_serializer'
+require_relative 'shared_examples_upload_serializer'
 
 describe VBADocuments::UploadSerializer, type: :serializer do
   subject { serialize(upload_submission, serializer_class: described_class) }
@@ -11,20 +11,4 @@ describe VBADocuments::UploadSerializer, type: :serializer do
   let(:attributes) { data['attributes'] }
 
   it_behaves_like 'VBADocuments::UploadSerializer'
-
-  context 'when status is vbms' do
-    let(:upload_submission_vbms) { build_stubbed(:upload_submission, status: 'vbms') }
-    let(:response) { serialize(upload_submission_vbms, serializer_class: described_class) }
-    let(:attributes_vbms) { JSON.parse(response)['data']['attributes'] }
-
-    it 'includes :status' do
-      expect(attributes_vbms['status']).to eq 'success'
-    end
-  end
-
-  context 'when status is not vbms' do
-    it 'includes :status' do
-      expect(attributes['status']).to eq upload_submission.status
-    end
-  end
 end

--- a/modules/vba_documents/spec/serializers/v1/upload_serializer_spec.rb
+++ b/modules/vba_documents/spec/serializers/v1/upload_serializer_spec.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../shared_upload_serializer'
+require_relative '../shared_examples_upload_serializer'
 
 describe VBADocuments::V1::UploadSerializer, type: :serializer do
   subject { serialize(upload_submission, serializer_class: described_class) }
 
-  let(:upload_submission) { build_stubbed(:upload_submission, status: 'vbms') }
+  let(:upload_submission) { build_stubbed(:upload_submission, :status_uploaded) }
   let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }
 
   it_behaves_like 'VBADocuments::UploadSerializer'
-
-  it 'includes :status' do
-    expect(attributes['status']).to eq upload_submission.status
-  end
 end

--- a/modules/vba_documents/spec/serializers/v2/upload_serializer_spec.rb
+++ b/modules/vba_documents/spec/serializers/v2/upload_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../shared_upload_serializer'
+require_relative '../shared_examples_upload_serializer'
 
 describe VBADocuments::V2::UploadSerializer, type: :serializer do
   subject { serialize(upload_submission, serializer_class: described_class) }
@@ -10,15 +10,11 @@ describe VBADocuments::V2::UploadSerializer, type: :serializer do
     allow(Settings.vba_documents).to receive(:v2_upload_endpoint_enabled).and_return(false)
   end
 
-  let(:upload_submission) { build_stubbed(:upload_submission, status: 'vbms') }
+  let(:upload_submission) { build_stubbed(:upload_submission, :status_uploaded) }
   let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }
 
   it_behaves_like 'VBADocuments::UploadSerializer'
-
-  it 'includes :status' do
-    expect(attributes['status']).to eq upload_submission.status
-  end
 
   context 'when observing is true' do
     before do


### PR DESCRIPTION
## Summary
This work is not behind a feature toggle.

The introduction of #17348, which replaced the JSON serializers, changed a few parts of the Benefits Intake API responses. The first was that `"type": "document_upload"` was changed to `"type": "upload"`. The second was that the order of the fields in the responses changed. We suspect that one or both of these changes may have impacted one of our API consumers, who recently reported an issue with their integration that fetches submission status updates. Setting the responses back to what they were before also allows the example responses in [our API documentation](https://developer.va.gov/explore/api/benefits-intake/docs?version=current) to match the actual responses again.

My team (Lighthouse Banana Peels) owns the `vba_documents` module.

## Related issue(s)
[API-40976](https://jira.devops.va.gov/browse/API-40976)

<img width="785" alt="Screenshot 2024-10-09 at 11 37 37 AM" src="https://github.com/user-attachments/assets/16b66b9c-dbd9-4b0b-8777-7fa5c0ca965a">

## Testing done
- [x] *New code is covered by unit tests*

A few new test cases were added for the `UploadSerializer`. In addition, the responses for each API endpoint were compared to identify any differences between the responses in this PR and the responses from prior to when #17348 was merged. No differences were detected, which is what we wanted to see.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `vba_documents` module only.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution – N/A
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
An extra set of eyes to verify the fields and their order in the response would be valuable.
