### PR TITLE
VaNotify - Update InProgress1880FormReminder error logic

### DIFF
--- a/modules/va_notify/app/sidekiq/va_notify/in_progress_1880_form_reminder.rb
+++ b/modules/va_notify/app/sidekiq/va_notify/in_progress_1880_form_reminder.rb
@@ -14,7 +14,7 @@ module VANotify
       return unless Flipper.enabled?(:in_progress_1880_form_reminder)
 
       in_progress_form = InProgressForm.find(form_id)
-      
+
       veteran = VANotify::Veteran.new(in_progress_form)
 
       return if veteran.first_name.blank?

--- a/modules/va_notify/app/sidekiq/va_notify/in_progress_1880_form_reminder.rb
+++ b/modules/va_notify/app/sidekiq/va_notify/in_progress_1880_form_reminder.rb
@@ -10,16 +10,15 @@ module VANotify
 
     FORM_NAME = '26-1880'
 
-    class MissingICN < StandardError; end
-
     def perform(form_id)
       return unless Flipper.enabled?(:in_progress_1880_form_reminder)
 
       in_progress_form = InProgressForm.find(form_id)
+      
       veteran = VANotify::Veteran.new(in_progress_form)
 
       return if veteran.first_name.blank?
-      raise MissingICN, "ICN not found for InProgressForm: #{in_progress_form.id}" if veteran.icn.blank?
+      return if veteran.icn.blank?
 
       template_id = Settings.vanotify.services.va_gov.template_id.form1880_reminder_email
       personalisation_details = {
@@ -28,6 +27,8 @@ module VANotify
       }
       OneTimeInProgressReminder.perform_async(in_progress_form.user_account_id, FORM_NAME, template_id,
                                               personalisation_details)
+    rescue VANotify::Veteran::MPINameError, VANotify::Veteran::MPIError
+      nil
     end
   end
 end

--- a/modules/va_notify/spec/sidekiq/in_progress_1880_form_reminder_spec.rb
+++ b/modules/va_notify/spec/sidekiq/in_progress_1880_form_reminder_spec.rb
@@ -8,15 +8,18 @@ describe VANotify::InProgress1880FormReminder, type: :worker do
   let(:in_progress_form) { create(:in_progress_1880_form, user_uuid: user.uuid) }
 
   describe '#perform' do
-    it 'fails if ICN is not present' do
+    it 'skips sending if ICN is not present' do
       user_without_icn = double('VANotify::Veteran')
-      allow(VANotify::Veteran).to receive(:new).and_return(user_without_icn)
       allow(user_without_icn).to receive_messages(first_name: 'first_name', icn: nil)
+      allow(VANotify::Veteran).to receive(:new).and_return(user_without_icn)
 
-      expect do
+      allow(VANotify::OneTimeInProgressReminder).to receive(:perform_async)
+
+      Sidekiq::Testing.inline! do
         described_class.new.perform(in_progress_form.id)
-      end.to raise_error(VANotify::InProgress1880FormReminder::MissingICN,
-                         "ICN not found for InProgressForm: #{in_progress_form.id}")
+      end
+
+      expect(VANotify::OneTimeInProgressReminder).not_to have_received(:perform_async)
     end
 
     it 'skips sending reminder email if there is no first name' do
@@ -30,6 +33,30 @@ describe VANotify::InProgress1880FormReminder, type: :worker do
         described_class.new.perform(in_progress_form.id)
       end
 
+      expect(VANotify::OneTimeInProgressReminder).not_to have_received(:perform_async)
+    end
+
+    it 'rescues VANotify::Veteran::MPIError and returns nil' do
+      allow(VANotify::OneTimeInProgressReminder).to receive(:perform_async)
+      allow(VANotify::Veteran).to receive(:new).and_raise(VANotify::Veteran::MPIError)
+
+      result = Sidekiq::Testing.inline! do
+        described_class.new.perform(in_progress_form.id)
+      end
+
+      expect(result).to eq(nil)
+      expect(VANotify::OneTimeInProgressReminder).not_to have_received(:perform_async)
+    end
+  
+    it 'rescues VANotify::Veteran::MPINameError and returns nil' do
+      allow(VANotify::OneTimeInProgressReminder).to receive(:perform_async)
+      allow(VANotify::Veteran).to receive(:new).and_raise(VANotify::Veteran::MPINameError)
+  
+      result = Sidekiq::Testing.inline! do
+        described_class.new.perform(in_progress_form.id)
+      end
+  
+      expect(result).to eq(nil)
       expect(VANotify::OneTimeInProgressReminder).not_to have_received(:perform_async)
     end
 

--- a/modules/va_notify/spec/sidekiq/in_progress_1880_form_reminder_spec.rb
+++ b/modules/va_notify/spec/sidekiq/in_progress_1880_form_reminder_spec.rb
@@ -47,15 +47,15 @@ describe VANotify::InProgress1880FormReminder, type: :worker do
       expect(result).to eq(nil)
       expect(VANotify::OneTimeInProgressReminder).not_to have_received(:perform_async)
     end
-  
+
     it 'rescues VANotify::Veteran::MPINameError and returns nil' do
       allow(VANotify::OneTimeInProgressReminder).to receive(:perform_async)
       allow(VANotify::Veteran).to receive(:new).and_raise(VANotify::Veteran::MPINameError)
-  
+
       result = Sidekiq::Testing.inline! do
         described_class.new.perform(in_progress_form.id)
       end
-  
+
       expect(result).to eq(nil)
       expect(VANotify::OneTimeInProgressReminder).not_to have_received(:perform_async)
     end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform): Updating Error Logic
- *(If bug, how to reproduce)
- *(What is the solution, why is this the solution?)
- *(Which team do you work for, does your team own the maintenance of this component?): VA Notify - yes, my team owns this module
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/gh/department-of-veterans-affairs/vanotify-team/1389

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
