### PR TITLE
Write benefits_intake_uuid to form submission attempts

### DIFF
--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -49,6 +49,10 @@ class FormSubmission < ApplicationRecord
         where.not(form_type: nil)
       end
     end
+
+    def benefits_intake_uuid
+      form_submission_attempts.order_by(:created_at, :asc).last.benefits_intake_uuid
+    end
   end
 
   def latest_pending_attempt

--- a/app/sidekiq/central_mail/submit_central_form686c_job.rb
+++ b/app/sidekiq/central_mail/submit_central_form686c_job.rb
@@ -83,7 +83,7 @@ module CentralMail
         saved_claim: claim,
         user_account: UserAccount.find_by(icn: claim.parsed_form['veteran_information']['icn'])
       )
-      FormSubmissionAttempt.create(form_submission:)
+      FormSubmissionAttempt.create(form_submission:, benefits_intake_uuid: intake_uuid)
     end
 
     def get_files_from_claim

--- a/app/sidekiq/lighthouse/income_and_assets_intake_job.rb
+++ b/app/sidekiq/lighthouse/income_and_assets_intake_job.rb
@@ -151,7 +151,8 @@ module Lighthouse
       form_submission[:user_account] = @user_account unless @user_account_uuid.nil?
 
       @form_submission = FormSubmission.create(**form_submission)
-      @form_submission_attempt = FormSubmissionAttempt.create(form_submission: @form_submission)
+      @form_submission_attempt = FormSubmissionAttempt.create(form_submission: @form_submission,
+                                                              benefits_intake_uuid: @intake_service.uuid)
 
       Datadog::Tracing.active_trace&.set_tag('benefits_intake_uuid', @intake_service.uuid)
     end

--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -168,7 +168,8 @@ module Lighthouse
         saved_claim: @claim,
         saved_claim_id: @claim.id
       )
-      @form_submission_attempt = FormSubmissionAttempt.create(form_submission:)
+      @form_submission_attempt = FormSubmissionAttempt.create(form_submission:,
+                                                              benefits_intake_uuid: @lighthouse_service.uuid)
     end
 
     def cleanup_file_paths

--- a/lib/data_migrations/write_benefits_intake_uuids_to_form_submission_attempts.rb
+++ b/lib/data_migrations/write_benefits_intake_uuids_to_form_submission_attempts.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DataMigrations
+  module WriteBenefitsIntakeUuidsToFormSubmissionAttempts
+    module_function
+
+    def run
+      FormSubmissionAttempt.all.find_each do |attempt|
+        next if attempt.benefits_intake_uuid
+
+        attempt.update(benefits_intake_uuid: attempt.form_submission.benefits_intake_uuid)
+      end
+    end
+  end
+end

--- a/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
+++ b/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
@@ -193,7 +193,8 @@ module Pensions
       form_submission[:user_account] = @user_account unless @user_account_uuid.nil?
 
       @form_submission = FormSubmission.create(**form_submission)
-      @form_submission_attempt = FormSubmissionAttempt.create(form_submission: @form_submission)
+      @form_submission_attempt = FormSubmissionAttempt.create(form_submission: @form_submission,
+                                                              benefits_intake_uuid: @intake_service.uuid)
 
       Datadog::Tracing.active_trace&.set_tag('benefits_intake_uuid', @intake_service.uuid)
     end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -71,7 +71,7 @@ module SimpleFormsApi
 
       def create_form_submission_attempt(uuid)
         form_submission = create_form_submission(uuid)
-        FormSubmissionAttempt.create(form_submission:)
+        FormSubmissionAttempt.create(form_submission:, benefits_intake_uuid: uuid)
       end
 
       def create_form_submission(uuid)

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -185,7 +185,7 @@ module SimpleFormsApi
 
       def create_form_submission_attempt(uuid)
         form_submission = create_form_submission(uuid)
-        FormSubmissionAttempt.create(form_submission:)
+        FormSubmissionAttempt.create(form_submission:, benefits_intake_uuid: uuid)
       end
 
       def create_form_submission(uuid)

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_uploader.rb
@@ -21,7 +21,7 @@ module SimpleFormsApi
         form_data: params.to_json,
         user_account: @current_user&.user_account
       )
-      FormSubmissionAttempt.create(form_submission:)
+      FormSubmissionAttempt.create(form_submission:, benefits_intake_uuid: uuid_and_location[:uuid])
 
       Datadog::Tracing.active_trace&.set_tag('uuid', uuid_and_location[:uuid])
       Rails.logger.info(

--- a/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_builder.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/s3/submission_builder.rb
@@ -8,7 +8,7 @@ module SimpleFormsApi
       def initialize(benefits_intake_uuid:) # rubocop:disable Lint/MissingSuper
         validate_input(benefits_intake_uuid)
 
-        @submission = FormSubmission.find_by(benefits_intake_uuid:)
+        @submission = FormSubmissionAttempt.find_by(benefits_intake_uuid:).form_submission
         validate_submission
 
         @attachments = []

--- a/modules/simple_forms_api/lib/tasks/write_benefits_intake_uuids_to_form_submission_attempts.rake
+++ b/modules/simple_forms_api/lib/tasks/write_benefits_intake_uuids_to_form_submission_attempts.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+namespace :data_migration do
+  task write_benefits_intake_uuids_to_form_submission_attempts: :environment do
+    DataMigrations::WriteBenefitsIntakeUuidsToFormSubmissionAttempts.run
+  end
+end


### PR DESCRIPTION
## Summary
This is the first part of a two-parter. The goal is to remove the `benefits_intake_uuid` field from the `form_submissions` table and hold those uuids entirely on the `form_submission_attempts` table. Currently, these UUIDs are kinda split in an awkward way between the two tables. The next part will be a migration to actually drop the column from `form_submissions`. But for now we just want to start writing the UUID to the right place and get a job ready that will transfer all historical UUIDs to the right place in their respective `form_submission_attempts` tables.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=83134444&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1636
