### PR TITLE
convert sentry logs to messages for ease of tracking

### DIFF
--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -41,21 +41,39 @@ module FormAttachmentCreate
       raise Common::Exceptions::InvalidFieldValue.new('file_data', filtered_params[:file_data].class.name)
     end
   rescue => e
-    log_exception_to_sentry(e, { context: 'FAC_validate', class: filtered_params[:file_data].class.name })
+    log_message_to_sentry(
+      'form attachment error 1',
+      :info,
+      phase: 'FAC_validate',
+      klass: filtered_params[:file_data].class.name,
+      exception: e.message
+    )
     raise e
   end
 
   def save_attachment_to_cloud!
     form_attachment.set_file_data!(filtered_params[:file_data], filtered_params[:password])
   rescue => e
-    log_exception_to_sentry(e, { context: 'FAC_cloud' })
+    log_message_to_sentry(
+      'form attachment error 2',
+      :info,
+      phase: 'FAC_cloud',
+      exception: e.message
+    )
     raise e
   end
 
   def save_attachment_to_db!
     form_attachment.save!
   rescue => e
-    log_exception_to_sentry(e, { context: 'FAC_db', errors: form_attachment.errors })
+    log_message_to_sentry(
+      'form attachment error 3',
+      :info,
+      phase: 'FAC_db',
+      errors: form_attachment.errors,
+      exception: e.message
+    )
+
     raise e
   end
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO*
- Switching from the `log_exception_to_sentry` helper to `log_message_to_sentry`, since we can easily do a substring search for the message in the latter to group all relevant logs.
- It was not straightforward to gather multiple exception-style logs together for debugging the 403 errors, this should make it more clear what's happening.
- 10-10 Health Enrollment EZ/CG

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93581
- previous attempt: https://github.com/department-of-veterans-affairs/va.gov-team/issues/92139

## Testing done

- [x] *New code is covered by unit tests*
- Previously we logged via Sentry's exception tracking mechanism. Now we log via the messages instead.
- No user-visible changes.

## What areas of the site does it impact?
*10-10EZ file uploads

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
