### PR TITLE
95595 Debts team addressLine2 `nill` bug

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/financial_status_report_service.rb
+++ b/modules/debts_api/lib/debts_api/v0/financial_status_report_service.rb
@@ -232,7 +232,10 @@ module DebtsApi
       schema_path = Rails.root.join('lib', 'debt_management_center', 'schemas', 'fsr.json').to_s
       errors = JSON::Validator.fully_validate(schema_path, form)
 
-      raise FSRInvalidRequest if errors.any?
+      if errors.any?
+        Rails.logger.error("DebtsApi::V0::FinancialStatusReportService validation failed: #{errors}")
+        raise FSRInvalidRequest
+      end
     end
 
     def send_confirmation_email(template_id)

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_builder.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_builder.rb
@@ -38,7 +38,10 @@ module DebtsApi
       schema_path = Rails.root.join('lib', 'debt_management_center', 'schemas', 'fsr.json').to_s
       errors = JSON::Validator.fully_validate(schema_path, form)
 
-      raise FSRInvalidRequest if errors.any?
+      if errors.any?
+        Rails.logger.error("DebtsApi::V0::FsrFormBuilder validation failed: #{errors}")
+        raise FSRInvalidRequest
+      end
     end
 
     def sanitize(form)

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_data_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_data_calculator.rb
@@ -77,7 +77,7 @@ module DebtsApi
         def address
           {
             'addresslineOne' => @personal_data['veteran_contact_information']['address']['address_line1'],
-            'addresslineTwo' => @personal_data['veteran_contact_information']['address']['address_line2'],
+            'addresslineTwo' => @personal_data['veteran_contact_information']['address']['address_line2'] || '',
             'addresslineThree' => @personal_data['veteran_contact_information']['address']['address_line3'] || '',
             'city' => @personal_data['veteran_contact_information']['address']['city'],
             'stateOrProvince' => @personal_data['veteran_contact_information']['address']['state_code'],

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::PersonalDataCalculator, type: :se
         pre_transform_fsr_form_data['personal_data']['veteran_contact_information']['address']['address_line2'] = nil
         calculator = described_class.new(pre_transform_fsr_form_data)
         calculator_data = calculator.get_personal_data
-        # expected_personal_data = post_transform_fsr_form_data['personalData']
 
         expect(calculator_data['address']['addresslineTwo']).to eq('')
       end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
@@ -11,20 +11,24 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::PersonalDataCalculator, type: :se
     let(:post_transform_fsr_form_data) do
       get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform')
     end
-
-    def get_personal_data
+    let(:transformer_data) do
       transformer = described_class.new(pre_transform_fsr_form_data)
-      @data = transformer.get_personal_data
+      transformer.get_personal_data
     end
 
     describe '#get_personal_data' do
-      before do
-        get_personal_data
-      end
-
       it 'gets personal data correct' do
         expected_personal_data = post_transform_fsr_form_data['personalData']
-        expect(expected_personal_data).to eq(@data)
+        expect(expected_personal_data).to eq(transformer_data)
+      end
+
+      it 'returns empty string for addressLine2 and addressLine3' do
+        pre_transform_fsr_form_data['personal_data']['veteran_contact_information']['address']['address_line2'] = nil
+        calculator = described_class.new(pre_transform_fsr_form_data)
+        calculator_data = calculator.get_personal_data
+        # expected_personal_data = post_transform_fsr_form_data['personalData']
+
+        expect(calculator_data['address']['addresslineTwo']).to eq('')
       end
     end
   end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::PersonalDataCalculator, type: :se
         calculator_data = calculator.get_personal_data
 
         expect(calculator_data['address']['addresslineTwo']).to eq('')
+        expect(calculator_data['address']['addresslineThree']).to eq('')
       end
     end
   end


### PR DESCRIPTION
We found out that we are erroring when validating form data that we have mutated. This PR fixes the issue (nil addressLine2 instead of empty string) and allows us to see what the validation issue was in the logs rather than having to guess/look up in progress forms.

[FWIW, we have added a monitor for this issue](https://vagov.ddog-gov.com/monitors/289709)

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*: NO
- *(Summarize the changes that have been made to the platform)*:
  - Fixed issue, added better logging, and added monitor for issue (not in this PR)
- *(If bug, how to reproduce)*: I was able to see the issue by running the following:
  ```
  1. Copied payload that was erroring from Staging env
  2. Ran IPF through transform
      ipf = DebtsApi::V0::FsrFormTransform::FullTransformService.new(full_transform_form)
      output = ipf.transform
  3. Ran output through validator
      schema_path = Rails.root.join('lib', 'debt_management_center', 'schemas', 'fsr.json').to_s
      errors = JSON::Validator.fully_validate(schema_path, output)
  4. Validated no errors
  ```
- *(What is the solution, why is this the solution?)*:
  - I think it's pretty straight forward. We were able to get the payload for a form and verify the error (addressLine2 was null/nil)
- *(Which team do you work for, does your team own the maintenance of this component?)*:
  - You can find me on OCTO Slack at #debt-resolution
- *(If introducing a flipper, what is the success criteria being targeted?)*: N/A

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
  - https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/95595
- *Link to previous change of the code/bug (if applicable)*: N/A
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*:
  - We were not checking for truthiness and passing a string, we would just pass nil/null on for addressLine2
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*:
  - I've verified the change by running the code above in rails console. We can verify again in staging
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
