### PR TITLE
Fix 2122(a) PDF generation validation errors #94683

### DIFF
--- a/modules/representation_management/app/controllers/representation_management/v0/pdf_generator_base_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/pdf_generator_base_controller.rb
@@ -48,45 +48,47 @@ module RepresentationManagement
       end
 
       def flatten_claimant_params(claimant_params)
-        country_code = normalize_country_code_to_alpha2(claimant_params.dig(:claimant, :address, :country))
+        claimant = claimant_params[:claimant]
+        address = claimant[:address]
+        country_code = normalize_country_code_to_alpha2(address[:country])
         {
-          claimant_first_name: claimant_params.dig(:claimant, :name, :first),
-          claimant_middle_initial: claimant_params.dig(:claimant, :name, :middle),
-          claimant_last_name: claimant_params.dig(:claimant, :name, :last),
-          claimant_date_of_birth: claimant_params.dig(:claimant, :date_of_birth),
-          claimant_relationship: claimant_params.dig(:claimant, :relationship),
-          claimant_address_line1: claimant_params.dig(:claimant, :address, :address_line1),
-          claimant_address_line2: claimant_params.dig(:claimant, :address, :address_line2),
-          claimant_city: claimant_params.dig(:claimant, :address, :city),
-          claimant_state_code: claimant_params.dig(:claimant, :address, :state_code),
+          claimant_first_name: claimant.dig(:name, :first),
+          claimant_middle_initial: claimant.dig(:name, :middle),
+          claimant_last_name: claimant.dig(:name, :last),
+          claimant_date_of_birth: claimant[:date_of_birth],
+          claimant_relationship: claimant[:relationship],
+          claimant_address_line1: address[:address_line1],
+          claimant_address_line2: address[:address_line2],
+          claimant_city: address[:city],
+          claimant_state_code: address[:state_code],
           claimant_country: country_code,
-          claimant_zip_code: claimant_params.dig(:claimant, :address, :zip_code),
-          claimant_zip_code_suffix: claimant_params.dig(:claimant, :address, :zip_code_suffix),
-          claimant_phone: claimant_params.dig(:claimant, :phone),
-          claimant_email: claimant_params.dig(:claimant, :email)
+          claimant_zip_code: address[:zip_code],
+          claimant_zip_code_suffix: address[:zip_code_suffix],
+          claimant_phone: claimant[:phone],
+          claimant_email: claimant[:email]
         }
       end
 
       def flatten_veteran_params(veteran_params)
-        country_code = normalize_country_code_to_alpha2(veteran_params.dig(:veteran, :address, :country))
-        {
-          veteran_first_name: veteran_params.dig(:veteran, :name, :first),
-          veteran_middle_initial: veteran_params.dig(:veteran, :name, :middle),
-          veteran_last_name: veteran_params.dig(:veteran, :name, :last),
-          veteran_social_security_number: veteran_params.dig(:veteran, :ssn),
-          veteran_va_file_number: veteran_params.dig(:veteran, :va_file_number),
-          veteran_date_of_birth: veteran_params.dig(:veteran, :date_of_birth),
-          veteran_service_number: veteran_params.dig(:veteran, :service_number),
-          veteran_address_line1: veteran_params.dig(:veteran, :address, :address_line1),
-          veteran_address_line2: veteran_params.dig(:veteran, :address, :address_line2),
-          veteran_city: veteran_params.dig(:veteran, :address, :city),
-          veteran_state_code: veteran_params.dig(:veteran, :address, :state_code),
+        veteran = veteran_params[:veteran]
+        address = veteran[:address]
+        country_code = normalize_country_code_to_alpha2(address[:country])
+        { veteran_first_name: veteran.dig(:name, :first),
+          veteran_middle_initial: veteran.dig(:name, :middle),
+          veteran_last_name: veteran.dig(:name, :last),
+          veteran_social_security_number: veteran[:ssn],
+          veteran_va_file_number: veteran[:va_file_number],
+          veteran_date_of_birth: veteran[:date_of_birth],
+          veteran_service_number: veteran[:service_number],
+          veteran_address_line1: address[:address_line1],
+          veteran_address_line2: address[:address_line2],
+          veteran_city: address[:city],
+          veteran_state_code: address[:state_code],
           veteran_country: country_code,
-          veteran_zip_code: veteran_params.dig(:veteran, :address, :zip_code),
-          veteran_zip_code_suffix: veteran_params.dig(:veteran, :address, :zip_code_suffix),
-          veteran_phone: veteran_params.dig(:veteran, :phone),
-          veteran_email: veteran_params.dig(:veteran, :email)
-        }
+          veteran_zip_code: address[:zip_code],
+          veteran_zip_code_suffix: address[:zip_code_suffix],
+          veteran_phone: veteran[:phone],
+          veteran_email: veteran[:email] }
       end
 
       def name_params_permitted

--- a/modules/representation_management/app/controllers/representation_management/v0/pdf_generator_base_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/pdf_generator_base_controller.rb
@@ -48,6 +48,7 @@ module RepresentationManagement
       end
 
       def flatten_claimant_params(claimant_params)
+        country_code = normalize_country_code_to_alpha2(claimant_params.dig(:claimant, :address, :country))
         {
           claimant_first_name: claimant_params.dig(:claimant, :name, :first),
           claimant_middle_initial: claimant_params.dig(:claimant, :name, :middle),
@@ -58,7 +59,7 @@ module RepresentationManagement
           claimant_address_line2: claimant_params.dig(:claimant, :address, :address_line2),
           claimant_city: claimant_params.dig(:claimant, :address, :city),
           claimant_state_code: claimant_params.dig(:claimant, :address, :state_code),
-          claimant_country: claimant_params.dig(:claimant, :address, :country),
+          claimant_country: country_code,
           claimant_zip_code: claimant_params.dig(:claimant, :address, :zip_code),
           claimant_zip_code_suffix: claimant_params.dig(:claimant, :address, :zip_code_suffix),
           claimant_phone: claimant_params.dig(:claimant, :phone),
@@ -67,6 +68,7 @@ module RepresentationManagement
       end
 
       def flatten_veteran_params(veteran_params)
+        country_code = normalize_country_code_to_alpha2(veteran_params.dig(:veteran, :address, :country))
         {
           veteran_first_name: veteran_params.dig(:veteran, :name, :first),
           veteran_middle_initial: veteran_params.dig(:veteran, :name, :middle),
@@ -79,7 +81,7 @@ module RepresentationManagement
           veteran_address_line2: veteran_params.dig(:veteran, :address, :address_line2),
           veteran_city: veteran_params.dig(:veteran, :address, :city),
           veteran_state_code: veteran_params.dig(:veteran, :address, :state_code),
-          veteran_country: veteran_params.dig(:veteran, :address, :country),
+          veteran_country: country_code,
           veteran_zip_code: veteran_params.dig(:veteran, :address, :zip_code),
           veteran_zip_code_suffix: veteran_params.dig(:veteran, :address, :zip_code_suffix),
           veteran_phone: veteran_params.dig(:veteran, :phone),
@@ -101,6 +103,14 @@ module RepresentationManagement
           zip_code
           zip_code_suffix
         ]
+      end
+
+      def normalize_country_code_to_alpha2(country_code)
+        if country_code.present?
+          IsoCountryCodes.find(country_code).alpha2
+        else
+          ''
+        end
       end
 
       def feature_enabled

--- a/modules/representation_management/app/models/representation_management/form_2122_base.rb
+++ b/modules/representation_management/app/models/representation_management/form_2122_base.rb
@@ -90,7 +90,8 @@ module RepresentationManagement
       validates :claimant_country, presence: true, length: { is: 2 }
       validates :claimant_state_code, presence: true, length: { is: 2 }
       validates :claimant_zip_code, presence: true, length: { is: 5 }, format: { with: FIVE_DIGIT_NUMBER }
-      validates :claimant_zip_code_suffix, length: { is: 4 }, format: { with: FOUR_DIGIT_NUMBER }
+      validates :claimant_zip_code_suffix, length: { is: 4 }, format: { with: FOUR_DIGIT_NUMBER },
+                                           if: -> { claimant_zip_code_suffix.present? }
       validates :claimant_phone, length: { is: 10 }, format: { with: TEN_DIGIT_NUMBER }
     end
 

--- a/modules/representation_management/spec/models/representation_management/form_2122_base_spec.rb
+++ b/modules/representation_management/spec/models/representation_management/form_2122_base_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe RepresentationManagement::Form2122Base, type: :model do
     it { expect(subject).not_to allow_value('1234A').for(:veteran_zip_code) }
     it { expect(subject).not_to allow_value('12345').for(:veteran_zip_code_suffix) }
     it { expect(subject).to allow_value('1234').for(:veteran_zip_code_suffix) }
+    it { expect(subject).to allow_value('').for(:veteran_zip_code_suffix) }
     it { expect(subject).to validate_length_of(:veteran_zip_code_suffix).is_equal_to(4) }
     it { expect(subject).to allow_value('1234567890').for(:veteran_phone) }
     it { expect(subject).not_to allow_value('123456789A').for(:veteran_phone) }
@@ -64,6 +65,7 @@ RSpec.describe RepresentationManagement::Form2122Base, type: :model do
     it { expect(subject_with_claimant).not_to allow_value('1234A').for(:claimant_zip_code) }
     it { expect(subject_with_claimant).not_to allow_value('12345').for(:claimant_zip_code_suffix) }
     it { expect(subject_with_claimant).to allow_value('1234').for(:claimant_zip_code_suffix) }
+    it { expect(subject_with_claimant).to allow_value('').for(:claimant_zip_code_suffix) }
     it { expect(subject_with_claimant).to validate_length_of(:claimant_zip_code_suffix).is_equal_to(4) }
     it { expect(subject_with_claimant).to allow_value('1234567890').for(:claimant_phone) }
     it { expect(subject_with_claimant).not_to allow_value('123456789A').for(:claimant_phone) }

--- a/modules/representation_management/spec/models/representation_management/form_2122a_data_spec.rb
+++ b/modules/representation_management/spec/models/representation_management/form_2122a_data_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe RepresentationManagement::Form2122aData, type: :model do
     it { expect(subject).not_to allow_value('1234A').for(:representative_zip_code) }
     it { expect(subject).not_to allow_value('12345').for(:representative_zip_code_suffix) }
     it { expect(subject).to allow_value('1234').for(:representative_zip_code_suffix) }
+    it { expect(subject).to allow_value('').for(:representative_zip_code_suffix) }
     it { expect(subject).to validate_length_of(:representative_zip_code_suffix).is_equal_to(4) }
     it { expect(subject).to validate_presence_of(:representative_phone) }
     it { expect(subject).to validate_length_of(:representative_phone).is_equal_to(10) }

--- a/modules/representation_management/spec/requests/representation_management/v0/pdf_generator_2122_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/pdf_generator_2122_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'RepresentationManagement::V0::PdfGenerator2122', type: :request 
               address_line2: '',
               city: 'ClaimantCity',
               state_code: 'CC',
-              country: 'US',
+              country: 'USA', # This is a 3 character country code as submitted by the frontend
               zip_code: '12345',
               zip_code_suffix: '6789'
             }
@@ -51,7 +51,7 @@ RSpec.describe 'RepresentationManagement::V0::PdfGenerator2122', type: :request 
               address_line2: '',
               city: 'VeteranCity',
               state_code: 'VC',
-              country: 'US',
+              country: 'USA', # This is a 3 character country code as submitted by the frontend
               zip_code: '98765',
               zip_code_suffix: '4321'
             }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This PR fixes some validation errors that were triggered when submitting the frontend request to generate a PDF of form 2122.  Specifically it converts three character country codes to 2 character codes to pass validation and fixes a zip code suffix validation that wasn't consistently implemented across multiple zip code suffixes.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94683

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing:* Use the front end in staging to generate a request body and run that against this code to ensure that validation errors are resolved.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas):* This only touches the `representation_management` module.

## Acceptance criteria

- [x]  I updated/added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature