### PR TITLE
try using EOF to prevent failures with large output

### DIFF
--- a/.github/workflows/be_review_prs.yml
+++ b/.github/workflows/be_review_prs.yml
@@ -57,8 +57,16 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'require-backend-approval')
         id: verify_approval
         run: |
-          BACKEND_REVIEWERS=$(echo '${{ steps.get_team_members.outputs.data }}' | jq -r '.[].login' | tr '\n' '|' | sed 's/|$//')
-          APPROVALS=$(echo '${{ steps.check_backend_review_group_approval_status.outputs.data }}' | jq -r '.[] | select(.state == "APPROVED") | .user.login' | grep -iE "$BACKEND_REVIEWERS" | wc -l)
+          BACKEND_REVIEWERS=$(cat <<'EOF' | jq -r '.[].login' | tr '\n' '|' | sed 's/|$//'
+          ${{ steps.get_team_members.outputs.data }}
+          EOF
+          )
+
+          APPROVALS=$(cat <<'EOF' | jq -r '.[] | select(.state == "APPROVED") | .user.login' | grep -iE "$BACKEND_REVIEWERS" | wc -l
+          ${{ steps.check_backend_review_group_approval_status.outputs.data }}
+          EOF
+          )
+
           echo "Number of backend-review-group approvals: $APPROVALS"
           if [ "$APPROVALS" -eq 0 ]; then
             echo "approval_status=required" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Error seen sometimes in CI runs:
```
/home/runner/work/_temp/3711f819-88c3-4533-82f2-1842aa10d536.sh: line 345: unexpected EOF while looking for matching `"'
Error: Process completed with exit code 2.
```
[Example from here](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/11349304416/job/31565085162?pr=18846#annotation:8:357)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93566

## Testing done

- test after merge. @stevenjcumming to watch for this error in the `check-approval-requirements` CI check. 


## What areas of the site does it impact?
Vets-api CI
