### PR TITLE
Fix Datadog Metric Logging on BenefitsIntakeStatusJob

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -108,8 +108,8 @@ class BenefitsIntakeStatusJob
     StatsD.increment("#{STATS_KEY}.#{form_id}.#{result}")
     StatsD.increment("#{STATS_KEY}.all_forms.#{result}")
     if result == 'failure'
-      tags = [service: 'veteran-facing-forms', function: "#{form_id} form submission to Lighthouse"]
-      statsd.increment('silent_failure', tags:)
+      tags = ['service:veteran-facing-forms', "function:#{form_id} form submission to Lighthouse"]
+      StatsD.increment('silent_failure', tags:)
       Rails.logger.error('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:, error_message:)
     else
       Rails.logger.info('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:)


### PR DESCRIPTION
## Summary

- tags must be array of strings
- correct statsd class 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/18824

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  syntax is correct