### PR TITLE
Fix swagger docs test for 2122 PDF generation

### DIFF
--- a/modules/representation_management/spec/requests/representation_management/v0/pdf_generator_2122_swagger_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/pdf_generator_2122_swagger_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe 'PDF Generator 21-22', openapi_spec: 'modules/representation_mana
 
       response '422', 'unprocessable entity response' do
         let(:pdf_generator2122) do
-          SwaggerSharedComponents::V0.body_examples[:pdf_generator2122].delete(:organization_name)
+          params = SwaggerSharedComponents::V0.body_examples[:pdf_generator2122]
+          params.delete(:organization_name)
+          params
         end
         schema '$ref' => '#/components/schemas/Errors'
         run_test!


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform):* I fixed a bug in a test that was silently failing before but an additional PR made it fail loudly.
- *(If bug, how to reproduce):* Just run the test suite.
- *(What is the solution, why is this the solution?):* The bug was supplying an empty hash when there was supposed to be data.  Previoulsy it didn't crash because the underlying code tested made liberal use of `dig`, which fails gracefully.  Now most of those `dig` calls have been replaced by direct hash access `hash[:key]` style.
- *(Which team do you work for, does your team own the maintenance of this component?):* FAR/ARM

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94905

## Testing done

- [x] *New code is covered by unit tests:* This is a fix of a test.
- *Describe what the old behavior was prior to the change:* The test suite failed.  This is a fix of a test that generated documentation.  It was not a test of behavior a user might encounter.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing:* I think in this case saying "Specs run" is the verification.  There was no change in the generated documentation from this change.
- *If this work is behind a flipper:* The underlying feature is behind a flipper but the code in this PR is only for the documentation test.

## Screenshots
N/A

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas):* Just the `representation_management` module.

## Acceptance criteria

- [x]  I fixed unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
