### PR TITLE
[SIMPLE_FORMS] feat: form remediation solution streamlining, test coverage, and documentation - PART 8

### DIFF
--- a/app/uploaders/simple_forms_api/form_remediation/uploader.rb
+++ b/app/uploaders/simple_forms_api/form_remediation/uploader.rb
@@ -48,7 +48,7 @@ module SimpleFormsApi
       attr_reader :config
 
       def s3_obj(file_path)
-        client = Aws::S3::Client.new(region: s3_settings.region)
+        client = Aws::S3::Client.new(region: config.s3_settings.region)
         resource = Aws::S3::Resource.new(client:)
         resource.bucket(config.s3_settings.bucket).object(file_path)
       end

--- a/app/uploaders/simple_forms_api/form_remediation/uploader.rb
+++ b/app/uploaders/simple_forms_api/form_remediation/uploader.rb
@@ -16,7 +16,7 @@ module SimpleFormsApi
         %w[bmp csv gif jpeg jpg json pdf png tif tiff txt zip]
       end
 
-      def initialize(directory:, config: Configuration::Base.new)
+      def initialize(directory:, config:)
         raise 'The S3 directory is missing.' if directory.blank?
         raise 'The configuration is missing.' unless config
 

--- a/lib/simple_forms_api/form_remediation/configuration/base.rb
+++ b/lib/simple_forms_api/form_remediation/configuration/base.rb
@@ -10,7 +10,7 @@ module SimpleFormsApi
           @id_type = :benefits_intake_uuid  # The field to query the FormSubmission by
           @include_manifest = true          # Include a CSV file containing manifest data
           @include_metadata = false         # Include a JSON file containing form submission metadata
-          @parent_dir = '/'                 # The base directory in the S3 bucket where the archive will be stored
+          @parent_dir = ''                  # The base directory in the S3 bucket where the archive will be stored
           @presign_s3_url = true            # Once archived to S3, the service should generate & return a presigned_url
         end
 
@@ -49,7 +49,7 @@ module SimpleFormsApi
         # hydrated and stored. This directory will automatically
         # be deleted once the archive process completes
         def temp_directory_path
-          @temp_directory_path ||= Rails.root.join("tmp/#{SecureRandom.hex}-archive/").to_s
+          Rails.root.join("tmp/#{SecureRandom.hex}-archive/").to_s
         end
 
         # Used in the SimpleFormsApi::FormRemediation::Uploader S3 uploader

--- a/lib/simple_forms_api/form_remediation/configuration/base.rb
+++ b/lib/simple_forms_api/form_remediation/configuration/base.rb
@@ -59,12 +59,12 @@ module SimpleFormsApi
 
         # Utility method, override to add your own team's preferred logging approach
         def log_info(message, **details)
-          Rails.logger.info(message, details)
+          Rails.logger.info({ message: }.merge(details))
         end
 
         # Utility method, override to add your own team's preferred logging approach
         def log_error(message, error, **details)
-          Rails.logger.error(message, details.merge(error: error.message, backtrace: error.backtrace.first(5)))
+          Rails.logger.error({ message:, error: error.message, backtrace: error.backtrace.first(5) }.merge(details))
         end
 
         # Utility method, override to add your own team's preferred logging approach

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
@@ -41,12 +41,14 @@ module SimpleFormsApi
         end
       end
 
-      def cleanup(path)
+      def cleanup!(path)
         log_info("Cleaning up path: #{path}")
         FileUtils.rm_rf(path)
       end
 
-      def create_temp_directory!(dir_path)
+      def create_directory!(dir_path)
+        return if File.directory?(dir_path)
+
         FileUtils.mkdir_p(dir_path)
       end
 
@@ -55,7 +57,7 @@ module SimpleFormsApi
         local_file_path = Pathname.new(s3_key).relative_path_from(Pathname.new(s3_dir))
         final_path = Pathname.new(local_dir).join(local_file_path)
 
-        create_temp_directory!(final_path.dirname)
+        create_directory!(final_path.dirname)
         final_path.to_s
       rescue => e
         handle_error('Error building local path from S3', e)

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
@@ -86,7 +86,8 @@ module SimpleFormsApi
         "#{Time.zone.today.strftime('%-m.%d.%y')}-Form#{form_number}"
       end
 
-      def write_manifest(row, new_manifest, path)
+      def write_manifest(row, path)
+        new_manifest = !File.exist?(path)
         CSV.open(path, 'ab') do |csv|
           csv << %w[SubmissionDateTime FormType VAGovID VeteranID FirstName LastName] if new_manifest
           csv << row

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
@@ -6,28 +6,43 @@ module SimpleFormsApi
   module FormRemediation
     module FileUtilities
       def zip_directory!(parent_dir, temp_dir, unique_filename)
-        raise "Directory not found: #{temp_dir}" unless File.directory?(temp_dir)
+        validate_directory_existence!(temp_dir)
+        zip_file_path = prepare_file_paths(parent_dir, temp_dir, unique_filename)
 
+        create_zip_file(zip_file_path, temp_dir)
+      rescue => e
+        handle_error("Failed to zip directory: #{temp_dir} to #{zip_file_path}", e)
+      end
+
+      def prepare_file_paths(parent_dir, temp_dir, unique_filename)
         s3_dir = build_path(:dir, parent_dir, 'remediation')
         s3_file_path = build_path(:file, s3_dir, unique_filename, ext: '.zip')
-        zip_file_path = build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
+        build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
+      end
 
+      def validate_directory_existence!(directory)
+        raise "Directory not found: #{directory}" unless File.directory?(directory)
+      end
+
+      def create_zip_file(zip_file_path, temp_dir)
         Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
-          Dir.chdir(temp_dir) do
-            Dir['**', '*'].uniq.each do |file|
-              next if File.directory?(file)
+          add_files_to_zip(zipfile, temp_dir)
+        end
+        zip_file_path
+      end
 
-              zipfile.add(file, File.join(temp_dir, file)) if File.file?(file)
-            end
+      def add_files_to_zip(zipfile, temp_dir)
+        Dir.chdir(temp_dir) do
+          Dir['**', '*'].uniq.each do |file|
+            next if File.directory?(file)
+
+            zipfile.add(file, File.join(temp_dir, file)) if File.file?(file)
           end
         end
-
-        zip_file_path
-      rescue => e
-        handle_error("Failed to zip temp directory: #{temp_dir} to location: #{zip_file_path}", e)
       end
 
       def cleanup(path)
+        log_info("Cleaning up path: #{path}")
         FileUtils.rm_rf(path)
       end
 
@@ -36,31 +51,33 @@ module SimpleFormsApi
       end
 
       def build_local_path_from_s3(s3_dir, s3_key, local_dir)
-        s3_dir = s3_dir.sub(%r{^/}, '') if s3_dir.start_with?('/')
-        s3_key = s3_key.sub(%r{^/}, '') if s3_key.start_with?('/')
-
+        clean_s3_path!(s3_dir, s3_key)
         local_file_path = Pathname.new(s3_key).relative_path_from(Pathname.new(s3_dir))
         final_path = Pathname.new(local_dir).join(local_file_path)
 
         create_temp_directory!(final_path.dirname)
         final_path.to_s
       rescue => e
-        config.handle_error("Error building local path from S3: #{e.message}", e)
+        handle_error('Error building local path from S3', e)
       end
 
-      def build_path(path_type, base_dir, *, ext: '.pdf')
+      def clean_s3_path!(*paths)
+        paths.each { |path| path.sub!(%r{^/}, '') if path.start_with?('/') }
+      end
+
+      def build_path(path_type, base_dir, *path_segments, ext: '.pdf')
         file_ext = path_type == :file ? ext : ''
-        path = Pathname.new(base_dir.to_s).join(*)
+        path = Pathname.new(base_dir.to_s).join(*path_segments)
         path = path.to_s + file_ext unless file_ext.empty?
         path.to_s
       end
 
-      def write_file(dir_path, file_name, payload)
-        File.write(File.join(dir_path, file_name), payload)
+      def write_file(dir_path, file_name, content)
+        File.write(File.join(dir_path, file_name), content)
       end
 
-      def unique_file_path(form_number, id)
-        [Time.zone.today.strftime('%-m.%d.%y'), 'form', form_number, 'vagov', id].join('_')
+      def unique_file_name(form_number, id)
+        "#{Time.zone.today.strftime('%-m.%d.%y')}_form_#{form_number}_vagov_#{id}"
       end
 
       def dated_directory_name(form_number)
@@ -68,20 +85,25 @@ module SimpleFormsApi
       end
 
       def write_manifest(row, new_manifest, path)
-        id = row[2]
         CSV.open(path, 'ab') do |csv|
           csv << %w[SubmissionDateTime FormType VAGovID VeteranID FirstName LastName] if new_manifest
           csv << row
         end
       rescue => e
-        handle_error("Failed writing manifest for submission: #{id}", e)
+        handle_error('Failed writing manifest for submission', e)
       end
 
-      private
+      def log_info(message, **details)
+        Rails.logger.info({ message: }.merge(details))
+      end
 
-      def handle_error(*, **)
-        config = Configuration::Base.new
-        config.handle_error(*, **)
+      def log_error(message, error, **details)
+        Rails.logger.error({ message:, error: error.message, backtrace: error.backtrace.first(5) }.merge(details))
+      end
+
+      def handle_error(message, error, **details)
+        log_error(message, error, **details)
+        raise error
       end
     end
   end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/jobs/archive_batch_processing_job.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/jobs/archive_batch_processing_job.rb
@@ -78,7 +78,7 @@ module SimpleFormsApi
         end
 
         def archive_submission(id)
-          config.s3_client.new(id:, parent_dir:, type:).upload
+          config.s3_client.new(config:, id:, type:).upload
         end
       end
     end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/jobs/archive_batch_processing_job.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/jobs/archive_batch_processing_job.rb
@@ -22,7 +22,7 @@ module SimpleFormsApi
           begin
             load_progress
             presigned_urls = upload(type:)
-            cleanup(PROGRESS_FILE_PATH)
+            cleanup!(PROGRESS_FILE_PATH)
             presigned_urls
           rescue => e
             @config.handle_error("#{self.class.name} execution failed", e)

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -87,21 +87,20 @@ module SimpleFormsApi
         config.handle_error('Failed to update manifest', e)
       end
 
-      def download_manifest(dir, s3_path)
-        local_path = File.join(dir, s3_path)
-        create_directory!(File.dirname(local_path))
-        s3_uploader.get_s3_file(s3_path, local_path)
-        CSV.open(local_path, 'w') unless File.exist?(local_path)
-        local_path
-      end
-
       def build_s3_manifest_path(form_number)
         path = build_path(:file, s3_directory_path, "manifest_#{dated_directory_name(form_number)}", ext: '.csv')
         path.sub(%r{^/}, '')
       end
 
+      def download_manifest(dir, s3_path)
+        local_path = File.join(dir, s3_path)
+        create_directory!(File.dirname(local_path))
+        s3_uploader.get_s3_file(s3_path, local_path)
+        local_path
+      end
+
       def write_and_upload_manifest(local_path)
-        write_manifest(manifest_row, !File.exist?(local_path), local_path)
+        write_manifest(manifest_row, local_path)
         upload_to_s3(local_path)
       end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -11,21 +11,18 @@ module SimpleFormsApi
 
       class << self
         def fetch_presigned_url(id, type: :submission)
-          new(id:).s3_generate_presigned_url(s3_upload_file_path, type:)
+          new(id:).generate_presigned_url(type:)
         end
       end
 
       def initialize(config:, type: :remediation, **options)
         @upload_type = type
         @config = config
-        @parent_dir = config.parent_dir
-        @presign_s3_url = config.presign_s3_url
-
-        @file_path = options[:file_path]
         @id = options[:id]
 
-        @archive_path, @manifest_row = build_archive!(config:, type:, **options)
-        @temp_directory_path = File.dirname(@archive_path)
+        assign_defaults(options)
+        initialize_archive
+        log_initialization
       rescue => e
         config.handle_error("#{self.class.name} initialization failed", e)
       end
@@ -34,10 +31,10 @@ module SimpleFormsApi
         config.log_info("Uploading #{upload_type}: #{id} to S3 bucket")
 
         upload_to_s3(archive_path)
-        s3_update_manifest if config.include_manifest
-        cleanup(s3_upload_file_path)
+        update_manifest if config.include_manifest
+        cleanup(archive_path)
 
-        return s3_generate_presigned_url(s3_get_presigned_path) if config.presign_s3_url
+        return generate_presigned_url if presign_required?
 
         id
       rescue => e
@@ -46,8 +43,21 @@ module SimpleFormsApi
 
       private
 
-      attr_reader :archive_path, :config, :id, :manifest_row, :parent_dir, :presign_s3_url, :temp_directory_path,
-                  :upload_type
+      attr_reader :archive_path, :config, :id, :manifest_row, :parent_dir, :temp_directory_path, :upload_type
+
+      def assign_defaults(options)
+        @file_path = options[:file_path]
+        @archive_path, @manifest_row = build_archive!(config:, type: upload_type, **options)
+        @temp_directory_path = File.dirname(archive_path)
+      end
+
+      def initialize_archive
+        @parent_dir = config.parent_dir
+      end
+
+      def log_initialization
+        config.log_info("Initialized S3Client for #{upload_type} with ID: #{id}")
+      end
 
       def build_archive!(**)
         config.submission_archive_class.new(**).build!
@@ -62,20 +72,38 @@ module SimpleFormsApi
         end
       end
 
-      def s3_update_manifest
+      def update_manifest
         form_number = manifest_row[1]
-        s3_path = build_path(:file, s3_directory_path, "manifest_#{dated_directory_name(form_number)}", ext: '.csv')
-        s3_path = s3_path.sub(%r{^/}, '')
+        local_path = fetch_or_create_manifest(form_number)
+        write_and_upload_manifest(local_path)
+      rescue => e
+        config.handle_error('Failed to update manifest', e)
+      end
+
+      def fetch_or_create_manifest(form_number)
+        s3_path = build_s3_manifest_path(form_number)
+        local_path = create_local_path(s3_path)
+        existing_manifest = s3_uploader.get_s3_file(s3_path, local_path)
+        CSV.open(local_path, 'w') if existing_manifest.blank?
+        local_path
+      end
+
+      def build_s3_manifest_path(form_number)
+        path = build_path(:file, s3_directory_path, "manifest_#{dated_directory_name(form_number)}", ext: '.csv')
+        path.sub(%r{^/}, '')
+      end
+
+      def create_local_path(s3_path)
         Dir.mktmpdir do |dir|
           local_path = File.join(dir, s3_path)
           FileUtils.mkdir_p(File.dirname(local_path))
-          existing_manifest = s3_uploader.get_s3_file(s3_path, local_path)
-          CSV.open(local_path, 'w') if existing_manifest.blank?
-          write_manifest(manifest_row, existing_manifest.blank?, local_path)
-          upload_to_s3(local_path)
+          local_path
         end
-      rescue => e
-        config.handle_error('Failed to update manifest', e)
+      end
+
+      def write_and_upload_manifest(local_path)
+        write_manifest(manifest_row, !File.exist?(local_path), local_path)
+        upload_to_s3(local_path)
       end
 
       def s3_uploader
@@ -86,21 +114,17 @@ module SimpleFormsApi
         @s3_directory_path ||= build_path(:dir, parent_dir, upload_type.to_s, dated_directory_name(manifest_row[1]))
       end
 
-      def s3_upload_file_path
-        ext = upload_type == :submission ? '.pdf' : '.zip'
-        @s3_upload_file_path ||= build_path(:file, s3_directory_path, archive_path, ext:)
+      def generate_presigned_url(type: upload_type)
+        s3_uploader.get_s3_link(s3_upload_file_path(type))
       end
 
-      def s3_get_presigned_path
-        build_path(:file, s3_directory_path, local_file_path.split('/').last, ext: '')
+      def s3_upload_file_path(type)
+        ext = type == :submission ? '.pdf' : '.zip'
+        build_path(:file, s3_directory_path, archive_path, ext:)
       end
 
-      def s3_generate_presigned_url(s3_path)
-        s3_uploader.get_s3_link(s3_path)
-      end
-
-      def local_file_path
-        @local_file_path ||= build_local_path_from_s3(s3_directory_path, s3_upload_file_path, temp_directory_path)
+      def presign_required?
+        config.presign_s3_url
       end
     end
   end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -16,8 +16,8 @@ module SimpleFormsApi
         @include_metadata = config.include_metadata
         @manifest_entry = nil
 
-        assign_defaults(options)
-        hydrate_submission_data unless submission_already_hydrated?
+        assign_data(options)
+        hydrate_submission_data
 
         @form_number = JSON.parse(submission&.form_data)['form_number']
       rescue => e
@@ -28,9 +28,9 @@ module SimpleFormsApi
         create_temp_directory!(temp_directory_path)
         process_submission_files
 
-        return "#{submission_file_path}.pdf" if archive_type == :submission
+        return "#{submission_file_name}.pdf" if archive_type == :submission
 
-        zip_path = zip_directory!(config.parent_dir, temp_directory_path, submission_file_path)
+        zip_path = zip_directory!(config.parent_dir, temp_directory_path, submission_file_name)
 
         [zip_path, manifest_entry]
       rescue => e
@@ -42,19 +42,13 @@ module SimpleFormsApi
       attr_reader :archive_type, :attachments, :config, :file_path, :form_number, :id, :include_manifest,
                   :include_metadata, :manifest_entry, :metadata, :submission, :temp_directory_path
 
-      def assign_defaults(options)
-        # The file paths of any hydrated attachments which were originally included in the submission
-        @attachments = options[:attachments]
-        # The local path where the submission PDF is stored
-        @file_path = options[:file_path]
-        # The FormSubmission object representing the original data payload submitted
-        @submission = options[:submission]
-        # The UUID returned from the Benefits Intake API upon original submission
-        @id = @submission&.send(config.id_type) || options[:id]
-        # Data appended to the original submission headers
-        @metadata = options[:metadata]
-        # The type of archive to be created (:submission or :remediation)
+      def assign_data(options)
         @archive_type = options[:type] || :remediation
+        @attachments = options[:attachments] || []
+        @file_path = options[:file_path]
+        @id = options[:submission]&.send(config.id_type) || options[:id]
+        @metadata = options[:metadata]
+        @submission = options[:submission]
       end
 
       def submission_already_hydrated?
@@ -62,19 +56,20 @@ module SimpleFormsApi
       end
 
       def hydrate_submission_data
+        return if submission_already_hydrated?
+
         raise "No #{config.id_type} was provided" unless id
 
         built_submission = config.remediation_data_class.new(id:, config:).hydrate!
-        # The local path where the submission PDF is stored
-        @file_path = built_submission.file_path
-        # The FormSubmission object representing the original data payload submitted
-        @submission = built_submission.submission
-        # The UUID returned from the Benefits Intake API upon original submission
-        @id = submission&.send(config.id_type)
-        # The file paths of any hydrated attachments which were originally included in the submission
-        @attachments = built_submission.attachments || []
-        # Data appended to the original submission headers
-        @metadata = built_submission.metadata
+
+        assign_data(
+          attachments: built_submission.attachments,
+          file_path: built_submission.file_path,
+          id: built_submission.submission&.send(config.id_type),
+          metadata: built_submission.metadata,
+          submission: built_submission.submission,
+          type: @archive_type
+        )
       end
 
       def process_submission_files
@@ -95,11 +90,11 @@ module SimpleFormsApi
       end
 
       def write_pdf
-        create_file("#{submission_file_path}.pdf", File.read(file_path), 'submission pdf')
+        create_file("#{submission_file_name}.pdf", File.read(file_path), 'submission pdf')
       end
 
       def write_metadata
-        create_file("metadata_#{submission_file_path}.json", metadata.to_json, 'metadata')
+        create_file("metadata_#{submission_file_name}.json", metadata.to_json, 'metadata')
       end
 
       def write_attachments
@@ -109,7 +104,7 @@ module SimpleFormsApi
 
       def process_attachment(attachment_number, file_path)
         config.log_info("Processing attachment ##{attachment_number}: #{file_path}")
-        create_file("attachment_#{attachment_number}__#{submission_file_path}.pdf", File.read(file_path), 'attachment')
+        create_file("attachment_#{attachment_number}__#{submission_file_name}.pdf", File.read(file_path), 'attachment')
       end
 
       def build_manifest_csv_entry
@@ -129,8 +124,8 @@ module SimpleFormsApi
         config.handle_error("Failed writing #{file_description} file #{file_name} for submission: #{id}", e)
       end
 
-      def submission_file_path
-        @submission_file_path ||= unique_file_path(form_number, id)
+      def submission_file_name
+        @submission_file_name ||= unique_file_name(form_number, id)
       end
     end
   end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -25,14 +25,16 @@ module SimpleFormsApi
       end
 
       def build!
-        create_temp_directory!(temp_directory_path)
+        create_directory!(temp_directory_path)
         process_submission_files
 
-        return "#{submission_file_name}.pdf" if archive_type == :submission
+        path = if archive_type == :submission
+                 "#{submission_file_name}.pdf"
+               else
+                 zip_directory!(config.parent_dir, temp_directory_path, submission_file_name)
+               end
 
-        zip_path = zip_directory!(config.parent_dir, temp_directory_path, submission_file_name)
-
-        [zip_path, manifest_entry]
+        [path, manifest_entry]
       rescue => e
         config.handle_error("Failed building submission: #{id}", e)
       end

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_remediation_data.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_remediation_data.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require 'simple_forms_api/form_remediation/configuration/base'
-
 module SimpleFormsApi
   module FormRemediation
     class SubmissionRemediationData
       attr_reader :file_path, :submission, :attachments, :metadata
 
-      def initialize(id:, config: Configuration::Base.new)
+      def initialize(id:, config:)
         @config = config
 
         validate_input(id)

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_remediation_data.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_remediation_data.rb
@@ -43,11 +43,11 @@ module SimpleFormsApi
 
       def validate_submission
         raise 'Submission was not found or invalid' unless submission&.send(config.id_type)
-        raise "#{self.class} cannot be built: Only VFF forms are supported" unless vff_form?
+        raise "#{self.class} cannot be built: Only VFF forms are supported" unless valid_form?
       end
 
       def fetch_submission_form_number
-        vff_forms_map.fetch(submission.form_type)
+        valid_forms_map.fetch(submission.form_type)
       end
 
       def build_form(form_number)
@@ -101,12 +101,12 @@ module SimpleFormsApi
         config.handle_error('Error parsing form data', e)
       end
 
-      def vff_forms_map
+      def valid_forms_map
         SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP
       end
 
-      def vff_form?
-        vff_forms_map.key?(submission.form_type)
+      def valid_form?
+        valid_forms_map.key?(submission.form_type)
       end
     end
   end

--- a/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
@@ -66,21 +66,21 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
     end
   end
 
-  describe '#cleanup' do
-    subject(:cleanup) { dummy_class.cleanup('/tmp/to_cleanup') }
+  describe '#cleanup!' do
+    subject(:cleanup!) { dummy_class.cleanup!('/tmp/to_cleanup') }
 
     it 'removes the directory' do
       expect(FileUtils).to receive(:rm_rf).with('/tmp/to_cleanup')
-      cleanup
+      cleanup!
     end
   end
 
-  describe '#create_temp_directory!' do
-    subject(:create_temp_directory!) { dummy_class.create_temp_directory!('/tmp/new_dir') }
+  describe '#create_directory!' do
+    subject(:create_directory!) { dummy_class.create_directory!('/tmp/new_dir') }
 
     it 'creates the directory' do
       expect(FileUtils).to receive(:mkdir_p).with('/tmp/new_dir')
-      create_temp_directory!
+      create_directory!
     end
   end
 

--- a/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
   end
 
   describe '#write_manifest' do
-    subject(:write_manifest) { dummy_class.write_manifest(row, new_manifest, path) }
+    subject(:write_manifest) { dummy_class.write_manifest(row, path) }
 
     let(:row) { %w[2024-10-08 form 123 veteran_id John Doe] }
     let(:path) { '/tmp/manifest.csv' }

--- a/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
@@ -88,9 +88,10 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
     subject(:build_local_path_from_s3) { dummy_class.build_local_path_from_s3(s3_dir, s3_key, temp_dir) }
 
     let(:local_file_path) { "#{temp_dir}#{unique_filename}.zip" }
+    let(:pathname) { Pathname.new(local_file_path) }
 
     it 'builds the local path from the S3 path' do
-      expect(FileUtils).to receive(:mkdir_p).with(File.dirname(local_file_path))
+      expect(FileUtils).to receive(:mkdir_p).with(pathname.dirname)
       expect(build_local_path_from_s3).to eq(local_file_path)
     end
   end

--- a/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
@@ -25,10 +25,9 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
 
     context 'when the temp directory exists' do
       before do
-        allow(File).to receive(:directory?).with(temp_dir).and_return(true)
+        allow(File).to receive_messages(directory?: true, file?: true)
         allow(Dir).to receive(:chdir).and_yield
         allow(Dir).to receive(:[]).with('**', '*').and_return(['file1.txt', 'file2.txt'])
-        allow(File).to receive(:file?).and_return(true)
       end
 
       it 'zips the directory and returns the zip file path' do
@@ -39,7 +38,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
 
     context 'when the temp directory does not exist' do
       it 'raises an error' do
-        allow(File).to receive(:directory?).with(temp_dir).and_return(false)
+        allow(File).to receive(:directory?).and_return(false)
         expect { zip_directory! }.to raise_error("Directory not found: #{temp_dir}")
       end
     end
@@ -48,7 +47,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
       let(:error_message) { 'zip error' }
 
       before do
-        allow(File).to receive(:directory?).with(temp_dir).and_return(true)
+        allow(File).to receive(:directory?).and_return(true)
         allow(Zip::File).to receive(:open).and_raise(StandardError.new(error_message))
       end
 

--- a/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
+  let(:dummy_class) { Class.new { extend SimpleFormsApi::FormRemediation::FileUtilities } }
+  let(:parent_dir) { '/parent_dir' }
+  let(:temp_dir) { 'tmp/abc-123-archive/' }
+  let(:unique_filename) { '10.8.24_form_20-10207_vagov_random-letters-n-numbers' }
+  let(:s3_dir) { "#{parent_dir}/remediation" }
+  let(:s3_key) { "#{s3_dir}/#{unique_filename}.zip" }
+
+  before do
+    allow(FileUtils).to receive(:mkdir_p)
+    allow(FileUtils).to receive(:rm_rf)
+    allow(Zip::File).to receive(:open)
+    allow(CSV).to receive(:open).and_yield(double(:csv, '<<' => true))
+  end
+
+  describe '#zip_directory!' do
+    subject(:zip_directory!) { dummy_class.zip_directory!(parent_dir, temp_dir, unique_filename) }
+
+    let(:zip_file_path) { "#{temp_dir}#{unique_filename}.zip" }
+
+    context 'when the temp directory exists' do
+      before do
+        allow(File).to receive(:directory?).with(temp_dir).and_return(true)
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dir).to receive(:[]).with('**', '*').and_return(['file1.txt', 'file2.txt'])
+        allow(File).to receive(:file?).and_return(true)
+      end
+
+      it 'zips the directory and returns the zip file path' do
+        expect(Zip::File).to receive(:open).with(zip_file_path, Zip::File::CREATE)
+        expect(zip_directory!).to eq(zip_file_path)
+      end
+    end
+
+    context 'when the temp directory does not exist' do
+      it 'raises an error' do
+        allow(File).to receive(:directory?).with(temp_dir).and_return(false)
+        expect { zip_directory! }.to raise_error("Directory not found: #{temp_dir}")
+      end
+    end
+
+    context 'when an error occurs during zipping' do
+      let(:error_message) { 'zip error' }
+
+      before do
+        allow(File).to receive(:directory?).with(temp_dir).and_return(true)
+        allow(Zip::File).to receive(:open).and_raise(StandardError.new(error_message))
+      end
+
+      it 'handles the error' do
+        expect(dummy_class).to receive(:handle_error).with(
+          "Failed to zip temp directory: #{temp_dir} to location: #{temp_dir}#{unique_filename}.zip",
+          instance_of(StandardError)
+        )
+        begin
+          zip_directory!
+        rescue
+          nil
+        end
+      end
+    end
+  end
+
+  describe '#cleanup' do
+    subject(:cleanup) { dummy_class.cleanup('/tmp/to_cleanup') }
+
+    it 'removes the directory' do
+      expect(FileUtils).to receive(:rm_rf).with('/tmp/to_cleanup')
+      cleanup
+    end
+  end
+
+  describe '#create_temp_directory!' do
+    subject(:create_temp_directory!) { dummy_class.create_temp_directory!('/tmp/new_dir') }
+
+    it 'creates the directory' do
+      expect(FileUtils).to receive(:mkdir_p).with('/tmp/new_dir')
+      create_temp_directory!
+    end
+  end
+
+  describe '#build_local_path_from_s3' do
+    subject(:build_local_path_from_s3) { dummy_class.build_local_path_from_s3(s3_dir, s3_key, temp_dir) }
+
+    let(:local_file_path) { "#{temp_dir}#{unique_filename}.zip" }
+
+    it 'builds the local path from the S3 path' do
+      expect(FileUtils).to receive(:mkdir_p).with(File.dirname(local_file_path))
+      expect(build_local_path_from_s3).to eq(local_file_path)
+    end
+  end
+
+  describe '#build_path' do
+    it 'builds the path for a directory' do
+      path = dummy_class.build_path(:dir, parent_dir, 'remediation')
+      expect(path).to eq("#{parent_dir}/remediation")
+    end
+
+    it 'builds the path for a file and appends the extension' do
+      path = dummy_class.build_path(:file, parent_dir, 'remediation', unique_filename, ext: '.zip')
+      expect(path).to eq("#{parent_dir}/remediation/#{unique_filename}.zip")
+    end
+  end
+
+  describe '#write_file' do
+    subject(:write_file) { dummy_class.write_file(dir_path, file_name, payload) }
+
+    let(:dir_path) { '/tmp' }
+    let(:file_name) { 'test.txt' }
+    let(:payload) { 'file content' }
+
+    it 'writes the file to the specified directory' do
+      expect(File).to receive(:write).with("#{dir_path}/#{file_name}", payload)
+      write_file
+    end
+  end
+
+  describe '#unique_file_path' do
+    subject(:unique_file_path) { dummy_class.unique_file_path(form_number, id) }
+
+    let(:form_number) { '20-10207' }
+    let(:id) { 'unique-form-id' }
+
+    it 'builds a unique file path' do
+      expect(unique_file_path).to eq("#{Time.zone.today.strftime('%-m.%d.%y')}_form_20-10207_vagov_#{id}")
+    end
+  end
+
+  describe '#dated_directory_name' do
+    subject(:dated_directory_name) { dummy_class.dated_directory_name(form_number) }
+
+    let(:form_number) { '20-10207' }
+
+    it 'builds a dated directory name' do
+      expect(dated_directory_name).to eq("#{Time.zone.today.strftime('%-m.%d.%y')}-Form#{form_number}")
+    end
+  end
+
+  describe '#write_manifest' do
+    subject(:write_manifest) { dummy_class.write_manifest(row, new_manifest, path) }
+
+    let(:row) { %w[2024-10-08 form 123 veteran_id John Doe] }
+    let(:path) { '/tmp/manifest.csv' }
+    let(:new_manifest) { true }
+
+    it 'writes a new manifest file with headers' do
+      expect(CSV).to receive(:open).with(path, 'ab').and_yield(double(:csv, '<<' => true))
+      write_manifest
+    end
+
+    it 'handles errors during manifest writing' do
+      allow(CSV).to receive(:open).and_raise(StandardError.new('write error'))
+      expect(dummy_class).to(
+        receive(:handle_error).with('Failed writing manifest for submission: 123', instance_of(StandardError))
+      )
+      begin
+        write_manifest
+      rescue
+        nil
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/file_utilities_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
 
       it 'handles the error' do
         expect(dummy_class).to receive(:handle_error).with(
-          "Failed to zip temp directory: #{temp_dir} to location: #{temp_dir}#{unique_filename}.zip",
+          "Failed to zip directory: #{temp_dir} to #{temp_dir}#{unique_filename}.zip",
           instance_of(StandardError)
         )
         begin
@@ -121,14 +121,14 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
     end
   end
 
-  describe '#unique_file_path' do
-    subject(:unique_file_path) { dummy_class.unique_file_path(form_number, id) }
+  describe '#unique_file_name' do
+    subject(:unique_file_name) { dummy_class.unique_file_name(form_number, id) }
 
     let(:form_number) { '20-10207' }
     let(:id) { 'unique-form-id' }
 
     it 'builds a unique file path' do
-      expect(unique_file_path).to eq("#{Time.zone.today.strftime('%-m.%d.%y')}_form_20-10207_vagov_#{id}")
+      expect(unique_file_name).to eq("#{Time.zone.today.strftime('%-m.%d.%y')}_form_20-10207_vagov_#{id}")
     end
   end
 
@@ -157,7 +157,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::FileUtilities do
     it 'handles errors during manifest writing' do
       allow(CSV).to receive(:open).and_raise(StandardError.new('write error'))
       expect(dummy_class).to(
-        receive(:handle_error).with('Failed writing manifest for submission: 123', instance_of(StandardError))
+        receive(:handle_error).with('Failed writing manifest for submission', instance_of(StandardError))
       )
       begin
         write_manifest

--- a/modules/simple_forms_api/spec/services/form_remediation/jobs/archive_batch_processing_job_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/jobs/archive_batch_processing_job_spec.rb
@@ -36,7 +36,7 @@ module SimpleFormsApi
           context 'with valid parameters' do
             it 'processes all submissions and generates presigned URLs' do
               perform
-              expect(Rails.logger).to have_received(:info).exactly(4).times
+              expect(Rails.logger).to have_received(:info).exactly(5).times
               expect(File).to have_received(:write).exactly(4).times
             end
           end

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -74,10 +74,16 @@ RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
     let(:instance) { described_class.new(id: benefits_intake_uuid, config:) }
 
     context 'when no errors occur' do
-      it 'logs a notification upon starting' do
+      it 'logs notifications' do
         upload
         expect(Rails.logger).to have_received(:info).with(
-          "Uploading remediation: #{benefits_intake_uuid} to S3 bucket", {}
+          { message: "Uploading remediation: #{benefits_intake_uuid} to S3 bucket" }
+        )
+        expect(Rails.logger).to have_received(:info).with(
+          { message: "Initialized S3Client for remediation with ID: #{benefits_intake_uuid}" }
+        )
+        expect(Rails.logger).to have_received(:info).with(
+          { message: "Cleaning up path: #{temp_file_path}/" }
         )
       end
 

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
       end
 
       context 'when a different parent_dir is provided' do
-        let(:instance) { described_class.new(id: benefits_intake_uuid) }
+        let(:instance) { described_class.new(id: benefits_intake_uuid, config:) }
 
         it 'returns the s3 directory' do
           expect(upload).to eq('/s3_url/stuff.pdf')
@@ -99,7 +99,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
         allow(File).to receive(:directory?).and_return(false)
       end
 
-      let(:instance) { described_class.new(benefits_intake_uuid:) }
+      let(:instance) { described_class.new(id: benefits_intake_uuid, config:) }
 
       it 'raises the error' do
         expect { upload }.to raise_exception(Errno::ENOENT)

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+require 'simple_forms_api/form_remediation/configuration/vff_config'
 
 RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
   include SimpleFormsApi::FormRemediation::FileUtilities

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_remediation_data_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_remediation_data_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+require 'simple_forms_api/form_remediation/configuration/vff_config'
 
 RSpec.describe SimpleFormsApi::FormRemediation::SubmissionRemediationData do
   let(:form_type) { '20-10207' }

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_remediation_data_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_remediation_data_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionRemediationData do
   let(:created_at) { 3.years.ago }
   let(:submission) { create(:form_submission, :pending, form_type:, form_data:, created_at:) }
   let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
-  let(:submission_instance) { described_class.new(id: benefits_intake_uuid) }
+  let(:config) { SimpleFormsApi::FormRemediation::Configuration::VffConfig.new }
+  let(:submission_instance) { described_class.new(id: benefits_intake_uuid, config:) }
   let(:filler) { instance_double(SimpleFormsApi::PdfFiller) }
   let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
   let(:metadata) do
@@ -67,10 +68,18 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionRemediationData do
     end
 
     context 'when benefits_intake_uuid is missing' do
-      let(:submission_instance) { described_class.new(stuff: 'thangs') }
+      let(:submission_instance) { described_class.new(stuff: 'thangs', config:) }
 
       it 'throws an error' do
         expect { new }.to raise_exception(ArgumentError, 'missing keyword: :id')
+      end
+    end
+
+    context 'when config is missing' do
+      let(:submission_instance) { described_class.new(stuff: 'thangs', id: benefits_intake_uuid) }
+
+      it 'throws an error' do
+        expect { new }.to raise_exception(ArgumentError, 'missing keyword: :config')
       end
     end
 


### PR DESCRIPTION
## Summary

This solution is designed to remediate form submissions which have failed submission and are over two weeks old. It is composed of several Ruby on Rails service objects which interact with each other.

The primary use-case for this solution is for form remediation. This process consists of the following:

1. Accept a form submission identifier.
1. Generate an archive payload consisting of the original form submission data as well as remediation specific documentation:
    1. Hydrate the original form submission
    1. Hydrate any original attachments that were a part of this submission
    1. Generate a JSON file with the original metadata from the submission
    1. Generate a manifest file to be used in the remediation process
1. Upload the generated archive as a .zip file onto the configured S3 bucket
1. Optionally return a presigned URL for accessing this file

This solution also provides a means for storing and retrieving a single .pdf copy of the originally submitted form.

The following image depicts how this solution is architected:

![Error Remediation Architecture Diagram_2024-10-07_14-14-25](https://github.com/user-attachments/assets/99c8d0a5-ad65-4cbd-8c76-b59988483c8c)


- This is part 8 of a larger PR which was too large and needed broken up. It updates logic which was erroneously introduced when refactoring existing code.

## Related issue(s)

- [Form Submission Remediation - Genericize S3 bucket archiving solution for external team usage](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/1954)

## Testing done

- [x] New logic is covered by unit tests

## Requested Feedback

Any
