### PR TITLE
VACMS-19450: Banner model migration

### DIFF
--- a/db/migrate/20241023222045_create_banners.rb
+++ b/db/migrate/20241023222045_create_banners.rb
@@ -1,0 +1,20 @@
+class CreateBanners < ActiveRecord::Migration[7.1]
+  def change
+    create_table :banners do |t|
+      t.integer :entity_id, null: false
+      t.string :entity_bundle
+      t.string :headline
+      t.string :alert_type
+      t.boolean :show_close
+      t.text :content
+      t.jsonb :context
+      t.boolean :operating_status_cta
+      t.boolean :email_updates_button
+      t.boolean :find_facilities_cta
+      t.boolean :limit_subpage_inheritance
+
+      t.timestamps
+    end
+    add_index :banners, :entity_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_21_182334) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_23_222045) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -294,6 +294,23 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_182334) do
     t.float "average_days"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "banners", force: :cascade do |t|
+    t.integer "entity_id", null: false
+    t.string "entity_bundle"
+    t.string "headline"
+    t.string "alert_type"
+    t.boolean "show_close"
+    t.text "content"
+    t.jsonb "context"
+    t.boolean "operating_status_cta"
+    t.boolean "email_updates_button"
+    t.boolean "find_facilities_cta"
+    t.boolean "limit_subpage_inheritance"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_id"], name: "index_banners_on_entity_id"
   end
 
   create_table "base_facilities", id: false, force: :cascade do |t|


### PR DESCRIPTION
## Summary
Adds 'banners' table migration.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19450

## Testing done
`bin/rails db:migrate`

## What areas of the site does it impact?
An module the Sitewide team is building for Banners.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
