### PR TITLE
EZR: Temporarily force the sending of submission failure

### DIFF
--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -62,6 +62,11 @@ module HCA
       user = User.find(user_uuid)
       parsed_form = self.class.decrypt_form(encrypted_form)
 
+      # Temporary. We need a way to test a failing form submission in staging.
+      # This will raise an error only if the flag is enabled.
+      # Will remove once we confirm the submission failure email is being sent.
+      raise if Flipper.enabled?(:ezr_use_va_notify_on_submission_failure)
+
       Form1010Ezr::Service.new(user).submit_sync(parsed_form)
     rescue VALIDATION_ERROR => e
       Form1010Ezr::Service.new(nil).log_submission_failure(parsed_form)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES `ezr_use_va_notify_on_submission_failure`*

We need a way to test submission failure emails in staging. This will cause all EZR submissions to fail if the flag is enabled. This flag is disabled in production and only enabled in staging. Once we QA in staging, this code will be reverted.

## Related issue(s)

- [PR 18620](https://github.com/department-of-veterans-affairs/vets-api/pull/18620)


## Testing done

- [x] *New code is covered by unit tests*

Covered by specs. We will be testing this in the staging environment.

## What areas of the site does it impact?
Form 10-10 EZR

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
