### PR TITLE
Make 26-4555 no longer need an ICN to go to the SAHSHA API

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -34,7 +34,7 @@ module SimpleFormsApi
 
         response = if intent_service.use_intent_api?
                      handle_210966_authenticated
-                   elsif form_is264555_and_should_use_lgy_api
+                   elsif params[:form_number] == '26-4555'
                      handle264555
                    else
                      submit_form_to_benefits_intake
@@ -211,10 +211,6 @@ module SimpleFormsApi
         }.compact
 
         lighthouse_service.perform_upload(**upload_params)
-      end
-
-      def form_is264555_and_should_use_lgy_api
-        params[:form_number] == '26-4555' && icn
       end
 
       def icn

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         allow_any_instance_of(LGY::Service).to receive(:post_grant_application).and_return(lgy_response)
       end
 
-      it 'calls LGY::Service' do
+      it 'makes the request to LGY::Service' do
         fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
                                        'vba_26_4555.json')
         data = JSON.parse(fixture_path.read)
@@ -367,8 +367,9 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         post '/simple_forms_api/v1/simple_forms', params: data
 
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['reference_number']).to eq reference_number
-        expect(JSON.parse(response.body)['status']).to eq body_status
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['reference_number']).to eq reference_number
+        expect(parsed_body['status']).to eq body_status
       end
     end
 


### PR DESCRIPTION
## Summary
This PR sends 26-4555s to the SAHSHA API regardless of whether the user has an ICN or not. It should _never_ go down the Benefits Intake API path.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=84586637&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1789
