### PR TITLE
Populate facilities cache if empty on request

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2034,6 +2034,7 @@ spec/support/vcr_cassettes/lighthouse/claims/200_response.yml @department-of-vet
 spec/support/vcr_cassettes/lighthouse/direct_deposit @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/dbex-trex  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/lighthouse/facilities.yml @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-facilities-frontend
 spec/support/vcr_cassettes/lighthouse/facilities_401.yml @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-facilities-frontend
+spec/support/vcr_cassettes/lighthouse/facilities/v1/200_facilities_facility_ids.yml @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/lighthouse/veteran_verification @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/map @department-of-veterans-affairs/octo-identity

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -82,6 +82,11 @@ module V0
     def active_facilities(lighthouse_facilities)
       active_ids = StdInstitutionFacility.active.pluck(:station_number).compact
 
+      if active_ids.empty?
+        HCA::StdInstitutionImportJob.new.perform
+        active_ids = StdInstitutionFacility.active.pluck(:station_number).compact
+      end
+
       lighthouse_facilities.select { |facility| active_ids.include?(facility.unique_id) }
     end
 

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -80,14 +80,18 @@ module V0
     private
 
     def active_facilities(lighthouse_facilities)
-      active_ids = StdInstitutionFacility.active.pluck(:station_number).compact
+      active_ids = cached_ves_facility_ids
 
       if active_ids.empty?
         HCA::StdInstitutionImportJob.new.perform
-        active_ids = StdInstitutionFacility.active.pluck(:station_number).compact
+        active_ids = cached_ves_facility_ids
       end
 
       lighthouse_facilities.select { |facility| active_ids.include?(facility.unique_id) }
+    end
+
+    def cached_ves_facility_ids
+      StdInstitutionFacility.active.pluck(:station_number).compact
     end
 
     def health_care_application

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -80,14 +80,19 @@ module V0
     private
 
     def active_facilities(lighthouse_facilities)
-      active_ids = cached_ves_facility_ids
-
-      if active_ids.empty?
-        HCA::StdInstitutionImportJob.new.perform
-        active_ids = cached_ves_facility_ids
-      end
-
+      active_ids = active_ves_facility_ids
       lighthouse_facilities.select { |facility| active_ids.include?(facility.unique_id) }
+    end
+
+    def active_ves_facility_ids
+      ids = cached_ves_facility_ids
+
+      return ids if ids.any?
+      return ids if Flipper.enabled?(:hca_retrieve_facilities_without_repopulating)
+
+      HCA::StdInstitutionImportJob.new.perform
+
+      cached_ves_facility_ids
     end
 
     def cached_ves_facility_ids

--- a/config/features.yml
+++ b/config/features.yml
@@ -101,6 +101,9 @@ features:
   hca_log_form_attachment_create:
     actor_type: user
     description: Enable logging all successful-looking attachment creation calls to Sentry at info-level
+  hca_retrieve_facilities_without_repopulating:
+    actor_type: user
+    description: Constrain facilities endpoint to only return existing facilities values - even if the table is empty, do not rerun the Job to populate it.
   cg1010_oauth_2_enabled:
     actor_type: user
     description: Use OAuth 2.0 Authentication for 10-10CG Form Mulesoft integration.

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
   end
 
   describe 'GET facilities' do
-    it 'responds with facilities data' do
+    it 'responds with facilities data for supported facilities' do
       StdInstitutionFacility.create(station_number: '042')
 
       VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
@@ -255,10 +255,12 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                                               'website' => 'https://www.cem.va.gov/cems/lots/BaxterSprings.asp' })
     end
 
-    it 'filters out facilities not yet supported downstream' do
+    it 'populates VES facilities cache if it returns no results' do
+      expect(StdInstitutionFacility.count).to eq(0)
       VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
         get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
       end
+      expect(StdInstitutionFacility.all.any?).to eq(true)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body[0]).to be_nil
     end

--- a/spec/support/vcr_cassettes/lighthouse/facilities/v1/200_facilities_facility_ids.yml
+++ b/spec/support/vcr_cassettes/lighthouse/facilities/v1/200_facilities_facility_ids.yml
@@ -126,4 +126,62 @@ http_interactions:
         - Sundown","friday":"Sunrise - Sundown","saturday":"Sunrise - Sundown","sunday":"Sunrise
         - Sundown"},"operatingStatus":{"code":"NORMAL"}}}],"links":{"self":"https://sandbox-api.va.gov/services/va_facilities/v1/facilities?page=1&per_page=10","first":"https://sandbox-api.va.gov/services/va_facilities/v1/facilities?page=1&per_page=10","next":"https://sandbox-api.va.gov/services/va_facilities/v1/facilities?page=2&per_page=10","last":"https://sandbox-api.va.gov/services/va_facilities/v1/facilities?page=257&per_page=10"},"meta":{"pagination":{"currentPage":1,"perPage":10,"totalPages":257,"totalEntries":2563}}}'
   recorded_at: Wed, 10 Apr 2024 20:19:43 GMT
+- request:
+    method: get
+    uri: 'https://sitewide-public-websites-income-limits-data.s3-us-gov-west-1.amazonaws.com/std_institution.csv'
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+        - application/json
+      Content-Type:
+        - application/json
+      User-Agent:
+        - Vets.gov Agent
+      Apikey:
+        - abcde
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+        - Wed, 10 Apr 2024 20:19:43 GMT
+      Content-Type:
+        - application/json
+      Connection:
+        - keep-alive
+      X-Ratelimit-Remaining-Minute:
+        - '47'
+      X-Ratelimit-Limit-Minute:
+        - '60'
+      Ratelimit-Remaining:
+        - '47'
+      Ratelimit-Limit:
+        - '60'
+      Ratelimit-Reset:
+        - '17'
+      Strict-Transport-Security:
+        - max-age=16000000; includeSubDomains; preload;
+        - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+        - "*"
+      Cache-Control:
+        - ''
+        - no-cache, no-store
+      X-Frame-Options:
+        - SAMEORIGIN
+      Pragma:
+        - no-cache
+      Transfer-Encoding:
+        - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: "ID,ACTIVATIONDATE,DEACTIVATIONDATE,NAME,STATIONNUMBER,VISTANAME,AGENCY_ID,STREETCOUNTRY_ID,STREETADDRESSLINE1,STREETADDRESSLINE2,STREETADDRESSLINE3,STREETCITY,STREETSTATE_ID,STREETCOUNTY_ID,STREETPOSTALCODE,MAILINGCOUNTRY_ID,MAILINGADDRESSLINE1,MAILINGADDRESSLINE2,MAILINGADDRESSLINE3,MAILINGCITY,MAILINGSTATE_ID,MAILINGCOUNTY_ID,MAILINGPOSTALCODE,FACILITYTYPE_ID,MFN_ZEG_RECIPIENT,PARENT_ID,REALIGNEDFROM_ID,REALIGNEDTO_ID,VISN_ID,VERSION,CREATED,UPDATED,CREATEDBY,UPDATEDBY\n
+1000250,,,AUDIE L. MURPHY MEMORIAL HOSP,671,AUDIE L. MURPHY MEMORIAL HOSP,1009121,1006840,7400 MERTON MINTER BLVD,,,SAN ANTONIO,1009348,,78229-4404,1006840,7400 MERTON MINTER BLVD,,,SAN ANTONIO,1009348,,78229-4404,1009231,1,1002217,,,1002217,0,2004-06-04 13:18:48 +0000,2015-12-28 10:05:46 +0000,Initial Load,DataBroker - CQ# 0938 12/09/2015\n
+1000090,,1969-12-31 00:00:00 +0000,CRAWFORD COUNTY CBOC (420),420,ZZ CRAWFORD COUNTY CBOC,1009121,1006840,,,,,1009342,,,,,,,,,,,1009197,0,,,,,0,2004-06-04 13:18:48 +0000,2007-05-07 10:18:36 +0000,Initial Load,Cleanup For Inactive Rows"
+  recorded_at: Wed, 10 Apr 2024 20:19:43 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- When retrieving the Facilities list for a State, if there are none, run the Job that populates the table. (The job takes ~6 seconds at present). This will allow local dev and Review Instance environments, or others with freshly built DBs, to work without having to manually run the Job from the command line.
- 10-10 Health Enrollment Team, EZ/CG

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95160

## Testing done

- [x] *New code is covered by unit tests*
- Before this change, trying to fill out the 10-10EZ form on a fresh environment was blocked when entering your preferred Facility. The options are populated by retrieving the State's Facilities from Lighthouse, and then filtering them down to the ones valid downstream with VES. With the cache table empty, the Lighthouse results always get pared down to an empty list until the Job runs at 4:30pm ET each day.
- Validation: via the Rails console, confirm that `StdInstitutionFacility.count` is `0` for the environment. (If not, ` StdInstitutionFacility.delete_all` will clear them out.) Proceed through the 10-10 EZ form until you select the State for your preferred VA facility, then confirm that the table is populated (with 4008 records at the moment) and that the dropdown of facilities populates with the relevant options.

## What areas of the site does it impact?
* 10-10EZ form Insurance section, Preferred Facility page

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
