### PR TITLE
[DBX-94173] add date of failure to 526 failure email

### DIFF
--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -76,7 +76,7 @@ class Form526StatusPollingJob
 
   def notify_veteran(submission_id)
     if Flipper.enabled?(:send_backup_submission_polling_failure_email_notice)
-      Form526SubmissionFailureEmailJob.perform_async(form526_submission_id: submission_id)
+      Form526SubmissionFailureEmailJob.perform_async(submission_id, Time.zone.now)
     end
   end
 end

--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -76,7 +76,7 @@ class Form526StatusPollingJob
 
   def notify_veteran(submission_id)
     if Flipper.enabled?(:send_backup_submission_polling_failure_email_notice)
-      Form526SubmissionFailureEmailJob.perform_async(submission_id, Time.zone.now)
+      Form526SubmissionFailureEmailJob.perform_async(submission_id, Time.now.utc)
     end
   end
 end

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -58,7 +58,7 @@ class Form526SubmissionFailureEmailJob
     raise e
   end
 
-  def perform(submission_id, date_of_failure = Time.zone.now)
+  def perform(submission_id, date_of_failure = Time.now.utc)
     @submission = Form526Submission.find(submission_id)
     @date_of_failure = date_of_failure
     send_email

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -124,7 +124,7 @@ class Form526SubmissionFailureEmailJob
 
   def log_success
     Rails.logger.info(
-      'Form526SubmissionFailureEmail notification dispatched',
+      'Form526SubmissionFailureEmailJob notification dispatched',
       {
         form526_submission_id: submission.id,
         timestamp: Time.now.utc
@@ -137,7 +137,7 @@ class Form526SubmissionFailureEmailJob
 
   def log_failure(error)
     Rails.logger.error(
-      'Form526SubmissionFailureEmail notification failed',
+      'Form526SubmissionFailureEmailJob notification failed',
       {
         form526_submission_id: submission&.id,
         error_message: error.try(:message),

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -58,8 +58,9 @@ class Form526SubmissionFailureEmailJob
     raise e
   end
 
-  def perform(submission_id)
+  def perform(submission_id, date_of_failure = Time.zone.now)
     @submission = Form526Submission.find(submission_id)
+    @date_of_failure = date_of_failure
     send_email
     track_remedial_action
     log_success
@@ -69,6 +70,10 @@ class Form526SubmissionFailureEmailJob
   end
 
   private
+
+  def format_failure_date(timestamp)
+    timestamp
+  end
 
   def send_email
     email_client = VaNotify::Service.new(Settings.vanotify.services.benefits_disability.api_key)
@@ -110,7 +115,7 @@ class Form526SubmissionFailureEmailJob
   end
 
   def date_of_failure
-    Time.zone.now.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.')
+    @date_of_failure.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.')
   end
 
   def track_remedial_action

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -71,10 +71,6 @@ class Form526SubmissionFailureEmailJob
 
   private
 
-  def format_failure_date(timestamp)
-    timestamp
-  end
-
   def send_email
     email_client = VaNotify::Service.new(Settings.vanotify.services.benefits_disability.api_key)
     template_id = Settings.vanotify.services.benefits_disability.template_id

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -104,8 +104,13 @@ class Form526SubmissionFailureEmailJob
       first_name: submission.get_first_name,
       date_submitted: submission.format_creation_time_for_mailers,
       forms_submitted: list_forms_submitted.presence || 'None',
-      files_submitted: list_files_submitted.presence || 'None'
+      files_submitted: list_files_submitted.presence || 'None',
+      date_of_failure:
     }
+  end
+
+  def date_of_failure
+    Time.zone.now.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.')
   end
 
   def track_remedial_action

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -54,7 +54,7 @@ module Sidekiq
         )
 
         if Flipper.enabled?(:send_backup_submission_exhaustion_email_notice)
-          ::Form526SubmissionFailureEmailJob.perform_async(form526_submission_id, Time.zone.now)
+          ::Form526SubmissionFailureEmailJob.perform_async(form526_submission_id, Time.now.utc)
         end
       rescue => e
         ::Rails.logger.error(

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -54,7 +54,7 @@ module Sidekiq
         )
 
         if Flipper.enabled?(:send_backup_submission_exhaustion_email_notice)
-          ::Form526SubmissionFailureEmailJob.perform_async(form526_submission_id:)
+          ::Form526SubmissionFailureEmailJob.perform_async(form526_submission_id, Time.zone.now)
         end
       rescue => e
         ::Rails.logger.error(

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
   end
 
   describe 'failures' do
-    let(:timestamp) { Time.zone.utc }
+    let(:timestamp) { Time.now.utc }
 
     context 'when all retries are exhausted' do
       let!(:form526_submission) { create(:form526_submission) }

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
   end
 
   describe 'failures' do
-    let(:timestamp) { Time.zone.now }
+    let(:timestamp) { Time.zone.utc }
 
     context 'when all retries are exhausted' do
       let!(:form526_submission) { create(:form526_submission) }

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
       end
 
       context 'when send_backup_submission_exhaustion_email_notice is enabled' do
-
         before do
           Flipper.enable(:send_backup_submission_exhaustion_email_notice)
         end

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -141,31 +141,35 @@ RSpec.describe Form526StatusPollingJob, type: :job do
 
       context 'when a failure type response is returned from the API' do
         context 'when send_backup_submission_exhaustion_email_notice is enabled' do
+          let(:timestamp) { Time.zone.now }
+
           before do
             Flipper.enable(:send_backup_submission_polling_failure_email_notice)
           end
 
           it 'enqueues a failure notification email job' do
-            pending_claim_ids = Form526Submission.pending_backup.pluck(:backup_submitted_claim_id)
+            Timecop.freeze(timestamp) do
+              pending_claim_ids = Form526Submission.pending_backup.pluck(:backup_submitted_claim_id)
 
-            response = double
-            allow(response).to receive(:body).and_return(api_response)
-            allow_any_instance_of(BenefitsIntakeService::Service)
-              .to receive(:get_bulk_status_of_uploads)
-              .with(pending_claim_ids)
-              .and_return(response)
+              response = double
+              allow(response).to receive(:body).and_return(api_response)
+              allow_any_instance_of(BenefitsIntakeService::Service)
+                .to receive(:get_bulk_status_of_uploads)
+                .with(pending_claim_ids)
+                .and_return(response)
 
-            expect(Form526SubmissionFailureEmailJob)
-              .not_to receive(:perform_async).with({ form526_submission_id: backup_submission_a.id })
-            expect(Form526SubmissionFailureEmailJob)
-              .not_to receive(:perform_async).with({ form526_submission_id: backup_submission_b.id })
+              expect(Form526SubmissionFailureEmailJob)
+                .not_to receive(:perform_async).with(backup_submission_a.id, timestamp)
+              expect(Form526SubmissionFailureEmailJob)
+                .not_to receive(:perform_async).with(backup_submission_b.id, timestamp)
 
-            expect(Form526SubmissionFailureEmailJob)
-              .to receive(:perform_async).once.ordered.with({ form526_submission_id: backup_submission_c.id })
-            expect(Form526SubmissionFailureEmailJob)
-              .to receive(:perform_async).once.ordered.with({ form526_submission_id: backup_submission_d.id })
+              expect(Form526SubmissionFailureEmailJob)
+                .to receive(:perform_async).once.ordered.with(backup_submission_c.id, timestamp)
+              expect(Form526SubmissionFailureEmailJob)
+                .to receive(:perform_async).once.ordered.with(backup_submission_d.id, timestamp)
 
-            Form526StatusPollingJob.new.perform
+              Form526StatusPollingJob.new.perform
+            end
           end
         end
 

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Form526StatusPollingJob, type: :job do
 
       context 'when a failure type response is returned from the API' do
         context 'when send_backup_submission_exhaustion_email_notice is enabled' do
-          let(:timestamp) { Time.zone.utc }
+          let(:timestamp) { Time.now.utc }
 
           before do
             Flipper.enable(:send_backup_submission_polling_failure_email_notice)

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Form526StatusPollingJob, type: :job do
 
       context 'when a failure type response is returned from the API' do
         context 'when send_backup_submission_exhaustion_email_notice is enabled' do
-          let(:timestamp) { Time.zone.now }
+          let(:timestamp) { Time.zone.utc }
 
           before do
             Flipper.enable(:send_backup_submission_polling_failure_email_notice)

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   subject { described_class }
 
   let(:email_service) { double('VaNotify::Service') }
-  let(:timestamp) { Time.zone.utc }
+  let(:timestamp) { Time.now.utc }
   let(:failure_timestamp) { timestamp.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.') }
 
   before do

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   subject { described_class }
 
   let(:email_service) { double('VaNotify::Service') }
-  let!(:timestamp) { Time.zone.now }
+  let(:timestamp) { Time.zone.utc }
   let(:failure_timestamp) { timestamp.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.') }
 
   before do

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   subject { described_class }
 
   let(:email_service) { double('VaNotify::Service') }
+  let!(:timestamp) { Time.zone.now }
+  let(:failure_timestamp) { timestamp.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.') }
 
   before do
     Sidekiq::Job.clear_all
@@ -26,6 +28,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
           personalisation: {
             first_name: form526_submission.get_first_name,
             date_submitted: form526_submission.format_creation_time_for_mailers,
+            date_of_failure: failure_timestamp,
             files_submitted: ['extXas.pdf', 'extXas.pdf', 'extXas.pdf'],
             forms_submitted: [
               'VA Form 21-4142',
@@ -38,17 +41,21 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
       end
 
       it 'dispatches a failure notification email with the expected params' do
-        expect(email_service).to receive(:send_email).with(expected_params)
+        Timecop.freeze(timestamp) do
+          expect(email_service).to receive(:send_email).with(expected_params)
 
-        subject.perform_async(form526_submission.id)
-        subject.drain
+          subject.perform_async(form526_submission.id)
+          subject.drain
+        end
       end
 
       it 'creates a remediation record for the submission' do
-        allow(email_service).to receive(:send_email)
-        expect { subject.new.perform(form526_submission.id) }.to change(Form526SubmissionRemediation, :count)
-        remediation = Form526SubmissionRemediation.where(form526_submission_id: form526_submission.id)
-        expect(remediation.present?).to be true
+        Timecop.freeze(timestamp) do
+          allow(email_service).to receive(:send_email)
+          expect { subject.new.perform(form526_submission.id) }.to change(Form526SubmissionRemediation, :count)
+          remediation = Form526SubmissionRemediation.where(form526_submission_id: form526_submission.id)
+          expect(remediation.present?).to be true
+        end
       end
     end
 
@@ -61,6 +68,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
           personalisation: {
             first_name: form526_submission.get_first_name,
             date_submitted: form526_submission.format_creation_time_for_mailers,
+            date_of_failure: failure_timestamp,
             files_submitted: ['extXas.pdf', 'extXas.pdf', 'extXas.pdf'],
             forms_submitted: 'None'
           }
@@ -74,10 +82,12 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
       end
 
       it 'replaces the forms list variable with a placeholder' do
-        expect(email_service).to receive(:send_email).with(expected_params)
+        Timecop.freeze(timestamp) do
+          expect(email_service).to receive(:send_email).with(expected_params)
 
-        subject.perform_async(form526_submission.id)
-        subject.drain
+          subject.perform_async(form526_submission.id)
+          subject.drain
+        end
       end
     end
 
@@ -89,6 +99,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
           personalisation: {
             first_name: form526_submission.get_first_name,
             date_submitted: form526_submission.format_creation_time_for_mailers,
+            date_of_failure: failure_timestamp,
             files_submitted: 'None',
             forms_submitted: [
               'VA Form 21-4142',
@@ -103,10 +114,12 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
       let!(:form526_submission) { create(:form526_submission, :with_everything) }
 
       it 'replaces the files list variable with a placeholder' do
-        expect(email_service).to receive(:send_email).with(expected_params)
+        Timecop.freeze(timestamp) do
+          expect(email_service).to receive(:send_email).with(expected_params)
 
-        subject.perform_async(form526_submission.id)
-        subject.drain
+          subject.perform_async(form526_submission.id)
+          subject.drain
+        end
       end
     end
   end

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
       it 'logs success' do
         Timecop.freeze(timestamp) do
           expect(Rails.logger).to receive(:info).with(
-            'Form526SubmissionFailureEmail notification dispatched',
+            'Form526SubmissionFailureEmailJob notification dispatched',
             { form526_submission_id: form526_submission.id, timestamp: }
           )
           subject.new.perform(form526_submission.id)
@@ -157,7 +157,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
       let(:error_message) { 'oh gosh oh jeeze oh no' }
       let(:expected_log) do
         [
-          'Form526SubmissionFailureEmail notification dispatched',
+          'Form526SubmissionFailureEmailJob notification dispatched',
           {
             form526_submission_id: form526_submission.id,
             error_message:,
@@ -178,7 +178,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
       it 'logs error' do
         Timecop.freeze(timestamp) do
           expect(Rails.logger).to receive(:error).with(
-            'Form526SubmissionFailureEmail notification failed',
+            'Form526SubmissionFailureEmailJob notification failed',
             {
               form526_submission_id: form526_submission.id,
               error_message:,


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Pass a timestamp into the 526 failure emailer
- remove a syntax error (named arguments)
- update classname in logs for consistency 

## Related issue(s)

- [Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94173)

## Testing done

- [x] *New code is covered by unit tests*

Run a staging test by doing the following
1. paste the new mailer object into a command line
2. update the `my_email` in the following script with yours (or wherever you want to send this)
3. paste the following script into the command line

```ruby
# change this, everything else is good
# my_email = <your email>

safe_sc_form = {"standardClaim"=>false, "isVaEmployee"=>false, "bankAccountType"=>"Checking", "bankAccountNumber"=>"123234454568", "bankRoutingNumber"=>"123343459", "bankName"=>"FakeUSA", "hasTrainingPay"=>false, "hasSeparationPay"=>false, "isTerminallyIll"=>false, "homelessOrAtRisk"=>"no", "phoneAndEmail"=>{"emailAddress"=>my_email}, "mailingAddress"=>{"country"=>"USA", "addressLine1"=>"123 Fake St", "city"=>"Fakesville", "state"=>"AR", "zipCode"=>"71635-3733"}, "serviceInformation"=>{"servicePeriods"=>[{"serviceBranch"=>"Navy", "dateRange"=>{"from"=>"2000-02-22", "to"=>"2002-02-22"}}]}, "privacyAgreementAccepted"=>true, "newPrimaryDisabilities"=> [{"condition"=>"PTSD", "cause"=>"NEW", "primaryDescription"=>"PTSD caused by bad things"}] }
sc1 = SavedClaim::DisabilityCompensation::Form526AllClaim.create(form: safe_sc_form.to_json)

safe_uuid = "123456789abcdefghijklmnop123456a"
ua = UserAccount.create(id: safe_uuid)

safe_auth_headers = {"va_eauth_csid"=>"DSLogon", "va_eauth_authenticationmethod"=>"DSLogon", "va_eauth_pnidtype"=>"SSN", "va_eauth_assurancelevel"=>"3", "va_eauth_firstName"=>"FAKEMAN", "va_eauth_lastName"=>"FAKELY", "va_eauth_issueinstant"=>(Time.now - 1.hour), "va_eauth_dodedipnid"=>"1234567890", "va_eauth_birlsfilenumber"=>"123456789", "va_eauth_pid"=>"12345678", "va_eauth_pnid"=>"123456789", "va_eauth_birthdate"=>(Time.now - 30.years), "va_eauth_authorization"=> {"authorizationResponse"=> {"status"=>"VETERAN", "idType"=>"SSN", "id"=>"123456789", "edi"=>"1234567890", "firstName"=>"FAKEMAN", "lastName"=>"FAKELY", "birthDate"=>(Time.now - 50.years), "gender"=>"MALE"}}.to_json, "va_eauth_authenticationauthority"=>"eauth", "va_eauth_service_transaction_id"=>"vagov-abc12345-a1bc-123a-12z3-a123b12c1de3"}

safe_form = { "form526"=> { "form526"=> { "claimantCertification"=>true, "standardClaim"=>false, "autoCestPDFGenerationDisabled"=>false, "applicationExpirationDate"=>(Time.now + 1.year), "overflowText"=>"", "bddQualified"=>false, "claimSubmissionSource"=>"VA.gov", "includeToxicExposure"=>false, "directDeposit"=>{"accountType"=>"CHECKING", "accountNumber"=>"1234567890", "routingNumber"=>"123456789", "bankName"=>"FakeUSA"}, "serviceInformation"=> { "servicePeriods"=> [ { "serviceBranch"=>"Marine Corps", "activeDutyBeginDate"=>"2000-01-01", "activeDutyEndDate"=>"2024-01-01" } ], "separationLocationName"=>"Fort Fake", "separationLocationCode"=>"1234567" }, "veteran"=> { "emailAddress"=>my_email, "currentMailingAddress"=>{ "country"=>"USA", "addressLine1"=>"123 Fake st ", "type"=>"DOMESTIC", "city"=>"Fakesville ", "state"=>"CO", "zipFirstFive"=>"80202" }, "currentlyVAEmployee"=>false }, "treatments"=> [ { "startDate"=>{"year"=>"2024", "month"=>"02"}, "treatedDisabilityNames"=>["Bilateral hearing loss"], "center"=>{"name"=>"Fake center", "country"=>"USA", "city"=>"Fakesville", "state"=>"CO"} } ], "disabilities"=> [ { "name"=>"Bilateral hearing loss", "disabilityActionType"=>"NEW", "serviceRelevance"=> "Caused by an in-service event, injury, or exposure\nhings were very loud" }, ], } }, "form4142"=>{ foo: 'bar' }, "form0781"=>{ foo: 'bar' }, "form8940"=>{ foo: 'bar' }, "flashes"=>[], "rrd_metadata"=>{"forward_to_mas_all_claims"=>true} }
data = Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'preneeds', 'extras.pdf'), 'application/pdf')
file1 = SupportingEvidenceAttachment.new
file1.set_file_data!(data)
file1.save!

file2 = SupportingEvidenceAttachment.new
file2.set_file_data!(data)
file2.save!

file3 = SupportingEvidenceAttachment.new
file3.set_file_data!(data)
file3.save!

safe_form['form526_uploads'] = [file1, file2, file3].each_with_index.map do |fi, idx|
  {
    "name"=>"Thing #{idx+1}.pdf",
    "confirmationCode"=>fi.guid,
    "attachmentId"=>"L015",
    "size"=>13721,
    "isEncrypted"=>false
  }
end

sub = Form526Submission.create(user_uuid: ua.id, form_json: safe_form.to_json, auth_headers_json: safe_auth_headers.to_json, saved_claim: sc1)
sub.save!

timestamp = Time.now.utc
Form526SubmissionFailureEmailJob.new.perform(sub.id, timestamp)

```


## Screenshots
*NOTE: email formatting issues are being worked on by design team, and out of scope for this work*

<img width="617" alt="Screenshot 2024-10-28 at 11 58 37 AM" src="https://github.com/user-attachments/assets/4c5f4c7f-c0e7-4939-8f02-185e401b3ba7">


## What areas of the site does it impact?
Veteran 526 submission failures, Zero Silent Failures

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

