### PR TITLE
Point to binstubs in setup docs

### DIFF
--- a/docs/setup/hybrid.md
+++ b/docs/setup/hybrid.md
@@ -4,6 +4,8 @@ In hybrid mode, you'll run vets-api natively, but run Postgres and Redis in Dock
 
 ## Base Setup
 
+Follow these steps, or alternatively use [binstubs](binstubs.md).
+
 1. Install Docker as referenced in the [Docker setup instructions](docker.md).
 
 1. Follow the [Native setup instructions](native.md), but skip any steps related to installing Postgres, Postgis, Redis or ClamAV. You *will* need to install the other dependencies such as pdftk.

--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -22,15 +22,16 @@ If the repo's Ruby version is updated later, you will need to install the newer 
 
 ### RVM Troubleshooting
 
-If you see an error like `Error running '__rvm_make -j10'` while installing a ruby version, this usually occurs because of a mismatch with the openssl package. 
+If you see an error like `Error running '__rvm_make -j10'` while installing a ruby version, this usually occurs because of a mismatch with the openssl package.
 
-Many of these types of errors occur because either the openssl path needs to be specified or there's a compatibility issue with the ruby version and the install openssl version. They may get resolved by explicitly adding the directory or trying newer openssl version.    
+Many of these types of errors occur because either the openssl path needs to be specified or there's a compatibility issue with the ruby version and the install openssl version. They may get resolved by explicitly adding the directory or trying newer openssl version.
 
 For example: `rvm install 3.3.3 -C --with-openssl-dir=/$(brew --prefix openssl@3)`
 
 ## Base Setup
 
-1. Follow the common [base setup](https://github.com/department-of-veterans-affairs/vets-api/blob/master/README.md#Base%20setup).
+1. Follow the common [base setup](https://github.com/department-of-veterans-affairs/vets-api/blob/master/README.md#Base%20setup). Or alternatively use [binstubs](binstubs.md).
+
 
 1. Install Bundler to manage Ruby dependencies
 
@@ -112,7 +113,7 @@ clamav:
 
 #### Mock ClamAV
 
-If you wish to mock ClamAV, please set the clamav mock setting to true in settings.local.yml. This will mock the clamav response in the [virus_scan code](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/common/virus_scan.rb#L14-L23). 
+If you wish to mock ClamAV, please set the clamav mock setting to true in settings.local.yml. This will mock the clamav response in the [virus_scan code](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/common/virus_scan.rb#L14-L23).
 
 ```
 clamav:
@@ -156,7 +157,7 @@ All of the OSX instructions assume `homebrew` is your [package manager](https://
 3. Install binary dependencies:
     ```bash
     brew bundle
-    ```	 
+    ```
 
 
 4. (Optional see Running Natively for more info) Enable ClamAV daemon:

--- a/docs/setup/running_natively.md
+++ b/docs/setup/running_natively.md
@@ -1,7 +1,7 @@
 ## Running the app Natively
 
 
-To run vets-api and its redis and postgres dependencies run the following command from within the repo you cloned 
+To run vets-api and its redis and postgres dependencies run the following command from within the repo you cloned
 in the above steps.
 
 ```
@@ -14,6 +14,7 @@ directory will be reflected automatically via a docker volume mount, just as
 they would be when running rails directly.
 
 ### Running tests
+Follow these steps, or alternatively use [binstubs](binstubs.md).
 
 - `bundle exec rake spec` - Run the entire test suite  ( for `rspec spec`). Test coverage statistics are in `coverage/index.html`.
 - `make guard` - Run the guard test server that reruns your tests after files are saved. Useful for TDD!
@@ -51,7 +52,7 @@ clamav:
   port: '33100'
 ```
 
-1. In another terminal window, navigate to the project directory and run 
+1. In another terminal window, navigate to the project directory and run
 ```
 docker-compose -f docker-compose-clamav.yml up
 ```


### PR DESCRIPTION
## Summary

Binstubs can simplify vets-api setup and testing so we should point people to those docs as an alternative to the traditional setup.

## Related issue(s)

I had an issue getting tests to run without a ton of failures until I ran tests with binstubs. @rjohnson2011 suggested updating docs. 
## What areas of the site does it impact?
docs

