### PR TITLE
[DBEX] log and monitor evidence upload failure email events

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -77,6 +77,7 @@ class Form526Submission < ApplicationRecord
   # MAX_PENDING_TIME aligns with the farthest out expectation given in the LH BI docs,
   # plus 1 week to accomodate for edge cases and our sidekiq jobs
   MAX_PENDING_TIME = 3.weeks
+  ZSF_DD_TAG_SERVICE = 'disability-application'
 
   # used to track in APMs between systems such as Lighthouse
   # example: can be used as a search parameter in Datadog

--- a/app/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'va_notify/service'
+require 'zero_silent_failures/monitor'
 
 module EVSS
   module DisabilityCompensationForm
     class Form526DocumentUploadFailureEmail < Job
       STATSD_METRIC_PREFIX = 'api.form_526.veteran_notifications.document_upload_failure_email'
+      ZSF_DD_TAG_FUNCTION = '526_evidence_upload_failure_email_queuing'
 
       # retry for one day
       sidekiq_options retry: 14
@@ -16,6 +18,11 @@ module EVSS
         error_message = msg['error_message']
         timestamp = Time.now.utc
         form526_submission_id, supporting_evidence_attachment_guid = msg['args']
+
+        log_info = { job_id:, timestamp:, form526_submission_id:, error_class:, error_message:,
+                     supporting_evidence_attachment_guid: }
+
+        Rails.logger.warn('Form526DocumentUploadFailureEmail retries exhausted', log_info)
 
         # Job status records are upserted in the JobTracker module
         # when the retryable_error_handler is called
@@ -33,20 +40,6 @@ module EVSS
           status: Form526JobStatus::STATUS[:exhausted],
           bgjob_errors: bgjob_errors.merge(new_error)
         )
-
-        Rails.logger.warn(
-          'Form526DocumentUploadFailureEmail retries exhausted',
-          {
-            job_id:,
-            timestamp:,
-            form526_submission_id:,
-            error_class:,
-            error_message:,
-            supporting_evidence_attachment_guid:
-          }
-        )
-
-        StatsD.increment("#{STATSD_METRIC_PREFIX}.exhausted")
       rescue => e
         Rails.logger.error(
           'Failure in Form526DocumentUploadFailureEmail#sidekiq_retries_exhausted',
@@ -62,17 +55,28 @@ module EVSS
           }
         )
         raise e
+      ensure
+        StatsD.increment("#{STATSD_METRIC_PREFIX}.exhausted")
+
+        cl = caller_locations.first
+        call_location = ZeroSilentFailures::Monitor::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)
+        zsf_monitor = ZeroSilentFailures::Monitor.new(Form526Submission::ZSF_DD_TAG_SERVICE)
+        user_account_id = begin
+          Form526Submission.find(form526_submission_id).user_account_id
+        rescue
+          nil
+        end
+
+        zsf_monitor.log_silent_failure(log_info, user_account_id, call_location:)
       end
 
       def perform(form526_submission_id, supporting_evidence_attachment_guid)
         super(form526_submission_id)
-        submission = Form526Submission.find(form526_submission_id)
+
+        submission = form526_submission(form526_submission_id)
 
         with_tracking('Form526DocumentUploadFailureEmail', submission.saved_claim_id, form526_submission_id) do
-          @notify_client ||= VaNotify::Service.new(Settings.vanotify.services.benefits_disability.api_key)
           send_notification_mailer(submission, supporting_evidence_attachment_guid)
-
-          StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
         end
       rescue => e
         retryable_error_handler(e)
@@ -83,32 +87,59 @@ module EVSS
       def send_notification_mailer(submission, supporting_evidence_attachment_guid)
         form_attachment = SupportingEvidenceAttachment.find_by!(guid: supporting_evidence_attachment_guid)
 
-        # We need to obscure the original filename since it may contain PII
+        # We need to obscure the original filename as it may contain PII
         obscured_filename = form_attachment.obscured_filename
-
         email_address = submission.veteran_email_address
         first_name = submission.get_first_name
         date_submitted = submission.format_creation_time_for_mailers
-        @notify_client.send_email(
+
+        notify_response = notify_client.send_email(
           email_address:,
           template_id: mailer_template_id,
           personalisation: { first_name:, filename: obscured_filename, date_submitted: }
         )
 
-        Rails.logger.info(
-          'Form526DocumentUploadFailureEmail notification dispatched',
-          {
-            obscured_filename:,
-            form526_submission_id: submission.id,
-            supporting_evidence_attachment_guid:,
-            timestamp: Time.now.utc
-          }
+        log_info = { obscured_filename:, form526_submission_id: submission.id,
+                     supporting_evidence_attachment_guid:, timestamp: Time.now.utc }
+
+        log_mailer_dispatch(log_info, notify_response)
+      end
+
+      def log_mailer_dispatch(log_info, email_response = {})
+        StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
+
+        Rails.logger.info('Form526DocumentUploadFailureEmail notification dispatched', log_info)
+
+        zsf_monitor.log_silent_failure_avoided(
+          log_info.merge(email_confirmation_id: email_response&.id),
+          @form526_submission&.user_account_id,
+          call_location:
         )
       end
 
+      def form526_submission(form526_submission_id)
+        @form526_submission ||= Form526Submission.find(form526_submission_id)
+      end
+
       def mailer_template_id
-        Settings.vanotify.services
-                .benefits_disability.template_id.form526_document_upload_failure_notification_template_id
+        notify_service_bd.template_id.form526_document_upload_failure_notification_template_id
+      end
+
+      def notify_client
+        @notify_client ||= VaNotify::Service.new(notify_service_bd.api_key)
+      end
+
+      def notify_service_bd
+        @notify_service_bd ||= Settings.vanotify.services.benefits_disability
+      end
+
+      def zsf_monitor
+        ZeroSilentFailures::Monitor.new(Form526Submission::ZSF_DD_TAG_SERVICE)
+      end
+
+      def call_location
+        cl = caller_locations.first
+        ZeroSilentFailures::Monitor::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)
       end
 
       def retryable_error_handler(error)

--- a/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require 'zero_silent_failures/monitor'
+
 module EVSS
   module DisabilityCompensationForm
     class SubmitUploads < Job
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526_upload'
+      ZSF_DD_TAG_FUNCTION = '526_evidence_upload_failure_email_queuing'
 
       # retry for one day
       sidekiq_options retry: 14
@@ -14,6 +17,9 @@ module EVSS
         error_message = msg['error_message']
         timestamp = Time.now.utc
         form526_submission_id = msg['args'].first
+        log_info = { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+
+        Rails.logger.warn('Submit Form 526 Upload Retries exhausted', log_info)
 
         form_job_status = Form526JobStatus.find_by(job_id:)
         bgjob_errors = form_job_status.bgjob_errors || {}
@@ -31,6 +37,8 @@ module EVSS
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
+
         if Flipper.enabled?(:form526_send_document_upload_failure_notification)
           # Extract original job arguments
           # (form526_submission_id already extracted above;
@@ -41,14 +49,19 @@ module EVSS
           guid = upload_data['confirmationCode']
           Form526DocumentUploadFailureEmail.perform_async(form526_submission_id, guid)
         end
-
-        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
-
-        ::Rails.logger.warn(
-          'Submit Form 526 Upload Retries exhausted',
-          { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
-        )
       rescue => e
+        cl = caller_locations.first
+        call_location = ZeroSilentFailures::Monitor::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)
+        Form526Submission.find_by(id: form526_submission_id)
+        zsf_monitor = ZeroSilentFailures::Monitor.new(Form526Submission::ZSF_DD_TAG_SERVICE)
+        user_account_id = begin
+          Form526Submission.find(form526_submission_id).user_account_id
+        rescue
+          nil
+        end
+
+        zsf_monitor.log_silent_failure(log_info, user_account_id, call_location:)
+
         ::Rails.logger.error(
           'Failure in SubmitUploads#sidekiq_retries_exhausted',
           {

--- a/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
@@ -52,7 +52,6 @@ module EVSS
       rescue => e
         cl = caller_locations.first
         call_location = ZeroSilentFailures::Monitor::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)
-        Form526Submission.find_by(id: form526_submission_id)
         zsf_monitor = ZeroSilentFailures::Monitor.new(Form526Submission::ZSF_DD_TAG_SERVICE)
         user_account_id = begin
           Form526Submission.find(form526_submission_id).user_account_id

--- a/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
            saved_claim_id: saved_claim.id,
            submitted_claim_id: '600130094')
   end
+  let(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission: submission, job_id: 1) }
+  let(:upload_data) { [submission.form[Form526Submission::FORM_526_UPLOADS].first] }
 
   describe 'perform' do
-    let(:upload_data) { [submission.form[Form526Submission::FORM_526_UPLOADS].first] }
     let(:document_data) { double(:document_data, valid?: true) }
 
     context 'when file_data exists' do
@@ -65,15 +66,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
       end
 
       context 'when all retries are exhausted' do
-        let!(:form526_job_status) do
-          create(
-            :form526_job_status,
-            :retryable_error,
-            form526_submission: submission,
-            job_id: 1
-          )
-        end
-
         let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file1.jpg', 'image/jpg') }
         let!(:attachment) do
           sea = SupportingEvidenceAttachment.new(guid: upload_data.first['confirmationCode'])
@@ -156,9 +148,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
 
   context 'catastrophic failure state' do
     describe 'when all retries are exhausted' do
-      let!(:form526_submission) { create(:form526_submission) }
-      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
-
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
           expect(StatsD).to receive(:increment).with("#{subject::STATSD_KEY_PREFIX}.exhausted")
@@ -166,6 +155,39 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
         end
         form526_job_status.reload
         expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+
+    describe 'when an error occurs during exhaustion handling and FailureEmail fails to enqueue' do
+      let!(:zsf_tag) { Form526Submission::ZSF_DD_TAG_SERVICE }
+      let!(:zsf_monitor) { ZeroSilentFailures::Monitor.new(zsf_tag) }
+      let!(:failure_email) { EVSS::DisabilityCompensationForm::Form526DocumentUploadFailureEmail }
+
+      before do
+        Flipper.enable(:form526_send_document_upload_failure_notification)
+        allow(ZeroSilentFailures::Monitor).to receive(:new).with(zsf_tag).and_return(zsf_monitor)
+      end
+
+      it 'logs a silent failure' do
+        expect(zsf_monitor).to receive(:log_silent_failure).with(
+          {
+            job_id: form526_job_status.job_id,
+            error_class: nil,
+            error_message: 'An error occured',
+            timestamp: instance_of(Time),
+            form526_submission_id: submission.id
+          },
+          nil,
+          call_location: instance_of(ZeroSilentFailures::Monitor::CallLocation)
+        )
+
+        args = { 'jid' => form526_job_status.job_id, 'args' => [submission.id, upload_data] }
+
+        expect do
+          subject.within_sidekiq_retries_exhausted_block(args) do
+            allow(failure_email).to receive(:perform_async).and_raise(StandardError, 'Simulated error')
+          end
+        end.to raise_error(StandardError, 'Simulated error')
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): ~YES~/NO*
- *(Summarize the changes that have been made to the platform)*
  - Logs **resolved** failures, where VA Notify is requested to dispatch an email notifying users of a failure associated with uploaded supplementary evidence
  - Logs **unresolved** silent failures, when a failure email job fails to enqueue
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)*
  - Logs messages identified as failures, which are made known to the user via email notification from VA Notify
  - Increments metrics to capture an issue
  - Supports logging and metrics requirements set by VA stakeholders
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95092

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
- Impacts logging and metrics data recorded in Datadog

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
