### PR TITLE
fix temp file issue

### DIFF
--- a/modules/ivc_champva/spec/services/pdf_filler_spec.rb
+++ b/modules/ivc_champva/spec/services/pdf_filler_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative IvcChampva::Engine.root.join('spec', 'support', 'pdf_matcher.rb')
+require IvcChampva::Engine.root.join('spec', 'support', 'pdf_matcher.rb')
 require IvcChampva::Engine.root.join('spec', 'spec_helper.rb')
+require IvcChampva::Engine.root.join('app', 'services', 'ivc_champva', 'pdf_stamper')
 
 describe IvcChampva::PdfFiller do
   forms = %w[vha_10_10d vha_10_7959f_1 vha_10_7959f_2 vha_10_7959c]
@@ -11,10 +12,12 @@ describe IvcChampva::PdfFiller do
     context 'when the filler is instantiated without a form_number' do
       it 'throws an error' do
         form_number = forms.first
-        data = JSON.parse(File.read("modules/ivc_champva/spec/fixtures/form_json/#{form_number}.json"))
+        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
+        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
+        data = JSON.parse(File.read(file_path))
         form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
         expect do
-          described_class.new(form_number: nil, form:)
+          described_class.new(form_number: nil, form: form)
         end.to raise_error(RuntimeError, 'form_number is required')
       end
     end
@@ -23,35 +26,69 @@ describe IvcChampva::PdfFiller do
       it 'throws an error' do
         form_number = forms.first
         expect do
-          described_class.new(form_number:, form: nil)
+          described_class.new(form_number: form_number, form: nil)
         end.to raise_error(RuntimeError, 'form needs a data attribute')
       end
     end
   end
 
-  # describe '#generate' do
-  #   forms.each do |file_name|
-  #     context "when mapping the pdf data given JSON file: #{file_name}" do
-  #       let(:form_number) { file_name.gsub('-min', '') }
-  #       let(:expected_pdf_path) { "tmp/#{file_name}-tmp.pdf" }
-  #       let(:data) { JSON.parse(File.read("modules/ivc_champva/spec/fixtures/form_json/#{file_name}.json")) }
-  #       let(:form) { "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
+  describe '#generate' do
+    context 'when the stamped template file exists' do
+      it 'generates the form correctly' do
+        form_number = forms.first
+        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
+        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
+        data = JSON.parse(File.read(file_path))
+        form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
+        pdf_filler = described_class.new(form_number: form_number, form: form)
 
-  #       after { FileUtils.rm_f(expected_pdf_path) }
+        allow(File).to receive(:exist?).and_return(true)
+        allow(IvcChampva::PdfStamper).to receive(:stamp_pdf)
+        allow(PdfForms).to receive(:new).and_return(double(fill_form: true))
+        allow(Common::FileHelpers).to receive(:delete_file_if_exists)
 
-  #       context 'when a legitimate JSON payload is provided' do
-  #         it 'properly fills out the associated PDF' do
-  #           filled_pdf_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'pdfs',
-  #                                             "#{file_name}-filled.pdf")
+        expect(pdf_filler.generate).to match(%r{tmp/#{form_number}-.*-tmp.pdf})
+      end
+    end
 
-  #           described_class.new(form_number:, form:).generate
+    context 'when the stamped template file does not exist' do
+      it 'raises an error' do
+        form_number = forms.first
+        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
+        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
+        data = JSON.parse(File.read(file_path))
+        form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
+        pdf_filler = described_class.new(form_number: form_number, form: form)
 
-  #           expect(expected_pdf_path).to match_pdf_content_of(filled_pdf_path)
-  #         end
-  #       end
-  #     end
-  #   end
-  # end
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect { pdf_filler.generate }.to raise_error(RuntimeError, /stamped template file does not exist/)
+      end
+    end
+  end
+
+  describe '#create_tempfile' do
+    context 'when creating a tempfile' do
+      it 'creates and copies the template form correctly' do
+        form_number = forms.first
+        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
+        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
+        data = JSON.parse(File.read(file_path))
+        form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
+        pdf_filler = described_class.new(form_number: form_number, form: form)
+
+        template_path = "#{IvcChampva::PdfFiller::TEMPLATE_BASE}/#{form_number}.pdf"
+        tempfile = double('Tempfile')
+
+        allow(Tempfile).to receive(:new).and_return(tempfile)
+        allow(IO).to receive(:copy_stream)
+        allow(tempfile).to receive(:close)
+
+        expect(IO).to receive(:copy_stream).with(template_path, tempfile)
+        pdf_filler.create_tempfile
+      end
+    end
+  end
 
   describe 'form mappings' do
     list = forms.map { |f| f.gsub('-min', '') }.uniq


### PR DESCRIPTION
## Summary
feat: Ensure unique template file names and fix file path issues

- Updated `generate` method to construct `generated_form_path` and `stamped_template_path` using `Rails.root.join` for better path handling.
- Added `create_tempfile` method to create a temporary file for the template, ensuring unique file names by including `SecureRandom.hex`.
- Modified `create_tempfile` method to use `Tempfile` for creating temporary files and copying the template file to the temporary file.
- Ensured that the `template_form_path` is correctly constructed using `TEMPLATE_BASE` and `form_number`.
- Added error handling to raise an exception if the stamped template file does not exist after copying.


## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/simple_forms_api/app/services/simple_forms_api/pdf_filler.rb

## Testing done

7959f1 and 1010d



## What areas of the site does it impact?
All ivc champva forms


