### PR TITLE
Stop incrementing silent_failure for Simple Forms

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -108,8 +108,6 @@ class BenefitsIntakeStatusJob
     StatsD.increment("#{STATS_KEY}.#{form_id}.#{result}")
     StatsD.increment("#{STATS_KEY}.all_forms.#{result}")
     if result == 'failure'
-      tags = ['service:veteran-facing-forms', "function:#{form_id} form submission to Lighthouse"]
-      StatsD.increment('silent_failure', tags:)
       Rails.logger.error('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:, error_message:)
     else
       Rails.logger.info('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:)


### PR DESCRIPTION
## Summary
This PR fixes a misunderstanding that I had where I thought on _every_ failed form submission we wanted to increment `silent_failure`. It turns out we only want to increment that on such cases where an email failed to send. This deletes the faulty incrementing but does not yet replace it because I'm not sure how to handle that yet.
