### PR TITLE
Bump googleauth from 1.11.1 to 1.11.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,8 +431,8 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.11.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    faraday (2.10.1)
+      faraday-net_http (>= 2.0, < 3.2)
       logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
@@ -442,7 +442,7 @@ GEM
       httpclient (>= 2.2)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
-    faraday-net_http (3.3.0)
+    faraday-net_http (3.1.1)
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,11 +528,6 @@ GEM
     google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.28.3-java)
-      bigdecimal
-      ffi (~> 1)
-      ffi-compiler (~> 1)
-      rake (>= 13)
     googleauth (1.11.2)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,8 +431,8 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.10.1)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.11.0)
+      faraday-net_http (>= 2.0, < 3.4)
       logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
@@ -442,7 +442,7 @@ GEM
       httpclient (>= 2.2)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
-    faraday-net_http (3.1.1)
+    faraday-net_http (3.3.0)
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
@@ -528,7 +528,12 @@ GEM
     google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
-    googleauth (1.11.1)
+    google-protobuf (4.28.3-java)
+      bigdecimal
+      ffi (~> 1)
+      ffi-compiler (~> 1)
+      rake (>= 13)
+    googleauth (1.11.2)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.1)
       jwt (>= 1.4, < 3.0)


### PR DESCRIPTION
## Summary

- Original PR: https://github.com/department-of-veterans-affairs/vets-api/pull/19050

## Related issue(s)

- n/a

## Acceptance criteria

- [x]  googleauth is 1.11.2