### PR TITLE
Refactor FormSubmissionAttempt to check for simple forms earlier before emailing

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -81,7 +81,7 @@ class FormSubmissionAttempt < ApplicationRecord
   private
 
   def should_send_simple_forms_email
-    form_number && Flipper.enabled?(:simple_forms_email_notifications)
+    simple_forms_form_number && Flipper.enabled?(:simple_forms_email_notifications)
   end
 
   def simple_forms_enqueue_result_email(notification_type)
@@ -89,7 +89,7 @@ class FormSubmissionAttempt < ApplicationRecord
     form_data = JSON.parse(raw_form_data)
     config = {
       form_data:,
-      form_number:,
+      form_number: simple_forms_form_number,
       confirmation_number: form_submission.benefits_intake_uuid,
       date_submitted: created_at.strftime('%B %d, %Y'),
       lighthouse_updated_at: lighthouse_updated_at&.strftime('%B %d, %Y')
@@ -114,11 +114,12 @@ class FormSubmissionAttempt < ApplicationRecord
     end
   end
 
-  def form_number
-    @form_number ||= if SimpleFormsApi::NotificationEmail::TEMPLATE_IDS.keys.include? form_submission.form_type
-                       form_submission.form_type
-                     else
-                       SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[form_submission.form_type]
-                     end
+  def simple_forms_form_number
+    @simple_forms_form_number ||=
+      if SimpleFormsApi::NotificationEmail::TEMPLATE_IDS.keys.include? form_submission.form_type
+        form_submission.form_type
+      else
+        SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[form_submission.form_type]
+      end
   end
 end

--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -25,13 +25,15 @@ class FormSubmissionAttempt < ApplicationRecord
 
     event :fail do
       after do
-        Rails.logger.info({
-                            message: 'Preparing to send Form Submission Attempt error email',
-                            form_submission_id:,
-                            benefits_intake_uuid: form_submission&.benefits_intake_uuid,
-                            form_type: form_submission&.form_type
-                          })
-        enqueue_result_email(:error) if Flipper.enabled?(:simple_forms_email_notifications)
+        if should_send_simple_forms_email
+          Rails.logger.info({
+                              message: 'Preparing to send Form Submission Attempt error email',
+                              form_submission_id:,
+                              benefits_intake_uuid: form_submission.benefits_intake_uuid,
+                              form_type: form_submission.form_type
+                            })
+          simple_forms_enqueue_result_email(:error)
+        end
       end
 
       transitions from: :pending, to: :failure
@@ -43,7 +45,7 @@ class FormSubmissionAttempt < ApplicationRecord
 
     event :vbms do
       after do
-        enqueue_result_email(:received) if Flipper.enabled?(:simple_forms_email_notifications)
+        simple_forms_enqueue_result_email(:received) if should_send_simple_forms_email
       end
 
       transitions from: :pending, to: :vbms
@@ -78,12 +80,16 @@ class FormSubmissionAttempt < ApplicationRecord
 
   private
 
-  def enqueue_result_email(notification_type)
+  def should_send_simple_forms_email
+    form_number && Flipper.enabled?(:simple_forms_email_notifications)
+  end
+
+  def simple_forms_enqueue_result_email(notification_type)
     raw_form_data = form_submission.form_data || '{}'
     form_data = JSON.parse(raw_form_data)
     config = {
       form_data:,
-      form_number: form_submission.form_type,
+      form_number:,
       confirmation_number: form_submission.benefits_intake_uuid,
       date_submitted: created_at.strftime('%B %d, %Y'),
       lighthouse_updated_at: lighthouse_updated_at&.strftime('%B %d, %Y')
@@ -106,5 +112,13 @@ class FormSubmissionAttempt < ApplicationRecord
         hour: HOUR_TO_SEND_NOTIFICATIONS, min: 0
       )
     end
+  end
+
+  def form_number
+    @form_number ||= if SimpleFormsApi::NotificationEmail::TEMPLATE_IDS.keys.include? form_submission.form_type
+                       form_submission.form_type
+                     else
+                       SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[form_submission.form_type]
+                     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -58,12 +58,7 @@ module SimpleFormsApi
       check_missing_keys(config)
 
       @form_data = config[:form_data]
-      incoming_form_number = config[:form_number]
-      @form_number = if TEMPLATE_IDS.keys.include?(incoming_form_number)
-                       incoming_form_number
-                     else
-                       SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[incoming_form_number]
-                     end
+      @form_number = config[:form_number]
       @confirmation_number = config[:confirmation_number]
       @date_submitted = config[:date_submitted]
       @lighthouse_updated_at = config[:lighthouse_updated_at]

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -30,19 +30,36 @@ RSpec.describe FormSubmissionAttempt, type: :model do
           .to transition_from(:pending).to(:failure).on_event(:fail)
       end
 
-      it 'sends an error email' do
-        notification_email = double
-        allow(notification_email).to receive(:send)
-        allow(SimpleFormsApi::NotificationEmail).to receive(:new).with(
-          config,
-          notification_type:,
-          user_account: anything
-        ).and_return(notification_email)
-        form_submission_attempt = create(:form_submission_attempt)
+      context 'is a simple form' do
+        let(:form_submission) { build(:form_submission, form_type: '21-4142') }
 
-        form_submission_attempt.fail!
+        it 'sends an error email' do
+          notification_email = double
+          allow(notification_email).to receive(:send)
+          allow(SimpleFormsApi::NotificationEmail).to receive(:new).with(
+            config,
+            notification_type:,
+            user_account: anything
+          ).and_return(notification_email)
+          form_submission_attempt = create(:form_submission_attempt, form_submission:)
 
-        expect(notification_email).to have_received(:send)
+          form_submission_attempt.fail!
+
+          expect(notification_email).to have_received(:send)
+        end
+      end
+
+      context 'is not a simple form' do
+        let(:form_submission) { build(:form_submission, form_type: 'some-other-form') }
+
+        it 'does not send an error email' do
+          allow(SimpleFormsApi::NotificationEmail).to receive(:new)
+          form_submission_attempt = create(:form_submission_attempt, form_submission:)
+
+          form_submission_attempt.fail!
+
+          expect(SimpleFormsApi::NotificationEmail).not_to have_received(:new)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
This PR refactors the `FormSubmissionAttempt` model in light of the fact that teams other than Simple Forms use it. This PR makes the model more explicit about when it sends a Simple Forms email vs other (or no) email.

## Related issue(s)
It doesn't resolve this issue but is related and some pre-work refactoring: https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=83509901&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1747