### PR TITLE
Add two recipients to daily report email

### DIFF
--- a/modules/appeals_api/config/mailinglists/report_daily.yml
+++ b/modules/appeals_api/config/mailinglists/report_daily.yml
@@ -16,6 +16,8 @@ production:
   - jacob.worrell@va.gov
   - janet.coutinho@va.gov
   - matthew.self2@va.gov
+  - maurice.debeary@coforma.io
+  - molly.trombley-mccann@coforma.io
   - premal.shah@va.gov
   - robin.garrison@adhocteam.us
   - rocio.de-santiago@coforma.io


### PR DESCRIPTION
![danny-devito-work-gif-by-quickbooks](https://github.com/user-attachments/assets/43e15b46-071c-4b70-b648-740f9af97ad3)

## Summary

- *This work is behind a feature toggle (flipper):NO*
This PR simply adds two new recipients to the Daily Decision Reviews Email Report.

- *(Which team do you work for, does your team own the maintenance of this component?)*
My team, Banana Peels, own this module and maintains it.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
[Add Maurice DeBeary and Molly Trombley to Daily Decision Review API report (Production)](https://jira.devops.va.gov/browse/API-41196)

## What areas of the site does it impact?
Only the Decision Reviews mailer.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

