### PR TITLE
API-41400 Fix to add back missing parameter

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
@@ -120,7 +120,7 @@ module ClaimsApi
                 dependent_claimant_poa_assignment_service(poa_code:)
               )
             else
-              ClaimsApi::V2::PoaFormBuilderJob.perform_async(power_of_attorney.id, form_number, @rep_id)
+              ClaimsApi::V2::PoaFormBuilderJob.perform_async(power_of_attorney.id, form_number, @rep_id, 'post')
             end
           end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Quick fix to regression in POA v2 BaseController call to PoaFormBuilderJob.

## Related issue(s)

[API-41400](https://jira.devops.va.gov/browse/API-41400)

## Testing done

- [ ] *New code is covered by unit tests*
- Adds back last string parameter in call to PoaFormBuilderJob.


## What areas of the site does it impact?
PoaFormBuilder v2

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
