### PR TITLE
API-41096-remove-trailing-spaces-from-name-in-rep-import

### DIFF
--- a/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
+++ b/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
@@ -89,6 +89,8 @@ module Veteran
       last_name, first_name, middle_initial = vso['Representative']
                                               .match(/(.*?), (.*?)(?: (.{0,1})[a-zA-Z]*)?$/).captures
 
+      last_name = last_name.strip
+
       rep = Veteran::Service::Representative.find_or_initialize_by(representative_id: vso['Registration Num'],
                                                                    first_name:,
                                                                    last_name:)

--- a/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Veteran::VSOReloader, type: :job do
     it 'loads a vso rep with the poa code' do
       VCR.use_cassette('veteran/ogc_vso_rep_data') do
         Veteran::VSOReloader.new.reload_vso_reps
-        expect(Veteran::Service::Representative.last.poa_codes).to include('091')
+        expect(Veteran::Service::Representative.last.poa_codes).to include('095')
         expect(Veteran::Service::Representative.where(representative_id: '').count).to eq 0
       end
     end
@@ -140,25 +140,32 @@ RSpec.describe Veteran::VSOReloader, type: :job do
       end
     end
 
-    context 'with multiple first names' do
-      it 'handles it correctly' do
+    context 'handling names' do
+      before do
         VCR.use_cassette('veteran/ogc_vso_rep_data') do
           Veteran::VSOReloader.new.reload_vso_reps
+        end
+      end
 
+      context 'with multiple first names' do
+        it 'handles it correctly' do
           veteran_rep = Veteran::Service::Representative.find_by!(representative_id: '82390')
           expect(veteran_rep.first_name).to eq('Anna Mae')
           expect(veteran_rep.middle_initial).to eq('B')
         end
       end
-    end
 
-    context 'invalid name' do
-      it 'handles it correctly' do
-        VCR.use_cassette('veteran/ogc_vso_rep_data') do
-          Veteran::VSOReloader.new.reload_vso_reps
-
+      context 'invalid name' do
+        it 'handles it correctly' do
           veteran_rep = Veteran::Service::Representative.find_by(representative_id: '82391')
           expect(veteran_rep).to be_nil
+        end
+      end
+
+      context 'when the last_name has trailing white space' do
+        it 'removes the trailing white space' do
+          veteran_rep = Veteran::Service::Representative.find_by(representative_id: '8240')
+          expect(veteran_rep.last_name).to eq('Good')
         end
       end
     end

--- a/spec/support/vcr_cassettes/veteran/ogc_vso_rep_data.yml
+++ b/spec/support/vcr_cassettes/veteran/ogc_vso_rep_data.yml
@@ -58,6 +58,10 @@ http_interactions:
         \  <TD>Lakewood</TD>\r\n   <TD>WA</TD>\r\n   <TD>Anderson, Edgar B</TD>\r\n
         \  <TD>Chicago</TD>\r\n   <TD>IL</TD>\r\n   <TD>'60635</TD>\r\n   <TD>8239</TD>\r\n</TR>\r\n\r\n
         \  <TR>\r\n
+        \  <TD>PTSD Association</TD>\r\n   <TD>'095</TD>\r\n   <TD>153-557-0736</TD>\r\n
+        \  <TD>Norfolk</TD>\r\n   <TD>WA</TD>\r\n   <TD>Good , Johnny B</TD>\r\n
+        \  <TD>New Orleans</TD>\r\n   <TD>LA</TD>\r\n   <TD>'60634</TD>\r\n   <TD>8240</TD>\r\n</TR>\r\n\r\n
+        \  <TR>\r\n
         \  <TD>African American PTSD Association</TD>\r\n   <TD>'091</TD>\r\n   <TD>253-589-0766</TD>\r\n
         \  <TD>Lakewood</TD>\r\n   <TD>WA</TD>\r\n   <TD>Anderson, Anna Mae B</TD>\r\n
         \  <TD>Chicago</TD>\r\n   <TD>IL</TD>\r\n   <TD>'60635</TD>\r\n   <TD>82390</TD>\r\n</TR>\r\n\r\n


### PR DESCRIPTION
## Summary
* Updates VCR to add test user with space at end of last name for import job
* Updates import job to strip trailing white space from last name
* Adds test for scenario

## Related issue(s)
[API-41096](https://jira.devops.va.gov/browse/API-41096)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/veteran/app/sidekiq/veteran/vso_reloader.rb
	modified:   modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
	modified:   spec/support/vcr_cassettes/veteran/ogc_vso_rep_data.yml

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
