### PR TITLE
95727 - Issue with data validation in submission `creditorName` and ` spouseFullName/last` [FSR]

### DIFF
--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/installment_contracts_other_debts_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/installment_contracts_other_debts_calculator.rb
@@ -42,7 +42,7 @@ module DebtsApi
         def get_installment_or_other_debt_data_for(item)
           data = {
             'purpose' => item['purpose'],
-            'creditorName' => item['creditor_name'],
+            'creditorName' => item['creditor_name'] || '',
             'originalAmount' => format_installment_debt_number(item['original_amount']),
             'unpaidBalance' => format_installment_debt_number(item['unpaid_balance']),
             'amountDueMonthly' => item['amount_due_monthly'],

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_data_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/personal_data_calculator.rb
@@ -102,7 +102,7 @@ module DebtsApi
             {
               'first' => @personal_data['spouse_full_name']['first'],
               'middle' => @personal_data['spouse_full_name']['middle'] || '',
-              'last' => @personal_data['spouse_full_name']['last']
+              'last' => @personal_data['spouse_full_name']['last'] || ''
             }
           else
             {

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/installment_contracts_other_debts_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/installment_contracts_other_debts_calculator_spec.rb
@@ -39,21 +39,14 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::InstallmentContractsOtherDebtsCal
         expect(expected_installment_contracts_other_debts_data).to eq(@total_data)
       end
 
-      it 'returns empty string for spouseFullName/last' do
-        pre_form_data['personal_data']['spouse_full_name']['last'] = nil
+      it 'returns empty string for creditorName' do
+        pre_form_data['installment_contracts'].first['creditor_name'] = nil
         calculator = described_class.new(pre_form_data)
         calculator_data = calculator.get_data
 
-        expect(calculator_data['spouseFullName']['last']).to eq('')
+        creditor_names = calculator_data.pluck('creditorName')
+        expect(creditor_names).to eq(['', ''])
       end
-
-      # it 'returns empty string for creditorName' do
-      #   pre_form_data['installment_contracts_and_other_debts']['creditor_name'] = nil
-      #   calculator = described_class.new(pre_form_data)
-      #   calculator_data = calculator.get_data
-      #
-      #   expect(calculator_data['installmentContractsAndOtherDebts']['creditorName']).to eq('')
-      # end
     end
   end
 end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/installment_contracts_other_debts_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/installment_contracts_other_debts_calculator_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::InstallmentContractsOtherDebtsCal
       get_fixture_absolute('modules/debts_api/spec/fixtures/pre_submission_fsr/post_transform')
     end
 
+    let(:transformer_data) do
+      transformer = described_class.new(pre_form_data)
+      transformer.get_data
+      transformer.get_totals_data
+    end
+
     def get_data
       transformer = described_class.new(pre_form_data)
       @data = transformer.get_data
@@ -32,6 +38,22 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::InstallmentContractsOtherDebtsCal
         expected_installment_contracts_other_debts_data = post_form_data['totalOfInstallmentContractsAndOtherDebts']
         expect(expected_installment_contracts_other_debts_data).to eq(@total_data)
       end
+
+      it 'returns empty string for spouseFullName/last' do
+        pre_form_data['personal_data']['spouse_full_name']['last'] = nil
+        calculator = described_class.new(pre_form_data)
+        calculator_data = calculator.get_data
+
+        expect(calculator_data['spouseFullName']['last']).to eq('')
+      end
+
+      # it 'returns empty string for creditorName' do
+      #   pre_form_data['installment_contracts_and_other_debts']['creditor_name'] = nil
+      #   calculator = described_class.new(pre_form_data)
+      #   calculator_data = calculator.get_data
+      #
+      #   expect(calculator_data['installmentContractsAndOtherDebts']['creditorName']).to eq('')
+      # end
     end
   end
 end

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/personal_data_calculator_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::PersonalDataCalculator, type: :se
         expect(expected_personal_data).to eq(transformer_data)
       end
 
+      it 'returns empty string for spouseFullName/last' do
+        pre_transform_fsr_form_data['personal_data']['spouse_full_name']['last'] = nil
+        calculator = described_class.new(pre_transform_fsr_form_data)
+        calculator_data = calculator.get_personal_data
+
+        expect(calculator_data['spouseFullName']['last']).to eq('')
+      end
+
       it 'returns empty string for addressLine2 and addressLine3' do
         pre_transform_fsr_form_data['personal_data']['veteran_contact_information']['address']['address_line2'] = nil
         calculator = described_class.new(pre_transform_fsr_form_data)


### PR DESCRIPTION
We found out that we are erroring when validating form data that we have mutated. This PR fixes the issue (nil `creditorName` and `spouseFullName/last` instead of empty string) and allows us to see what the validation issue was in the logs rather than having to guess/look up in progress forms.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*: NO
- *(Summarize the changes that have been made to the platform)*
Fixed issue, added better logging, and added monitor for issue (not in this PR)
- *(If bug, how to reproduce)*
```
1. Copied payload that was erroring from Staging env
2. Ran IPF through transform
    ipf = DebtsApi::V0::FsrFormTransform::FullTransformService.new(full_transform_form)
    output = ipf.transform
3. Ran output through validator
    schema_path = Rails.root.join('lib', 'debt_management_center', 'schemas', 'fsr.json').to_s
    errors = JSON::Validator.fully_validate(schema_path, output)
4. Validated no errors
```
- *(What is the solution, why is this the solution?)*
Default optional parameters where they are passed in as nil/null and default to ''.
- *(Which team do you work for, does your team own the maintenance of this component?)*
You can find me on OCTO Slack at #debt-resolution
- *(If introducing a flipper, what is the success criteria being targeted?)*N/A

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
[95727](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/95727)
- *Link to previous change of the code/bug (if applicable)*: N/A
- *Link to epic if not included in ticket*: N/A

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
We were not checking for truthiness and passing a string, we would just pass nil/null on for `creditorName` and `spouseFullName/last`
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
I've verified the change by running the code above in rails console. We can verify again in staging
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
