### PR TITLE
[Lighthouse Migration] Obtain user participant ID from reliable source

### DIFF
--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -37,7 +37,8 @@ class LighthouseSupplementalDocumentUploadProvider
 
     LighthouseDocument.new(
       claim_id: @form526_submission.submitted_claim_id,
-      participant_id: user.participant_id,
+      # Participant ID is persisted on the submission record
+      participant_id: @form526_submission.auth_headers['va_eauth_pid'],
       document_type: @va_document_type,
       file_name:
     )

--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -33,8 +33,6 @@ class LighthouseSupplementalDocumentUploadProvider
   #
   # @return [LighthouseDocument]
   def generate_upload_document(file_name)
-    user = User.find(@form526_submission.user_uuid)
-
     LighthouseDocument.new(
       claim_id: @form526_submission.submitted_claim_id,
       # Participant ID is persisted on the submission record

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -7,7 +7,6 @@ require 'support/disability_compensation_form/shared_examples/supplemental_docum
 
 RSpec.describe LighthouseSupplementalDocumentUploadProvider do
   let(:submission) { create(:form526_submission, :with_submitted_claim_id) }
-  let(:submission_user) { User.find(submission.user_uuid) }
   let(:file_body) { File.read(fixture_file_upload('doctors-note.pdf', 'application/pdf')) }
   let(:file_name) { Faker::File.file_name }
 
@@ -25,7 +24,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
   let(:lighthouse_document) do
     LighthouseDocument.new(
       claim_id: submission.submitted_claim_id,
-      participant_id: submission_user.participant_id,
+      participant_id: submission.auth_headers['va_eauth_pid'],
       document_type: va_document_type,
       file_name:
     )
@@ -62,7 +61,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
       expect(upload_document).to have_attributes(
         {
           claim_id: submission.submitted_claim_id,
-          participant_id: submission_user.participant_id,
+          participant_id: submission.auth_headers['va_eauth_pid'],
           document_type: va_document_type,
           file_name:
         }

--- a/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
       let(:expected_lighthouse_document) do
         LighthouseDocument.new(
           claim_id: submission.submitted_claim_id,
-          participant_id: user.participant_id,
+          participant_id: submission.auth_headers['va_eauth_pid'],
           document_type: 'L023',
           file_name: 'BDD_Instructions.pdf'
         )


### PR DESCRIPTION
As initially implemented, my `LighthouseSupplementalDocumentUploadProvider` service was obtaining a user `participant_id` off of a `User` object which I looked up off of the Form 526 Submission record's `user_uuid`. (`participant_id` is a required field for uploading documents to the Lighthouse Benefits Documents API)

However, I've since learned that user objects are only persisted when the user is logged in, and we need to get this information elsewhere. Fortunately, this ID is persisted in the submission's `auth_headers` hash so we can retrieve it directly from the submission record.

## Summary

- *This work is behind a feature toggle (flipper): YES this entire migration is behind a flipper and will be tested before it is rolled out in production


## Testing done

- [X] *New code is covered by unit tests*



## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) N/A
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
