### PR TITLE
84372: Update FailureNotificationEmailJob with silent failure metrics and use evidence template ids

### DIFF
--- a/app/sidekiq/decision_review/failure_notification_email_job.rb
+++ b/app/sidekiq/decision_review/failure_notification_email_job.rb
@@ -106,7 +106,9 @@ module DecisionReview
       StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.processing_records", submission_uploads.size)
 
       submission_uploads.each do |upload|
-        response = send_email_with_vanotify(upload.appeal_submission, upload.masked_attachment_filename, upload.created_at)
+        response = send_email_with_vanotify(upload.appeal_submission,
+                                            upload.masked_attachment_filename,
+                                            upload.created_at)
         upload.update(failure_notification_sent_at: DateTime.now)
 
         record_evidence_email_send_successful(upload, response.id)

--- a/app/sidekiq/decision_review/failure_notification_email_job.rb
+++ b/app/sidekiq/decision_review/failure_notification_email_job.rb
@@ -14,10 +14,23 @@ module DecisionReview
       SavedClaim::SupplementalClaim
     ].freeze
 
-    TEMPLATE_IDS = {
-      'HLR' => Settings.vanotify.services.benefits_decision_review.template_id.higher_level_review_form_error_email,
-      'NOD' => Settings.vanotify.services.benefits_decision_review.template_id.notice_of_disagreement_form_error_email,
-      'SC' => Settings.vanotify.services.benefits_decision_review.template_id.supplemental_claim_form_error_email
+    TEMPLATE_IDS = Settings.vanotify.services.benefits_decision_review.template_id
+
+    FORM_TEMPLATE_IDS = {
+      'HLR' => TEMPLATE_IDS.higher_level_review_form_error_email,
+      'NOD' => TEMPLATE_IDS.notice_of_disagreement_form_error_email,
+      'SC' => TEMPLATE_IDS.supplemental_claim_form_error_email
+    }.freeze
+
+    EVIDENCE_TEMPLATE_IDS = {
+      'NOD' => TEMPLATE_IDS.notice_of_disagreement_evidence_error_email,
+      'SC' => TEMPLATE_IDS.supplemental_claim_evidence_error_email
+    }.freeze
+
+    APPEAL_TYPE_TO_SERVICE_MAP = {
+      'HLR' => 'higher-level-review',
+      'NOD' => 'board-appeal',
+      'SC' => 'supplemental-claims'
     }.freeze
 
     ERROR_STATUS = 'error'
@@ -71,18 +84,19 @@ module DecisionReview
         date_submitted: created_at.strftime('%B %d, %Y')
       }
 
-      vanotify_service.send_email({ email_address:, template_id: TEMPLATE_IDS[submission.type_of_appeal],
-                                    personalisation: })
+      appeal_type = submission.type_of_appeal
+      template_id = filename.nil? ? FORM_TEMPLATE_IDS[appeal_type] : EVIDENCE_TEMPLATE_IDS[appeal_type]
+      vanotify_service.send_email({ email_address:, template_id:, personalisation: })
     end
 
     def send_form_emails
       StatsD.increment("#{STATSD_KEY_PREFIX}.form.processing_records", submissions.size)
 
       submissions.each do |submission|
-        send_email_with_vanotify(submission, nil, submission.created_at)
+        response = send_email_with_vanotify(submission, nil, submission.created_at)
         submission.update(failure_notification_sent_at: DateTime.now)
 
-        record_form_email_send_successful(submission)
+        record_form_email_send_successful(submission, response.id)
       rescue => e
         record_form_email_send_failure(submission, e)
       end
@@ -92,45 +106,59 @@ module DecisionReview
       StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.processing_records", submission_uploads.size)
 
       submission_uploads.each do |upload|
-        send_email_with_vanotify(upload.appeal_submission, upload.masked_attachment_filename, upload.created_at)
+        response = send_email_with_vanotify(upload.appeal_submission, upload.masked_attachment_filename, upload.created_at)
         upload.update(failure_notification_sent_at: DateTime.now)
 
-        record_evidence_email_send_successful(upload)
+        record_evidence_email_send_successful(upload, response.id)
       rescue => e
         record_evidence_email_send_failure(upload, e)
       end
     end
 
-    def record_form_email_send_successful(submission)
-      metadata = { submitted_appeal_uuid: submission.submitted_appeal_uuid, form_type: submission.type_of_appeal }
-      Rails.logger.info('DecisionReview::FailureNotificationEmailJob form email queued', metadata)
-      StatsD.increment("#{STATSD_KEY_PREFIX}.form.email_queued", tags: ["form_type:#{submission.type_of_appeal}"])
+    def record_form_email_send_successful(submission, notification_id)
+      appeal_type = submission.type_of_appeal
+      params = { submitted_appeal_uuid: submission.submitted_appeal_uuid, appeal_type:, notification_id: }
+      Rails.logger.info('DecisionReview::FailureNotificationEmailJob form email queued', params)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.form.email_queued", tags: ["appeal_type:#{appeal_type}"])
+
+      tags = ["service:#{APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}", 'function: form submission to Lighthouse']
+      StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
     end
 
     def record_form_email_send_failure(submission, e)
-      metadata = { submitted_appeal_uuid: submission.submitted_appeal_uuid, form_type: submission.type_of_appeal,
-                   message: e.message }
-      Rails.logger.error('DecisionReview::FailureNotificationEmailJob form error', metadata)
-      StatsD.increment("#{STATSD_KEY_PREFIX}.form.error", tags: ["form_type:#{submission.type_of_appeal}"])
+      appeal_type = submission.type_of_appeal
+      params = { submitted_appeal_uuid: submission.submitted_appeal_uuid, appeal_type:, message: e.message }
+      Rails.logger.error('DecisionReview::FailureNotificationEmailJob form error', params)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.form.error", tags: ["appeal_type:#{appeal_type}"])
     end
 
-    def record_evidence_email_send_successful(upload)
+    def record_evidence_email_send_successful(upload, notification_id)
       submission = upload.appeal_submission
-      metadata = { submitted_appeal_uuid: submission.submitted_appeal_uuid,
-                   lighthouse_upload_id: upload.lighthouse_upload_id,
-                   form_type: submission.type_of_appeal }
-      Rails.logger.info('DecisionReview::FailureNotificationEmailJob evidence email queued', metadata)
-      StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.email_queued", tags: ["form_type:#{submission.type_of_appeal}"])
+      appeal_type = submission.type_of_appeal
+      params = {
+        submitted_appeal_uuid: submission.submitted_appeal_uuid,
+        lighthouse_upload_id: upload.lighthouse_upload_id,
+        appeal_type:,
+        notification_id:
+      }
+      Rails.logger.info('DecisionReview::FailureNotificationEmailJob evidence email queued', params)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.email_queued", tags: ["appeal_type:#{appeal_type}"])
+
+      tags = ["service:#{APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}", 'function: evidence submission to Lighthouse']
+      StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
     end
 
     def record_evidence_email_send_failure(upload, e)
       submission = upload.appeal_submission
-      metadata = { submitted_appeal_uuid: submission.submitted_appeal_uuid,
-                   lighthouse_upload_id: upload.lighthouse_upload_id,
-                   form_type: submission.type_of_appeal,
-                   message: e.message }
-      Rails.logger.error('DecisionReview::FailureNotificationEmailJob evidence error', metadata)
-      StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.error", tags: ["form_type:#{submission.type_of_appeal}"])
+      appeal_type = submission.type_of_appeal
+      params = {
+        submitted_appeal_uuid: submission.submitted_appeal_uuid,
+        lighthouse_upload_id: upload.lighthouse_upload_id,
+        appeal_type:,
+        message: e.message
+      }
+      Rails.logger.error('DecisionReview::FailureNotificationEmailJob evidence error', params)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.error", tags: ["appeal_type:#{appeal_type}"])
     end
 
     def enabled?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1368,7 +1368,9 @@ vanotify:
       api_key: fake_secret
       template_id:
         higher_level_review_form_error_email: fake_hlr_template_id
+        notice_of_disagreement_evidence_error_email: fake_nod_evidence_template_id
         notice_of_disagreement_form_error_email: fake_nod_template_id
+        supplemental_claim_evidence_error_email: fake_sc_evidence_template_id
         supplemental_claim_form_error_email: fake_sc_template_id
     benefits_disability:
       api_key: fake_secret

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -162,7 +162,9 @@ vanotify:
       api_key: fake_secret
       template_id:
         higher_level_review_form_error_email: fake_hlr_template_id
+        notice_of_disagreement_evidence_error_email: fake_nod_evidence_template_id
         notice_of_disagreement_form_error_email: fake_nod_template_id
+        supplemental_claim_evidence_error_email: fake_sc_evidence_template_id
         supplemental_claim_form_error_email: fake_sc_template_id
     benefits_management_tools:
       api_key: fake_secret

--- a/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
@@ -330,7 +330,8 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
             expect(Rails.logger).to have_received(:info).with(*logger_params2)
 
             expect(StatsD).to have_received(:increment)
-              .with('worker.decision_review.failure_notification_email.evidence.email_queued', tags: ['appeal_type:NOD'])
+              .with('worker.decision_review.failure_notification_email.evidence.email_queued',
+                    tags: ['appeal_type:NOD'])
               .exactly(2).times
           end
         end

--- a/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
@@ -15,7 +15,17 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
   let(:guid3) { SecureRandom.uuid }
   let(:guid4) { SecureRandom.uuid }
 
-  let(:vanotify_service) { instance_double(VaNotify::Service, send_email: nil) }
+  let(:notification_id) { SecureRandom.uuid }
+  let(:notification_id2) { SecureRandom.uuid }
+  let(:vanotify_service) do
+    service = instance_double(VaNotify::Service)
+
+    response = instance_double(Notifications::Client::ResponseNotification, id: notification_id)
+    response2 = instance_double(Notifications::Client::ResponseNotification, id: notification_id2)
+    allow(service).to receive(:send_email).and_return(response, response2)
+
+    service
+  end
 
   let(:user_uuid) { create(:user, :loa3, ssn: '212222112').uuid }
   let(:user_uuid2) { create(:user, :loa3, uuid: SecureRandom.uuid, ssn: '412222112').uuid }
@@ -119,11 +129,13 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
                                                                               personalisation: anything,
                                                                               template_id: 'fake_hlr_template_id' })
 
-            expect(Rails.logger).to have_received(:info)
-              .with('DecisionReview::FailureNotificationEmailJob form email queued',
-                    { submitted_appeal_uuid: guid1, form_type: 'SC' })
+            logger_params = [
+              'DecisionReview::FailureNotificationEmailJob form email queued',
+              { submitted_appeal_uuid: guid1, appeal_type: 'SC', notification_id: }
+            ]
+            expect(Rails.logger).to have_received(:info).with(*logger_params)
             expect(StatsD).to have_received(:increment)
-              .with('worker.decision_review.failure_notification_email.form.email_queued', tags: ['form_type:SC'])
+              .with('worker.decision_review.failure_notification_email.form.email_queued', tags: ['appeal_type:SC'])
           end
         end
       end
@@ -273,11 +285,11 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
             subject.new.perform
 
             expect(vanotify_service).to have_received(:send_email).with({ email_address:,
-                                                                          template_id: 'fake_nod_template_id',
+                                                                          template_id: 'fake_nod_evidence_template_id',
                                                                           personalisation: })
 
             expect(vanotify_service).to have_received(:send_email).with({ email_address: email_address2,
-                                                                          template_id: 'fake_nod_template_id',
+                                                                          template_id: 'fake_nod_evidence_template_id',
                                                                           personalisation: personalisation2 })
 
             upload1 = AppealSubmissionUpload.find_by(lighthouse_upload_id: upload_guid1)
@@ -300,14 +312,25 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
             expect(mpi_service).to have_received(:find_profile_by_identifier)
               .with(identifier: user_uuid2, identifier_type: 'idme').once
 
-            expect(Rails.logger).to have_received(:info)
-              .with('DecisionReview::FailureNotificationEmailJob evidence email queued',
-                    { lighthouse_upload_id: upload_guid1, submitted_appeal_uuid: guid1, form_type: 'NOD' })
-            expect(Rails.logger).to have_received(:info)
-              .with('DecisionReview::FailureNotificationEmailJob evidence email queued',
-                    { lighthouse_upload_id: upload_guid5, submitted_appeal_uuid: guid3, form_type: 'NOD' })
+            logger_params = [
+              'DecisionReview::FailureNotificationEmailJob evidence email queued',
+              { submitted_appeal_uuid: guid1, lighthouse_upload_id: upload_guid1, appeal_type: 'NOD', notification_id: }
+            ]
+            expect(Rails.logger).to have_received(:info).with(*logger_params)
+
+            logger_params2 = [
+              'DecisionReview::FailureNotificationEmailJob evidence email queued',
+              {
+                submitted_appeal_uuid: guid3,
+                lighthouse_upload_id: upload_guid5,
+                appeal_type: 'NOD',
+                notification_id: notification_id2
+              }
+            ]
+            expect(Rails.logger).to have_received(:info).with(*logger_params2)
+
             expect(StatsD).to have_received(:increment)
-              .with('worker.decision_review.failure_notification_email.evidence.email_queued', tags: ['form_type:NOD'])
+              .with('worker.decision_review.failure_notification_email.evidence.email_queued', tags: ['appeal_type:NOD'])
               .exactly(2).times
           end
         end
@@ -325,11 +348,13 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
         it 'handles the error and increments the statsd metric' do
           expect { subject.new.perform }.not_to raise_exception
 
-          expect(Rails.logger).to have_received(:error)
-            .with('DecisionReview::FailureNotificationEmailJob form error',
-                  { submitted_appeal_uuid: guid1, form_type: 'SC', message: })
+          logger_params = [
+            'DecisionReview::FailureNotificationEmailJob form error',
+            { submitted_appeal_uuid: guid1, appeal_type: 'SC', message: }
+          ]
+          expect(Rails.logger).to have_received(:error).with(*logger_params)
           expect(StatsD).to have_received(:increment)
-            .with('worker.decision_review.failure_notification_email.form.error', tags: ['form_type:SC'])
+            .with('worker.decision_review.failure_notification_email.form.error', tags: ['appeal_type:SC'])
         end
       end
 
@@ -372,11 +397,13 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
         it 'handles the error and increments the statsd metric' do
           expect { subject.new.perform }.not_to raise_exception
 
-          expect(Rails.logger).to have_received(:error)
-            .with('DecisionReview::FailureNotificationEmailJob evidence error',
-                  { lighthouse_upload_id:, submitted_appeal_uuid: guid1, form_type: 'SC', message: })
+          logger_params = [
+            'DecisionReview::FailureNotificationEmailJob evidence error',
+            { submitted_appeal_uuid: guid1, lighthouse_upload_id:, appeal_type: 'SC', message: }
+          ]
+          expect(Rails.logger).to have_received(:error).with(*logger_params)
           expect(StatsD).to have_received(:increment)
-            .with('worker.decision_review.failure_notification_email.evidence.error', tags: ['form_type:SC'])
+            .with('worker.decision_review.failure_notification_email.evidence.error', tags: ['appeal_type:SC'])
         end
       end
 


### PR DESCRIPTION
## Summary
This PR updates the `FailureNotificationEmailJob` to increment the `silent_failure_avoided_no_confirmation` metric whenever a send email request to VANotify is completed. The evidence failure emails have also been updated to use a different template than the form emails. Logs have been updated to include the VANotify email notification id and make tag names more consistent.

The job is behind the flipper flag `decision_review_failure_notification_email_job_enabled`.

This is owned by the Benefits Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94461
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84372

## Testing done

- [x] *New code is covered by unit tests*
Tested locally and rspec tests

## What areas of the site does it impact?
StatsD and Sidekiq

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
