### PR TITLE
Convert Vets::Model from a class to a module

### DIFF
--- a/app/models/preneeds/base.rb
+++ b/app/models/preneeds/base.rb
@@ -6,7 +6,8 @@ require 'vets/model'
 # Should not be initialized directly
 #
 module Preneeds
-  class Base < Vets::Model
+  class Base
+    include Vets::Model
     # Override `as_json`
     #
     # @param options [Hash]

--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -8,11 +8,15 @@ class TrueClass; include Bool; end
 class FalseClass; include Bool; end
 
 module Vets
-  class Model
-    extend ActiveModel::Naming
+  module Model
+    extend ActiveSupport::Concern
     include ActiveModel::Model
     include ActiveModel::Serializers::JSON
     include Vets::Attributes
+
+    included do
+      extend ActiveModel::Naming
+    end
 
     def initialize(params = {})
       # Remove attributes that aren't defined in the class aka unknown

--- a/lib/vets/response.rb
+++ b/lib/vets/response.rb
@@ -3,7 +3,9 @@
 require 'vets/model'
 
 module Vets
-  class Response < Vets::Model
+  class Response
+    include Vets::Model
+
     STATUS_TEXTS = {
       200 => 'OK',
       403 => 'NOT_AUTHORIZED',

--- a/spec/lib/vets/model_spec.rb
+++ b/spec/lib/vets/model_spec.rb
@@ -3,12 +3,16 @@
 require 'rails_helper'
 require 'vets/model'
 
-class FakeApartment < Vets::Model
+class FakeApartment
+  include Vets::Model
+
   attribute :unit_number, Integer
   attribute :building_number, Integer
 end
 
-class FakeAddress < Vets::Model
+class FakeAddress
+  include Vets::Model
+
   attribute :street, String
   attribute :street2, String
   attribute :city, String


### PR DESCRIPTION
## Summary

- `Vets::Model` was previously a class, but because it can't be used directly, it should be a model 
    - `Vets::Model` is a replacement for Virtus gem
- This PR also updates `Preneeds::Base` and `Vets::Response`
- There's no functional difference, this is mostly superficial 

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Acceptance criteria

- [x]  Vets::Model is a module
- [x]  Former subclasses, not include it as a model