### PR TITLE
[10-10CG] Update submission job retries from 22 to 14

### DIFF
--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -9,7 +9,7 @@ module Form1010cg
     include Sidekiq::MonitoredWorker
     include SentryLogging
 
-    sidekiq_options(retry: 22)
+    sidekiq_options retry: 14
 
     sidekiq_retries_exhausted do |msg, _e|
       StatsD.increment("#{STATSD_KEY_PREFIX}failed_no_retries_left", tags: ["claim_id:#{msg['args'][0]}"])

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Form1010cg::SubmissionJob do
     create(:caregivers_assistance_claim)
   end
 
+  it 'has a retry count of 14' do
+    expect(described_class.get_sidekiq_options['retry']).to eq(14)
+  end
+
   it 'defines #notify' do
     expect(described_class.new.respond_to?(:notify)).to eq(true)
   end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Changing the retries on the form1010cg submission job from 22 to 14. This change makes it the same as our 1010EZ and 1010EZR submission jobs. (It will retry for roughly 1 day, while previously it was roughly 10 days). 
- 10-10 Health Apps

## Related issue(s)

 - https://github.com/department-of-veterans-affairs/va.gov-team/issues/93823
 - Updated documentation [here](https://github.com/department-of-veterans-affairs/va.gov-team/pull/95593)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
10-10CG 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
