### PR TITLE
remove unused OH reads feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1333,10 +1333,6 @@ features:
   va_dependents_new_fields_for_pdf:
     actor_typer: user
     description: Allows us to toggle the new fields on the front end for 686C-674
-  va_online_scheduling_enable_OH_reads:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for routing appointment read requests to the VetsAPI Gateway Service(VPG) instead of vaos-service.
   va_online_scheduling_enable_OH_cancellations:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION

## Summary

- This work is behind a feature toggle (flipper): NO*
- This change removes the `va_online_scheduling_enable_OH_reads` feature flag from configuration.  All code and tests referencing this flag was removed in #84592.

## Related issue(s)
https://app.zenhub.com/workspaces/appointments-oracle-health-integration-65a6e99ea522640e4d09393b/issues/gh/department-of-veterans-affairs/va.gov-team/94547

https://app.zenhub.com/workspaces/appointments-oracle-health-integration-65a6e99ea522640e4d09393b/issues/gh/department-of-veterans-affairs/va.gov-team/84592

## Testing done
- All tests referencing the removed feature flag were refactored in a previous PR.

## What areas of the site does it impact?
- VAOS Appointment module