### PR TITLE
Use EOF to prevent failures from unexpected characters in GHA's

### DIFF
--- a/.github/workflows/be_review_prs.yml
+++ b/.github/workflows/be_review_prs.yml
@@ -57,8 +57,16 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'require-backend-approval')
         id: verify_approval
         run: |
-          BACKEND_REVIEWERS=$(echo '${{ steps.get_team_members.outputs.data }}' | jq -r '.[].login' | tr '\n' '|' | sed 's/|$//')
-          APPROVALS=$(echo '${{ steps.check_backend_review_group_approval_status.outputs.data }}' | jq -r '.[] | select(.state == "APPROVED") | .user.login' | grep -iE "$BACKEND_REVIEWERS" | wc -l)
+          BACKEND_REVIEWERS=$(cat <<'EOF' | jq -r '.[].login' | tr '\n' '|' | sed 's/|$//'
+          ${{ steps.get_team_members.outputs.data }}
+          EOF
+          )
+
+          APPROVALS=$(cat <<'EOF' | jq -r '.[] | select(.state == "APPROVED") | .user.login' | grep -iE "$BACKEND_REVIEWERS" | wc -l
+          ${{ steps.check_backend_review_group_approval_status.outputs.data }}
+          EOF
+          )
+
           echo "Number of backend-review-group approvals: $APPROVALS"
           if [ "$APPROVALS" -eq 0 ]; then
             echo "approval_status=required" >> $GITHUB_OUTPUT

--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -25,6 +25,7 @@ jobs:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
+      # If no failures, no_failures=true
       - name: Audit PR Labels
         id: audit_pr_labels
         if: |
@@ -36,6 +37,7 @@ jobs:
         run: |
           echo "no_failures=true" >> $GITHUB_OUTPUT
 
+      # If test-passing label is present, ready_for_review=true
       - name: Audit Test Passing Label
         id: audit_passing_labels
         if: |
@@ -43,6 +45,7 @@ jobs:
         run: |
           echo "ready_for_review=true" >> $GITHUB_OUTPUT
 
+      # If require-backend-approval label is present, get reviews
       - name: Check backend-review-group approval status
         if: contains(github.event.pull_request.labels.*.name, 'require-backend-approval')
         id: check_backend_review_group_approval_status
@@ -52,6 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      #
       - name: Get backend-review-group members
         if: contains(github.event.pull_request.labels.*.name, 'require-backend-approval')
         id: get_team_members
@@ -65,8 +69,16 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'require-backend-approval')
         id: verify_approval
         run: |
-          BACKEND_REVIEWERS=$(echo '${{ steps.get_team_members.outputs.data }}' | jq -r '.[].login' | tr '\n' '|' | sed 's/|$//')
-          APPROVALS=$(echo '${{ steps.check_backend_review_group_approval_status.outputs.data }}' | jq -r '.[] | select(.state == "APPROVED") | .user.login' | grep -iE "$BACKEND_REVIEWERS" | wc -l)
+          BACKEND_REVIEWERS=$(cat <<'EOF' | jq -r '.[].login' | tr '\n' '|' | sed 's/|$//'
+          ${{ steps.get_team_members.outputs.data }}
+          EOF
+          )
+
+          APPROVALS=$(cat <<'EOF' | jq -r '.[] | select(.state == "APPROVED") | .user.login' | grep -iE "$BACKEND_REVIEWERS" | wc -l
+          ${{ steps.check_backend_review_group_approval_status.outputs.data }}
+          EOF
+          )
+
           echo "Number of backend-review-group approvals: $APPROVALS"
           if [ "$APPROVALS" -eq 0 ]; then
             echo "approval_status=required" >> $GITHUB_OUTPUT

--- a/docs/setup/hybrid.md
+++ b/docs/setup/hybrid.md
@@ -1,6 +1,6 @@
 # Developer Setup
 
-In hybrid mode, you will run vets-api natively, but run Postgres and Redis in Docker. By doing so you avoid any challenges of installing these two software packages and keeping them upgraded to the appropriate version.
+In hybrid mode, you'll run vets-api natively, but run Postgres and Redis in Docker. By doing so, you avoid the challenges of installing these two software packages and having to keep them upgraded to the appropriate version.
 
 ## Base Setup
 
@@ -28,13 +28,13 @@ redis:
 ## Running Deps
 
 1. To start Postgres and Redis: run `docker-compose -f docker-compose-deps.yml up` in one terminal window.
-2. In another terminal window, start `vets-api` as per the [native running instructions](running_natively.md). 
+2. In another terminal window, start `vets-api` as per the [native running instructions](running_natively.md).
   * Run `bin/setup` first to create the needed database tables.
 3. Confirm the API is successfully running by seeing if you can visit [the local Flipper page.](http://localhost:3000/flipper/features)
 
 ### Mock ClamAV
 
-If you wish to mock ClamAV, please set the clamav mock setting to true in settings.local.yml. This will mock the clamav response in the [virus_scan code](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/common/virus_scan.rb#L14-L23). 
+If you wish to mock ClamAV, please set the clamav mock setting to true in settings.local.yml. This will mock the clamav response in the [virus_scan code](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/common/virus_scan.rb#L14-L23).
 
 ```
 clamav:


### PR DESCRIPTION
## Summary

Error seen sometimes in CI runs:
```
/home/runner/work/_temp/3711f819-88c3-4533-82f2-1842aa10d536.sh: line 345: unexpected EOF while looking for matching `"'
Error: Process completed with exit code 2.
```
[Example from here](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/11349304416/job/31565085162?pr=18846#annotation:8:357)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93566

## Testing done

- Reproduced error locally by using various characters in approval comments, until it was determined that single quotes were causing the action to fail, which matches the case from above and [this one](https://github.com/department-of-veterans-affairs/vets-api/pull/18607#issuecomment-2377288194) from a few weeks ago, though further testing confirmed it was the single, not double quote in my comment. 


## What areas of the site does it impact?
Vets-api CI
