### PR TITLE
94148: Update NodCallbacksController to save all callbacks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -158,6 +158,7 @@ app/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-exp
 app/controllers/v1/supplemental_claims @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/decision_review_evidences_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/apidocs_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/v1/nod_callbacks_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/notice_of_disagreements_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/pension_ipf_callbacks_controller.rb @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/sessions_controller.rb  @department-of-veterans-affairs/octo-identity
@@ -1118,6 +1119,7 @@ spec/controllers/v0/virtual_agent @department-of-veterans-affairs/vfs-virtual-ag
 spec/controllers/v0/virtual_agent_token_msft_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/virtual_agent_token_nlu_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/controllers/v1/nod_callbacks_controller_spec.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
 spec/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/sessions_controller_spec.rb @department-of-veterans-affairs/octo-identity

--- a/app/controllers/v1/nod_callbacks_controller.rb
+++ b/app/controllers/v1/nod_callbacks_controller.rb
@@ -7,61 +7,77 @@ module V1
     include ActionController::HttpAuthentication::Token::ControllerMethods
     include DecisionReviewV1::Appeals::LoggingUtils
 
-    service_tag 'nod-callbacks'
+    service_tag 'appeal-application'
 
     skip_before_action :verify_authenticity_token, only: [:create]
     skip_before_action :authenticate, only: [:create]
     skip_after_action :set_csrf_header, only: [:create]
     before_action :authenticate_header, only: [:create]
 
-    STATUSES_TO_IGNORE = %w[sent delivered temporary-failure].freeze
+    STATSD_KEY_PREFIX = 'api.decision_review.notification_callback'
+
+    DELIVERED_STATUS = 'delivered'
 
     def create
-      return render json: nil, status: :not_found unless Flipper.enabled? :nod_callbacks_endpoint
+      return render json: nil, status: :not_found unless enabled?
 
       payload = JSON.parse(request.body.string)
+      status = payload['status']&.downcase
 
-      log_params = {
-        key: :callbacks,
-        form_id: '10182',
-        user_uuid: nil,
-        upstream_system: 'VANotify',
-        body: payload.merge('to' => '<FILTERED>') # scrub PII from logs
-      }
+      StatsD.increment("#{STATSD_KEY_PREFIX}.received", tags: { status: })
 
-      # save encrypted request body in database table for non-successful notifications
-      payload_status = payload['status']&.downcase
-      if STATUSES_TO_IGNORE.exclude? payload_status
-        begin
-          NodNotification.create!(payload:)
-        rescue ActiveRecord::RecordInvalid => e
-          log_formatted(**log_params.merge(is_success: false), params: { exception_message: e.message })
-          return render json: { message: 'failed' }
-        end
+      if status == DELIVERED_STATUS
+        StatsD.increment('silent_failure_avoided', tags: { service: 'appeal-application',
+                                                           function: 'appeal submission form or evidence' })
       end
 
-      log_formatted(**log_params.merge(is_success: true))
+      begin
+        NodNotification.create!(payload:, notification_id: payload['id'], status:)
+      rescue ActiveRecord::RecordInvalid => e
+        log_formatted(**log_params(payload, false), params: { exception_message: e.message })
+        return render json: { message: 'failed' }
+      end
+
+      log_formatted(**log_params(payload, true))
       render json: { message: 'success' }
     end
 
     private
+
+    def log_params(payload, is_success)
+      {
+        key: :decision_review_vanotify_callback,
+        form_id: '10182',
+        user_uuid: nil,
+        upstream_system: 'VANotify',
+        body: payload.merge('to' => '<FILTERED>'), # scrub PII from logs
+        is_success:,
+        params: {
+          notification_id: payload['id'],
+          callback_status: payload['status']
+        }
+      }
+    end
 
     def authenticate_header
       authenticate_user_with_token || authenticity_error
     end
 
     def authenticate_user_with_token
-      Rails.logger.info('nod-callbacks-74832 - Received request, authenticating')
       authenticate_with_http_token do |token|
-        return false if bearer_token_secret.nil?
+        is_authenticated = token == bearer_token_secret
+        Rails.logger.info('NodCallbacksController received callback', is_authenticated:)
 
-        token == bearer_token_secret
+        is_authenticated
       end
     end
 
     def authenticity_error
-      Rails.logger.info('nod-callbacks-74832 - Failed to authenticate request')
       render json: { message: 'Invalid credentials' }, status: :unauthorized
+    end
+
+    def enabled?
+      Flipper.enabled? :nod_callbacks_endpoint
     end
 
     def bearer_token_secret

--- a/config/features.yml
+++ b/config/features.yml
@@ -1580,7 +1580,7 @@ features:
     description: NOD Datadog RUM monitoring
   nod_callbacks_endpoint:
     actor_type: user
-    description: NOD VANotify notification callbacks endpoint
+    description: Enables Decision Review endpoint to process VANotify notification callbacks
     enable_in_development: true
   nod_confirmation_update:
     actor_type: user

--- a/db/migrate/20241018001623_add_column_notification_id_and_status_to_nod_notifications.rb
+++ b/db/migrate/20241018001623_add_column_notification_id_and_status_to_nod_notifications.rb
@@ -1,0 +1,6 @@
+class AddColumnNotificationIdAndStatusToNodNotifications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :nod_notifications, :notification_id, :string
+    add_column :nod_notifications, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -926,6 +926,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_163939) do
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "notification_id"
+    t.string "status"
   end
 
   create_table "oauth_sessions", force: :cascade do |t|

--- a/spec/controllers/v1/nod_callbacks_controller_spec.rb
+++ b/spec/controllers/v1/nod_callbacks_controller_spec.rb
@@ -27,20 +27,7 @@ RSpec.describe V1::NodCallbacksController, type: :controller do
     end
 
     context 'with payload' do
-      context 'if status is delivered' do
-        it 'returns success and does not save a record of the payload' do
-          post(:create, params:, as: :json)
-
-          expect(NodNotification).not_to receive(:create!)
-
-          expect(response).to have_http_status(:ok)
-
-          res = JSON.parse(response.body)
-          expect(res['message']).to eq 'success'
-        end
-      end
-
-      context 'if status is a failure that will not retry' do
+      context 'and the record successfully saved' do
         let(:status) { 'permanent-failure' }
 
         it 'returns success' do


### PR DESCRIPTION
## Summary

This PR updates the NodCallbackController to save all status messages of VANotify notification emails that were sent to Veterans. 

This feature is behind the `nod_callbacks_endpoint` flipper flag.

## Related issue(s)
#18958
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94148

## Testing done

- [x] *New code is covered by unit tests*
The code would ignore certain callback messages depending on the status. This change will start saving all notification callbacks to the endpoint. Additional logging and StatsD metrics are included.

## What areas of the site does it impact?
Callback url endpoint `v1/nod_callbacks`, db table `nod_notifications`, and StatsD

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
