### PR TITLE
dbex/90990: Prevent EP merges for the disability_compensation_production_tester flag

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -132,7 +132,9 @@ module Form526ClaimFastTrackingConcern
     Rails.logger.info('EP Merge total open EPs', id:, count: pending_eps.count)
     return unless pending_eps.count == 1
 
-    feature_enabled = Flipper.enabled?(:disability_526_ep_merge_api, User.find(user_uuid))
+    actor = OpenStruct.new({ flipper_id: submission.user_uuid })
+    feature_enabled = Flipper.enabled?(:disability_526_ep_merge_api,
+                                       actor) && !Flipper.enabled?(:disability_compensation_production_tester, actor)
     open_claim_review = open_claim_review?
     Rails.logger.info(
       'EP Merge open EP eligibility',

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -132,7 +132,7 @@ module Form526ClaimFastTrackingConcern
     Rails.logger.info('EP Merge total open EPs', id:, count: pending_eps.count)
     return unless pending_eps.count == 1
 
-    actor = OpenStruct.new({ flipper_id: submission.user_uuid })
+    actor = OpenStruct.new({ flipper_id: user_uuid })
     feature_enabled = Flipper.enabled?(:disability_526_ep_merge_api,
                                        actor) && !Flipper.enabled?(:disability_compensation_production_tester, actor)
     open_claim_review = open_claim_review?

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -133,8 +133,11 @@ module Form526ClaimFastTrackingConcern
     return unless pending_eps.count == 1
 
     actor = OpenStruct.new({ flipper_id: user_uuid })
-    feature_enabled = Flipper.enabled?(:disability_526_ep_merge_api,
-                                       actor) && !Flipper.enabled?(:disability_compensation_production_tester, actor)
+    feature_enabled = Flipper.enabled?(:disability_526_ep_merge_api, actor)
+    if Flipper.enabled?(:disability_compensation_production_tester, actor)
+      feature_enabled = false
+      Rails.logger.info("EP merge skipped for submission #{id}")
+    end
     open_claim_review = open_claim_review?
     Rails.logger.info(
       'EP Merge open EP eligibility',


### PR DESCRIPTION
This PR is to extend the existing functionality of the `disability_compensation_production_tester` flipper flag to explicitly prevent EP merges during a 526ez submission.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*
  - Implemented logic to negate the `disability_526_ep_merge_api` flag when the `disability_compensation_production_tester` flag is enabled for a particular test user
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits Experience Team 1 (DBEX-TREX) 🦖🦖🦖
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
  - [90990](https://github.com/department-of-veterans-affairs/va.gov-team/issues/90990)
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Local dev testing
1. Change [this line](url) to `return {}`
2. Change [this line](https://github.com/department-of-veterans-affairs/vets-api/blob/1cd17fdcc6801d4c6a91a9fd0f55ba1878119c3b/app/models/concerns/form526_claim_fast_tracking_concern.rb#L115) to `is_claim_fully_classified = true`
3. Find an existing submission from your local environment (or generate one), and note the `id` and the `user_uuid`
4. In the [flipper dashboard](http://localhost:3000/flipper/features/disability_compensation_production_tester), add the `user_uuid` via "Add an actor"
![image](https://github.com/user-attachments/assets/d5c79519-080c-4426-b34e-a7c2cf065c6c)
5. Open a local rails console (via `rails c`), and run the following (substituting your submission id)
```
submission_id=54
service=EVSS::DisabilityCompensationForm::SubmitForm526AllClaim.new
service.perform(submission_id)
```
6. Look for the following highlighted output (bottom right) for the "EP merge skipped for..." message, reflecting your submission id and user_uuid
7. Remove the user_uuid from flipper dashboard and/or try a different submission associated with a different user, then retest. The "EP merge skipped for..." message should be absent


## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
