### PR TITLE
Vebt 605 - Fix datadog error within School Certifying Officials email

### DIFF
--- a/app/sidekiq/education_form/send_school_certifying_officials_email.rb
+++ b/app/sidekiq/education_form/send_school_certifying_officials_email.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'gi/client'
 
 module EducationForm
   class SendSchoolCertifyingOfficialsEmail
@@ -30,7 +31,7 @@ module EducationForm
     private
 
     def get_institution(facility_code)
-      GIDSRedis.new.get_institution_details_v0({ id: facility_code })[:data][:attributes]
+      GI::Client.new.get_institution_details_v0({ id: facility_code })[:data][:attributes]
     end
 
     def school_changed?

--- a/app/sidekiq/education_form/send_school_certifying_officials_email.rb
+++ b/app/sidekiq/education_form/send_school_certifying_officials_email.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'gi/client'
 
 module EducationForm
@@ -31,7 +32,7 @@ module EducationForm
     private
 
     def get_institution(facility_code)
-      GI::Client.new.get_institution_details_v0({ id: facility_code })[:data][:attributes]
+      GI::Client.new.get_institution_details_v0({ id: facility_code }).body[:data][:attributes]
     end
 
     def school_changed?

--- a/spec/sidekiq/education_form/send_school_certifying_officials_email_spec.rb
+++ b/spec/sidekiq/education_form/send_school_certifying_officials_email_spec.rb
@@ -77,14 +77,43 @@ RSpec.describe EducationForm::SendSchoolCertifyingOfficialsEmail, type: :model, 
         gids_response = build(:gids_response)
         allow_any_instance_of(::GI::Client).to receive(:get_institution_details_v0)
           .and_return(gids_response)
-
-        allow_any_instance_of(ActionMailer::MessageDelivery).to receive(:deliver_now)
       end
 
       it 'sco email sent is true' do
         subject.perform(claim.id, true, '1')
         db_claim = SavedClaim::EducationBenefits::VA10203.find(claim.id)
         expect(db_claim.parsed_form['scoEmailSent']).to eq(true)
+      end
+
+      it 'sends the SCO and applicant emails with correct contents' do
+        # Clear any previous deliveries
+        ActionMailer::Base.deliveries.clear
+
+        # Perform the action that triggers email sending
+        subject.perform(claim.id, true, '1')
+
+        # Fetch the updated claim
+        db_claim = SavedClaim::EducationBenefits::VA10203.find(claim.id)
+
+        # Verify that scoEmailSent is true
+        expect(db_claim.parsed_form['scoEmailSent']).to eq(true)
+
+        # Verify that two emails were sent
+        expect(ActionMailer::Base.deliveries.count).to eq(2)
+
+        # Find the SCO email
+        sco_email = ActionMailer::Base.deliveries.find do |email|
+          email.to.include?('test@edu_sample.com')
+        end
+        expect(sco_email).not_to be_nil
+
+        # Verify the SCO email contents
+        expect(sco_email.subject).to eq('Applicant for VA Rogers STEM Scholarship')
+        expect(sco_email.from).to include('stage.va-notifications@public.govdelivery.com')
+        expect(sco_email.body.encoded).to include('<p>Dear VA School Certifying Official,</p>')
+
+        # Add a line to download the contents of the email to a file
+        File.write('tmp/sco_email_body.html', sco_email.body)
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO* No
- *(Summarize the changes that have been made to the platform)* Fix datadog error within School Certifying Officials email
- *(If bug, how to reproduce)* Check datadog to see if errors go away
- *(What is the solution, why is this the solution?)* To not use Redis with the Sidekiq job
- *(Which team do you work for, does your team own the maintenance of this component?)* VEBT
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira* https://jira.devops.va.gov/browse/VEBT-605
- *Link to previous change of the code/bug (if applicable)* N/A

## Testing done

- [ x] *New code is covered by unit tests* Yes
- *Describe what the old behavior was prior to the change* There were datadog errors saying the sidekiq job was exhausted
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing* Submit 10203, confirm SCO email is sent
- *If this work is behind a flipper:* N/A

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)* SCO Email

## Acceptance criteria

- [x ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x ]  No error nor warning in the console.
- [x ]  Events are being sent to the appropriate logging solution
- [x ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x ]  Feature/bug has a monitor built into Datadog (if applicable)

