### PR TITLE
94148: Migration for DecisionReviewNotificationAuditLog table

### DIFF
--- a/db/migrate/20241021182334_create_decision_review_notification_audit_log.rb
+++ b/db/migrate/20241021182334_create_decision_review_notification_audit_log.rb
@@ -1,0 +1,15 @@
+class CreateDecisionReviewNotificationAuditLog < ActiveRecord::Migration[7.1]
+  def change
+    create_table :decision_review_notification_audit_logs do |t|
+      t.text :notification_id
+      t.text :status
+      t.text :reference
+      t.text :payload_ciphertext
+      t.text :encrypted_kms_key
+
+      t.timestamps
+    end
+    add_index :decision_review_notification_audit_logs, :notification_id
+    add_index :decision_review_notification_audit_logs, :reference
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_18_163939) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_21_182334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -468,6 +468,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_163939) do
     t.text "encrypted_kms_key"
     t.index ["account_id", "created_at"], name: "index_covid_vaccine_registry_submissions_2"
     t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true
+  end
+
+  create_table "decision_review_notification_audit_logs", force: :cascade do |t|
+    t.text "notification_id"
+    t.text "status"
+    t.text "reference"
+    t.text "payload_ciphertext"
+    t.text "encrypted_kms_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notification_id"], name: "idx_on_notification_id_e2314be616"
+    t.index ["reference"], name: "index_decision_review_notification_audit_logs_on_reference"
   end
 
   create_table "deprecated_user_accounts", force: :cascade do |t|


### PR DESCRIPTION
## Summary
This PR is a migration to create the `decision_review_notification_audit_logs` table.
This table will be used to store VANotify payloads received by the `v1/nod_callbacks` endpoint.

No flipper is needed for this as it is a table migration.

This is owned by the Benefits Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94148

## Testing done
Migration was run locally

## What areas of the site does it impact?
Postgres DB

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
