### PR TITLE
95796 Reverting change to feature toggle actor type - IVC CHAMPVA Forms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -736,19 +736,19 @@ features:
     actor_type: user
     description: If enabled shows the digital form experience for form 40-0247
   form1010d:
-    actor_type: cookie_id
+    actor_type: user
     description: If enabled shows the digital form experience for form 10-10d (IVC CHAMPVA)
   form107959c:
-    actor_type: cookie_id
+    actor_type: user
     description: If enabled shows the digital form experience for form 10-7959c (IVC CHAMPVA other health insurance)
   form107959a:
-    actor_type: cookie_id
+    actor_type: user
     description: If enabled shows the digital form experience for form 10-7959a (IVC CHAMPVA claim form)
   form107959f1:
-    actor_type: cookie_id
+    actor_type: user
     description: If enabled shows the digital form experience for form 10-7959f-1 (Foreign Medical Program register form)
   form107959f2:
-    actor_type: cookie_id
+    actor_type: user
     description: If enabled shows the digital form experience for form 10-7959f-2 (Foreign Medical Program claim form)
   form_upload_flow:
     actor_type: user


### PR DESCRIPTION
## Summary

This PR reverts user types from `cookie_id` back to `user` ([previously, see this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/19055)). This needs to be done because we need access to the ability to whitelist user emails in a flipper (which does not appear to work when `actor_type: cookie_id`.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95796
- https://github.com/department-of-veterans-affairs/vets-api/pull/19055

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
