### PR TITLE
Batch DeleteOldPiiLogsJob deletions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1322,7 +1322,7 @@ spec/sidekiq/copay_notifications @department-of-veterans-affairs/vsa-debt-resolu
 spec/sidekiq/decision_review @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/education_form @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/education_form/create_daily_spool_files.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
-spec/sidekiq/delete_old_pii_logs_job.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
+spec/sidekiq/delete_old_pii_logs_job_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/sidekiq/evss/dependents_application_job_spec.rb  @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -612,6 +612,7 @@ app/sidekiq/cypress_viewport_updater @department-of-veterans-affairs/backend-rev
 app/sidekiq/decision_review @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/decision_review/form4142_submit.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/decision_review/submit_upload.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/delete_old_pii_logs_job.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/sidekiq/education_form @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/education_form/templates/10203.erb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/education_form/templates/1990.erb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -612,7 +612,6 @@ app/sidekiq/cypress_viewport_updater @department-of-veterans-affairs/backend-rev
 app/sidekiq/decision_review @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/decision_review/form4142_submit.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/decision_review/submit_upload.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/sidekiq/delete_old_pii_logs_job.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/sidekiq/education_form @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/education_form/templates/10203.erb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/education_form/templates/1990.erb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
@@ -1322,6 +1321,7 @@ spec/sidekiq/copay_notifications @department-of-veterans-affairs/vsa-debt-resolu
 spec/sidekiq/decision_review @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/education_form @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/education_form/create_daily_spool_files.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
+spec/sidekiq/delete_old_pii_logs_job.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/sidekiq/evss/dependents_application_job_spec.rb  @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/sidekiq/delete_old_pii_logs_job.rb
+++ b/app/sidekiq/delete_old_pii_logs_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeleteOldPiiLogsJob
   include Sidekiq::Job
 

--- a/app/sidekiq/delete_old_pii_logs_job.rb
+++ b/app/sidekiq/delete_old_pii_logs_job.rb
@@ -6,7 +6,7 @@ class DeleteOldPiiLogsJob
   sidekiq_options unique_for: 30.minutes, retry: false
 
   EXPIRATION_TIME = 2.weeks
-  BATCH_SIZE = 1000
+  BATCH_SIZE = 10000
 
   def perform
     loop do

--- a/app/sidekiq/delete_old_pii_logs_job.rb
+++ b/app/sidekiq/delete_old_pii_logs_job.rb
@@ -6,7 +6,7 @@ class DeleteOldPiiLogsJob
   sidekiq_options unique_for: 30.minutes, retry: false
 
   EXPIRATION_TIME = 2.weeks
-  BATCH_SIZE = 10000
+  BATCH_SIZE = 10_000
 
   def perform
     loop do

--- a/app/sidekiq/delete_old_pii_logs_job.rb
+++ b/app/sidekiq/delete_old_pii_logs_job.rb
@@ -1,15 +1,17 @@
-# frozen_string_literal: true
-
 class DeleteOldPiiLogsJob
   include Sidekiq::Job
 
-  sidekiq_options(unique_for: 30.minutes, retry: false)
+  sidekiq_options unique_for: 30.minutes, retry: false
 
   EXPIRATION_TIME = 2.weeks
+  BATCH_SIZE = 1000
 
   def perform
-    PersonalInformationLog.where(
-      'created_at < ?', EXPIRATION_TIME.ago
-    ).delete_all
+    loop do
+      records = PersonalInformationLog.where('created_at < ?', EXPIRATION_TIME.ago).limit(BATCH_SIZE)
+      break if records.empty?
+
+      records.delete_all
+    end
   end
 end

--- a/spec/sidekiq/delete_old_pii_logs_job_spec.rb
+++ b/spec/sidekiq/delete_old_pii_logs_job_spec.rb
@@ -11,5 +11,15 @@ RSpec.describe DeleteOldPiiLogsJob, type: :model do
       expect { subject.perform }.to change(PersonalInformationLog, :count).from(2).to(1)
       expect(model_exists?(new_log)).to eq(true)
     end
+
+    it 'deletes old records in batches' do
+      expect { subject.perform }.to change { PersonalInformationLog.where('created_at < ?', 2.weeks.ago).count }.to(0)
+      expect(model_exists?(new_log)).to eq(true)
+    end
+
+    it 'does not delete new records' do
+      subject.perform
+      expect(PersonalInformationLog.exists?(new_log.id)).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
We’ve identified that our PG Query Duration metric has [been spiking between 2:00-4:00 AM ET](https://vagov.ddog-gov.com/monitors/199084?from_ts=1729693621668&to_ts=1729780021668&eval_ts=1729756875247). After adjusting [several VBA jobs](https://vagov.ddog-gov.com/logs?query=%22VBADocuments%3A%3AUploadRemover%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1729745071236&to_ts=1729762990337&live=false) that run during this timeframe , and also ruling out autovacuuming, we found that the DeleteOldPiiLogsJob, which runs daily at 2:20 AM ET, has been [failing since October 11](https://vagov.ddog-gov.com/logs?query=%22DeleteOldPiiLogsJob%22%20status%3Aerror%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1727187022032&to_ts=1729779022032&live=true) (the same time the KMS key rotation job began - which is heavy on the database.).

The failure is due to a statement timeout, and after investigating via rails console, ~687,000 records match the `created_at < 2.weeks` query. Our theory is that because the `DeleteOldPiiLogsJob` job [doesn't retry](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/sidekiq/delete_old_pii_logs_job.rb#L6), failed deletions cause records to accumulate over time. This could also potentially be contributing to the [decline in RDS free space](https://vagov.ddog-gov.com/metric/explorer?fromUser=true&start=1722004312000&end=1729780312000&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMgYYBoAdNpQDYJGcGkIbhjwafIY2cAAVDwgPAC6VK7ueJih4VOqMxgxpfGjEyAacmg5oH07CAg5STgwTpmzGhCZiWii7XKKyul3ULf3TvRMyiJuHmijfgQeyYLBOR7HO4iJTjHh8TbyO4IADCUmEMBQIhmaB4QA), which we have had to increase recently. Additionally, rebalancing the created_at index after such a large deletion is resource intensive, possibly causing further query slowdowns.

This PR introduces batched deletions (10,000 records per batch) to avoid timeouts and ensure smoother performance. If issues persist, we may explore adjusting the job's schedule to shift load and observe query duration metrics.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1335/views/1?filterQuery=assignee%3ALindseySaari&pane=issue&itemId=84537853&issue=department-of-veterans-affairs%7Cva.gov-team%7C95678

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
