### PR TITLE
[DBX-94127/94128] add 526 backup failure email job

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -631,7 +631,10 @@ app/sidekiq/form526_failure_state_snapshot_job.rb @department-of-veterans-affair
 app/sidekiq/form526_paranoid_success_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_status_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_failed_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/form526_submission_failure_email_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_processing_report_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+
+
 app/sidekiq/gi_bill_feedback_submission_job.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/identity @department-of-veterans-affairs/octo-identity
@@ -1334,6 +1337,7 @@ spec/sidekiq/form526_confirmation_email_job_spec.rb @department-of-veterans-affa
 spec/sidekiq/form526_failure_state_snapshot_job_spec.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form526_paranoid_success_polling_job_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form526_status_polling_job_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/form526_submission_failure_email_job_spec.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form526_submission_processing_report_job_spec.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/form5655 @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/gi_bill_feedback_submission_job_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -633,8 +633,6 @@ app/sidekiq/form526_status_polling_job.rb @department-of-veterans-affairs/Disabi
 app/sidekiq/form526_submission_failed_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_failure_email_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_processing_report_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-
-
 app/sidekiq/gi_bill_feedback_submission_job.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/identity @department-of-veterans-affairs/octo-identity

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'va_notify/service'
+
+class Form526SubmissionFailureEmailJob
+  include Sidekiq::Job
+
+  attr_reader :submission_id
+
+  STATSD_PREFIX = 'api.form_526.veteran_notifications.form526_submission_failure_email'
+  # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/274bea7fb835e51626259ac16b32c33ab0b2088a/platform/practices/zero-silent-failures/logging-silent-failures.md#capture-silent-failures-state
+  DD_ZSF_TAGS = [
+    'service:disability-application',
+    'function:526_backup_submission_to_lighthouse'
+  ].freeze
+
+  sidekiq_options retry: 14
+
+  sidekiq_retries_exhausted do |msg, _ex|
+    job_id = msg['jid']
+    error_class = msg['error_class']
+    error_message = msg['error_message']
+    form526_submission_id = msg['args'].first
+    timestamp = Time.now.utc
+
+    Rails.logger.warn(
+      'Form526SubmissionFailureEmailJob retries exhausted',
+      {
+        job_id:,
+        timestamp:,
+        form526_submission_id:,
+        error_class:,
+        error_message:
+      }
+    )
+
+    StatsD.increment("#{STATSD_PREFIX}.exhausted")
+    StatsD.increment('silent_failure', tags: DD_ZSF_TAGS)
+  rescue => e
+    Rails.logger.error(
+      'Failure in Form526SubmissionFailureEmailJob#sidekiq_retries_exhausted',
+      {
+        job_id:,
+        messaged_content: e.message,
+        submission_id:,
+        pre_exhaustion_failure: {
+          error_class:,
+          error_message:
+        }
+      }
+    )
+    raise e
+  end
+
+  def perform(submission_id)
+    submission = Form526Submission.find(submission_id)
+    send_email(submission)
+    track_remedial_action(submission)
+    log_success(submission)
+  rescue => e
+    log_failure(e, submission)
+    raise
+  end
+
+  private
+
+  def send_email(submission)
+    email_client = VaNotify::Service.new(Settings.vanotify.services.benefits_disability.api_key)
+    template_id = Settings.vanotify.services.benefits_disability.template_id
+                          .form526_submission_failure_notification_template_id
+
+    email_client.send_email(
+      email_address: submission.veteran_email_address,
+      template_id:,
+      personalisation: {
+        first_name: submission.get_first_name,
+        date_submitted: submission.format_creation_time_for_mailers
+      }
+    )
+  end
+
+  def track_remedial_action(submission)
+    Form526SubmissionRemediation.create!(
+      form526_submission: submission,
+      remediation_type: Form526SubmissionRemediation.remediation_types['email_notified'],
+      lifecycle: ['Email failure notification sent']
+    )
+  end
+
+  def log_success(submission)
+    Rails.logger.info(
+      'Form526SubmissionFailureEmail notification dispatched',
+      {
+        form526_submission_id: submission.id,
+        timestamp: Time.now.utc
+      }
+    )
+
+    StatsD.increment("#{STATSD_PREFIX}.success")
+    StatsD.increment('silent_failure_avoided_no_confirmation', tags: DD_ZSF_TAGS)
+  end
+
+  def log_failure(error, submission)
+    Rails.logger.error(
+      'Form526SubmissionFailureEmail notification failed',
+      {
+        form526_submission_id: submission.id,
+        error_message: error.try(:message),
+        timestamp: Time.now.utc
+      }
+    )
+
+    StatsD.increment("#{STATSD_PREFIX}.error")
+  end
+end

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -14,11 +14,11 @@ class Form526SubmissionFailureEmailJob
     'function:526_backup_submission_to_lighthouse'
   ].freeze
   FORM_DESCRIPTIONS = {
-    "form4142" => 'VA Form 21-4142',
-    "form0781" => 'VA Form 21-0781',
-    "form0781a" => 'VA Form 21-0781a',
-    "form8940" => 'VA Form 21-8940'
-  }
+    'form4142' => 'VA Form 21-4142',
+    'form0781' => 'VA Form 21-0781',
+    'form0781a' => 'VA Form 21-0781a',
+    'form8940' => 'VA Form 21-8940'
+  }.freeze
 
   sidekiq_options retry: 14
 
@@ -100,6 +100,7 @@ class Form526SubmissionFailureEmailJob
 
   def files_submitted(uploads)
     return [] if uploads.nil?
+
     guids = uploads.map { |data| data&.dig('confirmationCode') }.compact
     files = SupportingEvidenceAttachment.where(guid: guids)
     files.map(&:obscured_filename)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1370,6 +1370,7 @@ vanotify:
       api_key: fake_secret
       template_id:
         form526_document_upload_failure_notification_template_id: form526_document_upload_failure_notification_template_id
+        form526_submission_failure_notification_template_id: form526_submission_failure_notification_template_id
         form4142_upload_failure_notification_template_id: form4142_upload_failure_notification_template_id
         form0781_upload_failure_notification_template_id: form0781_upload_failure_notification_template_id
     ivc_champva:

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -323,4 +323,18 @@ FactoryBot.define do
              success: false)
     end
   end
+
+  trait :with_uploads_and_ancillary_forms do
+    form_json do
+      with_ancillary = JSON.parse(File.read("#{submissions_path}/with_everything.json"))
+      with_uploads = JSON.parse(File.read("#{submissions_path}/with_uploads.json"))['form526_uploads']
+      with_uploads.each do |upload|
+        create(:supporting_evidence_attachment, :with_file_data, guid: upload['confirmationCode'])
+      end
+
+      with_ancillary['form526_uploads'] = with_uploads
+      with_ancillary['form526']['form526']['veteran']['emailAddress'] = 'test@example.com'
+      with_ancillary.to_json
+    end
+  end
 end

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -5,7 +5,16 @@ require 'rails_helper'
 RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   subject { described_class }
 
-  let!(:form526_submission) { create(:form526_submission) }
+  # [wipn8923] remove?
+  # let(:form_addendum) do
+  #   {
+  #     'form4142' => { foo: 'bar' },
+  #     'form0781' => { foo: 'bar' },
+  #     'form0781a' => { foo: 'bar' },
+  #     'form8940' => { foo: 'bar' },
+  #   }
+  # end
+  let!(:form526_submission) { create(:form526_submission, :with_uploads_and_ancillary_forms) }
   let(:email_service) { double('VaNotify::Service') }
 
   before do
@@ -19,11 +28,18 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   describe '#perform' do
     let(:expected_params) do
       {
-        email_address: 'test@email.com',
+        email_address: 'test@example.com',
         template_id: 'form526_submission_failure_notification_template_id',
         personalisation: {
           first_name: form526_submission.get_first_name,
-          date_submitted: form526_submission.format_creation_time_for_mailers
+          date_submitted: form526_submission.format_creation_time_for_mailers,
+          files_submitted: ["extXas.pdf", "extXas.pdf", "extXas.pdf"],
+          forms_submitted: [
+            "VA Form 21-4142",
+            "VA Form 21-0781",
+            "VA Form 21-0781a",
+            "VA Form 21-8940"
+          ]
         }
       }
     end

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
+  subject { described_class }
+
+  let!(:form526_submission) { create(:form526_submission) }
+  let(:email_service) { double('VaNotify::Service') }
+
+  before do
+    Sidekiq::Job.clear_all
+    allow(VaNotify::Service)
+      .to receive(:new)
+      .with(Settings.vanotify.services.benefits_disability.api_key)
+      .and_return(email_service)
+  end
+
+  describe '#perform' do
+    let(:expected_params) do
+      {
+        email_address: 'test@email.com',
+        template_id: 'form526_submission_failure_notification_template_id',
+        personalisation: {
+          first_name: form526_submission.get_first_name,
+          date_submitted: form526_submission.format_creation_time_for_mailers
+        }
+      }
+    end
+
+    it 'dispatches a failure notification email with an obscured filename' do
+      expect(email_service).to receive(:send_email).with(expected_params)
+
+      subject.perform_async(form526_submission.id)
+      subject.drain
+    end
+
+    it 'creates a remediation record for the submission' do
+      allow(email_service).to receive(:send_email)
+      expect { subject.new.perform(form526_submission.id) }.to change(Form526SubmissionRemediation, :count)
+      remediation = Form526SubmissionRemediation.where(form526_submission_id: form526_submission.id)
+      expect(remediation.present?).to be true
+    end
+  end
+
+  describe 'logging' do
+    let(:timestamp) { Time.now.utc }
+    let(:tags) { described_class::DD_ZSF_TAGS }
+
+    context 'on success' do
+      before do
+        allow(email_service).to receive(:send_email)
+      end
+
+      it 'increments StatsD' do
+        expect(StatsD).to receive(:increment).with("#{described_class::STATSD_PREFIX}.success")
+        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
+        subject.new.perform(form526_submission.id)
+        subject.drain
+      end
+
+      it 'logs success' do
+        Timecop.freeze(timestamp) do
+          expect(Rails.logger).to receive(:info).with(
+            'Form526SubmissionFailureEmail notification dispatched',
+            { form526_submission_id: form526_submission.id, timestamp: }
+          )
+          subject.new.perform(form526_submission.id)
+        end
+      end
+    end
+
+    context 'on failure' do
+      let(:error_message) { 'oh gosh oh jeeze oh no' }
+      let(:expected_log) do
+        [
+          'Form526SubmissionFailureEmail notification dispatched',
+          {
+            form526_submission_id: form526_submission.id,
+            error_message:,
+            timestamp:
+          }
+        ]
+      end
+
+      before do
+        allow(email_service).to receive(:send_email).and_raise error_message
+      end
+
+      it 'increments StatsD' do
+        expect(StatsD).to receive(:increment).with("#{described_class::STATSD_PREFIX}.error")
+        expect { subject.new.perform(form526_submission.id) }.to raise_error(error_message)
+      end
+
+      it 'logs error' do
+        Timecop.freeze(timestamp) do
+          expect(Rails.logger).to receive(:error).with(
+            'Form526SubmissionFailureEmail notification failed',
+            {
+              form526_submission_id: form526_submission.id,
+              error_message:,
+              timestamp:
+            }
+          )
+          expect { subject.new.perform(form526_submission.id) }.to raise_error(error_message)
+        end
+      end
+    end
+
+    context 'on exhaustion' do
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+      let(:expected_log) do
+        {
+          job_id: form526_job_status.job_id,
+          form526_submission_id: form526_submission.id,
+          error_class: 'WhoopsieDasiy',
+          error_message: 'aww shucks',
+          timestamp:
+        }
+      end
+      let(:exhaustion_block_args) do
+        {
+          'jid' => form526_job_status.job_id,
+          'args' => [form526_submission.id],
+          'error_class' => 'WhoopsieDasiy',
+          'error_message' => 'aww shucks'
+        }
+      end
+
+      it 'logs' do
+        Timecop.freeze(timestamp) do
+          subject.within_sidekiq_retries_exhausted_block(exhaustion_block_args) do
+            expect(Rails.logger).to receive(:warn).with(
+              'Form526SubmissionFailureEmailJob retries exhausted',
+              expected_log
+            )
+          end
+        end
+      end
+
+      it 'increments StatsD' do
+        Timecop.freeze(timestamp) do
+          subject.within_sidekiq_retries_exhausted_block(exhaustion_block_args) do
+            expect(StatsD).to receive(:increment).with("#{described_class::STATSD_PREFIX}.exhausted")
+            expect(StatsD).to receive(:increment).with('silent_failure', tags: described_class::DD_ZSF_TAGS)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -5,15 +5,6 @@ require 'rails_helper'
 RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   subject { described_class }
 
-  # [wipn8923] remove?
-  # let(:form_addendum) do
-  #   {
-  #     'form4142' => { foo: 'bar' },
-  #     'form0781' => { foo: 'bar' },
-  #     'form0781a' => { foo: 'bar' },
-  #     'form8940' => { foo: 'bar' },
-  #   }
-  # end
   let!(:form526_submission) { create(:form526_submission, :with_uploads_and_ancillary_forms) }
   let(:email_service) { double('VaNotify::Service') }
 
@@ -33,12 +24,12 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
         personalisation: {
           first_name: form526_submission.get_first_name,
           date_submitted: form526_submission.format_creation_time_for_mailers,
-          files_submitted: ["extXas.pdf", "extXas.pdf", "extXas.pdf"],
+          files_submitted: ['extXas.pdf', 'extXas.pdf', 'extXas.pdf'],
           forms_submitted: [
-            "VA Form 21-4142",
-            "VA Form 21-0781",
-            "VA Form 21-0781a",
-            "VA Form 21-8940"
+            'VA Form 21-4142',
+            'VA Form 21-0781',
+            'VA Form 21-0781a',
+            'VA Form 21-8940'
           ]
         }
       }

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
       }
     end
 
-    it 'dispatches a failure notification email with an obscured filename' do
+    it 'dispatches a failure notification email with the expected params' do
       expect(email_service).to receive(:send_email).with(expected_params)
 
       subject.perform_async(form526_submission.id)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO* (usecase will be)
- Add service for sending failure emails to veterans. unblocks following work:
  - leverage service in backup submission exhaustion
  - leverage service in backup polling on failure result
- [blocks this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18937)

## Related issue(s)

- [Ticket ](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94127)
- [Ticket 2](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94128)

## Testing done

- [x] *New code is covered by unit tests*
- flipper will enable integration testing in staging
- all objects load and functions tested via local command line

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
