### PR TITLE
VI-626 Add mhv_account_creation_api flipper

### DIFF
--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -58,7 +58,9 @@ module Login
     def create_mhv_account
       return unless Settings.mhv.account_creation.create_after_login
 
-      MHV::AccountCreatorJob.perform_async(current_user.user_verification.id) if Flipper.enabled?(:mhv_account_creation_api, @current_user)
+      MHV::AccountCreatorJob.perform_async(current_user.user_verification.id) if Flipper.enabled?(
+        :mhv_account_creation_after_login, @current_user
+      )
     end
   end
 end

--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -21,9 +21,7 @@ module Login
       update_account_login_stats(login_type)
       id_mismatch_validations
 
-      if Flipper.enabled?(:mhv_account_creation_api, @current_user)
-        create_mhv_account
-      end
+      create_mhv_account if Flipper.enabled?(:mhv_account_creation_api, @current_user)
 
       if Settings.test_user_dashboard.env == 'staging'
         TestUserDashboard::UpdateUser.new(current_user).call(Time.current)

--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -20,8 +20,7 @@ module Login
       Login::UserAcceptableVerifiedCredentialUpdater.new(user_account: @current_user.user_account).perform
       update_account_login_stats(login_type)
       id_mismatch_validations
-
-      create_mhv_account if Flipper.enabled?(:mhv_account_creation_api, @current_user)
+      create_mhv_account
 
       if Settings.test_user_dashboard.env == 'staging'
         TestUserDashboard::UpdateUser.new(current_user).call(Time.current)
@@ -59,7 +58,7 @@ module Login
     def create_mhv_account
       return unless Settings.mhv.account_creation.create_after_login
 
-      MHV::AccountCreatorJob.perform_async(current_user.user_verification.id)
+      MHV::AccountCreatorJob.perform_async(current_user.user_verification.id) if Flipper.enabled?(:mhv_account_creation_api, @current_user)
     end
   end
 end

--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -20,7 +20,10 @@ module Login
       Login::UserAcceptableVerifiedCredentialUpdater.new(user_account: @current_user.user_account).perform
       update_account_login_stats(login_type)
       id_mismatch_validations
-      create_mhv_account
+
+      if Flipper.enabled?(:mhv_account_creation_api, @current_user)
+        create_mhv_account
+      end
 
       if Settings.test_user_dashboard.env == 'staging'
         TestUserDashboard::UpdateUser.new(current_user).call(Time.current)

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -65,7 +65,8 @@ module SignIn
     def create_mhv_account
       return unless Settings.mhv.account_creation.create_after_login
 
-      MHV::AccountCreatorJob.perform_async(user_verification.id) if Flipper.enabled?(:mhv_account_creation_api, @current_user)
+      MHV::AccountCreatorJob.perform_async(user_verification.id) if Flipper.enabled?(:mhv_account_creation_after_login,
+                                                                                     @current_user)
     end
 
     def device_sso

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -33,7 +33,9 @@ module SignIn
       create_user_acceptable_verified_credential
       create_terms_code_container if needs_accepted_terms_of_use?
       create_code_container
-      create_mhv_account
+      if Flipper.enabled?(:mhv_account_creation_api, @current_user)
+        create_mhv_account
+      end
       user_code_map
     end
 

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -33,7 +33,7 @@ module SignIn
       create_user_acceptable_verified_credential
       create_terms_code_container if needs_accepted_terms_of_use?
       create_code_container
-      create_mhv_account if Flipper.enabled?(:mhv_account_creation_api, @current_user)
+      create_mhv_account
       user_code_map
     end
 
@@ -65,7 +65,7 @@ module SignIn
     def create_mhv_account
       return unless Settings.mhv.account_creation.create_after_login
 
-      MHV::AccountCreatorJob.perform_async(user_verification.id)
+      MHV::AccountCreatorJob.perform_async(user_verification.id) if Flipper.enabled?(:mhv_account_creation_api, @current_user)
     end
 
     def device_sso

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -33,9 +33,7 @@ module SignIn
       create_user_acceptable_verified_credential
       create_terms_code_container if needs_accepted_terms_of_use?
       create_code_container
-      if Flipper.enabled?(:mhv_account_creation_api, @current_user)
-        create_mhv_account
-      end
+      create_mhv_account if Flipper.enabled?(:mhv_account_creation_api, @current_user)
       user_code_map
     end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -829,7 +829,7 @@ features:
     actor_type: user
     description: Enables notifications to be sent for new copay statements
     enable_in_development: true
-  mhv_account_creation_api:
+  mhv_account_creation_after_login:
     actor_type: user
     descriptiom: Enables access to MHV Account Creation API
     enable_in_development: true

--- a/config/features.yml
+++ b/config/features.yml
@@ -829,6 +829,10 @@ features:
     actor_type: user
     description: Enables notifications to be sent for new copay statements
     enable_in_development: true
+  mhv_account_creation_api:
+    actor_type: user
+    descriptiom: Enables access to MHV Account Creation API
+    enable_in_development: true
   mhv_va_health_chat_enabled:
     actor_type: user
     description: Enables the VA Health Chat link at /my-health

--- a/spec/services/sign_in/user_code_map_creator_spec.rb
+++ b/spec/services/sign_in/user_code_map_creator_spec.rb
@@ -146,44 +146,42 @@ RSpec.describe SignIn::UserCodeMapCreator do
     end
 
     context 'creating an MHV account' do
-      shared_examples 'and when mhv account_creation create_after_login is disabled' do
+      context 'when mhv account_creation create_after_login is enabled' do
         before do
-          allow(Settings.mhv.account_creation).to receive(:create_after_login).and_return(false)
+          allow(Settings.mhv.account_creation).to receive(:create_after_login).and_return(true)
         end
 
-        it 'does not enqueue a job to create an MHV account' do
-          expect(MHV::AccountCreatorJob).not_to receive(:perform_async)
-          subject
-        end
-      end
-
-      context 'with mhv_account_creation_api flag enabled' do
-        before do
-          Flipper.enable :mhv_account_creation_api
-        end
-
-        context 'and when mhv account_creation create_after_login is enabled' do
+        context 'with mhv_account_creation_after_login flag enabled' do
           before do
-            allow(Settings.mhv.account_creation).to receive(:create_after_login).and_return(true)
+            allow(Flipper).to receive(:enabled?).with(:mhv_account_creation_after_login, anything).and_return(true)
           end
 
-          it 'enqueues a job to create an MHV account' do
-            expect(MHV::AccountCreatorJob).to receive(:perform_async).with(user_verification.id)
+          it 'does enqueue a job to create an MHV account' do
+            expect(MHV::AccountCreatorJob).to receive(:perform_async)
             subject
           end
         end
 
-        it_behaves_like 'and when mhv account_creation create_after_login is disabled'
+        context 'with mhv_account_creation_after_login flag disabled' do
+          before do
+            allow(Flipper).to receive(:enabled?).with(:mhv_account_creation_after_login, anything).and_return(false)
+          end
+
+          it 'does not enqueue a job to create an MHV account' do
+            expect(MHV::AccountCreatorJob).not_to receive(:perform_async)
+            subject
+          end
+        end
       end
 
-      context 'with mhv_account_creation_api flag is disabled' do
+      context 'when mhv account_creation create_after_login is disabled' do
         before do
-          Flipper.disable :mhv_account_creation_api
+          allow(Settings.mhv.account_creation).to receive(:create_after_login).and_return(false)
         end
 
-        context 'and when mhv account_creation create_after_login is enabled' do
+        context 'with mhv_account_creation_after_login flag enabled' do
           before do
-            allow(Settings.mhv.account_creation).to receive(:create_after_login).and_return(false)
+            allow(Flipper).to receive(:enabled?).with(:mhv_account_creation_after_login, anything).and_return(true)
           end
 
           it 'does not enqueue a job to create an MHV account' do
@@ -192,7 +190,16 @@ RSpec.describe SignIn::UserCodeMapCreator do
           end
         end
 
-        it_behaves_like 'and when mhv account_creation create_after_login is disabled'
+        context 'with mhv_account_creation_after_login flag disabled' do
+          before do
+            allow(Flipper).to receive(:enabled?).with(:mhv_account_creation_after_login, anything).and_return(false)
+          end
+
+          it 'does not enqueue a job to create an MHV account' do
+            expect(MHV::AccountCreatorJob).not_to receive(:perform_async)
+            subject
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): YES*
- *We are adding a a feature toggle `mhv_account_creation_api` in the BE to begin the phase rollout for the account creation api.*

## Related issue(s)

- [VI-626](https://jira.devops.va.gov/browse/VI-626)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
  **- The testing plan for rollout to to test the feature toggle locally (done), then on staging and then confirm on production that the feature toggle is effective.**
  
To test locally:
- [ ] In `config/settings.yml` set `create_after_login: true`
- [ ] Go to http://localhost:3000/flipper/features and find the new feature flag `mhv_account_creation_api`. Confirm it is enabled.
- [ ] Login to test if `create_mhv_account` is called, it should run `MHV::AccountCreatorJob.perform_async`
- [ ] Go back to http://localhost:3000/flipper/features and disable `mhv_account_creation_api`
- [ ] When disabled, we want to test if `create_mhv_account` is called upon logging in. It shouldn't.
- [ ] Optional, after disabling the feature flag we can edit the feature settings in the admin side of Flipper. You could play around with some of the settings and attempt more testing there.

## Screenshots
![image](https://github.com/user-attachments/assets/b3e8d155-6785-46e3-b0a0-3fbeaaa942a9)
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/b033f544-4039-454a-9cb6-864ba7da09db">


## What areas of the site does it impact?
- This impacts the `MHV::AccountCreatorJob` after a user logs in where the feature flag is enabled.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
