### PR TITLE
Param store normalization

### DIFF
--- a/chart/templates/cron-deployment.yaml
+++ b/chart/templates/cron-deployment.yaml
@@ -39,6 +39,13 @@ spec:
                       key: {{ $secret.name }}
               {{- end }}
               {{- end }}
+              {{- range $key, $path := .Values.parameters }}
+                - name: {{ $key }}
+                  valueFrom:
+                    secretKeyRef:
+                      name: common_environment_vars
+                      key: {{ $key }}
+              {{- end }}
           restartPolicy: OnFailure
           securityContext:
             fsGroup: {{ $root.Values.fsGroup }}

--- a/chart/templates/db-migrate-job.yaml
+++ b/chart/templates/db-migrate-job.yaml
@@ -33,6 +33,13 @@ spec:
                   key: {{ $secret.name }}
           {{- end }}
           {{- end }}
+          {{- range $key, $path := .Values.parameters }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: common_environment_vars
+                  key: {{ $key }}
+          {{- end }}
 
       restartPolicy: Never
       securityContext:

--- a/chart/templates/environment-secrets.yaml
+++ b/chart/templates/environment-secrets.yaml
@@ -34,7 +34,7 @@ spec:
   {{- range $key, $value := .Values.parameters }}
     - secretKey: {{ $key }}
       remoteRef:
-        key: {{ .Values.ssmPath }}{{ $value }}
+        key: {{ $.Values.ssmPath }}{{ $value }}
   {{- end }}
 
 {{- else }}

--- a/chart/templates/environment-secrets.yaml
+++ b/chart/templates/environment-secrets.yaml
@@ -1,3 +1,23 @@
+{{- if gt .Capabilities.KubeVersion.Minor "26" }}
+# NEW EKS CLUSTER
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vets_api_secretstore
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-4"
+spec:
+  provider:
+    aws:
+      service: ParameterStore
+      region: us-gov-west-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: vets-api
+
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -8,16 +28,32 @@ metadata:
     argocd.argoproj.io/sync-wave: "-3"
 spec:
   secretStoreRef:
-    name: secretstore-vets-api
+    name: vets_api_secretstore
     kind: SecretStore
+  data:
+  {{- range $key, $value := .Values.parameters }}
+    - secretKey: {{ $key }}
+      remoteRef:
+        key: {{ .Values.ssmPath }}{{ $value }}
+  {{- end }}
+
+{{- else }}
+##########################################
+# OLD EKS CLUSTER
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: common_environment_vars
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
   backendType: systemManager
   data:
-    - key: "SETTINGS__HOSTNAME"
-      name: "{{ .Values.ssmPath }}hostname"
-    - secretKey: health-quest.lighthouse.key
-      remoteRef:
-        key: {{ .Values.ssmPath }}/healthquest/key
-    - key: "SETTINGS__VSP_ENVIRONMENT"
-      name: "{{ .Values.ssmPath }}vsp_environment"
-    - key: "SETTINGS__VIRTUAL_HOSTS"
-      name: "{{ .Values.ssmPath }}virtual_hosts"
+  {{- range $varName, $relPath := .Values.parameters }}
+    - key: "{{ .Values.ssmPath }}{{ $relPath }}"
+      name: {{ $varName }}
+  {{- end }}
+
+{{- end }}

--- a/chart/templates/environment-secrets.yaml
+++ b/chart/templates/environment-secrets.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: common_environment_vars
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  secretStoreRef:
+    name: secretstore-vets-api
+    kind: SecretStore
+  backendType: systemManager
+  data:
+    - key: "SETTINGS__HOSTNAME"
+      name: "{{ .Values.ssmPath }}hostname"
+    - secretKey: health-quest.lighthouse.key
+      remoteRef:
+        key: {{ .Values.ssmPath }}/healthquest/key
+    - key: "SETTINGS__VSP_ENVIRONMENT"
+      name: "{{ .Values.ssmPath }}vsp_environment"
+    - key: "SETTINGS__VIRTUAL_HOSTS"
+      name: "{{ .Values.ssmPath }}virtual_hosts"

--- a/chart/templates/environment-secrets.yaml
+++ b/chart/templates/environment-secrets.yaml
@@ -52,7 +52,7 @@ spec:
   backendType: systemManager
   data:
   {{- range $varName, $relPath := .Values.parameters }}
-    - key: "{{ .Values.ssmPath }}{{ $relPath }}"
+    - key: "{{ $.Values.ssmPath }}{{ $relPath }}"
       name: {{ $varName }}
   {{- end }}
 

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -100,9 +100,6 @@ spec:
           volumeMounts:
 {{ toYaml $root.Values.common.volumeMounts | indent 12 }}
           env:
-            - name: SETTINGS__HOSTNAME
-              valueFrom:
-
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -122,6 +119,13 @@ spec:
                   name: {{ $keys }}
                   key: {{ $secret.name }}
           {{- end }}
+          {{- end }}
+          {{- range $key, $path := .Values.parameters }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: common_environment_vars
+                  key: {{ $key }}
           {{- end }}
         {{- if $root.Values.clamav.enabled  }}
         - name: clamav

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -100,6 +100,9 @@ spec:
           volumeMounts:
 {{ toYaml $root.Values.common.volumeMounts | indent 12 }}
           env:
+            - name: SETTINGS__HOSTNAME
+              valueFrom:
+
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -120,7 +120,7 @@ spec:
                   key: {{ $secret.name }}
           {{- end }}
           {{- end }}
-          {{- range $key, $path := .Values.parameters }}
+          {{- range $key, $path := $root.Values.parameters }}
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/worker-deployment.yaml
+++ b/chart/templates/worker-deployment.yaml
@@ -95,6 +95,13 @@ spec:
                   key: {{ $secret.name }}
           {{- end }}
           {{- end }}
+          {{- range $key, $path := .Values.parameters }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: common_environment_vars
+                  key: {{ $key }}
+          {{- end }}
         {{- if $root.Values.clamav.enabled  }}
         - name: clamav
           image: "{{ $root.Values.clamav.image.value }}:{{ $root.Values.clamav.image.tag }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,4 @@
+ssmPath: /dsva-vagov/vets-api/dev/
 appName:
 target_env:
 domain:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,8 @@
 ssmPath: /dsva-vagov/vets-api/dev/
+parameters:
+  SETTINGS__HOSTNAME: "hostname"
+  SETTINGS__VSP_ENVIRONMENT: "vsp_environment"
+  SETTINGS__VIRTUAL_HOSTS: "virtual_hosts"
 appName:
 target_env:
 domain:


### PR DESCRIPTION

## Summary

- Changes to the vets-api parent helm chart to include parameters store values from values set inside the parent helm chart
- These changes will allow movement toward a consistent helm chart for all environments - allowing environmental consistency and utilization by Preview Environment deployments

## Related issue(s)

- https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/94628

## Testing done

- Isolated test of changes done in a smaller representative helm chart
- Additional testing to be done in DEV environment post merge

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
vets-api deployments

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

