### PR TITLE
Add 526 v2 uploads refactor flag to features list

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -199,6 +199,10 @@ features:
     actor_type: user
     description: Diverts codepath to use refactored BD methods
     enable_in_development: true
+  claims_api_526_v2_uploads_bd_refactor:
+    actor_type: user
+    description: When enabled, sends 526 forms to BD via the refactored logic
+    enable_in_development: true
   confirmation_page_new:
     actor_type: user
     description: Enables the 2024 version of the confirmation page view in simple forms


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds feature flag to use refactored BD logic for 526 v2 uploads via DisabilityCompensationBenefitsDocumentsUploader.
- This logic is currently sending 526 forms to BD for upload in production, so the new flipper would control sending 526 forms to BD via the refactored logic.
- Success criteria: 526 form uploads sent to BD via 526 submit and 526 synchronous methods succeed without error with flipper enabled.
- Removal expectation: Flipper can be removed once 526 form uploads are confirmed working in production with flipper enabled and we've allowed some bake-in time; say 2 months.

## Related issue(s)

[API-41218](https://jira.devops.va.gov/browse/API-41218)

## Testing done

N/A

## What areas of the site does it impact?
Feature flags

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

