### PR TITLE
Allow RES Flipper to Be Partially Enabled

### DIFF
--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -118,7 +118,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   # Common method for VRE form submission:
   # * Adds information from user to payload
   # * Submits to VBMS if participant ID is there, to Lighthouse if not.
-  # * Sends email if user is present
+  # * Sends email
   # * Sends to RES or VRE service based on flipper status
   # @param user [User] user account of submitting user
   # @return [Hash] Response payload of service that was used (RES or VRE)
@@ -137,7 +137,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     VeteranReadinessEmploymentMailer.build(user.participant_id, email_addr,
                                            @sent_to_lighthouse).deliver_later
 
-    if Flipper.enabled?(:veteran_readiness_employment_to_res)
+    if Flipper.enabled?(:veteran_readiness_employment_to_res, user)
       send_to_res(user)
     else
       send_vre_form(user)


### PR DESCRIPTION
## Summary
- Add user to flipper check so the flipper can be partially enabled

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92651

## Testing done
None

## What areas of the site does it impact?
Users submitting VRE form will be sent to VRE or RES service depending on flipper.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  ~If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected~
- [x]  ~I added a screenshot of the developed feature~