### PR TITLE
MHV-62901: Images request status API implemented

### DIFF
--- a/lib/medical_records/bb_internal/client.rb
+++ b/lib/medical_records/bb_internal/client.rb
@@ -97,6 +97,16 @@ module BBInternal
       streaming_get(uri, token_headers, header_callback, yielder)
     end
 
+    ##
+    # check the status of a study job
+    # @return [Array] - [{ status: "COMPLETE", studyIdUrn: "111-1234567" percentComplete: 100, fileSize: "1.01 MB",
+    #   startDate: 1729777818853, endDate}]
+    #
+    def get_study_status
+      response = perform(:get, "bluebutton/studyjob/#{session.patient_id}", nil, token_headers)
+      response.body
+    end
+
     private
 
     ##

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/imaging_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/imaging_controller.rb
@@ -14,6 +14,10 @@ module MyHealth
           render_resource(bb_client.request_study(@study_id))
         end
 
+        def request_status
+          render_resource(bb_client.request_status)
+        end
+
         def images
           render_resource(bb_client.list_images(@study_id))
         end

--- a/modules/my_health/config/routes.rb
+++ b/modules/my_health/config/routes.rb
@@ -19,6 +19,7 @@ MyHealth::Engine.routes.draw do
       end
       resources :imaging, only: %i[index], defaults: { format: :json } do
         get 'request', on: :member, action: :request_download
+        get :status, on: :collection, action: :request_status
         get :images, on: :member
         get 'images/:series_id/:image_id', to: 'imaging#image', on: :member, as: :image
         get :dicom, on: :member

--- a/spec/lib/medical_records/bb_internal/client_spec.rb
+++ b/spec/lib/medical_records/bb_internal/client_spec.rb
@@ -87,4 +87,23 @@ describe BBInternal::Client do
       end
     end
   end
+
+  describe '#get_study_status' do
+    it 'retrieves the status of all study jobs' do
+      VCR.use_cassette 'mr_client/bb_internal/study_status' do
+        study_job_list = client.get_study_status
+
+        expect(study_job_list).to be_an(Array)
+        expect(study_job_list).not_to be_empty
+
+        first_study_job = study_job_list.first
+        expect(first_study_job).to be_a(Hash)
+
+        expect(first_study_job).to have_key('status')
+        expect(first_study_job['status']).to be_a(String)
+        expect(first_study_job).to have_key('studyIdUrn')
+        expect(first_study_job['studyIdUrn']).to be_a(String)
+      end
+    end
+  end
 end

--- a/spec/support/vcr_cassettes/mr_client/bb_internal/study_status.yml
+++ b/spec/support/vcr_cassettes/mr_client/bb_internal/study_status.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<MHV_MR_HOST>/mhvapi/v1/bluebutton/studyjob/11382904"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Token: "<SESSION_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 24 Oct 2024 17:07:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: '[{"status":"COMPLETE","statusText":"100","studyIdUrn":"453-2487450","percentComplete":100,"fileSize":"7.67
+        MB","fileSizeNumber":8041789,"startDate":1729777818853,"endDate":1729777843328},{"status":"COMPLETE","statusText":"100","studyIdUrn":"453-2487448","percentComplete":100,"fileSize":"253.91
+        KB","fileSizeNumber":260001,"startDate":1729777819179,"endDate":1729777826103},{"status":"ERROR","statusText":"100","studyIdUrn":"451-72913365","percentComplete":100,"fileSize":"","fileSizeNumber":null,"startDate":1729777819016,"endDate":1729778734008}]'
+  recorded_at: Thu, 24 Oct 2024 17:07:48 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary
- Images request status API created for checking the status of a radiology images request job

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-62901

> ### Research/Implement API call to determine if images have been requested
> Description
> Research/Implement API call to determine if images have been requested
> 
> Lexi and Scott have designs. We have a call that does two things: requests images and give you the request status. 
> 
> We want to be able to go to the images page without requesting images and also know the status (have we requested them or not?). 
> 
> Is there an API that will let us know if we have requested them or not. MHV classic does this somehow. 
> 
> Mike, Muazzam can help/know. 
> 
> Goal: find the API call to determine if we have requested images. Implement it on vets-api
> 
> User Story: As a Medical Images team, we want to research the API call to determine if images have been requested, so that 

## Testing done
- Test for the new client method written

## Screenshots
no UI changes

## What areas of the site does it impact?
MHV medical records

## Acceptance criteria
AC1 Research complete and documented
AC2 Call has been implemented into vets-api

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
