### PR TITLE
dbex/95149: add disability_526_new_confirmation_page feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -457,6 +457,9 @@ features:
   disability_526_toxic_exposure_ipf:
     actor_type: user
     description: enables new pages, processing, and submission of toxic exposure claims for in progress forms (ipf)
+  disability_526_new_confirmation_page:
+    actor_type: user
+    description: enables new confirmation page for form 526 submission confirmation page
   disability_526_toxic_exposure_document_upload_polling:
     actor_type: user
     description: enables the poll_form526_pdf call during the perform_ancillary_jobs step of submissions


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):* this work _**is**_ a feature toggle :)
- adds disability_526_new_confirmation_page  for future functionality
- only to be consumed on the client

## Related issue(s)

- [*Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95149)

## Testing done

- disability_526_new_confirmation_page shows up on flipper admin page

## Screenshots
![image](https://github.com/user-attachments/assets/fc9b6fe8-876a-4748-8f98-8953bcec41a8)


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
