### PR TITLE
[Lighthouse Document Upload Migration] Migrate Upload BDD Instructions job

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
+++ b/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
@@ -8,6 +8,9 @@ module EVSS
       extend Logging::ThirdPartyTransaction::MethodWrapper
 
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526_bdd_instructions'
+      # 'Other Correspondence' document type
+      BDD_INSTRUCTIONS_DOCUMENT_TYPE = 'L023'
+      BDD_INSTRUCTIONS_FILE_NAME = 'BDD_Instructions.pdf'
 
       # retry for one day
       sidekiq_options retry: 14
@@ -34,6 +37,13 @@ module EVSS
           status: Form526JobStatus::STATUS[:exhausted],
           bgjob_errors: bgjob_errors.merge(new_error)
         )
+
+        if Flipper.enabled?(:disability_compensation_use_api_provider_for_bdd_instructions)
+          submission = Form526Submission.find(form526_submission_id)
+
+          provider = api_upload_provider(submission)
+          provider.log_uploading_job_failure(self, error_class, error_message)
+        end
 
         StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
@@ -67,6 +77,21 @@ module EVSS
         }
       )
 
+      def self.api_upload_provider(submission)
+        user = User.find(submission.user_uuid)
+
+        ApiProviderFactory.call(
+          type: ApiProviderFactory::FACTORIES[:supplemental_document_upload],
+          options: {
+            form526_submission: submission,
+            document_type: BDD_INSTRUCTIONS_DOCUMENT_TYPE,
+            statsd_metric_prefix: STATSD_KEY_PREFIX
+          },
+          current_user: user,
+          feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS
+        )
+      end
+
       # Submits a BDD instruction PDF in to EVSS
       #
       # @param submission_id [Integer] The {Form526Submission} id
@@ -89,19 +114,18 @@ module EVSS
       private
 
       def upload_bdd_instructions
-        client.upload(file_body, document_data)
+        if Flipper.enabled?(:disability_compensation_use_api_provider_for_bdd_instructions)
+          provider = self.class.api_upload_provider(submission)
+
+          upload_document = provider.generate_upload_document(BDD_INSTRUCTIONS_FILE_NAME)
+          provider.submit_upload_document(upload_document, file_body)
+        else
+          EVSS::DocumentsService.new(submission.auth_headers).upload(file_body, document_data)
+        end
       end
 
       def file_body
         @file_body ||= File.read('lib/evss/disability_compensation_form/bdd_instructions.pdf')
-      end
-
-      def client
-        @client ||= if Flipper.enabled?(:disability_compensation_lighthouse_document_service_provider)
-                      # TODO: create client from lighthouse document service
-                    else
-                      EVSS::DocumentsService.new(submission.auth_headers)
-                    end
       end
 
       def retryable_error_handler(error)
@@ -112,10 +136,10 @@ module EVSS
       def document_data
         @document_data ||= EVSSClaimDocument.new(
           evss_claim_id: submission.submitted_claim_id,
-          file_name: 'BDD_Instructions.pdf',
+          file_name: BDD_INSTRUCTIONS_FILE_NAME,
           tracked_item_id: nil,
-          document_type: 'L023'
-        ) # 'Other Correspondence'
+          document_type: BDD_INSTRUCTIONS_DOCUMENT_TYPE
+        )
       end
     end
   end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1549,7 +1549,10 @@ features:
   disability_compensation_lighthouse_generate_pdf:
     actor_type: user
     description: If enabled uses the lighthouse Benefits Claims service to generate a 526 pdf
-  disability_compensation_lighthouse_upload_supplemental_document:
+  disability_compensation_use_api_provider_for_bdd_instructions:
+    actor_type: user
+    description: Provide a temporary killswitch for using the ApiProviderFactory to select an API for uploading BDD instructions
+  disability_compensation_upload_bdd_instructions_to_lighthouse:
     actor_type: user
     description: If enabled uses the Lighthouse Benefits Documents API to submit Form 526 documents
   disablity_benefits_browser_monitoring_enabled:

--- a/config/features.yml
+++ b/config/features.yml
@@ -1554,7 +1554,7 @@ features:
     description: Provide a temporary killswitch for using the ApiProviderFactory to select an API for uploading BDD instructions
   disability_compensation_upload_bdd_instructions_to_lighthouse:
     actor_type: user
-    description: If enabled uses the Lighthouse Benefits Documents API to submit Form 526 documents
+    description: If enabled uploads BDD instructions to Lighthouse Benefits Documents API instead of EVSS
   disablity_benefits_browser_monitoring_enabled:
     actor_type: user
     description: Datadog RUM monitoring for disability benefits applications

--- a/lib/disability_compensation/factories/api_provider_factory.rb
+++ b/lib/disability_compensation/factories/api_provider_factory.rb
@@ -56,7 +56,7 @@ class ApiProviderFactory
   FEATURE_TOGGLE_BRD = 'disability_compensation_lighthouse_brd'
   FEATURE_TOGGLE_GENERATE_PDF = 'disability_compensation_lighthouse_generate_pdf'
 
-  FEATURE_TOGGLE_UPLOAD_SUPPLEMENTAL_DOCUMENT = 'disability_compensation_lighthouse_upload_supplemental_document'
+  FEATURE_TOGGLE_UPLOAD_BDD_INSTRUCTIONS = 'disability_compensation_upload_bdd_instructions_to_lighthouse'
 
   attr_reader :type
 

--- a/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -280,7 +280,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
             Flipper.enable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
 
             subject.within_sidekiq_retries_exhausted_block(sidekiq_job_exhaustion_errors) do
-              expect_any_instance_of(LighthouseSupplementalDocumentUploadProvider).to receive(:log_uploading_job_failure)
+              expect_any_instance_of(LighthouseSupplementalDocumentUploadProvider)
+                .to receive(:log_uploading_job_failure)
                 .with(EVSS::DisabilityCompensationForm::UploadBddInstructions, 'Broken Job Error', 'Your Job Broke')
             end
           end

--- a/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
   before do
     Sidekiq::Job.clear_all
-    Flipper.disable(:disability_compensation_lighthouse_document_service_provider)
+    # Explain this change
+    Flipper.disable(:disability_compensation_use_api_provider_for_bdd_instructions)
   end
 
   let(:user) { FactoryBot.create(:user, :loa3) }
@@ -22,11 +23,11 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
            saved_claim_id: saved_claim.id,
            submitted_claim_id: '600130094')
   end
+  let(:file_read) { File.read('lib/evss/disability_compensation_form/bdd_instructions.pdf') }
 
   describe 'perform' do
     let(:client) { double(:client) }
     let(:document_data) { double(:document_data) }
-    let(:file_read) { File.read('lib/evss/disability_compensation_form/bdd_instructions.pdf') }
 
     before do
       allow(EVSS::DocumentsService)
@@ -62,6 +63,200 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
     end
   end
 
+  describe 'When an ApiProvider is used for uploads' do
+    before do
+      Flipper.enable(:disability_compensation_use_api_provider_for_bdd_instructions)
+      # StatsD metrics are incremented in several callbacks we're not testing here so we need to allow them
+      allow(StatsD).to receive(:increment)
+    end
+
+    context 'when the disability_compensation_upload_bdd_instructions_to_lighthouse flipper is enabled' do
+      let(:faraday_response) { instance_double(Faraday::Response) }
+      let(:lighthouse_request_id) { Faker::Number.number(digits: 8) }
+      let(:expected_statsd_metrics_prefix) do
+        'worker.evss.submit_form526_bdd_instructions.lighthouse_supplemental_document_upload_provider'
+      end
+
+      let(:expected_lighthouse_document) do
+        LighthouseDocument.new(
+          claim_id: submission.submitted_claim_id,
+          participant_id: user.participant_id,
+          document_type: 'L023',
+          file_name: 'BDD_Instructions.pdf'
+        )
+      end
+
+      before do
+        Flipper.enable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+
+        allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+          .and_return(faraday_response)
+
+        allow(faraday_response).to receive(:body).and_return(
+          {
+            'data' => {
+              'success' => true,
+              'requestId' => lighthouse_request_id
+            }
+          }
+        )
+      end
+
+      it 'uploads a BDD Instruction PDF to Lighthouse' do
+        expect(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+          .with(file_read, expected_lighthouse_document)
+
+        subject.perform_async(submission.id)
+        described_class.drain
+      end
+
+      it 'logs the upload attempt with the correct job prefix' do
+        expect(StatsD).to receive(:increment).with(
+          "#{expected_statsd_metrics_prefix}.upload_attempt"
+        )
+
+        subject.perform_async(submission.id)
+        described_class.drain
+      end
+
+      it 'increments the correct StatsD success metric' do
+        expect(StatsD).to receive(:increment).with(
+          "#{expected_statsd_metrics_prefix}.upload_success"
+        )
+
+        subject.perform_async(submission.id)
+        described_class.drain
+      end
+
+      it 'creates a pending Lighthouse526DocumentUpload record for the submission so we can poll Lighthouse later' do
+        upload_attributes = {
+          aasm_state: 'pending',
+          form526_submission_id: submission.id,
+          document_type: 'BDD Instructions',
+          lighthouse_document_request_id: lighthouse_request_id
+        }
+
+        expect(Lighthouse526DocumentUpload.where(**upload_attributes).count).to eq(0)
+
+        subject.perform_async(submission.id)
+        described_class.drain
+
+        expect(Lighthouse526DocumentUpload.where(**upload_attributes).count).to eq(1)
+      end
+
+      context 'when Lighthouse returns an error response' do
+        let(:error_response_body) do
+          # From vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
+          {
+            'errors' => [
+              {
+                'detail' => 'Something broke',
+                'status' => 400,
+                'title' => 'Bad Request',
+                'instance' => Faker::Internet.uuid
+              }
+            ]
+          }
+        end
+
+        before do
+          allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+            .with(file_read, expected_lighthouse_document)
+            .and_return(faraday_response)
+
+          allow(faraday_response).to receive(:body).and_return(error_response_body)
+        end
+
+        it 'logs the Lighthouse error response' do
+          expect(Rails.logger).to receive(:error).with(
+            'LighthouseSupplementalDocumentUploadProvider upload failed',
+            {
+              class: 'LighthouseSupplementalDocumentUploadProvider',
+              submission_id: submission.submitted_claim_id,
+              user_uuid: submission.user_uuid,
+              va_document_type_code: 'L023',
+              primary_form: 'Form526',
+              lighthouse_error_response: error_response_body
+            }
+          )
+
+          subject.perform_async(submission.id)
+          described_class.drain
+        end
+
+        it 'increments the correct status failure metric' do
+          expect(StatsD).to receive(:increment).with(
+            "#{expected_statsd_metrics_prefix}.upload_failure"
+          )
+
+          subject.perform_async(submission.id)
+          described_class.drain
+        end
+      end
+    end
+
+    # Upload to EVSS
+    context 'when the disability_compensation_upload_bdd_instructions_to_lighthouse flipper is disabled' do
+      before do
+        Flipper.disable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+        allow_any_instance_of(EVSS::DocumentsService).to receive(:upload)
+      end
+
+      let(:evss_claim_document) do
+        EVSSClaimDocument.new(
+          evss_claim_id: submission.submitted_claim_id,
+          document_type: 'L023',
+          file_name: 'BDD_Instructions.pdf'
+        )
+      end
+
+      let(:expected_statsd_metrics_prefix) do
+        'worker.evss.submit_form526_bdd_instructions.evss_supplemental_document_upload_provider'
+      end
+
+      it 'uploads the document via the EVSS Documents Service' do
+        expect_any_instance_of(EVSS::DocumentsService).to receive(:upload)
+          .with(file_read, evss_claim_document)
+
+        subject.perform_async(submission.id)
+        described_class.drain
+      end
+
+      it 'logs the upload attempt with the correct job prefix' do
+        expect(StatsD).to receive(:increment).with(
+          "#{expected_statsd_metrics_prefix}.upload_attempt"
+        )
+
+        subject.perform_async(submission.id)
+        described_class.drain
+      end
+
+      it 'increments the correct StatsD success metric' do
+        expect(StatsD).to receive(:increment).with(
+          "#{expected_statsd_metrics_prefix}.upload_success"
+        )
+
+        subject.perform_async(submission.id)
+        described_class.drain
+      end
+
+      context 'when an upload raises an EVSS response error' do
+        before do
+          allow_any_instance_of(EVSS::DocumentsService).to receive(:upload).and_raise(EVSS::ErrorMiddleware::EVSSError)
+        end
+
+        it 'logs an upload error' do
+          expect_any_instance_of(EVSSSupplementalDocumentUploadProvider).to receive(:log_upload_failure)
+
+          expect do
+            subject.perform_async(submission.id)
+            described_class.drain
+          end.to raise_error(EVSS::ErrorMiddleware::EVSSError)
+        end
+      end
+    end
+  end
+
   context 'catastrophic failure state' do
     describe 'when all retries are exhausted' do
       let!(:form526_submission) { create(:form526_submission) }
@@ -74,6 +269,47 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
         end
         form526_job_status.reload
         expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+
+      context 'when the API Provider uploads are enabled' do
+        let(:sidekiq_job_exhaustion_errors) do
+          {
+            'jid' => form526_job_status.job_id,
+            'error_class' => 'Broken Job Error',
+            'error_message' => 'Your Job Broke',
+            'args' => [form526_submission.id]
+          }
+        end
+
+        before do
+          Flipper.enable(:disability_compensation_use_api_provider_for_bdd_instructions)
+        end
+
+        context 'for a Lighthouse upload' do
+          before do
+            Flipper.enable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+          end
+
+          it 'logs the job failure' do
+            subject.within_sidekiq_retries_exhausted_block(sidekiq_job_exhaustion_errors) do
+              expect_any_instance_of(LighthouseSupplementalDocumentUploadProvider).to receive(:log_uploading_job_failure)
+                .with(EVSS::DisabilityCompensationForm::UploadBddInstructions, 'Broken Job Error', 'Your Job Broke')
+            end
+          end
+        end
+
+        context 'for an EVSS Upload' do
+          before do
+            Flipper.disable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+          end
+
+          it 'logs the job failure' do
+            subject.within_sidekiq_retries_exhausted_block(sidekiq_job_exhaustion_errors) do
+              expect_any_instance_of(EVSSSupplementalDocumentUploadProvider).to receive(:log_uploading_job_failure)
+                .with(EVSS::DisabilityCompensationForm::UploadBddInstructions, 'Broken Job Error', 'Your Job Broke')
+            end
+          end
+        end
       end
     end
   end

--- a/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
   before do
     Sidekiq::Job.clear_all
-    # Explain this change
     Flipper.disable(:disability_compensation_use_api_provider_for_bdd_instructions)
   end
 


### PR DESCRIPTION
Updates the `UploadBddInstructions` job to use the new ApiProviders for document uploads.

This will allow us to progressively transition BDD Instruction uploads to the new Lighthouse Documents Benefits API by turning on a flipper for more and more users.

Hides all new behavior behind a killswitch flipper,`disability_compensation_use_api_provider_for_bdd_instructions`, which will only use the API providers if turned on.

If that's enabled, the API Provider Factory itself will decide if we use the Lighthouse or EVSS provider client for the uploads, based on the status of the `disability_compensation_upload_bdd_instructions_to_lighthouse` flipper for the user who the submission belongs to


- *This work is behind a feature toggle (flipper): YES see above

- *(Which team do you work for, does your team own the maintenance of this component?)*

Benefits Disability

- *(If introducing a flipper, what is the success criteria being targeted?)*

100 percent of all uploads to Lighthouse succeed

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/83844

## Testing done

- [X] *New code is covered by unit tests*

This will be tested extensively in staging

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) N/A
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) not yet it will before launch
