### PR TITLE
[DBX-94173] Cleanup after 526 failure email staging test

### DIFF
--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -5,7 +5,7 @@ require 'va_notify/service'
 class Form526SubmissionFailureEmailJob
   include Sidekiq::Job
 
-  attr_reader :submission_id
+  attr_accessor :submission
 
   STATSD_PREFIX = 'api.form_526.veteran_notifications.form526_submission_failure_email'
   # https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/274bea7fb835e51626259ac16b32c33ab0b2088a/platform/practices/zero-silent-failures/logging-silent-failures.md#capture-silent-failures-state
@@ -59,28 +59,21 @@ class Form526SubmissionFailureEmailJob
   end
 
   def perform(submission_id)
-    submission = Form526Submission.find(submission_id)
-    send_email(submission)
-    track_remedial_action(submission)
-    log_success(submission)
+    @submission = Form526Submission.find(submission_id)
+    send_email
+    track_remedial_action
+    log_success
   rescue => e
-    log_failure(e, submission)
+    log_failure(e)
     raise
   end
 
   private
 
-  def send_email(submission)
+  def send_email
     email_client = VaNotify::Service.new(Settings.vanotify.services.benefits_disability.api_key)
     template_id = Settings.vanotify.services.benefits_disability.template_id
                           .form526_submission_failure_notification_template_id
-
-    personalisation = {
-      first_name: submission.get_first_name,
-      date_submitted: submission.format_creation_time_for_mailers,
-      forms_submitted: forms_submitted(submission.form),
-      files_submitted: files_submitted(submission.form['form526_uploads'])
-    }
 
     email_client.send_email(
       email_address: submission.veteran_email_address,
@@ -89,7 +82,7 @@ class Form526SubmissionFailureEmailJob
     )
   end
 
-  def forms_submitted(form)
+  def list_forms_submitted
     [].tap do |forms|
       forms << FORM_DESCRIPTIONS['form4142'] if form['form4142'].present?
       forms << FORM_DESCRIPTIONS['form0781'] if form['form0781'].present?
@@ -98,15 +91,24 @@ class Form526SubmissionFailureEmailJob
     end
   end
 
-  def files_submitted(uploads)
-    return [] if uploads.nil?
+  def list_files_submitted
+    return [] if form['form526_uploads'].blank?
 
-    guids = uploads.map { |data| data&.dig('confirmationCode') }.compact
+    guids = form['form526_uploads'].map { |data| data&.dig('confirmationCode') }.compact
     files = SupportingEvidenceAttachment.where(guid: guids)
     files.map(&:obscured_filename)
   end
 
-  def track_remedial_action(submission)
+  def personalisation
+    {
+      first_name: submission.get_first_name,
+      date_submitted: submission.format_creation_time_for_mailers,
+      forms_submitted: list_forms_submitted.presence || 'None',
+      files_submitted: list_files_submitted.presence || 'None'
+    }
+  end
+
+  def track_remedial_action
     Form526SubmissionRemediation.create!(
       form526_submission: submission,
       remediation_type: Form526SubmissionRemediation.remediation_types['email_notified'],
@@ -114,7 +116,7 @@ class Form526SubmissionFailureEmailJob
     )
   end
 
-  def log_success(submission)
+  def log_success
     Rails.logger.info(
       'Form526SubmissionFailureEmail notification dispatched',
       {
@@ -127,16 +129,20 @@ class Form526SubmissionFailureEmailJob
     StatsD.increment('silent_failure_avoided_no_confirmation', tags: DD_ZSF_TAGS)
   end
 
-  def log_failure(error, submission)
+  def log_failure(error)
     Rails.logger.error(
       'Form526SubmissionFailureEmail notification failed',
       {
-        form526_submission_id: submission.id,
+        form526_submission_id: submission&.id,
         error_message: error.try(:message),
         timestamp: Time.now.utc
       }
     )
 
     StatsD.increment("#{STATSD_PREFIX}.error")
+  end
+
+  def form
+    @form ||= submission.form
   end
 end

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -333,7 +333,6 @@ FactoryBot.define do
       end
 
       with_ancillary['form526_uploads'] = with_uploads
-      with_ancillary['form526']['form526']['veteran']['emailAddress'] = 'test@example.com'
       with_ancillary.to_json
     end
   end

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   subject { described_class }
 
-  let!(:form526_submission) { create(:form526_submission, :with_uploads_and_ancillary_forms) }
   let(:email_service) { double('VaNotify::Service') }
 
   before do
@@ -17,40 +16,104 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   end
 
   describe '#perform' do
-    let(:expected_params) do
-      {
-        email_address: 'test@example.com',
-        template_id: 'form526_submission_failure_notification_template_id',
-        personalisation: {
-          first_name: form526_submission.get_first_name,
-          date_submitted: form526_submission.format_creation_time_for_mailers,
-          files_submitted: ['extXas.pdf', 'extXas.pdf', 'extXas.pdf'],
-          forms_submitted: [
-            'VA Form 21-4142',
-            'VA Form 21-0781',
-            'VA Form 21-0781a',
-            'VA Form 21-8940'
-          ]
+    context 'when a user has additional form and files with their submission' do
+      let!(:form526_submission) { create(:form526_submission, :with_uploads_and_ancillary_forms) }
+
+      let(:expected_params) do
+        {
+          email_address: 'test@email.com',
+          template_id: 'form526_submission_failure_notification_template_id',
+          personalisation: {
+            first_name: form526_submission.get_first_name,
+            date_submitted: form526_submission.format_creation_time_for_mailers,
+            files_submitted: ['extXas.pdf', 'extXas.pdf', 'extXas.pdf'],
+            forms_submitted: [
+              'VA Form 21-4142',
+              'VA Form 21-0781',
+              'VA Form 21-0781a',
+              'VA Form 21-8940'
+            ]
+          }
         }
-      }
+      end
+
+      it 'dispatches a failure notification email with the expected params' do
+        expect(email_service).to receive(:send_email).with(expected_params)
+
+        subject.perform_async(form526_submission.id)
+        subject.drain
+      end
+
+      it 'creates a remediation record for the submission' do
+        allow(email_service).to receive(:send_email)
+        expect { subject.new.perform(form526_submission.id) }.to change(Form526SubmissionRemediation, :count)
+        remediation = Form526SubmissionRemediation.where(form526_submission_id: form526_submission.id)
+        expect(remediation.present?).to be true
+      end
     end
 
-    it 'dispatches a failure notification email with the expected params' do
-      expect(email_service).to receive(:send_email).with(expected_params)
+    context 'when a user has no additional additional forms their submission' do
+      let!(:form526_submission) { create(:form526_submission, :with_uploads) }
+      let(:expected_params) do
+        {
+          email_address: 'test@email.com',
+          template_id: 'form526_submission_failure_notification_template_id',
+          personalisation: {
+            first_name: form526_submission.get_first_name,
+            date_submitted: form526_submission.format_creation_time_for_mailers,
+            files_submitted: ['extXas.pdf', 'extXas.pdf', 'extXas.pdf'],
+            forms_submitted: 'None'
+          }
+        }
+      end
 
-      subject.perform_async(form526_submission.id)
-      subject.drain
+      before do
+        form526_submission.form['form526_uploads'].each do |upload|
+          create(:supporting_evidence_attachment, :with_file_data, guid: upload['confirmationCode'])
+        end
+      end
+
+      it 'replaces the forms list variable with a placeholder' do
+        expect(email_service).to receive(:send_email).with(expected_params)
+
+        subject.perform_async(form526_submission.id)
+        subject.drain
+      end
     end
 
-    it 'creates a remediation record for the submission' do
-      allow(email_service).to receive(:send_email)
-      expect { subject.new.perform(form526_submission.id) }.to change(Form526SubmissionRemediation, :count)
-      remediation = Form526SubmissionRemediation.where(form526_submission_id: form526_submission.id)
-      expect(remediation.present?).to be true
+    context 'when a user has no additional additional user-uploaded files their submission' do
+      let(:expected_params) do
+        {
+          email_address: 'test@email.com',
+          template_id: 'form526_submission_failure_notification_template_id',
+          personalisation: {
+            first_name: form526_submission.get_first_name,
+            date_submitted: form526_submission.format_creation_time_for_mailers,
+            files_submitted: 'None',
+            forms_submitted: [
+              'VA Form 21-4142',
+              'VA Form 21-0781',
+              'VA Form 21-0781a',
+              'VA Form 21-8940'
+            ]
+          }
+        }
+      end
+
+      let!(:form526_submission) { create(:form526_submission, :with_everything) }
+
+      it 'replaces the files list variable with a placeholder' do
+        expect(email_service).to receive(:send_email).with(expected_params)
+
+        subject.perform_async(form526_submission.id)
+        subject.drain
+      end
     end
   end
 
   describe 'logging' do
+    let!(:form526_submission) { create(:form526_submission, :with_uploads_and_ancillary_forms) }
+
     let(:timestamp) { Time.now.utc }
     let(:tags) { described_class::DD_ZSF_TAGS }
 

--- a/spec/support/disability_compensation_form/submissions/with_everything.json
+++ b/spec/support/disability_compensation_form/submissions/with_everything.json
@@ -2,6 +2,7 @@
   "form526": {
     "form526": {
       "veteran": {
+        "emailAddress": "test@email.com",
         "currentMailingAddress": {
           "country": "USA",
           "addressLine1": "1234 Couch Street",


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Acoomodate new Product / Design ask to insert 'None' into email template if Vet-provided files and / or ancillary forms are blank
- Refactor for redability
- add nil check to error logging
- Update shared spec logic

## Related issue(s)

- [Current Ticket for testing](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94173)
- [Initial Ticket 1](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94128)
- [Initial Ticket 2](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94127)
- [Previous PR 1 (where this is used)](https://github.com/department-of-veterans-affairs/vets-api/pull/18937)
- [Previous PR 2 (where this was originally added)](https://github.com/department-of-veterans-affairs/vets-api/pull/18928)

## Testing done

- [x] *New code is covered by unit tests*
-  Email template rejects an empty array for the `files_submitted` and `forms_submitted` arguments. After a cycle with design we agreed the best solution (which also avoides empty bullet points) is to simply interpolate 'None'
- Command line testing of staging to ensure email template was generated

Manual command line test code

```ruby
forms = ['VA Form 21-0781', 'VA Form 21-0781a']
files = ['thing.pdf', 'thang.txt']

# forms_submitted = 'None'
# files_submitted = 'None'

forms_submitted = forms
files_submitted = files

email_client = VaNotify::Service.new(Settings.vanotify.services.benefits_disability.api_key)
template_id = Settings.vanotify.services.benefits_disability.template_id
                      .form526_submission_failure_notification_template_id
email_client.send_email(
  email_address: <your email>,
  template_id:,
  personalisation: {
    first_name: "empty_strings",
    date_submitted: Date.today.strftime("%m/%d/%Y"),
    forms_submitted:,
    files_submitted:
  }
)
```

Or the job can be manually called if a submission exists with the desired components
```
Form526SubmissionFailureEmailJob.new.perform(submission.id)
```

## Screenshots
### Case of Args present
*NOTE: weird layout is being worked on by design, purpose here is simply to show correct interpolation*
<img width="704" alt="Screenshot 2024-10-24 at 12 16 31 PM" src="https://github.com/user-attachments/assets/30d4c5a7-d0b9-4b2f-b340-f9d283889023">


### Case of 'None'
<img width="632" alt="Screenshot 2024-10-24 at 11 58 52 AM" src="https://github.com/user-attachments/assets/00ccac16-1c8b-41ec-8864-bb8375565ec6">


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature