### PR TITLE
Increment silent_failure statsd count when LH submission fails

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -108,6 +108,8 @@ class BenefitsIntakeStatusJob
     StatsD.increment("#{STATS_KEY}.#{form_id}.#{result}")
     StatsD.increment("#{STATS_KEY}.all_forms.#{result}")
     if result == 'failure'
+      tags = [service: 'veteran-facing-forms', function: "#{form_id} form submission to Lighthouse"]
+      statsd.increment('silent_failure', tags:)
       Rails.logger.error('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:, error_message:)
     else
       Rails.logger.info('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:)


### PR DESCRIPTION
## Summary
This PR increments a statsd metric to count whenever a form submission fails silently, after we've submitted it to Lighthouse. We still need to add another similar incrementing call when we avoid a silent failure by emailing the Veteran.
