### PR TITLE
95914 Add new email template value for form 10-10d failure notifications - IVC CHAMPVA

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1390,6 +1390,7 @@ vanotify:
       api_key: fake_secret
       template_id:
         form_10_10d_email: form_10_10d_email
+        form_10_10d_failure_email: form_10_10d_failure_email
         form_10_7959f_1_email: form_10_7959f_1_email
         form_10_7959f_2_email: form_10_7959f_2_email
         form_10_7959c_email: form_10_7959c_email

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -21,6 +21,9 @@ module IvcChampva
       # Send each form UUID to DataDog
       forms.each do |form|
         StatsD.increment('ivc_champva.form_missing_status', tags: ["id:#{form.id}"])
+        # TODO: Pending a policy decision, we'll want to check if any forms have
+        # been missing a status for > X days. If so, here's where we'll also want
+        # to send the user an email asking them to resubmit their form.
       end
     rescue => e
       Rails.logger.error "IVC Forms MissingFormStatusJob Error: #{e.message}"


### PR DESCRIPTION
## Summary

- This PR adds the ID of a new VA Notify email template

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95914
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3179

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
