### PR TITLE
[10-10CG] Update retry_count increment for SubmissionJob

### DIFF
--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -27,13 +27,11 @@ module Form1010cg
         return
       end
 
-      # Increment on the 2nd run (initial run + 1 retry)
-      StatsD.increment("#{STATSD_KEY_PREFIX}applications_retried") if (params['retry_count']).zero?
+      # Add 1 to retry_count to match retry_monitoring logic
+      retry_count = Integer(params['retry_count']) + 1
 
-      # Increment on the 11th run (intial run + 10 retries)
-      if params['retry_count'] == 10
-        StatsD.increment("#{STATSD_KEY_PREFIX}failed_ten_retries", tags: ["params:#{params}"])
-      end
+      StatsD.increment("#{STATSD_KEY_PREFIX}applications_retried") if retry_count == 1
+      StatsD.increment("#{STATSD_KEY_PREFIX}failed_ten_retries", tags: ["params:#{params}"]) if retry_count == 10
     end
 
     def perform(claim_id)

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Form1010cg::SubmissionJob do
         end
       end
 
-      context 'retry_count is not 0 or 10' do
+      context 'retry_count is not 0 or 9' do
         let(:params) { { 'retry_count' => 5 } }
 
         it 'does not increment applications_retried statsd' do
@@ -68,8 +68,8 @@ RSpec.describe Form1010cg::SubmissionJob do
         end
       end
 
-      context 'retry_count is 10' do
-        let(:params) { { 'retry_count' => 10 } }
+      context 'retry_count is 9' do
+        let(:params) { { 'retry_count' => 9 } }
 
         it 'increments failed_ten_retries statsd' do
           expect do


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- After some testing in staging, we found the `failed_ten_retries` metric was not being incremented in the submission job. This was due to the logic in the `RetryMonitoring` middleware that adds a 1 to the `retry_count` when validating the `retry_limits_for_notification` value which determines if it should call the `notify` method. Since we had it set to 10 for the metric, it was passing a params value with a `retry_count` of 9 to the notify, which was then not incrementing due to the check for a 10 and not a 9. 
- 10-10 Health Apps
- `caregiver1010` flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93615

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
