### PR TITLE
94461: Add silent failure metrics and clean up other metrics for DR SavedClaim status updater jobs

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -71,8 +71,8 @@ module DecisionReview
 
       if status == ERROR_STATUS
         Rails.logger.info('DecisionReview::SavedClaimHlrStatusUpdaterJob form status error', guid: hlr.guid)
-        StatsD.increment('silent_failure', tags: { service: 'higher-level-review',
-                                                   function: 'lighthouse claim submission' })
+        tags = ['service:higher-level-review', 'function: form submission to Lighthouse']
+        StatsD.increment('silent_failure', tags:)
       end
 
       StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])

--- a/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_hlr_status_updater_job.rb
@@ -66,11 +66,13 @@ module DecisionReview
     end
 
     def handle_form_status_metrics_and_logging(hlr, status)
-      if status == ERROR_STATUS
-        # ignore logging and metrics for stale errors
-        return if JSON.parse(hlr.metadata || '{}')['status'] == ERROR_STATUS
+      # Skip logging and statsd metrics when there is no status change
+      return if JSON.parse(hlr.metadata || '{}')['status'] == status
 
+      if status == ERROR_STATUS
         Rails.logger.info('DecisionReview::SavedClaimHlrStatusUpdaterJob form status error', guid: hlr.guid)
+        StatsD.increment('silent_failure', tags: { service: 'higher-level-review',
+                                                   function: 'lighthouse claim submission' })
       end
 
       StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -91,8 +91,8 @@ module DecisionReview
 
       if status == ERROR_STATUS
         Rails.logger.info('DecisionReview::SavedClaimNodStatusUpdaterJob form status error', guid: nod.guid)
-        StatsD.increment('silent_failure', tags: { service: 'board-appeal',
-                                                   function: 'lighthouse claim submission' })
+        tags = ['service:board-appeal', 'function: form submission to Lighthouse']
+        StatsD.increment('silent_failure', tags:)
       end
 
       StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])
@@ -114,8 +114,8 @@ module DecisionReview
         if status == ERROR_STATUS
           Rails.logger.info('DecisionReview::SavedClaimNodStatusUpdaterJob evidence status error',
                             { guid: nod.guid, lighthouse_upload_id: upload_id, detail: upload['detail'] })
-          StatsD.increment('silent_failure', tags: { service: 'board-appeal',
-                                                     function: 'lighthouse evidence submission' })
+          tags = ['service:board-appeal', 'function: evidence submission to Lighthouse']
+          StatsD.increment('silent_failure', tags:)
         end
 
         StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])

--- a/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_nod_status_updater_job.rb
@@ -86,11 +86,13 @@ module DecisionReview
     end
 
     def handle_form_status_metrics_and_logging(nod, status)
-      if status == ERROR_STATUS
-        # ignore logging and metrics for stale errors
-        return if JSON.parse(nod.metadata || '{}')['status'] == ERROR_STATUS
+      # Skip logging and statsd metrics when there is no status change
+      return if JSON.parse(nod.metadata || '{}')['status'] == status
 
+      if status == ERROR_STATUS
         Rails.logger.info('DecisionReview::SavedClaimNodStatusUpdaterJob form status error', guid: nod.guid)
+        StatsD.increment('silent_failure', tags: { service: 'board-appeal',
+                                                   function: 'lighthouse claim submission' })
       end
 
       StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])
@@ -103,15 +105,17 @@ module DecisionReview
 
       uploads_metadata.each do |upload|
         status = upload['status']
+        upload_id = upload['id']
         result = false unless UPLOAD_SUCCESSFUL_STATUS.include? status
 
-        if status == ERROR_STATUS
-          upload_id = upload['id']
-          # Increment StatsD and log only for new errors
-          next if old_uploads_metadata.dig(upload_id, 'status') == ERROR_STATUS
+        # Skip logging and statsd metrics when there is no status change
+        next if old_uploads_metadata.dig(upload_id, 'status') == status
 
+        if status == ERROR_STATUS
           Rails.logger.info('DecisionReview::SavedClaimNodStatusUpdaterJob evidence status error',
                             { guid: nod.guid, lighthouse_upload_id: upload_id, detail: upload['detail'] })
+          StatsD.increment('silent_failure', tags: { service: 'board-appeal',
+                                                     function: 'lighthouse evidence submission' })
         end
 
         StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -91,8 +91,8 @@ module DecisionReview
 
       if status == ERROR_STATUS
         Rails.logger.info('DecisionReview::SavedClaimScStatusUpdaterJob form status error', guid: sc.guid)
-        StatsD.increment('silent_failure', tags: { service: 'supplemental-claims',
-                                                   function: 'lighthouse claim submission' })
+        tags = ['service:supplemental-claims', 'function: form submission to Lighthouse']
+        StatsD.increment('silent_failure', tags:)
       end
 
       StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])
@@ -114,8 +114,8 @@ module DecisionReview
         if status == ERROR_STATUS
           Rails.logger.info('DecisionReview::SavedClaimScStatusUpdaterJob evidence status error',
                             { guid: sc.guid, lighthouse_upload_id: upload_id, detail: upload['detail'] })
-          StatsD.increment('silent_failure', tags: { service: 'supplemental-claims',
-                                                     function: 'lighthouse evidence submission' })
+          tags = ['service:supplemental-claims', 'function: evidence submission to Lighthouse']
+          StatsD.increment('silent_failure', tags:)
         end
         StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])
       end

--- a/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_sc_status_updater_job.rb
@@ -86,11 +86,13 @@ module DecisionReview
     end
 
     def handle_form_status_metrics_and_logging(sc, status)
-      if status == ERROR_STATUS
-        # ignore logging and metrics for stale errors
-        return if JSON.parse(sc.metadata || '{}')['status'] == ERROR_STATUS
+      # Skip logging and statsd metrics when there is no status change
+      return if JSON.parse(sc.metadata || '{}')['status'] == status
 
+      if status == ERROR_STATUS
         Rails.logger.info('DecisionReview::SavedClaimScStatusUpdaterJob form status error', guid: sc.guid)
+        StatsD.increment('silent_failure', tags: { service: 'supplemental-claims',
+                                                   function: 'lighthouse claim submission' })
       end
 
       StatsD.increment("#{STATSD_KEY_PREFIX}.status", tags: ["status:#{status}"])
@@ -103,15 +105,17 @@ module DecisionReview
 
       uploads_metadata.each do |upload|
         status = upload['status']
+        upload_id = upload['id']
         result = false unless UPLOAD_SUCCESSFUL_STATUS.include? status
 
-        if status == ERROR_STATUS
-          upload_id = upload['id']
-          # Increment StatsD and log only for new errors
-          next if old_uploads_metadata.dig(upload_id, 'status') == ERROR_STATUS
+        # Skip logging and statsd metrics when there is no status change
+        next if old_uploads_metadata.dig(upload_id, 'status') == status
 
+        if status == ERROR_STATUS
           Rails.logger.info('DecisionReview::SavedClaimScStatusUpdaterJob evidence status error',
                             { guid: sc.guid, lighthouse_upload_id: upload_id, detail: upload['detail'] })
+          StatsD.increment('silent_failure', tags: { service: 'supplemental-claims',
+                                                     function: 'lighthouse evidence submission' })
         end
         StatsD.increment("#{STATSD_KEY_PREFIX}_upload.status", tags: ["status:#{status}"])
       end

--- a/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/saved_claim_nod_status_updater_job_spec.rb
@@ -191,6 +191,7 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
 
         let(:upload_id) { SecureRandom.uuid }
         let(:upload_id2) { SecureRandom.uuid }
+        let(:upload_id3) { SecureRandom.uuid }
 
         let(:metadata1) do
           {
@@ -213,12 +214,17 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
                 'status' => 'pending',
                 'detail' => nil,
                 'id' => upload_id2
+              },
+              {
+                'status' => 'processing',
+                'detail' => nil,
+                'id' => upload_id3
               }
             ]
           }
         end
 
-        it 'does not log or increment metrics for stale form error status' do
+        it 'does not increment metrics for unchanged form status' do
           SavedClaim::NoticeOfDisagreement.create(guid: guid1, form: '{}', metadata: '{"status":"error","uploads":[]}')
           SavedClaim::NoticeOfDisagreement.create(guid: guid2, form: '{}',
                                                   metadata: '{"status":"submitted","uploads":[]}')
@@ -246,7 +252,7 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
             .with('DecisionReview::SavedClaimNodStatusUpdaterJob form status error', guid: guid2)
         end
 
-        it 'does not log or increment metrics for stale evidence error status' do
+        it 'does not increment metrics for unchanged evidence status' do
           SavedClaim::NoticeOfDisagreement.create(guid: guid1, form: '{}', metadata: metadata1.to_json)
           appeal_submission = create(:appeal_submission, submitted_appeal_uuid: guid1)
           create(:appeal_submission_upload, appeal_submission:, lighthouse_upload_id: upload_id)
@@ -254,6 +260,7 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
           SavedClaim::NoticeOfDisagreement.create(guid: guid2, form: '{}', metadata: metadata2.to_json)
           appeal_submission2 = create(:appeal_submission, submitted_appeal_uuid: guid2)
           create(:appeal_submission_upload, appeal_submission: appeal_submission2, lighthouse_upload_id: upload_id2)
+          create(:appeal_submission_upload, appeal_submission: appeal_submission2, lighthouse_upload_id: upload_id3)
 
           expect(service).to receive(:get_notice_of_disagreement).with(guid1).and_return(response_pending)
           expect(service).to receive(:get_notice_of_disagreement).with(guid2).and_return(response_error)
@@ -261,12 +268,17 @@ RSpec.describe DecisionReview::SavedClaimNodStatusUpdaterJob, type: :job do
                                                                         .and_return(upload_response_error)
           expect(service).to receive(:get_notice_of_disagreement_upload).with(guid: upload_id2)
                                                                         .and_return(upload_response_error)
+          expect(service).to receive(:get_notice_of_disagreement_upload).with(guid: upload_id3)
+                                                                        .and_return(upload_response_processing)
 
           subject.new.perform
 
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.saved_claim_nod_status_updater_upload.status', tags: ['status:error'])
             .exactly(1).times
+          expect(StatsD).not_to have_received(:increment)
+            .with('worker.decision_review.saved_claim_nod_status_updater_upload.status', tags: ['status:processing'])
+
           expect(Rails.logger).not_to have_received(:info)
             .with('DecisionReview::SavedClaimNodStatusUpdaterJob evidence status error',
                   guid: anything, lighthouse_upload_id: upload_id, detail: anything)


### PR DESCRIPTION
## Summary
This update increments the StatsD metric `silent_failure` statsd metric for all of the form and evidence failures that are detected by the SavedClaim status updater jobs. This also updates the existing StatsD metrics to increment only when form or evidence status changes, instead of incrementing every time the statuses are polled.

This is owned by the Benefits Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94461

## Testing done

- [x] *New code is covered by unit tests*
Tested locally and spec tests

## What areas of the site does it impact?
This impacts statsd and the SavedClaim status updater jobs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
