### PR TITLE
Remove old flipper from features.yml

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -359,10 +359,6 @@ features:
   decision_review_sc_status_updater_enabled:
     actor_type: user
     description: Enables the Supplemental Claim status update batch job
-  decision_review_sc_use_lighthouse_api_for_form4142:
-    actor_type: user
-    description: Use Lighthouse API to submit Form 21-4142 from Supplemental Claims
-    enable_in_development: true
   decision_review_icn_updater_enabled:
     actor_type: user
     description: Enables the ICN lookup job


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Remove Flipper directing 4142s to Lighthouse - that is the default code path for all 4142s now

## Related issue(s)

- No ticket, just small code cleanup

## Testing done

- [ ] *New code is covered by unit tests*
- Tests for Flipper cases removed in previous PR, this just removes the flipper from `features.yml`

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Removes unused Flipper from list

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
