### PR TITLE
86428: Create ClaimVANotification table

### DIFF
--- a/db/migrate/20241017154903_create_claim_va_notifications.rb
+++ b/db/migrate/20241017154903_create_claim_va_notifications.rb
@@ -1,0 +1,12 @@
+class CreateClaimVANotifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :claim_va_notifications do |t|
+      t.string :form_type
+      t.references :saved_claim, null: false, foreign_key: true
+      t.boolean :email_sent
+      t.integer :email_template_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,6 +326,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_163939) do
     t.index ["state"], name: "index_central_mail_submissions_on_state"
   end
 
+  create_table "claim_va_notifications", force: :cascade do |t|
+    t.string "form_type"
+    t.bigint "saved_claim_id", null: false
+    t.boolean "email_sent"
+    t.integer "email_template_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["saved_claim_id"], name: "index_claim_va_notifications_on_saved_claim_id"
+  end
+
   create_table "claims_api_auto_established_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.integer "evss_id"
@@ -1653,6 +1663,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_163939) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "appeal_submissions", "user_accounts"
   add_foreign_key "async_transactions", "user_accounts"
+  add_foreign_key "claim_va_notifications", "saved_claims"
   add_foreign_key "claims_api_claim_submissions", "claims_api_auto_established_claims", column: "claim_id"
   add_foreign_key "deprecated_user_accounts", "user_accounts"
   add_foreign_key "deprecated_user_accounts", "user_verifications"


### PR DESCRIPTION
We send a confirmation email during the PensionBenefitsIntakeJob. There's no way to 'undo' this step, and we don't have any checks in place to see if the confirmation email was already sent, so this step could get run more than once if the job fails after this step. (It's unlikely the job will fail after this, since all we do afterwards is log the success, but in a worst-case scenario...)

Create a new DB table that holds VA notifications that can be checked before attempted duplicate sends

## Summary

- Create a new DB table ClaimVANotification

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86428
