### PR TITLE
Fix typo in 21-0966 notification email

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -303,7 +303,7 @@ module SimpleFormsApi
 
     def form21_0966_first_name
       if form_data['preparer_identification'] == 'SURVIVING_DEPENDENT'
-        form_data('surviving_dependent_full_name', 'first')
+        form_data.dig('surviving_dependent_full_name', 'first')
       else
         form_data.dig('veteran_full_name', 'first')
       end

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -613,6 +613,34 @@ describe SimpleFormsApi::NotificationEmail do
             }
           )
         end
+
+        context 'preparer is surviving dependent' do
+          before do
+            data['preparer_identification'] = 'SURVIVING_DEPENDENT'
+            config[:form_data] = data
+          end
+
+          it 'sends the email' do
+            allow(VANotify::EmailJob).to receive(:perform_async)
+
+            subject = described_class.new(config, notification_type:, user:)
+
+            subject.send
+
+            expect(VANotify::EmailJob).to have_received(:perform_async).with(
+              'survivor@dependent.com',
+              "form21_0966_#{notification_type}_email_template_id",
+              {
+                'first_name' => 'I',
+                'date_submitted' => date_submitted,
+                'confirmation_number' => 'confirmation_number',
+                'lighthouse_updated_at' => nil,
+                'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
+                                             ' (VA Form 21P-534 or VA Form 21P-534EZ)'
+              }
+            )
+          end
+        end
       end
 
       context 'template_id is missing', if: notification_type == :received do


### PR DESCRIPTION
## Summary
This PR fixes a Ruby syntax typo and adds a test for that typo.
