### PR TITLE
API-41095-va-gov-errors-slack-alert-fix-dd-timerange

### DIFF
--- a/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
+++ b/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
@@ -77,9 +77,20 @@ module ClaimsApi
       end
 
       def link_value(id)
+        time_stamps = datadog_timestamps
+
         "<https://vagov.ddog-gov.com/logs?query='#{id}'&agg_m=count&agg_m_source=base&agg_t=count&cols=" \
           'host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=' \
-          "desc&viz=stream&from_ts=#{(Time.now.to_i - (3 * 24 * 60 * 60)).to_i}&to_ts=#{Time.now.to_i}&live=true|"
+          "desc&viz=stream&from_ts=#{time_stamps[0]}&to_ts=#{time_stamps[1]}&live=true|"
+      end
+
+      # set the range to go back 3 days.  Link is based on an ID so any additional range should
+      # not add additional noise, but this covers the weekend for Monday morning links
+      def datadog_timestamps
+        current = Time.now.to_i * 1000 # Data dog uses milliseconds
+        three_days_ago = current - 259_200_000 # Three days ago
+
+        [three_days_ago, current]
       end
     end
   end

--- a/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
+++ b/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
   let(:link_text) do
     "<https://vagov.ddog-gov.com/logs?query='64738'&agg_m=" \
       'count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&' \
-      'refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1640803707&to_ts=' \
-      "1641062907&live=true|64738> \n<https://vagov.ddog-gov.com/logs?query='378249'&agg_m=count&" \
+      'refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1640803707000&to_ts=' \
+      "1641062907000&live=true|64738> \n<https://vagov.ddog-gov.com/logs?query='378249'&agg_m=count&" \
       'agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&' \
-      'refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1640803707&to_ts=' \
-      "1641062907&live=true|378249> \n"
+      'refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1640803707000&to_ts=' \
+      "1641062907000&live=true|378249> \n"
   end
 
   describe '#build_notification_message' do
@@ -33,11 +33,11 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
                          "Compensation Errors* \nTotal: 2 \n\n```123456 \n789101112 \n```  \n\n*Va Gov Disability " \
                          "Compensation Errors* \nTotal: 2 \n\n```<https://vagov.ddog-gov.com/logs?query='64738'&" \
                          'agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=' \
-                         'inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1640803707&' \
-                         "to_ts=1641062907&live=true|64738> \n<https://vagov.ddog-gov.com/logs?query='378249'&agg_m=" \
-                         'count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=' \
-                         'inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1640803707&' \
-                         "to_ts=1641062907&live=true|378249> \n```  \n\n*Power of " \
+                         'inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1640803707000&' \
+                         "to_ts=1641062907000&live=true|64738> \n<https://vagov.ddog-gov.com/logs?query='378249'" \
+                         '&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true' \
+                         '&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream' \
+                         "&from_ts=1640803707000&to_ts=1641062907000&live=true|378249> \n```  \n\n*Power of " \
                          "Attorney Errors* \nTotal: 2 \n\n```1314151617 \n181920212223 \n```  \n\n*Intent to " \
                          "File Errors* \nTotal: 1 \n\n*Evidence Waiver Errors* \nTotal: 2 " \
                          "\n\n```32333435 \n36373839 \n```  \n\n"


### PR DESCRIPTION
## Summary
* Fixes time range in link

## Related issue(s)
[API-41095](https://jira.devops.va.gov/browse/API-41095)

## Testing done
- [x] *New code is covered by unit tests*

#### Testing Notes
* If you can access the channel see an example link [here](https://lighthouseva.slack.com/archives/CJYJTRQ1F/p1728915555860939) (claim is under the Va Gov ...  heading)
* Otherwise to send your own you will need an errored claim, switch the channel to `vaapi-alerts-testing` make sure to have the testing key in your settings
* You can trigger the job from the console via `ClaimsApi::ReportHourlyUnsuccessfulSubmissions.perform_async`
    * Worth it to preview the message before sending, I always limit every query to 1 just to keep it down depending on your local data you could get a huge output
    
## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
	modified:   modules/claims_api/spec/services/failed_submissions_messenger_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
