### PR TITLE
94148: Update NodCallbacksController to save all notifications to DR audit log

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -225,6 +225,7 @@ app/models/concerns/redis_form.rb @department-of-veterans-affairs/backend-review
 app/models/concerns/set_guid.rb @department-of-veterans-affairs/backend-review-group
 app/models/concerns/temp_form_validation.rb @department-of-veterans-affairs/backend-review-group
 app/models/decision_review_evidence_attachment.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/decision_review_notification_audit_log.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/dependents_application.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/deprecated_user_account.rb @department-of-veterans-affairs/octo-identity
 app/models/disability_contention.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1150,6 +1151,7 @@ spec/factories/central_mail_submissions.rb @department-of-veterans-affairs/vfs-a
 spec/factories/coe_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/configurations.rb@department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/decision_review_evidence_attachment.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/factories/decision_review_notification_audit_logs.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/dependency_claim_no_vet_information.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/dependency_claim.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/dependency_verification_claim.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1533,6 +1535,7 @@ spec/models/async_transaction/base_spec.rb @department-of-veterans-affairs/vfs-a
 spec/models/async_transaction/va_profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/async_transaction/vet360 @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/bgs_dependents @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/models/decision_review_notification_audit_log_spec.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/dependents_application_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/deprecated_user_account_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/disability_contention_spec.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -159,6 +159,7 @@ app/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-exp
 app/controllers/v1/supplemental_claims @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/decision_review_evidences_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/apidocs_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/v1/nod_callbacks_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/notice_of_disagreements_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/pension_ipf_callbacks_controller.rb @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/sessions_controller.rb  @department-of-veterans-affairs/octo-identity
@@ -1121,6 +1122,7 @@ spec/controllers/v0/veteran_onboardings_controller_spec.rb @department-of-vetera
 spec/controllers/v0/virtual_agent @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/virtual_agent_token_msft_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/virtual_agent_token_nlu_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/controllers/v1/nod_callbacks_controller_spec.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
 spec/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/decision_review_notification_audit_log.rb
+++ b/app/models/decision_review_notification_audit_log.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'json_marshal/marshaller'
+
+class DecisionReviewNotificationAuditLog < ApplicationRecord
+  serialize :payload, coder: JsonMarshal::Marshaller
+
+  has_kms_key
+  has_encrypted :payload, key: :kms_key, **lockbox_options
+
+  validates(:payload, presence: true)
+
+  before_save :serialize_payload
+
+  private
+
+  def serialize_payload
+    self.payload = payload.to_json unless payload.is_a?(String)
+  end
+end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1590,7 +1590,7 @@ features:
     description: NOD Datadog RUM monitoring
   nod_callbacks_endpoint:
     actor_type: user
-    description: NOD VANotify notification callbacks endpoint
+    description: Enables Decision Review endpoint to process VANotify notification callbacks
     enable_in_development: true
   nod_confirmation_update:
     actor_type: user

--- a/spec/factories/decision_review_notification_audit_logs.rb
+++ b/spec/factories/decision_review_notification_audit_logs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :decision_review_notification_audit_log do
+    payload do
+      {
+        id: '6ba01111-f3ee-4a40-9d04-234asdfb6abab9c',
+        reference: 'reference-value',
+        to: 'test@test.com',
+        status: 'delivered',
+        created_at: '2023-01-10T00:04:25.273410Z',
+        completed_at: '2023-01-10T00:05:33.255911Z',
+        sent_at: '2023-01-10T00:04:25.775363Z',
+        notification_type: 'email',
+        status_reason: '',
+        provider: 'pinpoint'
+      }
+    end
+  end
+end

--- a/spec/models/decision_review_notification_audit_log_spec.rb
+++ b/spec/models/decision_review_notification_audit_log_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DecisionReviewNotificationAuditLog, type: :model do
+  let(:audit_log) { build(:decision_review_notification_audit_log) }
+
+  describe 'payload encryption' do
+    it 'encrypts the payload field' do
+      expect(subject).to encrypt_attr(:payload)
+    end
+  end
+
+  describe 'validations' do
+    it 'validates presence of payload' do
+      expect_attr_valid(audit_log, :payload)
+      audit_log.payload = nil
+      expect_attr_invalid(audit_log, :payload, "can't be blank")
+    end
+  end
+
+  describe '#serialize_payload' do
+    let(:payload) do
+      { a: 1 }
+    end
+
+    it 'serializes payload as json' do
+      audit_log.payload = payload
+      audit_log.save!
+
+      expect(audit_log.payload).to eq(payload.to_json)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR updates the NodCallbackController to save all status messages of VANotify notification emails that were sent to Veterans.

This feature is behind the nod_callbacks_endpoint flipper flag.

This is owned by the Benefits Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94148

## Testing done

- [x] *New code is covered by unit tests*
The old behavior would only save callbacks in a permanent failure state that would not retry to the `nod_notifications` table. 
The new behavior saves all received callbacks to a new table `decision_review_notification_audit_logs`. This feature will be tested in staging before being enabled in production.
This was tested locally using Postman for POSTing requests to the `v1/nod_callbacks` endpoint.

## What areas of the site does it impact?
This impacts the NodCallbackController endpoint and the `decision_review_notification_audit_logs` table.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
