### PR TITLE
94148: Add columns to nod_notifications

### DIFF
--- a/db/migrate/20241018001623_add_column_notification_id_and_status_to_nod_notifications.rb
+++ b/db/migrate/20241018001623_add_column_notification_id_and_status_to_nod_notifications.rb
@@ -1,0 +1,6 @@
+class AddColumnNotificationIdAndStatusToNodNotifications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :nod_notifications, :notification_id, :string
+    add_column :nod_notifications, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -926,6 +926,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_163939) do
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "notification_id"
+    t.string "status"
   end
 
   create_table "oauth_sessions", force: :cascade do |t|


### PR DESCRIPTION

## Summary
Adds `notification_id` and `status` to the `nod_notifications` table.

This is owned by Benefits Decision Reviews.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94148

## Testing done

- [ ] *New code is covered by unit tests*
Ran migration locally

## What areas of the site does it impact?
`nod_notifications` table

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
