### PR TITLE
93076 add facility type to service instantiation

### DIFF
--- a/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_submission_worker.rb
@@ -29,7 +29,9 @@ module CheckIn
       uuid, appointment_date, facility_type = opts.values_at(:uuid, :appointment_date, :facility_type)
       check_in_session = CheckIn::V2::Session.build(data: { uuid: })
 
-      claims_resp = TravelClaim::Service.build(check_in: check_in_session, params: { appointment_date: }).submit_claim
+      claims_resp = TravelClaim::Service.build(check_in: check_in_session,
+                                               params: { appointment_date:, facility_type: })
+                                        .submit_claim
 
       if should_handle_timeout(claims_resp)
         TravelClaimStatusCheckWorker.perform_in(5.minutes, uuid, appointment_date)


### PR DESCRIPTION
## Summary
Add facility type to TravelClaim::Service instantiation so that it can be used by the service class to use a different claim_number for Oracle Health claims.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93076

## Testing done
- [x] local integration testing
- [ ] will test in staging once deployed
- [ ] will monitor in production

## What areas of the site does it impact?
PCI and Oracle Health travel claims

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
