### PR TITLE
update service class to use a different client number

### DIFF
--- a/modules/check_in/app/services/travel_claim/service.rb
+++ b/modules/check_in/app/services/travel_claim/service.rb
@@ -12,7 +12,7 @@ module TravelClaim
   # @!attribute [r] redis_client
   #   @return [RedisClient]
   class Service
-    attr_reader :check_in, :appointment_date, :client, :redis_client, :response
+    attr_reader :check_in, :appointment_date, :redis_client, :response, :facility_type, :settings
 
     ##
     # Builds a Service instance
@@ -27,9 +27,10 @@ module TravelClaim
     end
 
     def initialize(opts = {})
+      @settings = Settings.check_in.travel_reimbursement_api_v2
       @check_in = opts[:check_in]
       @appointment_date = opts.dig(:params, :appointment_date)
-      @client = Client.build(check_in:)
+      @facility_type = opts.dig(:params, :facility_type) || ''
       @redis_client = RedisClient.build
       @response = Response
     end
@@ -85,6 +86,11 @@ module TravelClaim
     end
 
     private
+
+    def client
+      client_number = facility_type.downcase == 'oh' ? settings.client_number_oh : settings.client_number
+      @client ||= Client.build(check_in:, client_number:)
+    end
 
     def patient_icn
       redis_client.icn(uuid: check_in.uuid)


### PR DESCRIPTION
## Summary
This PR updates the Travel Claims service class to get the client number based on the passed-in facility type. This change allows us to use a different client number for Oracle Health facilities.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93075

## Testing done
- [x] tested locally
- [ ] will be testing in staging

## What areas of the site does it impact?
check-in experience Travel Claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
