### PR TITLE
Use form-provided email address instead of Profile email address, Part 2

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -76,9 +76,6 @@ module SimpleFormsApi
       return unless SUPPORTED_FORMS.include?(form_number)
       return unless flipper?
 
-      data = form_specific_data || empty_form_specific_data
-      return if data[:personalization]['first_name'].blank?
-
       template_id = TEMPLATE_IDS[form_number][notification_type]
       return unless template_id
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -83,9 +83,9 @@ module SimpleFormsApi
       return unless template_id
 
       if at
-        enqueue_email(at, template_id, data)
+        enqueue_email(at, template_id)
       else
-        send_email_now(template_id, data)
+        send_email_now(template_id)
       end
     end
 
@@ -100,49 +100,52 @@ module SimpleFormsApi
       Flipper.enabled?(:"form#{form_number.gsub('vba_', '')}_confirmation_email")
     end
 
-    def enqueue_email(at, template_id, data)
+    def enqueue_email(at, template_id)
+      email_from_form_data = get_email_address_from_form_data
+      first_name_from_form_data = get_first_name_from_form_data
+
+      # async job and form data includes email
+      if email_from_form_data && first_name_from_form_data
+        VANotify::EmailJob.perform_at(
+          at,
+          email_from_form_data,
+          template_id,
+          get_personalization(first_name_from_form_data)
+        )
       # async job and we have a UserAccount
-      if user_account
-        data[:personalization]['first_name'] = get_first_name
-        return if data[:personalization]['first_name'].blank?
+      elsif user_account
+        first_name_from_user_account = get_first_name_from_user_account
+        return unless first_name_from_user_account
 
         VANotify::UserAccountJob.perform_at(
           at,
           user_account.id,
           template_id,
-          data[:personalization]
-        )
-      # async job and we don't have a UserAccount but form data should include email
-      else
-        return if data[:email].blank? || data[:personalization]['first_name'].blank?
-
-        VANotify::EmailJob.perform_at(
-          at,
-          data[:email],
-          template_id,
-          data[:personalization]
+          get_personalization(first_name_from_user_account)
         )
       end
     end
 
-    def send_email_now(template_id, data)
+    def send_email_now(template_id)
+      email_from_form_data = get_email_address_from_form_data
+      first_name_from_form_data = get_first_name_from_form_data
+
+      # sync job and form data includes email
+      if email_from_form_data && first_name_from_form_data
+        VANotify::EmailJob.perform_async(
+          email_from_form_data,
+          template_id,
+          get_personalization(first_name_from_form_data)
+        )
       # sync job and we have a User
-      if user
-        return if data[:personalization]['first_name'].blank?
+      elsif user
+        first_name = get_first_name_from_form_data || get_first_name_from_user
+        return unless first_name
 
         VANotify::EmailJob.perform_async(
           user.va_profile_email,
           template_id,
-          data[:personalization]
-        )
-      # sync job and form data should include email
-      else
-        return if data[:email].blank? || data[:personalization]['first_name'].blank?
-
-        VANotify::EmailJob.perform_async(
-          data[:email],
-          template_id,
-          data[:personalization]
+          get_personalization(first_name)
         )
       end
     end
@@ -219,80 +222,6 @@ module SimpleFormsApi
       end
     end
 
-    def get_first_name
-      if user_account
-        mpi_response = MPI::Service.new.find_profile_by_identifier(identifier_type: 'ICN', identifier: user_account.icn)
-        if mpi_response
-          error = mpi_response.error
-          Rails.logger.error('MPI response error', { error: }) if error
-
-          first_name = mpi_response.profile&.given_names&.first
-          Rails.logger.error('MPI profile missing first_name') unless first_name
-
-          first_name
-        end
-      elsif user
-        first_name = user.first_name
-        Rails.logger.error('First name not found in user profile') unless first_name
-
-        first_name
-      end
-    end
-
-    # rubocop:disable Metrics/MethodLength
-    # email and personalization hash
-    def form_specific_data
-      case @form_number
-      when 'vba_21_0845'
-        email, first_name = form21_0845_contact_info
-
-        { email:, personalization: default_personalization(first_name) }
-      when 'vba_21p_0847'
-        {
-          email: @form_data['preparer_email'],
-          personalization: default_personalization(@form_data.dig('preparer_name', 'first'))
-        }
-      when 'vba_21_0966'
-        {
-          email: @user&.va_profile_email,
-          personalization: default_personalization(get_first_name)
-            .merge(form21_0966_personalization)
-        }
-      when 'vba_21_0972'
-        {
-          email: @form_data['preparer_email'],
-          personalization: default_personalization(@form_data.dig('preparer_full_name', 'first'))
-        }
-      when 'vba_21_4142'
-        {
-          email: @form_data.dig('veteran', 'email'),
-          personalization: default_personalization(@form_data.dig('veteran', 'full_name', 'first'))
-        }
-      when 'vba_21_10210'
-        email, first_name = form21_10210_contact_info
-
-        { email:, personalization: default_personalization(first_name) }
-      when 'vba_20_10206'
-        email, first_name = form20_10206_contact_info
-
-        { email:, personalization: default_personalization(first_name) }
-      when 'vba_20_10207'
-        email, first_name = form20_10207_contact_info
-
-        { email:, personalization: default_personalization(first_name) }
-      when 'vba_40_0247'
-        {
-          email: @form_data['applicant_email'],
-          personalization: default_personalization(@form_data.dig('applicant_full_name', 'first'))
-        }
-      end
-    end
-    # rubocop:enable Metrics/MethodLength
-
-    def empty_form_specific_data
-      { email: '', personalization: {} }
-    end
-
     # personalization hash shared by all simple form confirmation emails
     def default_personalization(first_name)
       {
@@ -341,8 +270,8 @@ module SimpleFormsApi
     # email and first name for form 21-0845
     def form21_0845_contact_info
       # (vet && signed in)
-      if @form_data['authorizer_type'] == 'veteran' && @user
-        [@user.va_profile_email, @form_data.dig('veteran_full_name', 'first')]
+      if @form_data['authorizer_type'] == 'veteran'
+        [@form_data['authorizer_email'] || @user&.va_profile_email, @form_data.dig('veteran_full_name', 'first')]
 
       # (non-vet && signed in) || (non-vet && anon)
       elsif @form_data['authorizer_type'] == 'nonVeteran'
@@ -359,13 +288,13 @@ module SimpleFormsApi
       # user's own claim
       # user is a veteran
       if @form_data['claim_ownership'] == 'self' && @form_data['claimant_type'] == 'veteran'
-        email = user&.va_profile_email || @form_data['veteran_email']
+        email = @form_data['veteran_email'] || user&.va_profile_email
         [email, @form_data.dig('veteran_full_name', 'first')]
 
       # user's own claim
       # user is not a veteran
       elsif @form_data['claim_ownership'] == 'self' && @form_data['claimant_type'] == 'non-veteran'
-        email = user&.va_profile_email || @form_data['claimant_email']
+        email = @form_data['claimant_email'] || user&.va_profile_email
         [email, @form_data.dig('claimant_full_name', 'first')]
 
       # someone else's claim

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -641,7 +641,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          'veteran.surname@address.com',
           'form21_4142_confirmation_email_template_id',
           {
             'first_name' => 'VETERAN',
@@ -683,7 +683,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          'my.long.email.address@email.com',
           'form21_10210_confirmation_email_template_id',
           {
             'first_name' => 'JACK',
@@ -731,7 +731,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          'preparer_address@email.com',
           'form21p_0847_confirmation_email_template_id',
           {
             'first_name' => 'ARTHUR',
@@ -774,7 +774,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(VANotify::EmailJob).to have_received(:perform_async).with(
-          user.va_profile_email,
+          'preparer@email.com',
           'form21_0972_confirmation_email_template_id',
           {
             'first_name' => 'PREPARE',
@@ -833,7 +833,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
               'abraham.lincoln@vets.gov',
               'form21_0966_confirmation_email_template_id',
               {
-                'first_name' => 'ABRAHAM',
+                'first_name' => 'VETERAN',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => confirmation_number,
                 'lighthouse_updated_at' => nil,
@@ -857,7 +857,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
               'abraham.lincoln@vets.gov',
               'form21_0966_confirmation_email_template_id',
               {
-                'first_name' => 'ABRAHAM',
+                'first_name' => 'VETERAN',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
                 'confirmation_number' => confirmation_number,
                 'lighthouse_updated_at' => nil,

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -108,11 +108,17 @@ describe SimpleFormsApi::NotificationEmail do
 
       context 'send at time is specified' do
         context 'user_account is passed in' do
+          let(:data) do
+            fixture_path = Rails.root.join(
+              'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210-min.json'
+            )
+            JSON.parse(fixture_path.read)
+          end
           let(:user_account) { create(:user_account) }
 
           it 'sends the email at the specified time' do
             time = double
-            profile = double(given_names: [double])
+            profile = double(given_names: ['Bob'])
             mpi_profile = double(profile:, error: nil)
             allow(VANotify::UserAccountJob).to receive(:perform_at)
             allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(mpi_profile)
@@ -141,46 +147,22 @@ describe SimpleFormsApi::NotificationEmail do
 
     describe '21_10210' do
       let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
-      let(:data) do
-        fixture_path = Rails.root.join(
-          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210.json'
-        )
-        JSON.parse(fixture_path.read)
-      end
       let(:config) do
         { form_data: data, form_number: 'vba_21_10210',
           confirmation_number: 'confirmation_number', date_submitted: }
       end
 
-      context 'users own claim' do
-        context 'is a veteran' do
-          context 'user is passed in' do
-            let(:user) { build(:user) }
+      context 'form data has an email address' do
+        let(:data) do
+          fixture_path = Rails.root.join(
+            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210.json'
+          )
+          JSON.parse(fixture_path.read)
+        end
 
-            it 'calls VANotify::EmailJob with user record email' do
-              allow(VANotify::EmailJob).to receive(:perform_async)
-              data['claim_ownership'] = 'self'
-              data['claimant_type'] = 'veteran'
-
-              subject = described_class.new(config, notification_type:, user:)
-
-              subject.send
-
-              expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                user.va_profile_email,
-                "form21_10210_#{notification_type}_email_template_id",
-                {
-                  'first_name' => 'JOHN',
-                  'date_submitted' => date_submitted,
-                  'confirmation_number' => 'confirmation_number',
-                  'lighthouse_updated_at' => nil
-                }
-              )
-            end
-          end
-
-          context 'user is not passed in' do
-            it 'calls VANotify::EmailJob with user record email' do
+        context 'users own claim' do
+          context 'is a veteran' do
+            it 'calls VANotify::EmailJob' do
               allow(VANotify::EmailJob).to receive(:perform_async)
               data['claim_ownership'] = 'self'
               data['claimant_type'] = 'veteran'
@@ -203,6 +185,129 @@ describe SimpleFormsApi::NotificationEmail do
           end
 
           context 'is not a veteran' do
+            it 'calls VANotify::EmailJob' do
+              allow(VANotify::EmailJob).to receive(:perform_async)
+              data['claim_ownership'] = 'self'
+              data['claimant_type'] = 'non-veteran'
+
+              subject = described_class.new(config, notification_type:)
+
+              subject.send
+
+              expect(VANotify::EmailJob).to have_received(:perform_async).with(
+                'claimant.long@address.com',
+                "form21_10210_#{notification_type}_email_template_id",
+                {
+                  'first_name' => 'JOE',
+                  'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+                  'confirmation_number' => 'confirmation_number',
+                  'lighthouse_updated_at' => nil
+                }
+              )
+            end
+          end
+        end
+
+        context 'someone elses claim' do
+          context 'claimant is a veteran' do
+            it 'calls VANotify::EmailJob' do
+              allow(VANotify::EmailJob).to receive(:perform_async)
+              data['claim_ownership'] = 'third-party'
+              data['claimant_type'] = 'veteran'
+
+              subject = described_class.new(config, notification_type:)
+
+              subject.send
+
+              expect(VANotify::EmailJob).to have_received(:perform_async).with(
+                'my.long.email.address@email.com',
+                "form21_10210_#{notification_type}_email_template_id",
+                {
+                  'first_name' => 'JACK',
+                  'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+                  'confirmation_number' => 'confirmation_number',
+                  'lighthouse_updated_at' => nil
+                }
+              )
+            end
+          end
+
+          context 'claimant is not a veteran' do
+            it 'calls VANotify::EmailJob' do
+              allow(VANotify::EmailJob).to receive(:perform_async)
+              data['claim_ownership'] = 'third-party'
+              data['claimant_type'] = 'non-veteran'
+
+              subject = described_class.new(config, notification_type:)
+
+              subject.send
+
+              expect(VANotify::EmailJob).to have_received(:perform_async).with(
+                'my.long.email.address@email.com',
+                "form21_10210_#{notification_type}_email_template_id",
+                {
+                  'first_name' => 'JACK',
+                  'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+                  'confirmation_number' => 'confirmation_number',
+                  'lighthouse_updated_at' => nil
+                }
+              )
+            end
+          end
+        end
+      end
+
+      context 'form data does not have an email address' do
+        let(:data) do
+          fixture_path = Rails.root.join(
+            'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210-min.json'
+          )
+          JSON.parse(fixture_path.read)
+        end
+
+        context 'users own claim' do
+          context 'is a veteran' do
+            context 'user is passed in' do
+              let(:user) { build(:user) }
+
+              it 'calls VANotify::EmailJob with user record email' do
+                allow(VANotify::EmailJob).to receive(:perform_async)
+                data['claim_ownership'] = 'self'
+                data['claimant_type'] = 'veteran'
+
+                subject = described_class.new(config, notification_type:, user:)
+
+                subject.send
+
+                expect(VANotify::EmailJob).to have_received(:perform_async).with(
+                  user.va_profile_email,
+                  "form21_10210_#{notification_type}_email_template_id",
+                  {
+                    'first_name' => 'JOHN',
+                    'date_submitted' => date_submitted,
+                    'confirmation_number' => 'confirmation_number',
+                    'lighthouse_updated_at' => nil
+                  }
+                )
+              end
+            end
+
+            context 'user is not passed in' do
+              it 'does not call VANotify::EmailJob' do
+                allow(VANotify::EmailJob).to receive(:perform_async)
+                data['claim_ownership'] = 'self'
+                data['claimant_type'] = 'veteran'
+
+                subject = described_class.new(config, notification_type:)
+
+                subject.send
+
+                expect(VANotify::EmailJob).not_to have_received(:perform_async)
+              end
+            end
+          end
+
+          context 'is not a veteran' do
             context 'user is passed in' do
               let(:user) { build(:user) }
 
@@ -210,6 +315,7 @@ describe SimpleFormsApi::NotificationEmail do
                 allow(VANotify::EmailJob).to receive(:perform_async)
                 data['claim_ownership'] = 'self'
                 data['claimant_type'] = 'non-veteran'
+                data['claimant_full_name'] = { 'first' => 'Joe' }
 
                 subject = described_class.new(config, notification_type:, user:)
 
@@ -229,7 +335,7 @@ describe SimpleFormsApi::NotificationEmail do
             end
 
             context 'user is not passed in' do
-              it 'calls VANotify::EmailJob' do
+              it 'does not call VANotify::EmailJob' do
                 allow(VANotify::EmailJob).to receive(:perform_async)
                 data['claim_ownership'] = 'self'
                 data['claimant_type'] = 'non-veteran'
@@ -238,66 +344,9 @@ describe SimpleFormsApi::NotificationEmail do
 
                 subject.send
 
-                expect(VANotify::EmailJob).to have_received(:perform_async).with(
-                  'claimant.long@address.com',
-                  "form21_10210_#{notification_type}_email_template_id",
-                  {
-                    'first_name' => 'JOE',
-                    'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-                    'confirmation_number' => 'confirmation_number',
-                    'lighthouse_updated_at' => nil
-                  }
-                )
+                expect(VANotify::EmailJob).not_to have_received(:perform_async)
               end
             end
-          end
-        end
-      end
-
-      context 'someone elses claim' do
-        context 'claimant is a veteran' do
-          it 'calls VANotify::EmailJob' do
-            allow(VANotify::EmailJob).to receive(:perform_async)
-            data['claim_ownership'] = 'third-party'
-            data['claimant_type'] = 'veteran'
-
-            subject = described_class.new(config, notification_type:)
-
-            subject.send
-
-            expect(VANotify::EmailJob).to have_received(:perform_async).with(
-              'my.long.email.address@email.com',
-              "form21_10210_#{notification_type}_email_template_id",
-              {
-                'first_name' => 'JACK',
-                'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-                'confirmation_number' => 'confirmation_number',
-                'lighthouse_updated_at' => nil
-              }
-            )
-          end
-        end
-
-        context 'claimant is not a veteran' do
-          it 'calls VANotify::EmailJob' do
-            allow(VANotify::EmailJob).to receive(:perform_async)
-            data['claim_ownership'] = 'third-party'
-            data['claimant_type'] = 'non-veteran'
-
-            subject = described_class.new(config, notification_type:)
-
-            subject.send
-
-            expect(VANotify::EmailJob).to have_received(:perform_async).with(
-              'my.long.email.address@email.com',
-              "form21_10210_#{notification_type}_email_template_id",
-              {
-                'first_name' => 'JACK',
-                'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-                'confirmation_number' => 'confirmation_number',
-                'lighthouse_updated_at' => nil
-              }
-            )
           end
         end
       end
@@ -409,84 +458,122 @@ describe SimpleFormsApi::NotificationEmail do
         { form_data: data, form_number: 'vba_21_0845', confirmation_number: 'confirmation_number', date_submitted: }
       end
 
-      describe 'signed in user' do
-        let(:user) { create(:user) }
+      context 'form data has an email address' do
+        describe 'signed in user' do
+          let(:user) { create(:user) }
 
-        it 'non-veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          data['authorizer_email'] = 'authorizer_email@example.com'
+          it 'non-veteran authorizer' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
+            data['authorizer_email'] = 'authorizer_email@example.com'
 
-          subject = described_class.new(config, user:)
+            subject = described_class.new(config, user:)
 
-          subject.send
+            subject.send
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.va_profile_email,
-            'form21_0845_confirmation_email_template_id',
-            {
-              'first_name' => 'JACK',
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
+            expect(VANotify::EmailJob).to have_received(:perform_async).with(
+              'authorizer_email@example.com',
+              'form21_0845_confirmation_email_template_id',
+              {
+                'first_name' => 'JACK',
+                'date_submitted' => date_submitted,
+                'confirmation_number' => 'confirmation_number',
+                'lighthouse_updated_at' => nil
+              }
+            )
+          end
+
+          it 'veteran authorizer' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
+            data['authorizer_type'] = 'veteran'
+            data['authorizer_email'] = 'authorizer_email@example.com'
+
+            subject = described_class.new(config, user: create(:user))
+
+            subject.send
+
+            expect(VANotify::EmailJob).to have_received(:perform_async).with(
+              'authorizer_email@example.com',
+              'form21_0845_confirmation_email_template_id',
+              {
+                'first_name' => 'JOHN',
+                'date_submitted' => date_submitted,
+                'confirmation_number' => 'confirmation_number',
+                'lighthouse_updated_at' => nil
+              }
+            )
+          end
         end
 
-        it 'veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          data['authorizer_type'] = 'veteran'
+        describe 'not signed in user' do
+          it 'non-veteran authorizer' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
+            # form requires email
+            data['authorizer_email'] = 'authorizer_email@example.com'
 
-          subject = described_class.new(config, user: create(:user))
+            subject = described_class.new(config)
 
-          allow(subject.user).to receive(:va_profile_email).and_return('abraham.lincoln@vets.gov')
+            subject.send
 
-          subject.send
+            expect(VANotify::EmailJob).to have_received(:perform_async).with(
+              'authorizer_email@example.com',
+              'form21_0845_confirmation_email_template_id',
+              {
+                'first_name' => 'JACK',
+                'date_submitted' => date_submitted,
+                'confirmation_number' => 'confirmation_number',
+                'lighthouse_updated_at' => nil
+              }
+            )
+          end
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            'abraham.lincoln@vets.gov',
-            'form21_0845_confirmation_email_template_id',
-            {
-              'first_name' => 'JOHN',
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
+          it 'veteran authorizer' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
+            # form does not require email
+            data['authorizer_type'] = 'veteran'
+
+            subject = described_class.new(config)
+
+            subject.send
+
+            expect(VANotify::EmailJob).not_to have_received(:perform_async)
+          end
         end
       end
 
-      describe 'not signed in user' do
-        it 'non-veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          # form requires email
-          data['authorizer_email'] = 'authorizer_email@example.com'
+      context 'form data does not have an email address' do
+        describe 'signed in user' do
+          let(:user) { create(:user) }
 
-          subject = described_class.new(config)
+          it 'sends an email with VANotify::EmailJob' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
 
-          subject.send
+            subject = described_class.new(config, user:)
 
-          expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            'authorizer_email@example.com',
-            'form21_0845_confirmation_email_template_id',
-            {
-              'first_name' => 'JACK',
-              'date_submitted' => date_submitted,
-              'confirmation_number' => 'confirmation_number',
-              'lighthouse_updated_at' => nil
-            }
-          )
+            subject.send
+
+            expect(VANotify::EmailJob).to have_received(:perform_async).with(
+              user.va_profile_email,
+              'form21_0845_confirmation_email_template_id',
+              {
+                'first_name' => 'JACK',
+                'date_submitted' => date_submitted,
+                'confirmation_number' => 'confirmation_number',
+                'lighthouse_updated_at' => nil
+              }
+            )
+          end
         end
 
-        it 'veteran authorizer' do
-          allow(VANotify::EmailJob).to receive(:perform_async)
-          # form does not require email
-          data['authorizer_type'] = 'veteran'
+        describe 'not signed in user' do
+          it 'does not send an email' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
 
-          subject = described_class.new(config)
+            subject = described_class.new(config)
 
-          subject.send
+            subject.send
 
-          expect(VANotify::EmailJob).not_to have_received(:perform_async)
+            expect(VANotify::EmailJob).not_to have_received(:perform_async)
+          end
         end
       end
     end
@@ -517,7 +604,7 @@ describe SimpleFormsApi::NotificationEmail do
             user.va_profile_email,
             'form21_0966_confirmation_email_template_id',
             {
-              'first_name' => user.first_name.upcase,
+              'first_name' => 'VETERAN',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil,

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
   end
 
   describe 'state machine' do
+    before { allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send) }
+
     let(:config) do
       {
         form_data: anything,

--- a/spec/sidekiq/benefits_intake_status_job_spec.rb
+++ b/spec/sidekiq/benefits_intake_status_job_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe BenefitsIntakeStatusJob, type: :job do
     end
 
     describe 'updating the form submission status' do
+      before { allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send) }
+
       it 'updates the status with vbms from the bulk status report endpoint' do
         pending_form_submissions = create_list(:form_submission, 1, :pending)
         batch_uuids = pending_form_submissions.map(&:benefits_intake_uuid)


### PR DESCRIPTION
## Summary
Part 2 of [this bigger draft PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18851). [Part 1 is here](https://github.com/department-of-veterans-affairs/vets-api/pull/18852).

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1731
