### PR TITLE
Save a record of 4142 forms submitted as part of Supplemental Claim

### DIFF
--- a/app/models/secondary_appeal_form.rb
+++ b/app/models/secondary_appeal_form.rb
@@ -1,48 +1,10 @@
 # frozen_string_literal: true
 
 class SecondaryAppealForm < ApplicationRecord
-  validates :guid, :form_id, presence: true
-  validate(:form_matches_schema)
-  validate(:form_must_be_string)
+  validates :guid, :form_id, :form, presence: true
 
   belongs_to :appeal_submission
 
   has_kms_key
   has_encrypted :form, key: :kms_key, **lockbox_options
-
-  private
-
-  def form_is_string
-    form.is_a?(String)
-  end
-
-  def form_must_be_string
-    errors.add(:form, :invalid_format, message: 'must be a json string') unless form_is_string
-  end
-
-  def form_matches_schema
-    return unless form_is_string
-
-    schema = VetsJsonSchema::SCHEMAS[form_id]
-
-    schema_errors = JSON::Validator.fully_validate_schema(schema, { errors_as_objects: true })
-    clear_cache = false
-    unless schema_errors.empty?
-      Rails.logger.error('SecondaryAppealForm schema failed validation! Attempting to clear cache.',
-                         { errors: schema_errors })
-      clear_cache = true
-    end
-
-    validation_errors = JSON::Validator.fully_validate(schema, JSON.parse(form),
-                                                       { errors_as_objects: true, clear_cache: })
-
-    validation_errors.each do |e|
-      errors.add(e[:fragment], e[:message])
-      e[:errors]&.flatten(2)&.each { |nested| errors.add(nested[:fragment], nested[:message]) if nested.is_a? Hash }
-    end
-
-    unless validation_errors.empty?
-      Rails.logger.error('SavedClaim form did not pass validation', { guid:, errors: validation_errors })
-    end
-  end
 end

--- a/lib/decision_review_v1/appeals/supplemental_claim_services.rb
+++ b/lib/decision_review_v1/appeals/supplemental_claim_services.rb
@@ -72,12 +72,39 @@ module DecisionReviewV1
             submit_form4142(form_data: rejiggered_payload)
           end
           form4142_response, uuid = response_container
+
+          if Flipper.enabled?(:decision_review_track_4142_submissions)
+            save_form4142_submission(appeal_submission_id:, rejiggered_payload:, guid: uuid)
+          end
+
           form4142_submission_info_message = parse_form412_response_to_log_msg(
             appeal_submission_id:, data: form4142_response, uuid:, bm:
           )
           ::Rails.logger.info(form4142_submission_info_message)
           form4142_response
         end
+      end
+
+      def save_form4142_submission(appeal_submission_id:, rejiggered_payload:, guid:)
+        form_record = SecondaryAppealForm.new(
+          form: rejiggered_payload.to_json,
+          form_id: '21-4142',
+          appeal_submission_id: appeal_submission_id,
+          guid: guid
+        )
+        form_record.save!
+      rescue => e
+        ::Rails.logger.error({
+                               error_message: e.message,
+                               form_id: DecisionReviewV1::FORM4142_ID,
+                               parent_form_id: DecisionReviewV1::SUPP_CLAIM_FORM_ID,
+                               message: 'Supplemental Claim Form4142 Persistence Errored',
+                               appeal_submission_id:,
+                               lighthouse_submission: {
+                                 id: uuid
+                               }
+                             })
+        raise e
       end
 
       ##

--- a/spec/factories/secondary_appeal_forms.rb
+++ b/spec/factories/secondary_appeal_forms.rb
@@ -20,7 +20,27 @@ FactoryBot.define do
           isRequestingOwnMedicalRecords: true
 
         },
-        providerFacility: [{}],
+        providerFacility: [{
+          providerFacilityName: 'provider 1',
+          treatmentDateRange: [
+            {
+              from: '1980-1-1',
+              to: '1985-1-1'
+            },
+            {
+              from: '1986-1-1',
+              to: '1987-1-1'
+            }
+          ],
+          providerFacilityAddress: {
+            street: '123 Main Street',
+            street2: '1B',
+            city: 'Baltimore',
+            state: 'MD',
+            country: 'USA',
+            postalCode: '21200-1111'
+          }
+        }],
         preparerIdentification: {
           relationshipToVeteran: 'self'
         },

--- a/spec/models/secondary_appeal_form_spec.rb
+++ b/spec/models/secondary_appeal_form_spec.rb
@@ -9,23 +9,10 @@ RSpec.describe SecondaryAppealForm, type: :model do
   describe 'validations' do
     before do
       expect(subject).to be_valid
-      expect(JSON::Validator).to receive(:fully_validate).at_least(:twice).and_call_original
     end
 
     it { is_expected.to validate_presence_of(:guid) }
-
-    it 'errors if trying to validate without a form_id' do
-      subject.form_id = nil
-      expect { subject.valid? }.to raise_error(JSON::Schema::SchemaParseError)
-    end
-
-    it 'rejects forms with missing elements' do
-      bad_form = JSON.parse(subject.form).deep_dup
-      bad_form.delete('privacyAgreementAccepted')
-      subject.form = bad_form.to_json
-      expect(subject).not_to be_valid
-      expect(subject.errors.full_messages.size).to eq(1)
-      expect(subject.errors.full_messages).to include(/privacyAgreementAccepted/)
-    end
+    it { is_expected.to validate_presence_of(:form_id) }
+    it { is_expected.to validate_presence_of(:form) }
   end
 end

--- a/spec/requests/v1/supplemental_claims_spec.rb
+++ b/spec/requests/v1/supplemental_claims_spec.rb
@@ -128,31 +128,115 @@ RSpec.describe 'V1::SupplementalClaims', type: :request do
                                    'V1::SupplementalClaimsController#create exception % (SC_V1)'
     end
 
-    subject do
-      post '/v1/supplemental_claims',
-           params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
-           headers:
+    context 'when tracking 4142 is enabled' do
+      subject do
+        post '/v1/supplemental_claims',
+             params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
+             headers:
+      end
+
+      before do
+        Flipper.enable(:decision_review_track_4142_submissions)
+      end
+
+      it 'creates a supplemental claim and queues and saves a 4142 form when 4142 info is provided' do
+        VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
+              expect { subject }.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
+              expect(response).to be_successful
+              parsed_response = JSON.parse(response.body)
+              id = parsed_response['data']['id']
+              expect(previous_appeal_submission_ids).not_to include id
+              appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+              expect(appeal_submission.type_of_appeal).to eq('SC')
+              expect do
+                DecisionReview::Form4142Submit.drain
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(-1)
+
+              # SavedClaim should be created with request data and list of uploaded forms
+              request_body = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json)
+              saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
+              expect(saved_claim.form).to eq(request_body.to_json)
+              expect(saved_claim.uploaded_forms).to contain_exactly '21-4142'
+
+              # SecondaryAppealForm should be created with 4142 data and user data
+              expected_form4142_data = VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV')['form4142']
+              veteran_data = {
+                'vaFileNumber' => '796111863',
+                'veteranSocialSecurityNumber' => '796111863',
+                'veteranFullName' => {
+                  'first' => 'abraham',
+                  'middle' => nil,
+                  'last' => 'lincoln'
+                },
+                'veteranDateOfBirth' => '1809-02-12',
+                'veteranAddress' => { 'addressLine1' => '123  Main St', 'city' => 'New York', 'countryCodeISO2' => 'US',
+                                      'zipCode5' => '30012', 'country' => 'US', 'postalCode' => '30012' },
+                'email' => 'josie@example.com',
+                'veteranPhone' => '5558001111'
+              }
+              expected_form4142_data_with_user = veteran_data.merge(expected_form4142_data)
+              saved4142 = SecondaryAppealForm.last
+              saved_4142_json = JSON.parse(saved4142.form)
+              expect(saved_4142_json).to eq(expected_form4142_data_with_user)
+              expect(saved4142.form_id).to eq('21-4142')
+              expect(saved4142.appeal_submission.id).to eq(appeal_submission.id)
+            end
+          end
+        end
+      end
     end
 
-    it 'creates a supplemental claim and queues a 4142 form when 4142 info is provided' do
-      VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
-        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
-          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
-            previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
-            expect { subject }.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
-            expect(response).to be_successful
-            parsed_response = JSON.parse(response.body)
-            id = parsed_response['data']['id']
-            expect(previous_appeal_submission_ids).not_to include id
-            appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
-            expect(appeal_submission.type_of_appeal).to eq('SC')
-            expect { DecisionReview::Form4142Submit.drain }.to change(DecisionReview::Form4142Submit.jobs, :size).by(-1)
+    context 'when tracking 4142 is disabled' do
+      before do
+        Flipper.disable(:decision_review_track_4142_submissions)
+      end
 
-            # SavedClaim should be created with request data and list of uploaded forms
-            request_body = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json)
-            saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
-            expect(saved_claim.form).to eq(request_body.to_json)
-            expect(saved_claim.uploaded_forms).to contain_exactly '21-4142'
+      it 'creates a supplemental claim and queues a 4142 form when 4142 info is provided' do
+        VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
+              expect do
+                post '/v1/supplemental_claims',
+                     params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
+                     headers:
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
+              expect(response).to be_successful
+              parsed_response = JSON.parse(response.body)
+              id = parsed_response['data']['id']
+              expect(previous_appeal_submission_ids).not_to include id
+              appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+              expect(appeal_submission.type_of_appeal).to eq('SC')
+              expect do
+                DecisionReview::Form4142Submit.drain
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(-1)
+
+              # SavedClaim should be created with request data and list of uploaded forms
+              request_body = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json)
+              saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
+              expect(saved_claim.form).to eq(request_body.to_json)
+              expect(saved_claim.uploaded_forms).to contain_exactly '21-4142'
+            end
+          end
+        end
+      end
+
+      it 'does not persist a SecondaryAppealForm for the 4142' do
+        VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              expect do
+                post '/v1/supplemental_claims',
+                     params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
+                     headers:
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
+              expect do
+                DecisionReview::Form4142Submit.drain
+              end.not_to change(SecondaryAppealForm, :count)
+            end
           end
         end
       end
@@ -207,6 +291,7 @@ RSpec.describe 'V1::SupplementalClaims', type: :request do
             expect(AppealSubmissionUpload.count).to eq 0
             expect(DecisionReview::SubmitUpload).not_to have_enqueued_sidekiq_job(anything)
             expect(SavedClaim.count).to eq 0
+            expect(SecondaryAppealForm.count).to eq 0
           end
         end
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Save a SecondaryAppealForm object of type '21-4142' when it is successfully submitted to Lighthouse as part of submitting a SupplementalClaim
- Remove schema validation for SecondaryAppealForm because we want to save even malformed form data for audit purposes
- Upcoming: Poll for status and set a delete_date when form is completely successful or failed
- Decision Reviews team, we own this controller and code path
- Success if form information can be saved without error for every 4142 submission

## Related issue(s)

department-of-veterans-affairs/va.gov-team/issues/95001

## Testing done

- [X] *New code is covered by unit tests*
- Before this change, we logged the status of the request to submit the 4142, but we did not persist information about the form or it's guid in Lighthouse, so we could not poll for its status as it moved through Lighthouse and CMP. This is part of tracking silent failures.
- Submit a Supplemental Claim with 4142 info, see a record persisted in the DB
- Tests for both enabled and disabled
- Test in Staging, roll out for some percentage of users in Prod and verify no errors before enabling for all users

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
No changes to user experience. Saves additional data when a Supplemental Claim is submitted.

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution NOTE: future work will add DataDog stats
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Should we add DD logging at this stage? If so, what metric?
