### PR TITLE
[VI-647] Gracefully handle external JWK rotations

### DIFF
--- a/lib/sign_in/idme/configuration.rb
+++ b/lib/sign_in/idme/configuration.rb
@@ -98,6 +98,10 @@ module SignIn
         30.minutes
       end
 
+      def log_prefix
+        '[SignIn][Idme][Service]'
+      end
+
       # Faraday connection object with breakers, snakecase and json response middleware
       # @return Faraday::Connection connection to make http calls
       #

--- a/lib/sign_in/idme/service.rb
+++ b/lib/sign_in/idme/service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'sign_in/public_jwks'
 require 'sign_in/idme/configuration'
 require 'sign_in/idme/errors'
 require 'mockdata/writer'
@@ -7,11 +8,13 @@ require 'mockdata/writer'
 module SignIn
   module Idme
     class Service < Common::Client::Base
+      include SignIn::PublicJwks
       configuration Configuration
 
       attr_accessor :type
 
-      def render_auth(state: SecureRandom.hex, acr: Constants::Auth::IDME_LOA1, operation: Constants::Auth::AUTHORIZE)
+      def render_auth(state: SecureRandom.hex, acr: Constants::Auth::IDME_LOA1,
+                      operation: Constants::Auth::AUTHORIZE)
         Rails.logger.info('[SignIn][Idme][Service] Rendering auth, ' \
                           "state: #{state}, acr: #{acr}, operation: #{operation}")
         RedirectUrlGenerator.new(redirect_uri: auth_url, params_hash: auth_params(acr, state, operation)).perform
@@ -48,23 +51,6 @@ module SignIn
       end
 
       private
-
-      def public_jwks
-        @public_jwks ||= Rails.cache.fetch(config.jwks_cache_key, expires_in: config.jwks_cache_expiration) do
-          response = perform(:get, config.public_jwks_path, nil, nil)
-          Rails.logger.info('[SignIn][Idme][Service] Get Public JWKs Success')
-
-          parse_public_jwks(response:)
-        end
-      rescue Common::Client::Errors::ClientError => e
-        raise_client_error(e, 'Get Public JWKs')
-      end
-
-      def parse_public_jwks(response:)
-        jwks = JWT::JWK::Set.new(response.body)
-        jwks.select! { |key| key[:use] == 'sig' }
-        jwks
-      end
 
       def auth_params(acr, state, operation)
         {
@@ -174,11 +160,12 @@ module SignIn
 
       def jwt_decode(encoded_jwt)
         verify_expiration = true
+
         decoded_jwt = JWT.decode(
           encoded_jwt,
           nil,
           verify_expiration,
-          { verify_expiration:, algorithm: config.jwt_decode_algorithm, jwks: public_jwks }
+          { verify_expiration:, algorithm: config.jwt_decode_algorithm, jwks: method(:jwks_loader) }
         ).first
         log_parsed_credential(decoded_jwt) if config.log_credential
 

--- a/lib/sign_in/logingov/configuration.rb
+++ b/lib/sign_in/logingov/configuration.rb
@@ -102,6 +102,10 @@ module SignIn
         30.minutes
       end
 
+      def log_prefix
+        '[SignIn][Logingov][Service]'
+      end
+
       def connection
         @connection ||= Faraday.new(
           base_path,

--- a/lib/sign_in/logingov/service.rb
+++ b/lib/sign_in/logingov/service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'sign_in/public_jwks'
 require 'sign_in/logingov/configuration'
 require 'sign_in/logingov/errors'
 require 'mockdata/writer'
@@ -7,6 +8,7 @@ require 'mockdata/writer'
 module SignIn
   module Logingov
     class Service < Common::Client::Base
+      include SignIn::PublicJwks
       configuration Configuration
 
       DEFAULT_SCOPES = [
@@ -144,7 +146,7 @@ module SignIn
           encoded_jwt,
           nil,
           verify_expiration,
-          { verify_expiration:, algorithm: config.jwt_decode_algorithm, jwks: public_jwks }
+          { verify_expiration:, algorithm: config.jwt_decode_algorithm, jwks: method(:jwks_loader) }
         ).first
       rescue JWT::JWKError
         raise Errors::PublicJWKError, '[SignIn][Logingov][Service] Public JWK is malformed'
@@ -154,21 +156,6 @@ module SignIn
         raise Errors::JWTExpiredError, '[SignIn][Logingov][Service] JWT has expired'
       rescue JWT::DecodeError
         raise Errors::JWTDecodeError, '[SignIn][Logingov][Service] JWT is malformed'
-      end
-
-      def public_jwks
-        @public_jwks ||= Rails.cache.fetch(config.jwks_cache_key, expires_in: config.jwks_cache_expiration) do
-          response = perform(:get, config.public_jwks_path, nil, nil)
-          Rails.logger.info('[SignIn][Logingov][Service] Get Public JWKs Success')
-
-          parse_public_jwks(response:)
-        end
-      rescue Common::Client::Errors::ClientError => e
-        raise_client_error(e, 'Get Public JWKs')
-      end
-
-      def parse_public_jwks(response:)
-        JWT::JWK::Set.new(response.body).select { |key| key[:use] == 'sig' }
       end
 
       def get_authn_context(current_ial)

--- a/lib/sign_in/public_jwks.rb
+++ b/lib/sign_in/public_jwks.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SignIn
+  module PublicJwks
+    private
+
+    def jwks_loader(**options)
+      if options[:kid_not_found]
+        Rails.logger.info("#{config.log_prefix} JWK not found, reloading public JWKs")
+        Rails.cache.delete_matched(config.jwks_cache_key)
+        @public_jwks = nil
+      end
+
+      public_jwks
+    end
+
+    def public_jwks
+      @public_jwks ||= Rails.cache.fetch(config.jwks_cache_key, expires_in: config.jwks_cache_expiration) do
+        response = perform(:get, config.public_jwks_path, nil, nil)
+        Rails.logger.info("#{config.log_prefix} Get Public JWKs Success")
+
+        parse_public_jwks(response:)
+      end
+    rescue Common::Client::Errors::ClientError => e
+      raise_client_error(e, 'Get Public JWKs')
+    end
+
+    def parse_public_jwks(response:)
+      jwks = JWT::JWK::Set.new(response.body)
+      jwks.select! { |key| key[:use] == 'sig' }
+      jwks
+    end
+  end
+end

--- a/spec/lib/sign_in/idme/service_spec.rb
+++ b/spec/lib/sign_in/idme/service_spec.rb
@@ -154,7 +154,7 @@ describe SignIn::Idme::Service do
   describe '#user_info' do
     let(:test_client_cert_path) { 'spec/fixtures/sign_in/oauth_test.crt' }
     let(:test_client_key_path) { 'spec/fixtures/sign_in/oauth_test.key' }
-    let(:expected_jwks_log) { '[SignIn][Idme][Service] Get Public JWKs Success' }
+    let(:expected_jwks_fetch_log) { '[SignIn][Idme][Service] Get Public JWKs Success' }
 
     before do
       allow(Settings.idme).to receive_messages(client_cert_path: test_client_cert_path,
@@ -252,27 +252,60 @@ describe SignIn::Idme::Service do
     context 'when the public JWK response is not cached' do
       it 'logs information to rails logger' do
         VCR.use_cassette('identity/idme_200_responses') do
-          expect(Rails.logger).to receive(:info).with(expected_jwks_log)
+          expect(Rails.logger).to receive(:info).with(expected_jwks_fetch_log)
           subject.user_info(token)
         end
       end
     end
 
-    context 'when the public JWK response is cached' do
+    context 'when the public JWKs response is cached' do
       let(:cache_key) { 'idme_public_jwks' }
       let(:cache_expiration) { 30.minutes }
       let(:response) { double(body: 'some-body') }
+      let(:redis_store) { ActiveSupport::Cache::RedisCacheStore.new(redis: MockRedis.new) }
 
       before do
-        allow(Rails.cache).to receive(:fetch).with(cache_key, expires_in: cache_expiration).and_return(response)
-        allow(JWT).to receive(:decode).and_return([])
-        allow(JWT::JWK::Set).to receive(:new).and_return([])
+        allow(Rails).to receive(:cache).and_return(redis_store)
+        Rails.cache.clear
+        allow(Rails.logger).to receive(:info)
       end
 
-      it 'does not log expected_jwks_log' do
+      after do
+        Rails.cache.clear
+      end
+
+      it 'uses the cached JWK response' do
         VCR.use_cassette('identity/idme_200_responses') do
-          expect(Rails.logger).not_to receive(:info).with(expected_jwks_log)
           subject.user_info(token)
+          expect(Rails.logger).to have_received(:info).with(expected_jwks_fetch_log)
+        end
+
+        VCR.use_cassette('identity/idme_200_responses') do
+          subject.user_info(token)
+          expect(Rails.logger).not_to receive(:info).with(expected_jwks_fetch_log)
+        end
+      end
+
+      context 'when the JWK is not found in the cached JWKs' do
+        let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
+        let(:jwks) { JWT::JWK::Set.new([JWT::JWK::RSA.new(rsa_key)]) }
+        let(:expected_jwk_reload_log) { '[SignIn][Idme][Service] JWK not found, reloading public JWKs' }
+
+        before do
+          allow(Rails.cache).to receive(:delete_matched).and_call_original
+        end
+
+        it 'clears the cache and fetches the public JWKs again' do
+          Rails.cache.write(cache_key, jwks, expires_in: cache_expiration)
+
+          VCR.use_cassette('identity/idme_200_responses') do
+            subject.user_info(token)
+
+            expect(Rails.cache).to have_received(:delete_matched).with(cache_key)
+            expect(Rails.logger).to have_received(:info).with(expected_jwk_reload_log)
+            expect(Rails.logger).to have_received(:info).with(expected_jwks_fetch_log)
+            expect(Rails.cache.read(cache_key)).not_to eq(jwks)
+          end
         end
       end
     end

--- a/spec/lib/sign_in/logingov/service_spec.rb
+++ b/spec/lib/sign_in/logingov/service_spec.rb
@@ -169,6 +169,8 @@ describe SignIn::Logingov::Service do
   end
 
   describe '#token' do
+    let(:expected_jwks_fetch_log) { '[SignIn][Logingov][Service] Get Public JWKs Success' }
+
     before do
       Timecop.freeze(Time.zone.at(current_time))
     end
@@ -178,13 +180,12 @@ describe SignIn::Logingov::Service do
     end
 
     context 'when the request is successful' do
-      let(:expected_jwks_log) { '[SignIn][Logingov][Service] Get Public JWKs Success' }
       let(:expected_token_log) { "[SignIn][Logingov][Service] Token Success, code: #{code}" }
       let(:expected_access_token) { 'mHO_gU3WooLm0xoDxIAulw' }
       let(:expected_logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2 }
 
       it 'logs information to rails logger', vcr: { cassette_name: 'identity/logingov_200_responses' } do
-        expect(Rails.logger).to receive(:info).with(expected_jwks_log)
+        expect(Rails.logger).to receive(:info).with(expected_jwks_fetch_log)
         expect(Rails.logger).to receive(:info).with(expected_token_log)
         subject.token(code)
       end
@@ -195,26 +196,6 @@ describe SignIn::Logingov::Service do
 
       it 'returns a logingov acr', vcr: { cassette_name: 'identity/logingov_200_responses' } do
         expect(subject.token(code)[:logingov_acr]).to eq(expected_logingov_acr)
-      end
-
-      context 'when the public JWK response is cached' do
-        let(:cache_key) { 'logingov_public_jwks' }
-        let(:cache_expiration) { 30.minutes }
-        let(:response) { double(body: 'some-body') }
-
-        before do
-          allow(Rails.cache).to receive(:fetch).with(cache_key, expires_in: cache_expiration).and_return(response)
-          allow(JWT).to receive(:decode).and_return([{ 'acr' => 'some-acr' }])
-          allow(JWT::JWK::Set).to receive(:new).and_return([])
-        end
-
-        it 'does not log expected_jwks_log' do
-          VCR.use_cassette('identity/logingov_200_responses') do
-            expect(Rails.logger).to receive(:info).with(expected_token_log)
-            expect(Rails.logger).not_to receive(:info).with(expected_jwks_log)
-            subject.token(code)
-          end
-        end
       end
     end
 
@@ -274,6 +255,73 @@ describe SignIn::Logingov::Service do
       it 'raises a jwt malformed error with expected message',
          vcr: { cassette_name: 'identity/logingov_jwks_malformed' } do
         expect { subject.token(code) }.to raise_error(expected_error, expected_error_message)
+      end
+    end
+
+    context 'when the public JWKs response is not cached' do
+      let(:expected_jwks_fetch_log) { '[SignIn][Logingov][Service] Get Public JWKs Success' }
+
+      before do
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it 'fetches the public JWKs' do
+        VCR.use_cassette('identity/logingov_200_responses') do
+          subject.token(code)
+
+          expect(Rails.logger).to have_received(:info).with(expected_jwks_fetch_log)
+        end
+      end
+    end
+
+    context 'when the public JWKs response is cached' do
+      let(:cache_key) { 'logingov_public_jwks' }
+      let(:cache_expiration) { 30.minutes }
+      let(:redis_store) { ActiveSupport::Cache::RedisCacheStore.new(redis: MockRedis.new) }
+
+      before do
+        allow(Rails).to receive(:cache).and_return(redis_store)
+        Rails.cache.clear
+        allow(Rails.logger).to receive(:info)
+      end
+
+      after do
+        Rails.cache.clear
+      end
+
+      it 'uses the cached JWKs response' do
+        VCR.use_cassette('identity/logingov_200_responses') do
+          subject.token(code)
+
+          expect(Rails.logger).to have_received(:info).with(expected_jwks_fetch_log)
+        end
+        VCR.use_cassette('identity/logingov_200_responses') do
+          expect(Rails.logger).not_to receive(:info).with(expected_jwks_fetch_log)
+          subject.token(code)
+        end
+      end
+
+      context 'when the JWK is not found in the cached JWKs' do
+        let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
+        let(:jwks) { JWT::JWK::Set.new([JWT::JWK::RSA.new(rsa_key)]) }
+        let(:expected_jwk_reload_log) { '[SignIn][Logingov][Service] JWK not found, reloading public JWKs' }
+
+        before do
+          allow(Rails.cache).to receive(:delete_matched).and_call_original
+        end
+
+        it 'clears the cache and fetches the public JWKs again' do
+          Rails.cache.write(cache_key, jwks)
+
+          VCR.use_cassette('identity/logingov_200_responses') do
+            subject.token(code)
+
+            expect(Rails.cache).to have_received(:delete_matched).with(cache_key)
+            expect(Rails.logger).to have_received(:info).with(expected_jwk_reload_log)
+            expect(Rails.logger).to have_received(:info).with(expected_jwks_fetch_log)
+            expect(Rails.cache.read(cache_key)).not_to eq(jwks)
+          end
+        end
       end
     end
   end

--- a/spec/support/vcr_cassettes/identity/idme_jwks_jwt_malformed.yml
+++ b/spec/support/vcr_cassettes/identity/idme_jwks_jwt_malformed.yml
@@ -73,6 +73,78 @@ http_interactions:
       string: '{"keys":[{"kty":"RSA","e":"AQAB","n":"rz70i-ikqlO-MRx_0HDK_UVSGsc2YdoCtdobRFQ4AaaEoTaqOKpVk65dbrUVg45hw7m5zncVg1twX1Is8Xc3_kklvzxKmzeVsC_m03MN4yiZ6xEPReHHsucAUP8xRT-gGUMrWcSHWUdadczE52Gvdb_hr51IDuKFDeqfnxklluucbJk8IT15neuLQkLs5rOsn3BAubTDN2Xh9HEy5iSZ0WKJwlY418V1ccUN3QYvIfrUywF1UPNeIAFkl7UlSNkp1dyi_n_QaW6yyx9m3VoHCUtOlN1NxYeV_aeEm6agake2rbwwG2gfOSXz2lYfOGamgwMo9MhIKKq0zmc9EPiJ_Q","kid":"9WSOx_eAXYDxiFou_suVIzGiNxBarsylEONVPbv1yTg","x5t":"4C90hZxBY9uxzI1DFLXb2KPj2dg=","x5c":["MIIHQTCCBimgAwIBAgIQAhhrK6N40KdBvLY3kD2KhjANBgkqhkiG9w0BAQsF\nADB1MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYD\nVQQLExB3d3cuZGlnaWNlcnQuY29tMTQwMgYDVQQDEytEaWdpQ2VydCBTSEEy\nIEV4dGVuZGVkIFZhbGlkYXRpb24gU2VydmVyIENBMB4XDTIyMTAwMTAwMDAw\nMFoXDTIzMTEwMTIzNTk1OVowgcsxEzARBgsrBgEEAYI3PAIBAxMCVVMxGTAX\nBgsrBgEEAYI3PAIBAhMIRGVsYXdhcmUxHTAbBgNVBA8MFFByaXZhdGUgT3Jn\nYW5pemF0aW9uMRAwDgYDVQQFEwc0Nzg0MzI3MQswCQYDVQQGEwJVUzERMA8G\nA1UECBMIVmlyZ2luaWExDzANBgNVBAcTBk1jTGVhbjEUMBIGA1UEChMLSUQu\nbWUsIEluYy4xITAfBgNVBAMTGHNpZ25pbmcuYXBpLmlkbWVsYWJzLmNvbTCC\nASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8+9IvopKpTvjEcf9Bw\nyv1FUhrHNmHaArXaG0RUOAGmhKE2qjiqVZOuXW61FYOOYcO5uc53FYNbcF9S\nLPF3N/5JJb88Sps3lbAv5tNzDeMomesRD0Xhx7LnAFD/MUU/oBlDK1nEh1lH\nWnXMxOdhr3W/4a+dSA7ihQ3qn58ZJZbrnGyZPCE9eZ3ri0JC7OazrJ9wQLm0\nwzdl4fRxMuYkmdFiicJWONfFdXHFDd0GLyH61MsBdVDzXiABZJe1JUjZKdXc\nov5/0GlusssfZt1aBwlLTpTdTcWHlf2nhJumoGpHtq28MBtoHzkl89pWHzhm\npoMDKPTISCiqtM5nPRD4if0CAwEAAaOCA3QwggNwMB8GA1UdIwQYMBaAFD3T\nUKXWoK3u80pgCmXTIdT4+NYPMB0GA1UdDgQWBBQzVgdfozQCBDNEUtnht2Xa\nX0oK2jAjBgNVHREEHDAaghhzaWduaW5nLmFwaS5pZG1lbGFicy5jb20wDgYD\nVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB1\nBgNVHR8EbjBsMDSgMqAwhi5odHRwOi8vY3JsMy5kaWdpY2VydC5jb20vc2hh\nMi1ldi1zZXJ2ZXItZzMuY3JsMDSgMqAwhi5odHRwOi8vY3JsNC5kaWdpY2Vy\ndC5jb20vc2hhMi1ldi1zZXJ2ZXItZzMuY3JsMEoGA1UdIARDMEEwCwYJYIZI\nAYb9bAIBMDIGBWeBDAEBMCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGln\naWNlcnQuY29tL0NQUzCBiAYIKwYBBQUHAQEEfDB6MCQGCCsGAQUFBzABhhho\ndHRwOi8vb2NzcC5kaWdpY2VydC5jb20wUgYIKwYBBQUHMAKGRmh0dHA6Ly9j\nYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFNIQTJFeHRlbmRlZFZhbGlk\nYXRpb25TZXJ2ZXJDQS5jcnQwCQYDVR0TBAIwADCCAX8GCisGAQQB1nkCBAIE\nggFvBIIBawFpAHYA6D7Q2j71BjUy51covIlryQPTy9ERa+zraeF3fW0GvW4A\nAAGDkT0xsAAABAMARzBFAiB0VtILAXb7vArIymLRvnRpmU6gR8/eOxbCpWGD\nT/1l6wIhALxNYroT/M6Felmr1dXzUSAPh88WDWKD3Qx3h9mqRDn5AHcAs3N3\nB+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAGDkT0x+QAABAMASDBG\nAiEAukjwM3NzCDOhu4N8TJBJ6/SPME+oE5ghKjyWUhPpff4CIQDSrg/AgjSZ\nvzfXNmYDQMmIjMKlHyP6UQTL5iu8fCRXGwB2ALc++yTfnE26dfI5xbpY9Gxd\n/ELPep81xJ4dCYEl7bSZAAABg5E9Mc4AAAQDAEcwRQIhAOk3ltmwqYdCSOXO\n/8bn2n4G54lCN8/xjm2izahW2PzYAiBdYJggBUKa8FQDvdtwART6Cf8O/CI0\nFCA+6jkKa6H04jANBgkqhkiG9w0BAQsFAAOCAQEAr/1sTFYoOR28cJca4ZEc\nDXfcCyuw3iZ2QKz/PnmB0LRotaUpCzqlLuPFZcCk633ZoavOijYsAepZspHa\ny/ORAQejONr7pRQRRzbSv7O1DiBE8OuH8ZGdGTrB1PnfseOnFPRxlS5IGhqI\ndi2FhnCL9RbjdfLOrLLt6mHx43PQ6iCunXAkxW2XU1IEb7TqBV03KR6ttJUK\nNCpI1cENgcRS62HV5+YFZGPQHZZUrS8ueLPCW5297/tDaPmBtgOWr4gSqiSY\ngY0gLluOgxuHWt8T67h+iZYTEhDsCswJFnCtJA6C+CYS7siajzd0DEBv3gUw\nv3gE4pDsy62D/8vg6pjfFw=="]}]}'
   recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
 - request:
+    method: get
+    uri: https://api.idmelabs.com/oidc/.well-known/jwks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.idmelabs.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - allow-from https://nextgenid-mbetenantworkflow.azurewebsites.net
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - frame-ancestors https://nextgenid-mbetenantworkflow.azurewebsites.net
+      Etag:
+      - W/"dba68a519b00d7f452e79971a398650f"
+      X-Request-Id:
+      - 5b1d220c-4b01-4409-b9a5-367ab3c99ca9
+      X-Runtime:
+      - '0.026178'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Node:
+      - sandbox-core-02.idmeinc.net
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 26 Jul 2023 19:56:07 GMT
+      Content-Length:
+      - '14658'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - idme-session=88eca8f8acd1591f22201dcbfd01a760; domain=.idmelabs.com; path=/;
+        expires=Thu, 27 Jul 2023 19:56:07 GMT; secure; HttpOnly; SameSite=None
+      Server-Timing:
+      - ak_p; desc="1690401366974_1752320020_1303469004_11342_12901_31_-_-";dur=1
+      - cdn-cache; desc=MISS
+      - edge; dur=68
+      - origin; dur=46
+    body:
+      encoding: UTF-8
+      string: '{"keys":[{"kty":"RSA","e":"AQAB","n":"rz70i-ikqlO-MRx_0HDK_UVSGsc2YdoCtdobRFQ4AaaEoTaqOKpVk65dbrUVg45hw7m5zncVg1twX1Is8Xc3_kklvzxKmzeVsC_m03MN4yiZ6xEPReHHsucAUP8xRT-gGUMrWcSHWUdadczE52Gvdb_hr51IDuKFDeqfnxklluucbJk8IT15neuLQkLs5rOsn3BAubTDN2Xh9HEy5iSZ0WKJwlY418V1ccUN3QYvIfrUywF1UPNeIAFkl7UlSNkp1dyi_n_QaW6yyx9m3VoHCUtOlN1NxYeV_aeEm6agake2rbwwG2gfOSXz2lYfOGamgwMo9MhIKKq0zmc9EPiJ_Q","kid":"9WSOx_eAXYDxiFou_suVIzGiNxBarsylEONVPbv1yTg","x5t":"4C90hZxBY9uxzI1DFLXb2KPj2dg=","x5c":["MIIHQTCCBimgAwIBAgIQAhhrK6N40KdBvLY3kD2KhjANBgkqhkiG9w0BAQsF\nADB1MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYD\nVQQLExB3d3cuZGlnaWNlcnQuY29tMTQwMgYDVQQDEytEaWdpQ2VydCBTSEEy\nIEV4dGVuZGVkIFZhbGlkYXRpb24gU2VydmVyIENBMB4XDTIyMTAwMTAwMDAw\nMFoXDTIzMTEwMTIzNTk1OVowgcsxEzARBgsrBgEEAYI3PAIBAxMCVVMxGTAX\nBgsrBgEEAYI3PAIBAhMIRGVsYXdhcmUxHTAbBgNVBA8MFFByaXZhdGUgT3Jn\nYW5pemF0aW9uMRAwDgYDVQQFEwc0Nzg0MzI3MQswCQYDVQQGEwJVUzERMA8G\nA1UECBMIVmlyZ2luaWExDzANBgNVBAcTBk1jTGVhbjEUMBIGA1UEChMLSUQu\nbWUsIEluYy4xITAfBgNVBAMTGHNpZ25pbmcuYXBpLmlkbWVsYWJzLmNvbTCC\nASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8+9IvopKpTvjEcf9Bw\nyv1FUhrHNmHaArXaG0RUOAGmhKE2qjiqVZOuXW61FYOOYcO5uc53FYNbcF9S\nLPF3N/5JJb88Sps3lbAv5tNzDeMomesRD0Xhx7LnAFD/MUU/oBlDK1nEh1lH\nWnXMxOdhr3W/4a+dSA7ihQ3qn58ZJZbrnGyZPCE9eZ3ri0JC7OazrJ9wQLm0\nwzdl4fRxMuYkmdFiicJWONfFdXHFDd0GLyH61MsBdVDzXiABZJe1JUjZKdXc\nov5/0GlusssfZt1aBwlLTpTdTcWHlf2nhJumoGpHtq28MBtoHzkl89pWHzhm\npoMDKPTISCiqtM5nPRD4if0CAwEAAaOCA3QwggNwMB8GA1UdIwQYMBaAFD3T\nUKXWoK3u80pgCmXTIdT4+NYPMB0GA1UdDgQWBBQzVgdfozQCBDNEUtnht2Xa\nX0oK2jAjBgNVHREEHDAaghhzaWduaW5nLmFwaS5pZG1lbGFicy5jb20wDgYD\nVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB1\nBgNVHR8EbjBsMDSgMqAwhi5odHRwOi8vY3JsMy5kaWdpY2VydC5jb20vc2hh\nMi1ldi1zZXJ2ZXItZzMuY3JsMDSgMqAwhi5odHRwOi8vY3JsNC5kaWdpY2Vy\ndC5jb20vc2hhMi1ldi1zZXJ2ZXItZzMuY3JsMEoGA1UdIARDMEEwCwYJYIZI\nAYb9bAIBMDIGBWeBDAEBMCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGln\naWNlcnQuY29tL0NQUzCBiAYIKwYBBQUHAQEEfDB6MCQGCCsGAQUFBzABhhho\ndHRwOi8vb2NzcC5kaWdpY2VydC5jb20wUgYIKwYBBQUHMAKGRmh0dHA6Ly9j\nYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFNIQTJFeHRlbmRlZFZhbGlk\nYXRpb25TZXJ2ZXJDQS5jcnQwCQYDVR0TBAIwADCCAX8GCisGAQQB1nkCBAIE\nggFvBIIBawFpAHYA6D7Q2j71BjUy51covIlryQPTy9ERa+zraeF3fW0GvW4A\nAAGDkT0xsAAABAMARzBFAiB0VtILAXb7vArIymLRvnRpmU6gR8/eOxbCpWGD\nT/1l6wIhALxNYroT/M6Felmr1dXzUSAPh88WDWKD3Qx3h9mqRDn5AHcAs3N3\nB+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAGDkT0x+QAABAMASDBG\nAiEAukjwM3NzCDOhu4N8TJBJ6/SPME+oE5ghKjyWUhPpff4CIQDSrg/AgjSZ\nvzfXNmYDQMmIjMKlHyP6UQTL5iu8fCRXGwB2ALc++yTfnE26dfI5xbpY9Gxd\n/ELPep81xJ4dCYEl7bSZAAABg5E9Mc4AAAQDAEcwRQIhAOk3ltmwqYdCSOXO\n/8bn2n4G54lCN8/xjm2izahW2PzYAiBdYJggBUKa8FQDvdtwART6Cf8O/CI0\nFCA+6jkKa6H04jANBgkqhkiG9w0BAQsFAAOCAQEAr/1sTFYoOR28cJca4ZEc\nDXfcCyuw3iZ2QKz/PnmB0LRotaUpCzqlLuPFZcCk633ZoavOijYsAepZspHa\ny/ORAQejONr7pRQRRzbSv7O1DiBE8OuH8ZGdGTrB1PnfseOnFPRxlS5IGhqI\ndi2FhnCL9RbjdfLOrLLt6mHx43PQ6iCunXAkxW2XU1IEb7TqBV03KR6ttJUK\nNCpI1cENgcRS62HV5+YFZGPQHZZUrS8ueLPCW5297/tDaPmBtgOWr4gSqiSY\ngY0gLluOgxuHWt8T67h+iZYTEhDsCswJFnCtJA6C+CYS7siajzd0DEBv3gUw\nv3gE4pDsy62D/8vg6pjfFw=="]}]}'
+  recorded_at: Wed, 26 Oct 2022 18:30:02 GMT
+- request:
     method: post
     uri: https://api.idmelabs.com/oauth/token
     body:
@@ -186,6 +258,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "\"\\\"eyJraWQiOiJ3T0s4WEI1RzNiNEI2QXd1TDNuUmdEVkNQYmZ0RHZBTkpJQ09vbDlXVTgwIiwiYWxnIjoiUlNBLU9BRVAiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0.hmqW65SIrJMlz0AbuwrSvT6bovYRH6MQxoJOMkRwj71azBq_28eMfsk9z5Znt_l3xqdzLaNmaPICn63MfQPO5yezQFAf3yTm1DE54xk7B_BaklzOMd43MpCEcGujK7Px4C9GGPtpbEDvKrh1EO4pt1Nq6Ue5o-4CUPueJ5WVK66ZHY6T4wwM-DrBnD7hTR0833BXdq_AL2XCrjxMUkXbJijGtklV84xBHVvThoXGd9DKHK0wHrbHvxSdB3wuvhTy-y55QmWVifbQCQf9ZWAKD-2_wC0YNs9qwN81iKKm1xoe9YZ3JXEZijRb767D-MWMYOGxKKnH7QzRbpSeX3p8dw.q-KYiO6PAt1j_1yE1P-XCQ.TM2JjLNUb2xgHhGMAUI1UO5pn2Um5m7hctMZsAe3XaxxOxzwdl37oPhVRe0pkBr7-K2cJv-28PLYFmAn6RBb7fSCDQZP-0LmSjDOUDw4jHEwDBVW3bDPNzFkyZWcOxnyXBLkv-0dTa5bSNalK_ccz1IXM3-VFuOgPJK15DpTnJmdbSFKuHjgrBqKKy542ipg8g14f0g_dpSFN6sri-D6HUPst6OI7p-OMROdMKejriKprWmFF4xxvzyvieJMrBXQswBo3TA9fWaLyAE6Lzv0-TfBdiR_UPrO7KbWWReA3KXs_WqfHfOVwcA6mrlji0xFeZ3YipFXcwkGSethNwUrRoSZEnQ7j8EQ8UYHdIaSVUggvMSZW_LzteemkA6BHF3Pzq9aUn_aJA2BB_CrrL_TY9_cPwjK1cLYWq6EfHKhYjw3fXybVzIxLMuBimYYOy7wK16-z_rKOJNzlPnGhraiuV8Ogc5g3SAnQNJYVkMLgxQTcmI8-qcsBddihEHN242EQM1JRjTVok8aEsOB-v2Phdb3oEn5qvcg7xrLg6MhQ5ihbowoUo9QfTO2P-XOxjMftLI6TTadKxvX1H_XQD-S7hlQD_c7KxPv-tFLpf1-O9DCLlDzwvsu-ULOR_pQl52UYehzH4mf5vstyvFxvVGGaWDqtAFtDDs65ZQmXwcVye98EWS0e28wRuuHWWiF-NVRYM5ggfVPnSg5hplMchS0iZVtPKlaWPUYT91n3J3cEwTrT7LIzDR4bzOMtiQqRn_CL2nZHPkgbVMxJgOSbhbJ_71gjjwL7bCIQtNZWdKZPU9Bw7fqZXSLhM02qDROoM-KtSJNNYXwAcqP2yPs5YWLX7egYcTclHdy7FWE_iBz6DnrUR44Xq4KmyLmRET8sQiTzS18gSiJ2XibSyg4p7_dTUZUiURDcmuSFNy9JY27ixygRRRAOBGcPVmho7tS85DKRkOD8jGpxVVHD-EKOa4z9NtToZGqIWbDPv-_baMhC07I9ZPdBNgB42qKcSazh1FUjgeEnhT59Xhtm4LedOj0hXUruHLgfXH5srTT05_ag6y7SeojsK1Vv05PdrAcrJd0gEsEuJ0bsTJ3SxXwrMW64x25lLsHJ8UpCSLHglJqKnC6Rt9a_CjYvLXlqZ3EC3-Ea1GWGm1wY16JjB7H0UqTIiuU10m0s50WeEJ4elnais8eiBrWvogAW_iN9_Nuk8Z35B32CHRHmVCnzeMFfl_Qo-25sGueqBvXL8zrmSomqj0-Tt-TVD_5_yV00XAQkXgxySnOMDG4iMHqjJhMYOUpInRoDhGleZRPkCEomI-WdslpDD9Qlri609r26AoErnPxiR0avx-PS8txx7KK8Qw3KvNPRMW4UGzyoew298uSZGq6p0GjjRWwbaR4fw4P9LEDEJcOTyMIHULIlib_XkI2dIRdaHjXCGd1MQVllQQwzbWEkAJyGTmGJW-q1NL9-q2EUqlybf_lJ_g9rRq9G4rkuralJRoKtJ00YcDl70P_dpGUt78jPzG_Uvyg0hI3c6zmwnz5TNGla4Pp307Q6z10zI9OpMuZdX9V9CNsUt7SS4yRmkL27SjS2LHqDaCoiW5iZH-JgIDtbqxJThzVDrQcb2u8QVPc-IS4x3_RLU35NjU.H4AiWOkNvhW0JjC2iHEpF5NxVe4anPQtBSs7D6-J3P4\\\"\""
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Dec 2021 16:09:22 GMT
 recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/identity/logingov_jwks_jwt_malformed.yml
+++ b/spec/support/vcr_cassettes/identity/logingov_jwks_jwt_malformed.yml
@@ -81,6 +81,86 @@ http_interactions:
       string: '{"keys":[{"alg":"RS256","use":"sig","kty":"RSA","n":"qRoNXLUugbenQTBHswfiGoKuhKkvUPP6A1GllxEZEAX86FiFSrXr7x_suHZ4cBytsmtFuYGymJZAGTk7DLzvMW0BHZpVtMZ3qvBDsYbNQGN4oLLxIy5-Q1rT1XTZhNkJwaj7gndbKHpQ33FqNQphhdchXB28N9GekDCJKzwEEThhxHkBxhq-hYAkd6rZ2fLiiyd5C4MSO0pMB-E_oGrNdYhCoydaFqVAhojn8am9za-JkjZIE9-Shlv_CQGt0yr91h3agVxeR2aeuZjQmvrhALJUeeJxG4D_Xl-w4v_O6nl0nllKXKHFxjP4ejDdNbht2a1L9BgJoYBjq6pUcWT49w","e":"AQAB","kid":"f5c6a17039f274361a18b13c"}]}'
   recorded_at: Tue, 22 Aug 2023 00:03:27 GMT
 - request:
+    method: get
+    uri: https://idp.int.identitysandbox.gov/api/openid_connect/certs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '483'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 22 Aug 2023 00:03:27 GMT
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=604800, public
+      Vary:
+      - Accept, Origin
+      Strict-Transport-Security:
+      - max-age=31556952; includeSubDomains; preload
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 5f14d1b5-4589-4a31-b17e-76cf843a00f2
+      X-Download-Options:
+      - noopen
+      X-Runtime:
+      - '0.002092'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - 'frame-ancestors ''self''; default-src ''self''; child-src ''self''; form-action
+        ''self''; block-all-mixed-content; connect-src ''self'' *.nr-data.net; font-src
+        ''self'' data: https://idp.int.identitysandbox.gov; img-src ''self'' data:
+        login.gov https://idp.int.identitysandbox.gov https://s3.us-west-2.amazonaws.com;
+        media-src ''self''; object-src ''none''; script-src ''self'' js-agent.newrelic.com
+        *.nr-data.net https://idp.int.identitysandbox.gov ''nonce-''; style-src ''self''
+        https://idp.int.identitysandbox.gov ''unsafe-inline''; base-uri ''self'''
+      Set-Cookie:
+      - ahoy_track=true; path=/; SameSite=Lax; Secure; HttpOnly
+      - ahoy_visit=0ea2794c-9f89-4f22-8c33-aefbc882f45f; path=/; expires=Tue, 22 Aug
+        2023 00:18:27 GMT; SameSite=Lax; Secure; HttpOnly
+      - ahoy_visitor=0633ffe6-5dfb-4a8b-8249-6d7417508d78; path=/; expires=Fri, 22
+        Aug 2025 00:03:27 GMT; SameSite=Lax; Secure; HttpOnly
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 efe54e8b68e074d39b2ecd249f85100a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - HIO50-C1
+      Alt-Svc:
+      - h3=":443"; ma=86400
+      X-Amz-Cf-Id:
+      - 3CWeSgx1aR8NXxmRqpRykK403Y_ubZUAfI3EaL_3cE7SsSp0JC7sWQ==
+    body:
+      encoding: UTF-8
+      string: '{"keys":[{"alg":"RS256","use":"sig","kty":"RSA","n":"qRoNXLUugbenQTBHswfiGoKuhKkvUPP6A1GllxEZEAX86FiFSrXr7x_suHZ4cBytsmtFuYGymJZAGTk7DLzvMW0BHZpVtMZ3qvBDsYbNQGN4oLLxIy5-Q1rT1XTZhNkJwaj7gndbKHpQ33FqNQphhdchXB28N9GekDCJKzwEEThhxHkBxhq-hYAkd6rZ2fLiiyd5C4MSO0pMB-E_oGrNdYhCoydaFqVAhojn8am9za-JkjZIE9-Shlv_CQGt0yr91h3agVxeR2aeuZjQmvrhALJUeeJxG4D_Xl-w4v_O6nl0nllKXKHFxjP4ejDdNbht2a1L9BgJoYBjq6pUcWT49w","e":"AQAB","kid":"f5c6a17039f274361a18b13c"}]}'
+  recorded_at: Tue, 22 Aug 2023 00:03:27 GMT
+- request:
     method: post
     uri: 'https://idp.int.identitysandbox.gov/api/openid_connect/token'
     body:
@@ -129,7 +209,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{ "access_token" : "mHO_gU3WooLm0xoDxIAulw", "token_type" : "Bearer", "expires_in" : 900, "id_token" : "eyJraWQiOiJmNWNlMTIzOWUzOWQzZGE4MzZmOTYzYmNjZDg1Zjg1ZDU3ZDQzMzVjZmRjNmExNzAzOWYyNzQzNjFhMThiMTNjIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJlYmYyZTZlZC01M2I2LTQwOWQtYTMwYS1jYzk4YWUyYWRjMDEiLCJpc3MiOiJodHRwczovL2lkcC5pbnQuaWRlbnRpdHlzYW5kYm94Lmdvdi8iLCJlbWFpbCI6ImpvZS5uaXF1ZXR0ZStsZ292aWFsMkBvZGRiYWxsLmlvIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImdpdmVuX25hbWUiOiJqb2VpYWwyIiwiZmFtaWx5X25hbWUiOiJ0ZXN0bGFzdG5hbWUiLCJiaXJ0aGRhdGUiOiIxOTgwLTA4LTE2Iiwic29jaWFsX3NlY3VyaXR5X251bWJlciI6IjEwMjk5ODc3NSIsImFkZHJlc3MiOnsiZm9ybWF0dGVkIjoiMjI4IE4gU3BlbmNlciBSZFxuUGF4dG9uLCBNQSAwMTYxMiIsInN0cmVldF9hZGRyZXNzIjoiMjI4IE4gU3BlbmNlciBSZCIsImxvY2FsaXR5IjoiUGF4dG9uIiwicmVnaW9uIjoiTUEiLCJwb3N0YWxfY29kZSI6IjAxNjEyIn0sInZlcmlmaWVkX2F0IjoxNjM2NDc4Nzg1LCJpYWwiOiJodHRwOi8vaWRtYW5hZ2VtZW50Lmdvdi9ucy9hc3N1cmFuY2UvaWFsLzIiLCJhYWwiOiJ1cm46Z292OmdzYTphYzpjbGFzc2VzOnNwOlBhc3N3b3JkUHJvdGVjdGVkVHJhbnNwb3J0OmR1byIsImFjciI6Imh0dHA6Ly9pZG1hbmFnZW1lbnQuZ292L25zL2Fzc3VyYW5jZS9pYWwvMiIsIm5vbmNlIjoiYzY0YzBjNzcyYjdiNDM1ZDdkZWVhMTM1ZDY3NDg2ZjgiLCJhdWQiOiJodHRwczovL3NxYS5lYXV0aC52YS5nb3YvaXNhbS9zcHMvc2FtbDIwc3Avc2FtbDIwIiwianRpIjoibW9rQ2xwV1FRSWZVdzNMTG1MM0F6dyIsImF0X2hhc2giOiJ4aW9Ubk9aVEFaZ2w5N0FqSHJ0Q0xBIiwiY19oYXNoIjoiWDdNMG00SnRwQlJDQTZzNk5jb243ZyIsImV4cCI6MTY5MjY2MzkzOCwiaWF0IjoxNjkyNjYzMDM4LCJuYmYiOjE2OTI2NjMwMzh9.pvy7yGYMewc-nLvcO7C-Wu1DIk58HaUSo9FloN8mOEuNPk8WqmXeV7el0jMUi7nwe_fyUn-yqvaGp7wJ11a3gAHbYGJWrfDfp4_nl6sL0B5ZX6wwlK-lppcSJcLMEQQbXW4LO8SzGSfQP07Mzp5IH35WTF3FZVaE-xBekGI4jj4dnsuCYGE13cOQpYMpfmJPKm4Pzpe6L257Mjzim50ufXSHlmxdxD5ldx_tA1AktRXtfHszrXXh7zdO2zmRvLe4VqZc13G1NJxP4HfNh_FPWJ5--Jn_BKp5HqroETr02Ubl2T0dzYqlH8qd3Z2_4cxblwkix6W8uo6VaoKYbZkDSQ" }'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Dec 2021 16:09:22 GMT
 - request:
     method: get
@@ -183,6 +263,6 @@ http_interactions:
                  "email" : "user@test.com", "email_verified" : true, "given_name" : "Bob", "family_name" : "User",
                  "birthdate" : "1993-01-01", "social_security_number" : "999-11-9999", "address" : { "formatted" : "1 Microsoft Way\nApt 3\nBayside, NY 11364",
                  "street_address" : "1 Microsoft Way\nApt 3", "locality" : "Bayside", "region" : "NY", "postal_code" : "11364" }, "verified_at" : 1635465286 }'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Dec 2021 16:09:22 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Summary

- Handle situations where a JWT is is encoded with a new key but is being verified with the old JWK that is cached.
- the `jwt` gem has a built in way of handling this using a `jwks_loader` method (They say lambda but I think a method is cleaner in this case). [`jwks_loader`](https://github.com/jwt/ruby-jwt?tab=readme-ov-file#json-web-key-jwk), [`jwt/jwk/key_finder.rb#L31-L43`](https://github.com/jwt/ruby-jwt/blob/42f905c7fb734d009f311017b17a7645d5ee1e0c/lib/jwt/jwk/key_finder.rb#L31-L43)
- Basically what this does is it first tries to find the JWK in the cache by calling `jwks_loader`, if the JWK is not found - it calls `jwks_loader(kid_not_found: true)`. This will clear the cache and fetch and use the new JWKS.

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-647

## Testing done

- Test SiS login with idme and logingov

## What areas of the site does it impact?
Sign-in Service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

