### PR TITLE
CreateIntentToFileJob handle nil logging values

### DIFF
--- a/app/sidekiq/lighthouse/create_intent_to_file_job.rb
+++ b/app/sidekiq/lighthouse/create_intent_to_file_job.rb
@@ -29,7 +29,7 @@ module Lighthouse
       in_progress_form_id, veteran_icn = msg['args']
       in_progress_form = InProgressForm.find(in_progress_form_id)
       itf_log_monitor = BenefitsClaims::IntentToFile::Monitor.new
-      form_type = in_progress_form.form_id
+      form_type = in_progress_form&.form_id
       itf_type = ITF_FORMS[form_type]
 
       itf_log_monitor.track_create_itf_exhaustion(itf_type, in_progress_form, error)
@@ -37,11 +37,11 @@ module Lighthouse
       # create ITF queue exhaustion entry
       exhaustion = IntentToFileQueueExhaustion.create({
                                                         form_type:,
-                                                        form_start_date: in_progress_form.created_at,
+                                                        form_start_date: in_progress_form&.created_at,
                                                         veteran_icn:
                                                       })
       ::Rails.logger.info(
-        "IntentToFileQueueExhaustion id: #{exhaustion.id} entry created", {
+        "IntentToFileQueueExhaustion id: #{exhaustion&.id} entry created", {
           intent_to_file_queue_exhaustion: exhaustion
         }
       )
@@ -59,12 +59,12 @@ module Lighthouse
     def perform(in_progress_form_id, veteran_icn, participant_id)
       init(in_progress_form_id, veteran_icn, participant_id)
 
-      itf_log_monitor.track_create_itf_begun(itf_type, form.created_at.to_s, form.user_account_id)
+      itf_log_monitor.track_create_itf_begun(itf_type, form&.created_at&.to_s, form&.user_account_id)
 
       service = BenefitsClaims::Service.new(veteran_icn)
       service.create_intent_to_file(itf_type, '')
 
-      itf_log_monitor.track_create_itf_success(itf_type, form.created_at.to_s, form.user_account_id)
+      itf_log_monitor.track_create_itf_success(itf_type, form&.created_at&.to_s, form&.user_account_id)
     rescue => e
       triage_rescued_error(e)
     end
@@ -106,7 +106,7 @@ module Lighthouse
       elsif exception.instance_of?(FormNotFoundError)
         itf_log_monitor.track_missing_form(form, exception)
       else
-        itf_log_monitor.track_create_itf_failure(itf_type, form.created_at.to_s, form.user_account_id, exception)
+        itf_log_monitor.track_create_itf_failure(itf_type, form&.created_at&.to_s, form&.user_account_id, exception)
         raise exception
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Handles nil values when logging in Lighthouse::CreateIntentToFileJob

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95098)

## Testing done

- [x] *New code is covered by unit tests*
- [x] `bundle exec rails c` and `Lighthouse::CreateIntentToFileJob.perform_sync(1,1,1)` should print an error message "Lighthouse::CreateIntentToFileJob create  ITF failed" and not "error: undefined method 'created at' for nil"

## What areas of the site does it impact?
Pensions

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

