### PR TITLE
Fix status update bug when polling multiple Lighthouse document records

### DIFF
--- a/lib/lighthouse/benefits_documents/form526/update_documents_status_service.rb
+++ b/lib/lighthouse/benefits_documents/form526/update_documents_status_service.rb
@@ -39,7 +39,7 @@ module BenefitsDocuments
 
       # @param lighthouse526_document_uploads [Lighthouse526DocumentUpload] a collection of
       # Lighthouse526DocumentUpload records polled for status updates on Lighthouse's '/uploads/status' endpoint
-      # @param lighthouse_status_response [Hash] the parsed JSON response body from the Lighthouse '/uploads/status' endpoint
+      # @param lighthouse_status_response [Hash] the parsed JSON response body from the endpoint
       def initialize(lighthouse526_document_uploads, lighthouse_status_response)
         @lighthouse526_document_uploads = lighthouse526_document_uploads
         @lighthouse_status_response = lighthouse_status_response

--- a/lib/lighthouse/benefits_documents/form526/update_documents_status_service.rb
+++ b/lib/lighthouse/benefits_documents/form526/update_documents_status_service.rb
@@ -39,6 +39,7 @@ module BenefitsDocuments
 
       # @param lighthouse526_document_uploads [Lighthouse526DocumentUpload] a collection of
       # Lighthouse526DocumentUpload records polled for status updates on Lighthouse's '/uploads/status' endpoint
+      # @param lighthouse_status_response [Hash] the parsed JSON response body from the Lighthouse '/uploads/status' endpoint
       def initialize(lighthouse526_document_uploads, lighthouse_status_response)
         @lighthouse526_document_uploads = lighthouse526_document_uploads
         @lighthouse_status_response = lighthouse_status_response
@@ -66,34 +67,29 @@ module BenefitsDocuments
         document_upload = @lighthouse526_document_uploads.find_by!(lighthouse_document_request_id: status['requestId'])
         statsd_document_base_key(STATSD_DOCUMENT_TYPE_KEY_MAP[document_upload.document_type])
 
-        status_updater(status, document_upload)
-        @status_updater.update_status
+        status_updater = BenefitsDocuments::Form526::UploadStatusUpdater.new(status, document_upload)
+        status_updater.update_status
 
         if document_upload.completed?
           # ex. 'api.form526.lighthouse_document_upload_processing_status.bdd_instructions.complete'
           StatsD.increment("#{@statsd_document_base_key}.#{STATSD_DOCUMENT_COMPLETE_KEY}")
         elsif document_upload.failed?
-          log_failure(document_upload)
-        elsif @status_updater.processing_timeout?
+          log_failure(status_updater, document_upload)
+        elsif status_updater.processing_timeout?
           # Triggered when a document is still pending more than 24 hours after processing began
           # ex. 'api.form526.lighthouse_document_upload_processing_status.bdd_instructions.processing_timeout'
           StatsD.increment("#{@statsd_document_base_key}.#{STATSD_PROCESSING_TIMEOUT_KEY}")
         end
       end
 
-      def status_updater(status, document_upload)
-        # UploadStatusUpdater encapsulates all parsing of a status response from Lighthouse
-        @status_updater ||= BenefitsDocuments::Form526::UploadStatusUpdater.new(status, document_upload)
-      end
-
       def statsd_document_base_key(statsd_document_type_key)
         @statsd_document_base_key ||= "#{STATSD_BASE_KEY}.#{statsd_document_type_key}"
       end
 
-      def log_failure(document_upload)
+      def log_failure(status_updater, document_upload)
         # Because Lighthouse's processing steps are subject to change, these metrics must be dynamic.
         # Currently, this should return either CLAIMS_EVIDENCE or BENEFITS_GATEWAY_SERVICE
-        failure_step = @status_updater.get_failure_step
+        failure_step = status_updater.get_failure_step
 
         # ex. 'api.form526.lighthouse_document_upload_processing_status.bdd_instructions.failed.claims_evidence'
         StatsD.increment("#{@statsd_document_base_key}.#{STATSD_DOCUMENT_FAILED_KEY}.#{failure_step.downcase}")


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*

No, this job is currently running in production


- *(Summarize the changes that have been made to the platform)*

This corrects a bug in the polling code that parses responses from the Lighthouse `uploads/status` API endpoint. This endpoint takes a batch of ids from documents we have uploaded to Lighthouse and reports their status in processing on their end. We use this to keep track of the document in our system, and whether it was successfully processed asynchronously by Lighthouse.

Currently, a service object for updating a single document in our system is actually memoized, meaning in a loop of batched record statuses, it will keep running the first document update over and over instead of updating all of the documents properly.

- *(If bug, how to reproduce)*
I discovered this in testing for another ticket, when trying to loop through multiple records. I've added a test with multiple records so we don't miss this situation again.


- *(What is the solution, why is this the solution?)*

Directly instantiates the service object (`BenefitsDocuments::Form526::UploadStatusUpdater`) in every step of the loop instead of memoizing it.

- *(Which team do you work for, does your team own the maintenance of this component?)*

Disability Benefits team 2, and yes.


- *(If introducing a flipper, what is the success criteria being targeted?)*\


N/A

## Testing done

- [X] *New code is covered by unit tests*


## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)

