### PR TITLE
[API-41119] Remove participant id from dependent claimant POA assignment logs

### DIFF
--- a/modules/claims_api/app/services/claims_api/dependent_claimant_poa_assignment_service.rb
+++ b/modules/claims_api/app/services/claims_api/dependent_claimant_poa_assignment_service.rb
@@ -36,9 +36,7 @@ module ClaimsApi
     end
 
     def log(level: :info, **rest)
-      ClaimsApi::Logger.log('dependent_claimant_poa_assignment_service',
-                            level:, dependent_participant_id: @dependent_participant_id,
-                            poa_code: @poa_code, veteran_participant_id: @veteran_participant_id, **rest)
+      ClaimsApi::Logger.log('dependent_claimant_poa_assignment_service', level:, poa_code: @poa_code, **rest)
     end
 
     def assign_poa_to_dependent_via_manage_ptcpnt_rlnshp?


### PR DESCRIPTION
## Summary

See title. This work is behind a feature flag - no participant ids were logged in production.

## Related issue(s)

[API-41119](https://jira.devops.va.gov/browse/API-41119)

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Dependent POA Assignment Service logs

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
