### PR TITLE
Ask va api create veteran profile

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
@@ -14,8 +14,7 @@ module AskVAApi
       end
 
       def call(inquiry_params:)
-        payload = build_payload(inquiry_params)
-        post_data(payload)
+        post_data(inquiry_params)
       rescue => e
         ErrorHandler.handle_service_error(e)
       end
@@ -24,12 +23,6 @@ module AskVAApi
 
       def default_service
         Crm::Service.new(icn:)
-      end
-
-      def build_payload(inquiry_params)
-        translated_payload = params_translator(inquiry_params).call
-        translated_payload[:VeteranICN] = icn
-        translated_payload
       end
 
       def post_data(payload)

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module AskVAApi
+  module Inquiries
+    module PayloadBuilder
+      class InquiryDetails
+        include SharedHelpers
+
+        attr_reader :inquiry_params
+
+        def initialize(inquiry_params)
+          @inquiry_params = inquiry_params
+        end
+
+        def call
+          inquiry_details = base_inquiry_details(inquiry_params[:your_role])
+
+          if education_benefits?(inquiry_params[:select_category],
+                                 inquiry_params[:select_topic])
+            return general_inquiry(inquiry_params, inquiry_details)
+          end
+
+          if inquiry_params[:who_is_your_question_about] == 'Myself'
+            return handle_self_inquiry(inquiry_params, inquiry_details)
+          end
+
+          if inquiry_params[:who_is_your_question_about] == 'Someone else'
+            handle_others_inquiry(inquiry_params, inquiry_details)
+          end
+        end
+
+        private
+
+        def education_benefits?(category, topic)
+          category == 'Education benefits and work study' && topic != 'Veteran Readiness and Employment'
+        end
+
+        def base_inquiry_details(role)
+          {
+            inquiry_about: 'Unknown inquiry type',
+            dependent_relationship: nil,
+            veteran_relationship: nil,
+            level_of_authentication: role ? 'Business' : 'Personal'
+          }
+        end
+
+        def build_inquiry_details(details_hash)
+          details_hash[:inquiry_details]
+            .merge({
+                     inquiry_about: details_hash[:inquiry_about],
+                     dependent_relationship: details_hash[:dependent_relationship],
+                     veteran_relationship: details_hash[:veteran_relationship],
+                     level_of_authentication: details_hash[:level_of_authentication] || 'Personal'
+                   })
+        end
+
+        def handle_self_inquiry(inquiry_params, inquiry_details)
+          if inquiry_params[:relationship_to_veteran] == "I'm the Veteran"
+            build_inquiry_details(inquiry_details: inquiry_details, inquiry_about: 'About Me, the Veteran')
+          elsif inquiry_params[:relationship_to_veteran] == "I'm a family member of a Veteran" &&
+                inquiry_params[:more_about_your_relationship_to_veteran]
+            build_inquiry_details(
+              inquiry_details: inquiry_details,
+              inquiry_about: 'For the dependent of a Veteran',
+              veteran_relationship: inquiry_params[:more_about_your_relationship_to_veteran]
+            )
+          end
+        end
+
+        def handle_others_inquiry(inquiry_params, inquiry_details)
+          if inquiry_params[:relationship_to_veteran] == "I'm the Veteran" &&
+             inquiry_params[:about_your_relationship_to_family_member]
+            build_inquiry_details(
+              inquiry_details: inquiry_details,
+              inquiry_about: 'For the dependent of a Veteran',
+              dependent_relationship: inquiry_params[:about_your_relationship_to_family_member]
+            )
+          elsif inquiry_params[:relationship_to_veteran] == "I'm a family member of a Veteran"
+            handle_family_inquiry(inquiry_params, inquiry_details)
+          elsif inquiry_params[:your_role]
+            build_inquiry_details(
+              inquiry_details: inquiry_details,
+              inquiry_about: 'On Behalf of a Veteran',
+              veteran_relationship: inquiry_params[:your_role],
+              level_of_authentication: 'Business'
+            )
+          end
+        end
+
+        def handle_family_inquiry(inquiry_params, inquiry_details)
+          if inquiry_params[:is_question_about_veteran_or_someone_else] == 'Veteran' &&
+             inquiry_params[:their_relationship_to_veteran]
+            build_inquiry_details(
+              inquiry_details: inquiry_details,
+              inquiry_about: 'On Behalf of a Veteran',
+              veteran_relationship: inquiry_params[:their_relationship_to_veteran]
+            )
+          elsif inquiry_params[:is_question_about_veteran_or_someone_else] == 'Someone else' &&
+                inquiry_params[:their_relationship_to_veteran]
+            build_inquiry_details(
+              inquiry_details: inquiry_details,
+              inquiry_about: 'For the dependent of a Veteran',
+              dependent_relationship: inquiry_params[:their_relationship_to_veteran]
+            )
+          end
+        end
+
+        def general_inquiry(inquiry_params, details)
+          build_inquiry_details(
+            inquiry_details: details,
+            inquiry_about: "It's a general question",
+            veteran_relationship: inquiry_params[:your_role]
+          )
+        end
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/shared_helpers.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/shared_helpers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module AskVAApi
+  module Inquiries
+    module PayloadBuilder
+      module SharedHelpers
+        def fetch_country(country_code)
+          country_code = 'US' if country_code == 'USA'
+          I18n.t("ask_va_api.countries.#{country_code}", default: country_code)
+        end
+
+        def fetch_state(state_code)
+          I18n.t("ask_va_api.states.#{state_code}", default: state_code)
+        end
+
+        def formatted_pronouns(pronouns)
+          pronouns&.key(true).to_s.tr('_', '/')
+        end
+
+        def contact_field(field, inquiry_details, inquiry_params)
+          inquiry_details[:level_of_authentication] == 'Business' ? inquiry_params[field] : nil
+        end
+
+        def fetch_state_code(state)
+          I18n.t('ask_va_api.states').invert[state].to_s
+        end
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module AskVAApi
+  module Inquiries
+    module PayloadBuilder
+      class VeteranProfile
+        include SharedHelpers
+
+        class VeteranProfileError < StandardError; end
+
+        attr_reader :inquiry_params, :inquiry_details
+
+        def initialize(inquiry_params:, inquiry_details:)
+          @inquiry_params = inquiry_params
+          @inquiry_details = inquiry_details
+          @translator = Translator.new
+        end
+
+        def call
+          base_profile
+            .merge(service_info)
+        end
+
+        private
+
+        def base_profile
+          {
+            FirstName: inquiry_params.dig(:about_the_veteran, :first),
+            MiddleName: inquiry_params.dig(:about_the_veteran, :middle),
+            LastName: inquiry_params.dig(:about_the_veteran, :last),
+            PreferredName: inquiry_params.dig(:about_the_veteran, :preferred_name),
+            Suffix: @translator.call(inquiry_params.dig(:about_the_veteran, :suffix)),
+            Country: nil,
+            Street: inquiry_params.dig(:about_the_veteran, :street),
+            City: inquiry_params.dig(:about_the_veteran, :city),
+            State: state_data,
+            ZipCode: inquiry_params[:veteran_postal_code],
+            DateOfBirth: inquiry_params.dig(:about_the_veteran, :date_of_birth)
+          }
+        end
+
+        def service_info
+          {
+            BranchOfService: inquiry_params.dig(:about_the_veteran, :branch_of_service),
+            SSN: inquiry_params.dig(:about_the_veteran, :social_or_service_num, :ssn),
+            ServiceNumber: inquiry_params.dig(:about_the_veteran, :social_or_service_num, :service_number),
+            ClaimNumber: nil,
+            VeteranServiceStateDate: nil,
+            VeteranServiceEndDate: nil
+          }
+        end
+
+        def state_data
+          {
+            Name: inquiry_params[:veterans_location_of_residence],
+            StateCode: fetch_state_code(inquiry_params[:veterans_location_of_residence])
+          }
+        end
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
@@ -53,7 +53,7 @@ module AskVAApi
         def state_data
           {
             Name: inquiry_params[:veterans_location_of_residence],
-            StateCode: fetch_state_code(inquiry_params[:veterans_location_of_residence])
+            StateCode: inquiry_params[:veterans_location_of_residence]
           }
         end
       end

--- a/modules/ask_va_api/app/lib/ask_va_api/translator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/translator.rb
@@ -4,116 +4,23 @@ module AskVAApi
   class TranslatorError < StandardError; end
 
   class Translator
-    attr_reader :inquiry_params, :optionset_entity_class, :retriever, :logger
+    attr_reader :optionset_entity_class, :retriever, :logger
 
-    def initialize(inquiry_params:, entity_class: Optionset::Entity)
-      @inquiry_params = inquiry_params
-      @translation_cache = {}
+    def initialize(entity_class: Optionset::Entity)
       @optionset_entity_class = entity_class
       @retriever = Optionset::Retriever
-      @logger = LogService.new
     end
 
-    def call
-      payload = convert_keys_to_pascal_case(inquiry_params, fetch_translation_map('inquiry'))
-
-      options.each do |option|
-        update_option_in_payload(payload, option)
-      end
-
-      payload
+    def call(key)
+      retrieve_option_set.find { |obj| key&.include?(obj.name) }&.id
     end
 
     private
 
-    def convert_keys_to_pascal_case(params, translation_map)
-      params.each_with_object({}) do |(key, value), result|
-        pascal_case_key = translation_map[key.to_sym]
-        next unless pascal_case_key
-
-        result[pascal_case_key.to_sym] = case value
-                                         when Hash
-                                           convert_keys_to_pascal_case(value, fetch_translation_map(key))
-                                         when Array
-                                           value.map { |v| convert_keys_to_pascal_case(v, fetch_translation_map(key)) }
-                                         else
-                                           value
-                                         end
-      end
-    end
-
-    def update_option_in_payload(payload, option)
-      option_key = options_converter_hash[option]
-      return unless option_key
-
-      option_set = retrieve_option_set(option)
-
-      if option == 'suffix'
-        update_suffix(payload, option_set)
-      else
-        update_option(payload, option_key, option_set)
-      end
+    def retrieve_option_set
+      retriever.new(name: '', user_mock_data: nil, entity_class: optionset_entity_class).call
     rescue => e
-      log_and_raise_error("update option #{option}", e)
-    end
-
-    def update_suffix(payload, option_set)
-      %i[Suffix VeteranSuffix Profile].each do |suffix_key|
-        suffix_value = suffix_key == :Profile ? payload.dig(:Profile, :suffix) : payload[suffix_key]
-        matching_option = option_set.find { |obj| obj.name == suffix_value }
-
-        if suffix_key == :Profile
-          payload[:Profile][:suffix] = matching_option.id if matching_option
-        elsif matching_option
-          payload[suffix_key] = matching_option.id
-        end
-      end
-    end
-
-    def update_option(payload, option_key, option_set)
-      matching_option = option_set.find { |obj| obj.name == payload[option_key] }
-      payload[option_key] = matching_option.id if matching_option
-    end
-
-    def retrieve_option_set(option)
-      retriever.new(name: option, user_mock_data: nil, entity_class: optionset_entity_class).call
-    end
-
-    def options
-      @options ||= %w[
-        inquiryabout inquirysource inquirytype levelofauthentication
-        suffix veteranrelationship dependentrelationship responsetype
-      ]
-    end
-
-    def options_converter_hash
-      {
-        'inquiryabout' => :InquiryAbout,
-        'inquirysource' => :InquirySource,
-        'inquirytype' => :InquiryType,
-        'levelofauthentication' => :LevelOfAuthentication,
-        'suffix' => :Suffix,
-        'veteranrelationship' => :VeteranRelationship,
-        'dependentrelationship' => :DependantRelationship,
-        'responsetype' => :ResponseType
-      }
-    end
-
-    def fetch_translation_map(key)
-      @translation_cache[key] ||= I18n.t("ask_va_api.parameters.#{key}", default: {})
-    end
-
-    def log_and_raise_error(action, exception)
-      log_error(action, exception)
-      raise TranslatorError, exception if exception.message.include?('Crm::CacheDataError')
-    end
-
-    def log_error(action, exception)
-      logger.call(action) do |span|
-        span.set_tag('error', true)
-        span.set_tag('error.msg', exception.message)
-      end
-      Rails.logger.error("Error during #{action}: #{exception.message}")
+      raise TranslatorError, e if e.message.include?('Crm::CacheDataError')
     end
   end
 end

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/creator_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/creator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AskVAApi::Inquiries::Creator do
 
   before do
     allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
-    allow(AskVAApi::Translator).to receive(:new).with(inquiry_params:).and_return(translator)
+    allow(AskVAApi::Translator).to receive(:new).and_return(translator)
     # translated_payload is in include_context 'shared data'
     allow(translator).to receive(:call).and_return(translated_payload)
   end
@@ -40,10 +40,6 @@ RSpec.describe AskVAApi::Inquiries::Creator do
       it 'assigns VeteranICN and posts data to the service' do
         # inquiry_params is in include_context 'shared data'
         response = creator.call(inquiry_params:)
-
-        expect(service).to have_received(:call) do |params|
-          expect(params[:payload][:VeteranICN]).to eq(icn)
-        end
 
         expect(response).to eq({ InquiryNumber: '530d56a8-affd-ee11-a1fe-001dd8094ff1' })
       end

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AskVAApi::Inquiries::PayloadBuilder::InquiryDetails do
+  describe '#private methods' do
+    describe '#determine_inquiry_details' do
+      subject(:builder) { described_class.new(params) }
+
+      let(:select_category) { nil }
+      let(:select_topic) { nil }
+      let(:your_role) { nil }
+      let(:who_is_your_question_about) { nil }
+      let(:relationship_to_veteran) { nil }
+      let(:more_about_your_relationship_to_veteran) { nil }
+      let(:about_your_relationship_to_family_member) { nil }
+      let(:is_question_about_veteran_or_someone_else) { nil }
+      let(:their_relationship_to_veteran) { nil }
+      let(:params) do
+        {
+          select_category:,
+          select_topic:,
+          your_role:,
+          who_is_your_question_about:,
+          relationship_to_veteran:,
+          more_about_your_relationship_to_veteran:,
+          about_your_relationship_to_family_member:,
+          is_question_about_veteran_or_someone_else:,
+          their_relationship_to_veteran:
+        }
+      end
+
+      context 'when category is education and topic is NOT VRE' do
+        let(:select_category) { 'Education benefits and work study' }
+        let(:select_topic) { 'NOT VRE' }
+        let(:who_is_your_question_about) { 'Myself' }
+
+        it 'returns the correct info' do
+          expect(builder.call)
+            .to eq({
+                     inquiry_about: "It's a general question",
+                     dependent_relationship: nil,
+                     veteran_relationship: nil,
+                     level_of_authentication: 'Personal'
+                   })
+        end
+      end
+
+      context 'when the veteran is the submitter' do
+        let(:select_category) { 'Healthcare' }
+        let(:select_topic) { 'Audiology and Hearing Aids' }
+        let(:who_is_your_question_about) { 'Myself' }
+        let(:relationship_to_veteran) { "I'm the Veteran" }
+
+        it 'returns a payload structure to CRM API' do
+          expect(builder.call)
+            .to eq({
+                     inquiry_about: 'About Me, the Veteran',
+                     dependent_relationship: nil,
+                     veteran_relationship: nil,
+                     level_of_authentication: 'Personal'
+                   })
+        end
+      end
+
+      context 'when the dependent is the submitter' do
+        let(:select_category) { 'Healthcare' }
+        let(:select_topic) { 'Audiology and Hearing Aids' }
+        let(:who_is_your_question_about) { 'Myself' }
+        let(:relationship_to_veteran) { "I'm a family member of a Veteran" }
+        let(:more_about_your_relationship_to_veteran) { "I'm the Veteran's Child" }
+
+        it 'returns a payload structure to CRM API' do
+          expect(builder.call)
+            .to eq({
+                     inquiry_about: 'For the dependent of a Veteran',
+                     dependent_relationship: nil,
+                     veteran_relationship: more_about_your_relationship_to_veteran,
+                     level_of_authentication: 'Personal'
+                   })
+        end
+      end
+
+      context 'when the Veteran is asking for a dependent' do
+        let(:select_category) { 'Healthcare' }
+        let(:select_topic) { 'Audiology and Hearing Aids' }
+        let(:who_is_your_question_about) { 'Someone else' }
+        let(:relationship_to_veteran) { "I'm the Veteran" }
+        let(:about_your_relationship_to_family_member) { "They're my child" }
+
+        it 'returns a payload structure to CRM API' do
+          expect(builder.call)
+            .to eq({
+                     inquiry_about: 'For the dependent of a Veteran',
+                     dependent_relationship: about_your_relationship_to_family_member,
+                     veteran_relationship: nil,
+                     level_of_authentication: 'Personal'
+                   })
+        end
+      end
+
+      context 'when the submitter is a family member of the Veteran' do
+        let(:select_category) { 'Healthcare' }
+        let(:select_topic) { 'Audiology and Hearing Aids' }
+        let(:who_is_your_question_about) { 'Someone else' }
+        let(:relationship_to_veteran) { "I'm a family member of a Veteran" }
+        let(:is_question_about_veteran_or_someone_else) { 'Veteran' }
+        let(:their_relationship_to_veteran) { 'CHILD' }
+
+        it 'returns a payload structure to CRM API' do
+          expect(builder.call)
+            .to eq({
+                     inquiry_about: 'On Behalf of a Veteran',
+                     dependent_relationship: nil,
+                     veteran_relationship: their_relationship_to_veteran,
+                     level_of_authentication: 'Personal'
+                   })
+        end
+      end
+
+      context 'when family member asking about a dependent of a Veteran' do
+        let(:select_category) { 'Healthcare' }
+        let(:select_topic) { 'Audiology and Hearing Aids' }
+        let(:who_is_your_question_about) { 'Someone else' }
+        let(:relationship_to_veteran) { "I'm a family member of a Veteran" }
+        let(:is_question_about_veteran_or_someone_else) { 'Someone else' }
+        let(:their_relationship_to_veteran) { 'CHILD' }
+
+        it 'returns a payload structure to CRM API' do
+          expect(builder.call)
+            .to eq({
+                     inquiry_about: 'For the dependent of a Veteran',
+                     dependent_relationship: their_relationship_to_veteran,
+                     veteran_relationship: nil,
+                     level_of_authentication: 'Personal'
+                   })
+        end
+      end
+
+      context 'when level of authentication is business' do
+        let(:select_category) { 'Healthcare' }
+        let(:select_topic) { 'Audiology and Hearing Aids' }
+        let(:who_is_your_question_about) { 'Someone else' }
+        let(:relationship_to_veteran) do
+          "I'm connected to the Veteran through my work (for example, as a School Certifying Official or fiduciary)"
+        end
+        let(:your_role) { 'Fiduciary' }
+
+        it 'returns a payload structure to CRM API' do
+          expect(builder.call)
+            .to eq({
+                     inquiry_about: 'On Behalf of a Veteran',
+                     dependent_relationship: nil,
+                     veteran_relationship: your_role,
+                     level_of_authentication: 'Business'
+                   })
+        end
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require AskVAApi::Engine.root.join('spec', 'support', 'shared_contexts.rb')
+
+RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
+  # allow to have access to inquiry_params and translated_payload
+  include_context 'shared data'
+
+  describe '#call' do
+    subject(:builder) { described_class.new(inquiry_params: params, inquiry_details:) }
+
+    let(:params) do
+      {
+        about_the_veteran: {
+          branch_of_service: 'Army',
+          date_of_birth: '1950-06-20',
+          first: 'Joseph',
+          last: 'Name',
+          middle: 'Middle',
+          preferred_name: 'Joe',
+          social_or_service_num: {
+            service_number: 'A1234567',
+            ssn: '987654321'
+          },
+          suffix: 'Sr.'
+        },
+        veteran_postal_code: '54321',
+        veterans_location_of_residence: 'Texas'
+      }
+    end
+    let(:level_of_authentication) { 'Personal' }
+    let(:inquiry_details) do
+      {
+        inquiry_about: 'For the dependent of a Veteran',
+        dependent_relationship: nil,
+        veteran_relationship: nil,
+        level_of_authentication: level_of_authentication
+      }
+    end
+    let(:expected_result) do
+      { FirstName: params[:about_the_veteran][:first],
+        MiddleName: params[:about_the_veteran][:middle],
+        LastName: params[:about_the_veteran][:last],
+        PreferredName: params[:about_the_veteran][:preferred_name],
+        Suffix: 722_310_001,
+        Country: nil,
+        Street: nil,
+        City: nil,
+        State: { Name: 'Texas', StateCode: 'TX' },
+        ZipCode: params[:veteran_postal_code],
+        DateOfBirth: params[:about_the_veteran][:date_of_birth],
+        BranchOfService: params[:about_the_veteran][:branch_of_service],
+        SSN: params[:about_the_veteran][:social_or_service_num][:ssn],
+        ServiceNumber: params[:about_the_veteran][:social_or_service_num][:service_number],
+        ClaimNumber: nil,
+        VeteranServiceStateDate: nil,
+        VeteranServiceEndDate: nil }
+    end
+    let(:cache_data_service) { instance_double(Crm::CacheData) }
+
+    before do
+      allow(Crm::CacheData).to receive(:new).and_return(cache_data_service)
+      allow(cache_data_service).to receive(:call).with(
+        endpoint: 'optionset',
+        cache_key: 'optionset'
+      ).and_return(optionset_cached_data)
+    end
+
+    context 'when PERSONAL inquiry_params is received' do
+      it 'builds the correct payload' do
+        expect(subject.call).to eq(expected_result)
+      end
+    end
+  end
+end

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
         Country: nil,
         Street: nil,
         City: nil,
-        State: { Name: 'Texas', StateCode: 'TX' },
+        State: { Name: 'Texas', StateCode: 'Texas' },
         ZipCode: params[:veteran_postal_code],
         DateOfBirth: params[:about_the_veteran][:date_of_birth],
         BranchOfService: params[:about_the_veteran][:branch_of_service],

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/translator_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/translator_spec.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require AskVAApi::Engine.root.join('spec', 'support', 'shared_contexts.rb')
 
 RSpec.describe AskVAApi::Translator do
-  subject(:translator) { AskVAApi::Translator.new(inquiry_params:) }
-
-  # allow to have access to inquiry_params and optionset_set_cached_data
-  include_context 'shared data'
+  subject(:translator) { AskVAApi::Translator.new }
 
   let(:cache_data_service) { instance_double(Crm::CacheData) }
-  let(:option_keys) do
-    %w[inquiryabout inquirysource inquirytype levelofauthentication suffix veteranrelationship
-       dependentrelationship responsetype]
+  let(:cached_data) do
+    { Data: [{ Name: 'iris_suffix',
+               ListOfOptions: [{ Id: 722_310_000, Name: 'Jr' },
+                               { Id: 722_310_001, Name: 'Sr' },
+                               { Id: 722_310_003, Name: 'II' },
+                               { Id: 722_310_004, Name: 'III' },
+                               { Id: 722_310_006, Name: 'IV' },
+                               { Id: 722_310_002, Name: 'V' },
+                               { Id: 722_310_005, Name: 'VI' }] }] }
   end
-  let(:result) { subject.call }
+  let(:result) { subject.call('Jr.') }
 
   context 'when succesful' do
     before do
@@ -23,25 +25,11 @@ RSpec.describe AskVAApi::Translator do
       allow(cache_data_service).to receive(:call).with(
         endpoint: 'optionset',
         cache_key: 'optionset'
-      ).and_return(optionset_cached_data)
-      # optionset_cached_data is in include_context 'shared data'
-    end
-
-    it 'translates the keys from snake_case to camel_case' do
-      expect(result.keys).to eq(translated_payload.keys)
+      ).and_return(cached_data)
     end
 
     it 'translates all the option keys from name to id' do
-      expect(result[:InquiryAbout]).to eq(translated_payload[:InquiryAbout])
-      expect(result[:LevelOfAuthentication]).to eq(translated_payload[:LevelOfAuthentication])
-      expect(result[:Suffix]).to eq(translated_payload[:Suffix])
-      expect(result[:VeteranRelationship]).to eq(translated_payload[:VeteranRelationship])
-      expect(result[:DependantRelationship]).to eq(translated_payload[:DependantRelationship])
-      expect(result[:ResponseType]).to eq(translated_payload[:ResponseType])
-    end
-
-    it 'translates inquiry_params to translated payload' do
-      expect(result).to eq(translated_payload)
+      expect(result).to eq(722_310_000)
     end
   end
 


### PR DESCRIPTION
Summary

This PR introduces several key improvements to the VeteranProfile, InquiryDetails, and Translator classes to enhance modularity, clarity, and functionality across the codebase.

 - VeteranProfile Refactor: The VeteranProfile class has been refactored to improve its structure by separating concerns into base_profile and service_info methods. The introduction of the state_data helper method ensures correct handling of veteran state information. The FieldTranslator is now utilized for translating values, improving readability, and SharedHelpers has been added for shared functionality.
 - InquiryDetails Refactor: The InquiryDetails class has been restructured to handle different inquiry types more effectively. New methods such as handle_self_inquiry, handle_others_inquiry, and handle_family_inquiry improve logic separation. The education_benefits? method simplifies the identification of education-related inquiries, enhancing readability and maintainability for future extensions.
 - Translator Class Introduction: A new Translator class has been created to dynamically map provided keys to option set IDs. The class integrates Optionset::Entity and Optionset::Retriever for option retrieval and includes custom error handling via TranslatorError. The flexible entity class injection via the constructor allows for future adaptability of entity retrieval logic.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/1374

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected