### PR TITLE
Add sign-in service specific web_origins

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,9 @@ module VetsAPI
     config.middleware.insert_before 0, Rack::Cors, logger: -> { Rails.logger } do
       allow do
         regex = Regexp.new(Settings.web_origin_regex)
-        origins { |source, _env| Settings.web_origin.split(',').include?(source) || source.match?(regex) }
+        web_origins = Settings.web_origin.split(',') + Array(Settings.sign_in.web_origins)
+
+        origins { |source, _env| web_origins.include?(source) || source.match?(regex) }
         resource '*', headers: :any,
                       methods: :any,
                       credentials: true,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,6 +81,8 @@ sign_in:
   sts_client:
     base_url: http://localhost:3000
     key_path: spec/fixtures/sign_in/sts_client.pem
+  web_origins:
+    - http://localhost:4000
 
 terms_of_use:
   current_version: v1


### PR DESCRIPTION
## Summary

- Add Sign-in Service specific web_origins to sign_in settings. This is for clients that only use the SiS portion of vets-api and helps keep things separated for the eventual split

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-396

## Testing
- Test SiS and SSOe auth on vets-website
- Test SiS auth on identity-dashboard locally (optional) 


## What areas of the site does it impact?
web_origins, sis

## Acceptance criteria
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

