### PR TITLE
Reverting Sign in Service MHV MPI lookup by mhv_uuid

### DIFF
--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -176,10 +176,7 @@ module SignIn
 
     def mpi_response_profile
       @mpi_response_profile ||=
-        if mhv_correlation_id
-          mpi_service.find_profile_by_identifier(identifier: mhv_correlation_id,
-                                                 identifier_type: MPI::Constants::MHV_UUID)&.profile
-        elsif idme_uuid
+        if idme_uuid
           mpi_service.find_profile_by_identifier(identifier: idme_uuid,
                                                  identifier_type: MPI::Constants::IDME_UUID)&.profile
         elsif logingov_uuid

--- a/spec/services/sign_in/attribute_validator_spec.rb
+++ b/spec/services/sign_in/attribute_validator_spec.rb
@@ -366,8 +366,8 @@ RSpec.describe SignIn::AttributeValidator do
         let(:address) { nil }
         let(:mhv_correlation_id) { 'some-mhv-correlation-id' }
         let(:email) { 'some-email' }
-        let(:identifier) { mhv_correlation_id }
-        let(:identifier_type) { MPI::Constants::MHV_UUID }
+        let(:identifier) { idme_uuid }
+        let(:identifier_type) { MPI::Constants::IDME_UUID }
 
         context 'and credential is missing mhv icn' do
           let(:mhv_icn) { nil }


### PR DESCRIPTION
## Summary

- This PR reverts a change that preferred MPI lookup by mhv_uuid when a user authenticates with MHV

## What areas of the site does it impact?
Authentication
