### PR TITLE
Fix Simple Forms statsd -> StatsD typo

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -109,7 +109,7 @@ class BenefitsIntakeStatusJob
     StatsD.increment("#{STATS_KEY}.all_forms.#{result}")
     if result == 'failure'
       tags = [service: 'veteran-facing-forms', function: "#{form_id} form submission to Lighthouse"]
-      statsd.increment('silent_failure', tags:)
+      StatsD.increment('silent_failure', tags:)
       Rails.logger.error('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:, error_message:)
     else
       Rails.logger.info('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:)


### PR DESCRIPTION
## Summary
This PR fixes a typo where I originally had `statsd` and it should have been `StatsD`.
