### PR TITLE
Switch Settings.dig to dot notation

### DIFF
--- a/app/controllers/v1/nod_callbacks_controller.rb
+++ b/app/controllers/v1/nod_callbacks_controller.rb
@@ -80,7 +80,7 @@ module V1
     end
 
     def bearer_token_secret
-      Settings.dig(:nod_vanotify_status_callback, :bearer_token)
+      Settings.nod_vanotify_status_callback.bearer_token
     end
 
     def enabled?

--- a/app/controllers/v1/pension_ipf_callbacks_controller.rb
+++ b/app/controllers/v1/pension_ipf_callbacks_controller.rb
@@ -63,7 +63,7 @@ module V1
     end
 
     def bearer_token_secret
-      Settings.dig(:pension_ipf_vanotify_status_callback, :bearer_token)
+      Settings.pension_ipf_vanotify_status_callback.bearer_token
     end
 
     def log_params(payload)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1783,6 +1783,12 @@ brd:
   api_key: 'fake_key'
   base_name: 'https://something.fake.va.gov'
 
+nod_vanotify_status_callback:
+  bearer_token: bearer_token_secret
+
+pension_ipf_vanotify_status_callback:
+  bearer_token: bearer_token_secret
+
 travel_pay:
   sts:
     service_account_id: ~

--- a/modules/appeals_api/app/controllers/appeals_api/appealable_issues/v0/appealable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/appealable_issues/v0/appealable_issues_controller.rb
@@ -41,7 +41,7 @@ module AppealsApi::AppealableIssues::V0
 
     def token_validation_api_key
       # FIXME: rename token storage key
-      Settings.dig(:modules_appeals_api, :token_validation, :contestable_issues, :api_key)
+      Settings.modules_appeals_api.token_validation.contestable_issues.api_key
     end
 
     def get_caseflow_response

--- a/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v0/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v0/higher_level_reviews_controller.rb
@@ -128,7 +128,7 @@ module AppealsApi::HigherLevelReviews::V0
     end
 
     def token_validation_api_key
-      Settings.dig(:modules_appeals_api, :token_validation, :higher_level_reviews, :api_key)
+      Settings.modules_appeals_api.token_validation.higher_level_reviews.api_key
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/legacy_appeals/v0/legacy_appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/legacy_appeals/v0/legacy_appeals_controller.rb
@@ -38,7 +38,7 @@ module AppealsApi::LegacyAppeals::V0
     end
 
     def token_validation_api_key
-      Settings.dig(:modules_appeals_api, :token_validation, :legacy_appeals, :api_key)
+      Settings.modules_appeals_api.token_validation.legacy_appeals.api_key
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements/evidence_submissions_controller.rb
@@ -78,7 +78,6 @@ module AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreements
 
     def token_validation_api_key
       Settings.modules_appeals_api.token_validation.notice_of_disagreements.api_key
-
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements/evidence_submissions_controller.rb
@@ -77,7 +77,8 @@ module AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreements
     end
 
     def token_validation_api_key
-      Settings.dig(:modules_appeals_api, :token_validation, :notice_of_disagreements, :api_key)
+      Settings.modules_appeals_api.token_validation.notice_of_disagreements.api_key
+
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v0/notice_of_disagreements_controller.rb
@@ -128,7 +128,7 @@ module AppealsApi::NoticeOfDisagreements::V0
     end
 
     def token_validation_api_key
-      Settings.dig(:modules_appeals_api, :token_validation, :notice_of_disagreements, :api_key)
+      Settings.modules_appeals_api.token_validation.notice_of_disagreements.api_key
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims/evidence_submissions_controller.rb
@@ -77,7 +77,7 @@ module AppealsApi::SupplementalClaims::V0::SupplementalClaims
     end
 
     def token_validation_api_key
-      Settings.dig(:modules_appeals_api, :token_validation, :supplemental_claims, :api_key)
+      Settings.modules_appeals_api.token_validation.supplemental_claims.api_key
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v0/supplemental_claims_controller.rb
@@ -127,7 +127,7 @@ module AppealsApi::SupplementalClaims::V0
     end
 
     def token_validation_api_key
-      Settings.dig(:modules_appeals_api, :token_validation, :supplemental_claims, :api_key)
+      Settings.modules_appeals_api.token_validation.supplemental_claims.api_key
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/appeals_controller.rb
@@ -36,7 +36,7 @@ module AppealsApi
       end
 
       def token_validation_api_key
-        Settings.dig(:modules_appeals_api, :token_validation, :appeals_status, :api_key)
+        Settings.modules_appeals_api.token_validation.appeals_status.api_key
       end
     end
   end

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/openid_auth.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/openid_auth.rb
@@ -64,7 +64,7 @@ module AppealsApi
     private
 
     def unsafe_mode?
-      Rails.env.development? && Settings.dig(:modules_appeals_api, :enable_unsafe_mode)
+      Rails.env.development? && Settings.modules_appeals_api.enable_unsafe_mode
     end
 
     # Override this in individual controllers

--- a/modules/covid_vaccine/app/sidekiq/covid_vaccine/scheduled_batch_job.rb
+++ b/modules/covid_vaccine/app/sidekiq/covid_vaccine/scheduled_batch_job.rb
@@ -32,7 +32,7 @@ module CovidVaccine
     private
 
     def enrollment_upload_enabled?
-      Settings.dig('covid_vaccine', 'enrollment_service', 'job_enabled')
+      Settings.covid_vaccine.enrollment_service.job_enabled
     end
 
     def handle_errors(ex)


### PR DESCRIPTION
## Summary

- Most settings are accessed via dot notation (`Settings.parent_key.child_key`)
- Using `.dig` can obscure the use of those keys by making them difficult to find 
- The dot notation makes them easier to find
- If dot notation isn't possible, dig is acceptable 

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  Settings.dig is only used where dot notation isn't possible or difficult