### PR TITLE
[VI-478] adds mhv account creation request log

### DIFF
--- a/lib/mhv/account_creation/service.rb
+++ b/lib/mhv/account_creation/service.rb
@@ -11,6 +11,7 @@ module MHV
         params = build_create_account_params(icn:, email:, tou_occurred_at:)
 
         create_account_with_cache(icn:, force: break_cache, expires_in: 1.day) do
+          Rails.logger.info("#{config.logging_prefix} create_account request", { icn: })
           response = perform(:post, config.account_creation_path, params, authenticated_header(icn:))
           normalize_response_body(response.body)
         end

--- a/spec/lib/mhv/account_creation/service_spec.rb
+++ b/spec/lib/mhv/account_creation/service_spec.rb
@@ -25,12 +25,21 @@ describe MHV::AccountCreation::Service do
 
     context 'when making a request' do
       let(:expected_tou_datetime) { tou_occurred_at.iso8601 }
+      let(:expected_log_message) { "#{log_prefix} create_account request" }
+      let(:expected_log_payload) { { icn: } }
 
       it 'sends vaTermsOfUseDateTime in the correct format' do
         VCR.use_cassette('mhv/account_creation/account_creation_service_200_created') do
           subject
           expect(a_request(:post, "#{account_creation_base_url}/#{account_creation_path}")
           .with(body: /"vaTermsOfUseDateTime":"#{expected_tou_datetime}"/)).to have_been_made
+        end
+      end
+
+      it 'logs the create account request' do
+        VCR.use_cassette('mhv/account_creation/account_creation_service_200_created') do
+          subject
+          expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
         end
       end
     end
@@ -57,7 +66,7 @@ describe MHV::AccountCreation::Service do
           end
         end
 
-        it 'logs the create account request' do
+        it 'logs the create account success' do
           VCR.use_cassette(successful_response_cassette) do
             subject
             expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)


### PR DESCRIPTION
## Summary

- Adds a log recording a request to the MHV account creation API for a new account; this provides a baseline to measure successes and failures agains.

## Related issue(s)

-  VI-478

## Testing done

- [x] *New code is covered by unit tests*
- Use the `MHV::AccountCreation::Service` to request a new MHV account, be sure to set `break_cache` to `true` to force the service to attempt to call out to MHV.
- You should see the following log
```ruby
MHV::AccountCreation::Service.new.create_account(icn:, email:, tou_occurred_at:, break_cache: true)
Rails -- [MHV][AccountCreation][Service] create_account request -- { :icn => "1008704012V552302" }
```
