### PR TITLE
Decision Reviews| Remove 4142 flipper

### DIFF
--- a/lib/decision_review_v1/appeals/supplemental_claim_services.rb
+++ b/lib/decision_review_v1/appeals/supplemental_claim_services.rb
@@ -60,7 +60,8 @@ module DecisionReviewV1
       end
 
       ##
-      # Creates a new 4142(a) PDF, and sends to central mail
+      # Creates a new 4142(a) PDF, and sends to Lighthouse or central mail
+      # Sending to central mail is deprecated
       #
       # @param appeal_submission_id
       # @param rejiggered_payload

--- a/lib/decision_review_v1/appeals/supplemental_claim_services.rb
+++ b/lib/decision_review_v1/appeals/supplemental_claim_services.rb
@@ -60,8 +60,7 @@ module DecisionReviewV1
       end
 
       ##
-      # Creates a new 4142(a) PDF, and sends to Lighthouse or central mail
-      # Sending to central mail is deprecated
+      # Creates a new 4142(a) PDF, and sends to Lighthouse
       #
       # @param appeal_submission_id
       # @param rejiggered_payload
@@ -250,24 +249,18 @@ module DecisionReviewV1
 
       def submit_form4142(form_data:)
         processor = DecisionReviewV1::Processor::Form4142Processor.new(form_data:)
+        service = BenefitsIntake::Service.new
+        service.request_upload
 
-        if Flipper.enabled? :decision_review_sc_use_lighthouse_api_for_form4142
-          service = BenefitsIntake::Service.new
-          service.request_upload
+        payload = {
+          metadata: processor.request_body['metadata'],
+          document: processor.request_body['document'],
+          upload_url: service.location
+        }
 
-          payload = {
-            metadata: processor.request_body['metadata'],
-            document: processor.request_body['document'],
-            upload_url: service.location
-          }
+        response = service.perform_upload(**payload)
 
-          response = service.perform_upload(**payload)
-
-          [response, service.uuid]
-        else
-          response = CentralMail::Service.new.upload(processor.request_body)
-          [response, nil]
-        end
+        [response, service.uuid]
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/spec/requests/v1/supplemental_claims_spec.rb
+++ b/spec/requests/v1/supplemental_claims_spec.rb
@@ -134,28 +134,26 @@ RSpec.describe 'V1::SupplementalClaims', type: :request do
            headers:
     end
 
-    before do
-      Flipper.disable :decision_review_sc_use_lighthouse_api_for_form4142
-    end
-
     it 'creates a supplemental claim and queues a 4142 form when 4142 info is provided' do
       VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
-        VCR.use_cassette('central_mail/submit_4142') do
-          previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
-          expect { subject }.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
-          expect(response).to be_successful
-          parsed_response = JSON.parse(response.body)
-          id = parsed_response['data']['id']
-          expect(previous_appeal_submission_ids).not_to include id
-          appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
-          expect(appeal_submission.type_of_appeal).to eq('SC')
-          expect { DecisionReview::Form4142Submit.drain }.to change(DecisionReview::Form4142Submit.jobs, :size).by(-1)
+        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+            previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
+            expect { subject }.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
+            expect(response).to be_successful
+            parsed_response = JSON.parse(response.body)
+            id = parsed_response['data']['id']
+            expect(previous_appeal_submission_ids).not_to include id
+            appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+            expect(appeal_submission.type_of_appeal).to eq('SC')
+            expect { DecisionReview::Form4142Submit.drain }.to change(DecisionReview::Form4142Submit.jobs, :size).by(-1)
 
-          # SavedClaim should be created with request data and list of uploaded forms
-          request_body = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json)
-          saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
-          expect(saved_claim.form).to eq(request_body.to_json)
-          expect(saved_claim.uploaded_forms).to contain_exactly '21-4142'
+            # SavedClaim should be created with request data and list of uploaded forms
+            request_body = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json)
+            saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
+            expect(saved_claim.form).to eq(request_body.to_json)
+            expect(saved_claim.uploaded_forms).to contain_exactly '21-4142'
+          end
         end
       end
     end
@@ -179,14 +177,16 @@ RSpec.describe 'V1::SupplementalClaims', type: :request do
 
     it 'creates a supplemental claim and queues evidence jobs when additionalDocuments info is provided' do
       VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-UPLOADS-200_V1') do
-        VCR.use_cassette('central_mail/submit_4142') do
-          VCR.use_cassette('decision_review/SC-GET-UPLOAD-URL-200_V1') do
-            expect { subject }.to change(DecisionReview::SubmitUpload.jobs, :size).by(2)
-            expect(response).to be_successful
-            parsed_response = JSON.parse(response.body)
-            id = parsed_response['data']['id']
-            appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
-            expect(appeal_submission.type_of_appeal).to eq('SC')
+        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+            VCR.use_cassette('decision_review/SC-GET-UPLOAD-URL-200_V1') do
+              expect { subject }.to change(DecisionReview::SubmitUpload.jobs, :size).by(2)
+              expect(response).to be_successful
+              parsed_response = JSON.parse(response.body)
+              id = parsed_response['data']['id']
+              appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+              expect(appeal_submission.type_of_appeal).to eq('SC')
+            end
           end
         end
       end

--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -21,13 +21,18 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
     let(:request_body) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV') }
 
     context 'when form4142 data exists' do
-      context 'and feature flag is disabled' do
-        before do
-          Flipper.disable :decision_review_sc_use_lighthouse_api_for_form4142
-        end
+      it '#decrypt_form properly decrypts encrypted payloads' do
+        form4142 = request_body['form4142']
+        payload = get_and_rejigger_required_info(
+          request_body:, form4142:, user:
+        )
+        enc_payload = payload_encrypted_string(payload)
+        expect(subject.new.decrypt_form(enc_payload)).to eq(payload)
+      end
 
-        it 'generates a 4142 PDF and sends it to central mail' do
-          VCR.use_cassette('central_mail/submit_4142') do
+      it 'generates a 4142 PDF and sends it to Lighthouse API' do
+        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
             expect do
               form4142 = request_body['form4142']
               payload = get_and_rejigger_required_info(
@@ -37,44 +42,10 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
               subject.perform_async(appeal_submission.id, enc_payload, submitted_appeal_uuid)
               subject.drain
             end.to trigger_statsd_increment('worker.decision_review.form4142_submit.success', times: 1)
-              .and trigger_statsd_increment('api.central_mail.upload.total', times: 1)
-              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue', times: 1)
-              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue', times: 1)
-          end
-        end
-      end
-
-      context 'and feature flag is enabled' do
-        before do
-          Flipper.enable :decision_review_sc_use_lighthouse_api_for_form4142
-        end
-
-        it '#decrypt_form properly decrypts encrypted payloads' do
-          form4142 = request_body['form4142']
-          payload = get_and_rejigger_required_info(
-            request_body:, form4142:, user:
-          )
-          enc_payload = payload_encrypted_string(payload)
-          expect(subject.new.decrypt_form(enc_payload)).to eq(payload)
-        end
-
-        it 'generates a 4142 PDF and sends it to Lighthouse API' do
-          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
-            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
-              expect do
-                form4142 = request_body['form4142']
-                payload = get_and_rejigger_required_info(
-                  request_body:, form4142:, user:
-                )
-                enc_payload = payload_encrypted_string(payload)
-                subject.perform_async(appeal_submission.id, enc_payload, submitted_appeal_uuid)
-                subject.drain
-              end.to trigger_statsd_increment('worker.decision_review.form4142_submit.success', times: 1)
-                .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue',
-                                              times: 1)
-                .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue',
-                                              times: 1)
-            end
+              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.enqueue',
+                                            times: 1)
+              .and trigger_statsd_increment('shared.sidekiq.default.DecisionReview_Form4142Submit.dequeue',
+                                            times: 1)
           end
         end
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
Removing a previous Flipper toggle that determined whether 4142 forms submitted with a Supplemental Claim were sent directly to Central Mail (old behavior) or through Lighthouse (new behavior). The new behavior has been in place for months, time to clear out the Flipper.

## Related issue(s)

- [Github issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94720)

## Testing done

- [X ] *New code is covered by unit tests*
- *Deleted tests for old code path*
- *Updated all existing tests to follow new code path and use correct VCR cassettes*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Only touches the 4142 submission process when that form is included as part of a Supplemental Claim submission

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
