### PR TITLE
Add template id for 21-0966 error email

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1306,6 +1306,7 @@ vanotify:
         form1990emeb_denied_confirmation_email: form1990emeb_denied_confirmation_email_template_id
         form1995_confirmation_email: form1995_confirmation_email_template_id
         form21_0966_confirmation_email: form21_0966_confirmation_email_template_id
+        form21_0966_error_email: form21_0966_error_email_template_id
         form21_0972_confirmation_email: form21_0972_confirmation_email_template_id
         form21_0972_error_email: form21_0972_error_email_template_id
         form21_0972_received_email: form21_0972_received_email_template_id

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -18,7 +18,7 @@ module SimpleFormsApi
       },
       'vba_21_0966' => {
         confirmation: Settings.vanotify.services.va_gov.template_id.form21_0966_confirmation_email,
-        error: nil,
+        error: Settings.vanotify.services.va_gov.template_id.form21_0966_error_email,
         received: nil
       },
       'vba_21_0972' => {

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -592,17 +592,17 @@ describe SimpleFormsApi::NotificationEmail do
       end
       let(:user) { create(:user, :loa3) }
 
-      context 'template_id is provided', if: notification_type == :confirmation do
-        it 'sends the confirmation email' do
+      context 'template_id is provided', unless: notification_type == :received do
+        it 'sends the email' do
           allow(VANotify::EmailJob).to receive(:perform_async)
 
-          subject = described_class.new(config, user:)
+          subject = described_class.new(config, notification_type:, user:)
 
           subject.send
 
           expect(VANotify::EmailJob).to have_received(:perform_async).with(
             user.va_profile_email,
-            'form21_0966_confirmation_email_template_id',
+            "form21_0966_#{notification_type}_email_template_id",
             {
               'first_name' => 'Veteran',
               'date_submitted' => date_submitted,
@@ -615,7 +615,7 @@ describe SimpleFormsApi::NotificationEmail do
         end
       end
 
-      context 'template_id is missing', if: notification_type != :confirmation do
+      context 'template_id is missing', if: notification_type == :received do
         let(:data) do
           fixture_path = Rails.root.join(
             'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'


### PR DESCRIPTION
## Summary
This PR adds a template id for the 21-0966 error email to vets-api. The manifests repo has already been updated.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=83509901&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1747
