### PR TITLE
9622: use translations file md5 instead of timestamp

### DIFF
--- a/modules/mobile/docs/openapi.yaml
+++ b/modules/mobile/docs/openapi.yaml
@@ -3750,7 +3750,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/InflectionHeader'
         - description: |
-            When this endpoint responds with a 200, it includes a Content-Version header. That value is an epoch time integer that the frontend will store and send as the current_version parameter. When this value is less than the translation file's last modified time, it responds with a 200 status and the newest version of the translations file. If the timestamp is equal to the translation file's last modified time, it responds with 204 and no content.
+            When this endpoint responds with a 200, it includes a Content-Version header. The frontend is expected to store that value and include it as the `current_version` query param. When the `current_version` is omited or does not match the server's current version, the server responds with a 200 status, the newest version of the translations file, and the header including the newest version id. If the `current_version` matches the server's current version, the server responds with 204 and no content.
           in: query
           name: current_version
           required: false
@@ -3775,9 +3775,9 @@ paths:
                 type: string
                 enum: [ application/json ]
             Content-Version:
-              description: Epoch time integer of the last modified time of the file being downloaded.
+              description: Current version of the file being downloaded.
               schema:
-                type: integer
+                type: string
           description: OK
         '204':
           description: No Content.


### PR DESCRIPTION
## Summary

Fixes an issue found when testing the translations download. The previous approach of using the git timestamp doesn't work in deployed environments because the app is mounted within docker. This changes to using the file MD5, which I've already confirmed is accessible in staging. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9622

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None. It's a new endpoint. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
