### PR TITLE
Adjust window for KMS rotation job

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -207,7 +207,7 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   mgr.register('0 2,9,16 * * 1-5', 'VBADocuments::FlipperStatusAlert')
 
   # Rotates Lockbox/KMS record keys and _ciphertext fields every October 12th (when the KMS key auto-rotate)
-  mgr.register('0 3 * * *', 'KmsKeyRotation::BatchInitiatorJob')
+  mgr.register('10 1 * * *', 'KmsKeyRotation::BatchInitiatorJob')
 
   # Updates veteran representatives address attributes (including lat, long, location, address fields, email address, phone number) # rubocop:disable Layout/LineLength
   mgr.register('0 3 * * *', 'Representatives::QueueUpdates')


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
We’ve identified that our PG Query Duration metric has [been spiking between 2:00-4:00 AM ET](https://vagov.ddog-gov.com/monitors/199084?from_ts=1729693621668&to_ts=1729780021668&eval_ts=1729756875247). After adjusting [several VBA jobs](https://vagov.ddog-gov.com/logs?query=%22VBADocuments%3A%3AUploadRemover%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1729745071236&to_ts=1729762990337&live=false) that run during this timeframe , and also ruling out autovacuuming, we found that the KMS rotation job has been [failing since October 11](https://vagov.ddog-gov.com/logs?query=%22DeleteOldPiiLogsJob%22%20status%3Aerror%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1727187022032&to_ts=1729779022032&live=true) (the same time the KMS key rotation job began - which is heavy on the database.).

This PR moves the `KmsKeyRotation::BatchInitiatorJob` to the 1:10 AM window to prevent clustering in heavily loaded windows, like the 2-4 AM period. The 5am timeslot was considered the ideal option due to fewer scheduled jobs, but it coincides with the start of increasing traffic for the day. Since this job runs annually to rotate millions of records, we want the re-encryption process to complete it's rotation process before morning traffic peaks to avoid database congestion and other cascading issues impacting Veteran services.

The outcomes (or _lack_ thereof) from this change will guide the next steps in our investigation. The `KmsKeyRotation::BatchInitiatorJob` job appears to be related to the statement timeout issue we've observed, as its timing aligns with the rotation job that started on October 11. Currently, the impact seems limited to the 2:25-3:45 AM window, where, this job runs. There may also be additional factors at play here. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95678

## Testing done

- [x] *New code is covered by unit tests* N/A
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
