### PR TITLE
Api 41220 - 526 v2 uploads use new flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -199,6 +199,10 @@ features:
     actor_type: user
     description: Diverts codepath to use refactored BD methods
     enable_in_development: true
+  claims_api_526_v2_uploads_bd_refactor:
+    actor_type: user
+    description: When enabled, sends 526 forms to BD via the refactored logic
+    enable_in_development: true
   confirmation_page_new:
     actor_type: user
     description: Enables the 2024 version of the confirmation page view in simple forms

--- a/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_benefits_documents_uploader.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_benefits_documents_uploader.rb
@@ -62,7 +62,7 @@ module ClaimsApi
       end
 
       def claim_bd_upload_document(claim, pdf_path)
-        if Flipper.enabled? :claims_api_bd_refactor
+        if Flipper.enabled? :claims_api_526_v2_uploads_bd_refactor
           DisabilityCompensation::DisabilityDocumentService.new.create_upload(claim:, pdf_path:)
         else
           ClaimsApi::BD.new.upload(claim:, pdf_path:)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Updates DisabilityCompensationBenefitsDocumentsUploader to use new flipper claims_api_526_v2_uploads_bd_refactor to control whether to use refactored BD upload_document logic rather than original upload logic.
- Builds on work merged in [API-40300](https://jira.devops.va.gov/browse/API-40300), just changes the flipper.

## Related issue(s)

[API-41220](https://jira.devops.va.gov/browse/API-41220)
[API-41218](https://jira.devops.va.gov/browse/API-41218) --> Adds flipper used herein
[API-40300](https://jira.devops.va.gov/browse/API-40300) --> Implementation of refactored BD upload logic, merged previously

## Testing done

- [x] *New code is covered by unit tests*
- Behaves in the same manner as prior implementation, but the flipper used to control whether to use the refactored BD implementation has been changed from claims_api_bd_refactor to claims_api_526_v2_uploads_bd_refactor to allow for more control of our testing and production rollout.
- Tested via Postman calls to 526 v2 526/synchronous and 526 (regular submit) to exercise the updated logic, with flipper enabled and disabled.

## What areas of the site does it impact?
526/synchronous submission 526 form uploads
526 submission 526 form uploads

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

