### PR TITLE
[DBX-18767] update 526 remediations to use new duplicate paradigm

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -423,7 +423,7 @@ class Form526Submission < ApplicationRecord
   end
 
   def duplicate?
-    last_remediation&.ignored_as_duplicate || false
+    last_remediation&.ignored_as_duplicate?
   end
 
   def remediated?

--- a/app/models/form526_submission_remediation.rb
+++ b/app/models/form526_submission_remediation.rb
@@ -21,10 +21,6 @@ class Form526SubmissionRemediation < ApplicationRecord
     end
   end
 
-  def ignored_as_duplicate?
-    remediation_type == 'ignored_as_duplicate'
-  end
-
   private
 
   def initialize_lifecycle

--- a/app/models/form526_submission_remediation.rb
+++ b/app/models/form526_submission_remediation.rb
@@ -21,6 +21,10 @@ class Form526SubmissionRemediation < ApplicationRecord
     end
   end
 
+  def ignored_as_duplicate?
+    remediation_type == 'ignored_as_duplicate'
+  end
+
   private
 
   def initialize_lifecycle
@@ -32,7 +36,7 @@ class Form526SubmissionRemediation < ApplicationRecord
   end
 
   def ensure_success_if_ignored_as_duplicate
-    errors.add(:success, 'must be true if ignored as duplicate') if ignored_as_duplicate && !success
+    errors.add(:success, 'must be true if ignored as duplicate') if ignored_as_duplicate? && !success
   end
 
   def log_to_datadog(context)

--- a/spec/factories/form526_submission_remediations.rb
+++ b/spec/factories/form526_submission_remediations.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     association :form526_submission
     lifecycle { ['datetime -- context'] }
     success { true }
-    ignored_as_duplicate { false }
+    remediation_type { :manual }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
   end

--- a/spec/models/form526_submission_remediation_spec.rb
+++ b/spec/models/form526_submission_remediation_spec.rb
@@ -54,13 +54,6 @@ RSpec.describe Form526SubmissionRemediation, type: :model do
   end
 
   describe 'instance methods' do
-    describe 'ignored_as_duplicate?' do
-      it 'checks if a records remediation_type is ignored_as_duplicate' do
-        subject.update(remediation_type: described_class.remediation_types[:ignored_as_duplicate])
-        expect(subject.ignored_as_duplicate?).to be true
-      end
-    end
-
     describe '#mark_as_unsuccessful' do
       let(:timestamped_context) { "#{Time.current.strftime('%Y-%m-%d %H:%M:%S')} -- #{remediate_context}" }
 

--- a/spec/models/form526_submission_remediation_spec.rb
+++ b/spec/models/form526_submission_remediation_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe Form526SubmissionRemediation, type: :model do
         subject.mark_as_unsuccessful(remediate_context)
       end
 
-      it 'is invalid if ignored_as_duplicate is true and success is false' do
-        subject.ignored_as_duplicate = true
+      it 'is invalid if remediation_type is ignored_as_duplicate and success is false' do
+        subject.remediation_type = :ignored_as_duplicate
         subject.success = false
         expect(subject).not_to be_valid
       end
 
       it 'is valid if ignored_as_duplicate is true and success is true' do
-        subject.ignored_as_duplicate = true
+        subject.remediation_type = :ignored_as_duplicate
         subject.success = true
         expect(subject).to be_valid
       end
@@ -54,6 +54,13 @@ RSpec.describe Form526SubmissionRemediation, type: :model do
   end
 
   describe 'instance methods' do
+    describe 'ignored_as_duplicate?' do
+      it 'checks if a records remediation_type is ignored_as_duplicate' do
+        subject.update(remediation_type: described_class.remediation_types[:ignored_as_duplicate])
+        expect(subject.ignored_as_duplicate?).to be true
+      end
+    end
+
     describe '#mark_as_unsuccessful' do
       let(:timestamped_context) { "#{Time.current.strftime('%Y-%m-%d %H:%M:%S')} -- #{remediate_context}" }
 

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1494,13 +1494,13 @@ RSpec.describe Form526Submission do
         FactoryBot.create(:form526_submission_remediation, form526_submission: subject)
       end
 
-      it 'returns true if the most recent remediation ignored_as_duplicate value is true' do
-        remediation.update(ignored_as_duplicate: true)
+      it 'returns true if the most recent remediation_type is ignored_as_duplicate' do
+        remediation.update(remediation_type: :ignored_as_duplicate)
         expect(subject).to be_duplicate
       end
 
-      it 'returns false if the most recent remediation ignored_as_duplicate value is false' do
-        remediation.update(ignored_as_duplicate: false)
+      it 'returns false if the most recent remediation_type is not ignored_as_duplicate' do
+        remediation.update(remediation_type: :manual)
         expect(subject).not_to be_duplicate
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- We used to have 2 types of remediation for silent failures, now we have 3 so we are ditching the `ignored_as_duplicate` boolean in favor of a type enum
- This supports upcomming ZSF email notification work for 526

## Related issue(s)

- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1263/views/2?filterQuery=assignee%3ASamStuckey&pane=issue&itemId=82453998&issue=department-of-veterans-affairs%7Cvets-api%7C18767)

## Testing done

- [x] *New code is covered by unit tests*
- manual testing in a command line of new methods,
- migrated the data points via a prod command line. All Form526SubmisisonRemediations that have `ignored_as_duplicate: true` now also have a `remediation_type: :ignored_as_duplicate`

## What areas of the site does it impact?
526 submission ZSF monitoring

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
