### PR TITLE
Revert "fix temp file issue"

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/pdf_filler.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/pdf_filler.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'common/file_helpers'
-require 'securerandom'
 
 module IvcChampva
   class PdfFiller
@@ -19,12 +18,10 @@ module IvcChampva
     end
 
     def generate(current_loa = nil)
-      generated_form_path = Rails.root.join("tmp/#{name}-#{SecureRandom.hex}-tmp.pdf").to_s
-      stamped_template_path = Rails.root.join("tmp/#{name}-#{SecureRandom.hex}-stamped.pdf").to_s
-
-      tempfile = create_tempfile
-      FileUtils.touch(tempfile)
-      FileUtils.copy_file(tempfile.path, stamped_template_path)
+      template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
+      generated_form_path = "tmp/#{name}-tmp.pdf"
+      stamped_template_path = "tmp/#{name}-stamped.pdf"
+      FileUtils.copy(template_form_path, stamped_template_path)
 
       if File.exist? stamped_template_path
         begin
@@ -37,16 +34,6 @@ module IvcChampva
         end
       else
         raise "stamped template file does not exist: #{stamped_template_path}"
-      end
-    end
-
-    def create_tempfile
-      # Tempfile workaround inspired by this:
-      #   https://github.com/actions/runner-images/issues/4443#issuecomment-965391736
-      template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
-      Tempfile.new(['', '.pdf'], Rails.root.join('tmp')).tap do |tmpfile|
-        IO.copy_stream(template_form_path, tmpfile)
-        tmpfile.close
       end
     end
 

--- a/modules/ivc_champva/spec/services/pdf_filler_spec.rb
+++ b/modules/ivc_champva/spec/services/pdf_filler_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require IvcChampva::Engine.root.join('spec', 'support', 'pdf_matcher.rb')
+require_relative IvcChampva::Engine.root.join('spec', 'support', 'pdf_matcher.rb')
 require IvcChampva::Engine.root.join('spec', 'spec_helper.rb')
-require IvcChampva::Engine.root.join('app', 'services', 'ivc_champva', 'pdf_stamper')
 
 describe IvcChampva::PdfFiller do
   forms = %w[vha_10_10d vha_10_7959f_1 vha_10_7959f_2 vha_10_7959c]
@@ -12,12 +11,10 @@ describe IvcChampva::PdfFiller do
     context 'when the filler is instantiated without a form_number' do
       it 'throws an error' do
         form_number = forms.first
-        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
-        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
-        data = JSON.parse(File.read(file_path))
+        data = JSON.parse(File.read("modules/ivc_champva/spec/fixtures/form_json/#{form_number}.json"))
         form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
         expect do
-          described_class.new(form_number: nil, form: form)
+          described_class.new(form_number: nil, form:)
         end.to raise_error(RuntimeError, 'form_number is required')
       end
     end
@@ -26,69 +23,35 @@ describe IvcChampva::PdfFiller do
       it 'throws an error' do
         form_number = forms.first
         expect do
-          described_class.new(form_number: form_number, form: nil)
+          described_class.new(form_number:, form: nil)
         end.to raise_error(RuntimeError, 'form needs a data attribute')
       end
     end
   end
 
-  describe '#generate' do
-    context 'when the stamped template file exists' do
-      it 'generates the form correctly' do
-        form_number = forms.first
-        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
-        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
-        data = JSON.parse(File.read(file_path))
-        form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        pdf_filler = described_class.new(form_number: form_number, form: form)
+  # describe '#generate' do
+  #   forms.each do |file_name|
+  #     context "when mapping the pdf data given JSON file: #{file_name}" do
+  #       let(:form_number) { file_name.gsub('-min', '') }
+  #       let(:expected_pdf_path) { "tmp/#{file_name}-tmp.pdf" }
+  #       let(:data) { JSON.parse(File.read("modules/ivc_champva/spec/fixtures/form_json/#{file_name}.json")) }
+  #       let(:form) { "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data) }
 
-        allow(File).to receive(:exist?).and_return(true)
-        allow(IvcChampva::PdfStamper).to receive(:stamp_pdf)
-        allow(PdfForms).to receive(:new).and_return(double(fill_form: true))
-        allow(Common::FileHelpers).to receive(:delete_file_if_exists)
+  #       after { FileUtils.rm_f(expected_pdf_path) }
 
-        expect(pdf_filler.generate).to match(%r{tmp/#{form_number}-.*-tmp.pdf})
-      end
-    end
+  #       context 'when a legitimate JSON payload is provided' do
+  #         it 'properly fills out the associated PDF' do
+  #           filled_pdf_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'pdfs',
+  #                                             "#{file_name}-filled.pdf")
 
-    context 'when the stamped template file does not exist' do
-      it 'raises an error' do
-        form_number = forms.first
-        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
-        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
-        data = JSON.parse(File.read(file_path))
-        form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        pdf_filler = described_class.new(form_number: form_number, form: form)
+  #           described_class.new(form_number:, form:).generate
 
-        allow(File).to receive(:exist?).and_return(false)
-
-        expect { pdf_filler.generate }.to raise_error(RuntimeError, /stamped template file does not exist/)
-      end
-    end
-  end
-
-  describe '#create_tempfile' do
-    context 'when creating a tempfile' do
-      it 'creates and copies the template form correctly' do
-        form_number = forms.first
-        file_path = Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', "#{form_number}.json")
-        expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
-        data = JSON.parse(File.read(file_path))
-        form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        pdf_filler = described_class.new(form_number: form_number, form: form)
-
-        template_path = "#{IvcChampva::PdfFiller::TEMPLATE_BASE}/#{form_number}.pdf"
-        tempfile = double('Tempfile')
-
-        allow(Tempfile).to receive(:new).and_return(tempfile)
-        allow(IO).to receive(:copy_stream)
-        allow(tempfile).to receive(:close)
-
-        expect(IO).to receive(:copy_stream).with(template_path, tempfile)
-        pdf_filler.create_tempfile
-      end
-    end
-  end
+  #           expect(expected_pdf_path).to match_pdf_content_of(filled_pdf_path)
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
 
   describe 'form mappings' do
     list = forms.map { |f| f.gsub('-min', '') }.uniq


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#19060.
Something is causing the final S3 bucket name name the UUID before the form name.
We need the form name to come before the UUID. 
If the UUID comes before the form name, the PEGA system can't process it.
It should be this format: vha_10_7959f_1-cf1b6e07204447096d9bf37837c61df7.pdf
not 0099687f-7e9c-45a9-8865-ac67f0d7ef31_vha_10_7959f_1.pdf
