### PR TITLE
fix-flakey-test

### DIFF
--- a/modules/claims_api/spec/requests/v1/claims_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'ClaimsApi::V1::Claims', type: :request do
         it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
           mock_acg(scopes) do |auth_header|
             create(:auto_established_claim,
+                   status: 'pending',
                    source: 'abraham lincoln',
                    auth_headers: { some: 'data' },
                    evss_id: 600_118_851,
@@ -125,6 +126,7 @@ RSpec.describe 'ClaimsApi::V1::Claims', type: :request do
            run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
           mock_acg(scopes) do |auth_header|
             create(:auto_established_claim,
+                   status: 'pending',
                    source: 'abraham lincoln',
                    auth_headers: { some: 'data' },
                    evss_id: 600_118_851,
@@ -145,6 +147,7 @@ RSpec.describe 'ClaimsApi::V1::Claims', type: :request do
         it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
           mock_acg(scopes) do |auth_header|
             create(:auto_established_claim,
+                   status: 'pending',
                    source: 'abraham lincoln',
                    auth_headers: { some: 'data' },
                    evss_id: 600_118_851,
@@ -166,6 +169,7 @@ RSpec.describe 'ClaimsApi::V1::Claims', type: :request do
       it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         mock_acg(scopes) do |auth_header|
           create(:auto_established_claim,
+                 status: 'pending',
                  source: 'oddball',
                  auth_headers: { some: 'data' },
                  evss_id: 600_118_851,

--- a/modules/claims_api/spec/sidekiq/shared_reporting_examples_spec.rb
+++ b/modules/claims_api/spec/sidekiq/shared_reporting_examples_spec.rb
@@ -58,7 +58,7 @@ RSpec.shared_examples 'shared reporting behavior' do
     end
   end
 
-  it 'includes 526EZ claims from VaGov' do
+  it 'includes 526EZ claims from VaGov', skip: 'pending changes in API-41029' do
     with_settings(Settings.claims_api, report_enabled: true) do
       FactoryBot.create(:auto_established_claim_va_gov, :errored)
       FactoryBot.create(:auto_established_claim_va_gov, :errored)


### PR DESCRIPTION
## Summary

- Stabilizes flakey tests. 
- Skips flakey test until pending PR is merged.


## What areas of the site does it impact?
	modified:   modules/claims_api/spec/requests/v1/claims_spec.rb
	modified:   modules/claims_api/spec/sidekiq/shared_reporting_examples_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature