### PR TITLE
Fix AccreditedOrganization Model flaky spec

### DIFF
--- a/spec/models/accredited_organization_spec.rb
+++ b/spec/models/accredited_organization_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AccreditedOrganization, type: :model do
   describe 'validations' do
-    subject { build(:accredited_organization) }
+    subject { build(:accredited_organization, poa_code: 'A12') }
 
     it { is_expected.to have_many(:accredited_individuals).through(:accreditations) }
 


### PR DESCRIPTION
## Summary

- This sets the `poa_code` on model validation specs. The factory's random poa code can sometimes only contain numeric characters which breaks the case sensitivity check in the shoulda matcher uniqueness assertion. 

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
