### PR TITLE
added status constant to queue exhaustion model

### DIFF
--- a/app/models/intent_to_file_queue_exhaustion.rb
+++ b/app/models/intent_to_file_queue_exhaustion.rb
@@ -6,4 +6,8 @@ class IntentToFileQueueExhaustion < ApplicationRecord
   # processing that will be done for retry attempts will be
   # specified in the future.
   validates :veteran_icn, presence: true
+
+  STATUS = {
+    unprocessed: 'unprocessed'
+  }.freeze
 end

--- a/app/sidekiq/lighthouse/create_intent_to_file_job.rb
+++ b/app/sidekiq/lighthouse/create_intent_to_file_job.rb
@@ -26,6 +26,7 @@ module Lighthouse
     # exhausted attempts will be logged in intent_to_file_queue_exhaustions table
     sidekiq_options retry: 14, queue: 'low'
     sidekiq_retries_exhausted do |msg, error|
+      ::Rails.logger.info("Create Intent to File Job exhausted all retries for in_progress_form_id: #{msg['args'][0]}")
       in_progress_form_id, veteran_icn = msg['args']
       in_progress_form = InProgressForm.find(in_progress_form_id)
       itf_log_monitor = BenefitsClaims::IntentToFile::Monitor.new


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Added a new enum constant to the ITF queue exhaustion model that'll be populating the new status column on the intent_to_file_queue_exhaustions table. Only one status (`unprocessed`) for now, but will add more in the future as we flesh out ITF remediation process. Also, added additional logging message for queue exhaustion start.
- Pension benefits team to own this change.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91283)
- [*Link to schema change PR*](https://github.com/department-of-veterans-affairs/vets-api/pull/18985)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
