### PR TITLE
Migrate settings-related ENVs to use Settings directly

### DIFF
--- a/app/sidekiq/education_form/create_daily_spool_files.rb
+++ b/app/sidekiq/education_form/create_daily_spool_files.rb
@@ -115,12 +115,7 @@ module EducationForm
             # This mailer is intended to only work for development, staging and NOT production
             # Rails.env will return 'production' on the development & staging servers and  which
             # will trip the unwary. To be safe, use Settings.hostname
-            email_staging_spool_files(contents) if
-              # local developer development
-              Rails.env.eql?('development') ||
-
-              # VA Staging environment where we really want this to work.
-              Settings.hostname.eql?('staging-api.va.gov')
+            email_staging_spool_files(contents) if local_or_staging_env?
 
             # track and update the records as processed once the file has been successfully written
             track_submissions(region_id)
@@ -238,6 +233,10 @@ module EducationForm
 
     def email_staging_spool_files(contents)
       CreateStagingSpoolFilesMailer.build(contents).deliver_now
+    end
+
+    def local_or_staging_env?
+      Rails.env.eql?('development') || Settings.hostname.eql?('staging-api.va.gov')
     end
   end
 end

--- a/app/sidekiq/education_form/create_daily_spool_files.rb
+++ b/app/sidekiq/education_form/create_daily_spool_files.rb
@@ -114,13 +114,13 @@ module EducationForm
             # send copy of staging spool files to testers
             # This mailer is intended to only work for development, staging and NOT production
             # Rails.env will return 'production' on the development & staging servers and  which
-            # will trip the unwary. To be safe, use ENV['HOSTNAME']
+            # will trip the unwary. To be safe, use Settings.hostname
             email_staging_spool_files(contents) if
               # local developer development
               Rails.env.eql?('development') ||
 
               # VA Staging environment where we really want this to work.
-              ENV['HOSTNAME'].eql?('staging-api.va.gov')
+              Settings.hostname.eql?('staging-api.va.gov')
 
             # track and update the records as processed once the file has been successfully written
             track_submissions(region_id)

--- a/config/initializers/add_local_config.rb
+++ b/config/initializers/add_local_config.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-if defined?(ENV.fetch('VSP_ENVIRONMENT', nil))
-  Settings.prepend_source!(Rails.root.join("config/settings/#{ENV.fetch('VSP_ENVIRONMENT', nil)}.local.yml").to_s)
+vsp_environment = ENV.fetch('VSP_ENVIRONMENT', nil) || ENV.fetch('SETTINGS__VSP_ENVIRONMENT', nil)
+
+if vsp_environment
+  source = Rails.root.join("config/settings/#{vsp_environment}.local.yml").to_s
+  Settings.prepend_source!(source)
   Settings.reload!
 end

--- a/config/initializers/kms_encrypted.rb
+++ b/config/initializers/kms_encrypted.rb
@@ -2,7 +2,7 @@
 
 require 'kms_encrypted'
 ENV['KMS_KEY_ID'] ||= 'insecure-test-key' if Rails.env.development? || Rails.env.test?
-KmsEncrypted.key_id = ENV['KMS_KEY_ID']
+KmsEncrypted.key_id = ENV.fetch('KMS_KEY_ID', nil)
 
 Rails.application.reloader.to_prepare do
   KmsEncrypted::Model.prepend KmsEncryptedModelPatch

--- a/config/initializers/kms_encrypted.rb
+++ b/config/initializers/kms_encrypted.rb
@@ -2,7 +2,7 @@
 
 require 'kms_encrypted'
 ENV['KMS_KEY_ID'] ||= 'insecure-test-key' if Rails.env.development? || Rails.env.test?
-KmsEncrypted.key_id = ENV.fetch 'KMS_KEY_ID'
+KmsEncrypted.key_id = ENV['KMS_KEY_ID']
 
 Rails.application.reloader.to_prepare do
   KmsEncrypted::Model.prepend KmsEncryptedModelPatch

--- a/modules/claims_api/lib/brd/brd.rb
+++ b/modules/claims_api/lib/brd/brd.rb
@@ -71,7 +71,7 @@ module ClaimsApi
                     Settings.brd.base_name
                   end
 
-      api_key = Settings.brd&.api_key || ENV.fetch('BRD_API_KEY', '')
+      api_key = Settings.brd&.api_key || ''
       raise StandardError, 'BRD api_key missing' if api_key.blank?
 
       Faraday.new("https://#{base_name}/benefits-reference-data/v1",

--- a/rakelib/routes_csv.rake
+++ b/rakelib/routes_csv.rake
@@ -6,7 +6,6 @@ namespace :routes do
     all_routes = Rails.application.routes.routes
     require 'action_dispatch/routing/inspector'
     inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
-    # puts inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, ENV['CONTROLLER'])
     puts inspector.format(CSVFormatter.new)
   end
 end
@@ -26,13 +25,11 @@ class CSVFormatter
 
   def section(routes)
     routes.map do |r|
-      # @buffer << "#{r[:name]},#{r[:verb]},#{r[:path]},#{r[:reqs]}"
       @buffer << "#{r[:path]},#{r[:reqs]}"
     end
   end
 
   def header(_routes)
-    # @buffer << 'Prefix,Verb,URI Pattern,Controller#Action'
     @buffer << 'Prefix,Controller#Action'
   end
 

--- a/spec/sidekiq/education_form/create_daily_spool_files_spec.rb
+++ b/spec/sidekiq/education_form/create_daily_spool_files_spec.rb
@@ -126,7 +126,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
     context 'with records in staging', run_at: '2016-09-16 03:00:00 EDT' do
       before do
-        ENV['HOSTNAME'] = 'staging-api.va.gov'
         application_1606.saved_claim.form = {}.to_json
         FactoryBot.create(:va1990_western_region)
         FactoryBot.create(:va1995_full_form)
@@ -134,14 +133,12 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
         ActionMailer::Base.deliveries.clear
       end
 
-      after do
-        ENV['HOSTNAME'] = nil
-      end
-
       it 'processes the valid messages' do
-        expect(Flipper).to receive(:enabled?).with(any_args).and_return(false).at_least(:once)
-        expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(4).to(0)
-        expect(ActionMailer::Base.deliveries.count).to be > 0
+        with_settings(Settings, hostname: 'staging-api.va.gov') do
+          expect(Flipper).to receive(:enabled?).with(any_args).and_return(false).at_least(:once)
+          expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(4).to(0)
+          expect(ActionMailer::Base.deliveries.count).to be > 0
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- As part of normalizing helm charts and parameter store paths, the environment variables are given a prefix of `SETTINGS` and separator `__`. 
- This converts ENVs from the helm charts to Settings. This allows for the ENVs in the helm charts to be updated without affecting vets-api. 

Additionally, in `modules/claims_api/lib/brd/brd.rb` the ENV and Setting.brd where accessing the same value, so it was simplified (if `Setting.brd.api_key` is nil then so is `ENV['BRD_API_KEY']`) 

There is one exception, `VSP_ENVIRONMENT` is being accessed in an initializer before Settings is reload, so I think it needs to be an ENV. Eventually it can be updated to only use `SETTINGS__VSP_ENVIRONMENT`.

## Related issue(s)

- Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/95566

## Testing done

- [ ] CI tests pass

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  No ENV from the helm charts are accessed as a hash (ie `ENV['']` or `ENV.fetch `)