### PR TITLE
Track sc 4142 submissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2118,3 +2118,6 @@ modules/accredited_representative_portal/app/services/accredited_representative_
 config/form_profile_mappings/FORM-MOCK-AE-DESIGN-PATTERNS.yml @department-of-veterans-affairs/tmf-auth-exp-design-patterns @department-of-veterans-affairs/backend-review-group
 postman/vets-api.pm-collection.json @department-of-veterans-affairs/backend-review-group
 postman/Dockerfile @department-of-veterans-affairs/backend-review-group
+app/models/secondary_appeal_form.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
+spec/factories/secondary_appeal_forms.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
+spec/models/secondary_appeal_form_spec.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group

--- a/app/models/secondary_appeal_form.rb
+++ b/app/models/secondary_appeal_form.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SecondaryAppealForm < ApplicationRecord
+  validates :guid, presence: true
+  validate(:form_matches_schema)
+  validate(:form_must_be_string)
+  
+  belongs_to :appeal_submission
+
+  has_kms_key
+  has_encrypted :form, key: :kms_key, **lockbox_options
+
+  private
+
+  def form_is_string
+    form.is_a?(String)
+  end
+
+  def form_must_be_string
+    errors.add(:form, :invalid_format, message: 'must be a json string') unless form_is_string
+  end
+
+  def form_matches_schema
+    
+  end
+end

--- a/app/models/secondary_appeal_form.rb
+++ b/app/models/secondary_appeal_form.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class SecondaryAppealForm < ApplicationRecord
-  validates :guid, presence: true
+  validates :guid, :form_id, presence: true
   validate(:form_matches_schema)
   validate(:form_must_be_string)
-  
+
   belongs_to :appeal_submission
 
   has_kms_key
@@ -21,6 +21,26 @@ class SecondaryAppealForm < ApplicationRecord
   end
 
   def form_matches_schema
-    
+    return unless form_is_string
+
+    schema = VetsJsonSchema::SCHEMAS[form_id]
+
+    schema_errors = JSON::Validator.fully_validate_schema(schema, { errors_as_objects: true })
+    clear_cache = false
+    unless schema_errors.empty?
+      Rails.logger.error('SecondaryAppealForm schema failed validation! Attempting to clear cache.', { errors: schema_errors })
+      clear_cache = true
+    end
+
+    validation_errors = JSON::Validator.fully_validate(schema, JSON.parse(form), { errors_as_objects: true, clear_cache: })
+
+    validation_errors.each do |e|
+      errors.add(e[:fragment], e[:message])
+      e[:errors]&.flatten(2)&.each { |nested| errors.add(nested[:fragment], nested[:message]) if nested.is_a? Hash }
+    end
+
+    unless validation_errors.empty?
+      Rails.logger.error('SavedClaim form did not pass validation', { guid:, errors: validation_errors })
+    end
   end
 end

--- a/app/models/secondary_appeal_form.rb
+++ b/app/models/secondary_appeal_form.rb
@@ -28,11 +28,13 @@ class SecondaryAppealForm < ApplicationRecord
     schema_errors = JSON::Validator.fully_validate_schema(schema, { errors_as_objects: true })
     clear_cache = false
     unless schema_errors.empty?
-      Rails.logger.error('SecondaryAppealForm schema failed validation! Attempting to clear cache.', { errors: schema_errors })
+      Rails.logger.error('SecondaryAppealForm schema failed validation! Attempting to clear cache.',
+                         { errors: schema_errors })
       clear_cache = true
     end
 
-    validation_errors = JSON::Validator.fully_validate(schema, JSON.parse(form), { errors_as_objects: true, clear_cache: })
+    validation_errors = JSON::Validator.fully_validate(schema, JSON.parse(form),
+                                                       { errors_as_objects: true, clear_cache: })
 
     validation_errors.each do |e|
       errors.add(e[:fragment], e[:message])

--- a/db/migrate/20241016183742_create_secondary_appeal_form.rb
+++ b/db/migrate/20241016183742_create_secondary_appeal_form.rb
@@ -1,0 +1,16 @@
+class CreateSecondaryAppealForm < ActiveRecord::Migration[7.1]
+  def change
+    create_table :secondary_appeal_forms do |t|
+      t.string :form_id
+      t.text :encrypted_kms_key
+      t.text :form_ciphertext
+      t.uuid :guid
+      t.string :status
+      t.datetime :status_updated_at
+      t.references :appeal_submission
+      t.datetime :delete_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_16_172752) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_16_183742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1050,6 +1050,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_172752) do
     t.string "error_details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "secondary_appeal_forms", force: :cascade do |t|
+    t.string "form_id"
+    t.text "encrypted_kms_key"
+    t.text "form_ciphertext"
+    t.uuid "guid"
+    t.string "status"
+    t.datetime "status_updated_at"
+    t.bigint "appeal_submission_id"
+    t.datetime "delete_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appeal_submission_id"], name: "index_secondary_appeal_forms_on_appeal_submission_id"
   end
 
   create_table "service_account_configs", force: :cascade do |t|

--- a/spec/factories/secondary_appeal_forms.rb
+++ b/spec/factories/secondary_appeal_forms.rb
@@ -1,13 +1,38 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :secondary_appeal_form do
+  factory :secondary_appeal_form4142, class: 'SecondaryAppealForm' do
     guid { SecureRandom.uuid }
+    form_id { '21-4142' }
     form do
       {
+        veteran: {
+          fullName: {
+            first: 'Person',
+            last: 'McPerson'
+          },
+          dateOfBirth: '1983-01-23',
+          ssn: '111223333',
+          address: {
+
+          },
+          homePhone: '123-456-7890',
+
+        },
+        patientIdentification: {
+          isRequestingOwnMedicalRecords: true
+
+        },
+        providerFacility: [{}],
+        preparerIdentification: {
+          relationshipToVeteran: 'self'
+        },
+        acknowledgeToReleaseInformation: true,
+        limitedConsent: 'some string',
         privacyAgreementAccepted: true
+
       }.to_json
     end
-    appeal_submission_id { SecureRandom.uuid }
+    appeal_submission
   end
 end

--- a/spec/factories/secondary_appeal_forms.rb
+++ b/spec/factories/secondary_appeal_forms.rb
@@ -13,11 +13,8 @@ FactoryBot.define do
           },
           dateOfBirth: '1983-01-23',
           ssn: '111223333',
-          address: {
-
-          },
-          homePhone: '123-456-7890',
-
+          address: {},
+          homePhone: '123-456-7890'
         },
         patientIdentification: {
           isRequestingOwnMedicalRecords: true
@@ -30,7 +27,6 @@ FactoryBot.define do
         acknowledgeToReleaseInformation: true,
         limitedConsent: 'some string',
         privacyAgreementAccepted: true
-
       }.to_json
     end
     appeal_submission

--- a/spec/factories/secondary_appeal_forms.rb
+++ b/spec/factories/secondary_appeal_forms.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :secondary_appeal_form do
+    guid { SecureRandom.uuid }
+    form do
+      {
+        privacyAgreementAccepted: true
+      }.to_json
+    end
+    appeal_submission_id { SecureRandom.uuid }
+  end
+end

--- a/spec/models/secondary_appeal_form_spec.rb
+++ b/spec/models/secondary_appeal_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SecondaryAppealForm, type: :model do
   describe 'validations' do
     before do
       expect(subject).to be_valid
-      expect(JSON::Validator).to receive(:fully_validate).at_least(2).times.and_call_original
+      expect(JSON::Validator).to receive(:fully_validate).at_least(:twice).and_call_original
     end
 
     it { is_expected.to validate_presence_of(:guid) }

--- a/spec/models/secondary_appeal_form_spec.rb
+++ b/spec/models/secondary_appeal_form_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SecondaryAppealForm, type: :model do
+  subject { build(:secondary_appeal_form, form_id: '4142') }
+
+  it 'validates the presence of a guid' do
+    subject.guid = nil
+    expect(subject).not_to be_valid
+  end
+
+  context 'validates against the form schema' do
+    before do
+      expect(subject).to be_valid
+      expect(JSON::Validator).to receive(:fully_validate).once.and_call_original
+    end
+
+    it 'rejects forms with missing elements' do
+      bad_form = JSON.parse(subject).deep_dup.delete('something')
+      subject.form = bad_form.to_json
+      expect(subject).not_to be_valid
+      expect(subject.errors.full_messages.size).to eq(1)
+      expect(subject.errors.full_messages).to include(/something/)
+    end
+  end
+  
+end

--- a/spec/models/secondary_appeal_form_spec.rb
+++ b/spec/models/secondary_appeal_form_spec.rb
@@ -1,28 +1,31 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'decision_review_v1/service'
 
 RSpec.describe SecondaryAppealForm, type: :model do
-  subject { build(:secondary_appeal_form, form_id: '4142') }
+  subject { build(:secondary_appeal_form4142) }
 
-  it 'validates the presence of a guid' do
-    subject.guid = nil
-    expect(subject).not_to be_valid
-  end
-
-  context 'validates against the form schema' do
+  describe 'validations' do
     before do
       expect(subject).to be_valid
-      expect(JSON::Validator).to receive(:fully_validate).once.and_call_original
+      expect(JSON::Validator).to receive(:fully_validate).at_least(2).times.and_call_original
+    end
+
+    it { is_expected.to validate_presence_of(:guid) }
+
+    it 'errors if trying to validate without a form_id' do
+      subject.form_id = nil
+      expect { subject.valid? }.to raise_error(JSON::Schema::SchemaParseError)
     end
 
     it 'rejects forms with missing elements' do
-      bad_form = JSON.parse(subject).deep_dup.delete('something')
+      bad_form = JSON.parse(subject.form).deep_dup
+      bad_form.delete('privacyAgreementAccepted')
       subject.form = bad_form.to_json
       expect(subject).not_to be_valid
       expect(subject.errors.full_messages.size).to eq(1)
-      expect(subject.errors.full_messages).to include(/something/)
+      expect(subject.errors.full_messages).to include(/privacyAgreementAccepted/)
     end
   end
-  
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- We want to track the status of 4142 forms that are submitted as part of submitting a Supplemental Claim. This PR adds the database table and model that we will use to track them, but does not actually implement the tracking.
- This work belongs to the Decision Reviews Team
- No functionality is added in this PR, so the Flipper is not yet included

## Related issue(s)

[department-of-veterans-affairs/va.gov-team/issues/95001](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95001)

## Testing done

- [X] *New code is covered by unit tests*
- Create and save an instance of the new model, verify the validations are working

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Creates a new table and model, including a factory and tests for that model

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

How do we feel about the model name? I know there is some desire to move away from the term "appeal"
