### PR TITLE
Add migration for Secondary Appeal Form

### DIFF
--- a/db/migrate/20241018163939_create_secondary_appeal_form.rb
+++ b/db/migrate/20241018163939_create_secondary_appeal_form.rb
@@ -1,0 +1,16 @@
+class CreateSecondaryAppealForm < ActiveRecord::Migration[7.1]
+  def change
+    create_table :secondary_appeal_forms do |t|
+      t.string :form_id
+      t.text :encrypted_kms_key
+      t.text :form_ciphertext
+      t.uuid :guid
+      t.string :status
+      t.datetime :status_updated_at
+      t.references :appeal_submission
+      t.datetime :delete_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_16_172752) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_18_163939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1052,6 +1052,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_172752) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "secondary_appeal_forms", force: :cascade do |t|
+    t.string "form_id"
+    t.text "encrypted_kms_key"
+    t.text "form_ciphertext"
+    t.uuid "guid"
+    t.string "status"
+    t.datetime "status_updated_at"
+    t.bigint "appeal_submission_id"
+    t.datetime "delete_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appeal_submission_id"], name: "index_secondary_appeal_forms_on_appeal_submission_id"
+  end
+
   create_table "service_account_configs", force: :cascade do |t|
     t.string "service_account_id", null: false
     t.text "description", null: false
@@ -1545,12 +1559,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_172752) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_profile_id"
-    t.integer "bdn_clone_id"
-    t.integer "bdn_clone_line"
-    t.boolean "bdn_clone_active"
     t.date "cert_issue_date"
     t.date "del_date"
     t.date "date_last_certified"
+    t.integer "bdn_clone_id"
+    t.integer "bdn_clone_line"
+    t.boolean "bdn_clone_active"
     t.index ["bdn_clone_active"], name: "index_vye_user_infos_on_bdn_clone_active"
     t.index ["bdn_clone_id"], name: "index_vye_user_infos_on_bdn_clone_id"
     t.index ["bdn_clone_line"], name: "index_vye_user_infos_on_bdn_clone_line"


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Added a migration to create a `secondary_appeal_forms` table
- First step in tracking submission of 4142 forms that are submitted as part of a Supplemental Claim
- Decision Reviews Team

## Related issue(s)

[department-of-veterans-affairs/va.gov-team/issues/95001](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95001)

## Testing done

No tests because this is only the migration and schema change

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Adds a table to the DB

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
