### PR TITLE
Make association two-way

### DIFF
--- a/app/models/appeal_submission.rb
+++ b/app/models/appeal_submission.rb
@@ -14,6 +14,7 @@ class AppealSubmission < ApplicationRecord
   has_encrypted :upload_metadata, key: :kms_key, **lockbox_options
 
   has_many :appeal_submission_uploads, dependent: :destroy
+  has_many :secondary_appeal_forms, dependent: :destroy
 
   scope :failure_not_sent, -> { where(failure_notification_sent_at: nil).order(id: :asc) }
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO* - model existence is not behind a flipper. All behavior is.
- Previously added a belongs_to to SecondaryAppealForm, needed the has_many on AppealSubmission
- optional, dependent: destroy
- Decision Reviews, yes

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/95001

## Testing done

- [ ] *New code is covered by unit tests*
- Could find the AppealSubmission from the SecondaryAppealForm, but not the other way
- Create an AppealSubmission with SecondaryAppealForm in staging, verify in console that lookup works both ways

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
No user facing changes, just a Rails association

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature