### PR TITLE
[DBEX] log and monitor form 4142 failure email events

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
@@ -7,7 +7,7 @@ module EVSS
   module DisabilityCompensationForm
     class Form4142DocumentUploadFailureEmail < Job
       STATSD_METRIC_PREFIX = 'api.form_526.veteran_notifications.form4142_upload_failure_email'
-      ZSF_DD_TAG_FUNCTION  = 'Form 526 Flow - Form 4142 failure email sending'
+      ZSF_DD_TAG_FUNCTION  = '526_form_4142_upload_failure_email_sending'
 
       # retry for one day
       sidekiq_options retry: 14


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): ~YES~/NO*
- *(Summarize the changes that have been made to the platform)*
  - Logs **resolved** failures, where VA Notify is requested to dispatch an email notifying users of a failure associated with the submission of form 21-4142
  - Logs **unresolved** silent failures, when a form 4142 failure email job fails to enqueue
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)*
  - Logs messages identified as silent failures
  - Increments metrics to capture an issue
  - Supports logging and metrics requirements set by VA stakeholders
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95092

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
- Impacts logging and metrics data recorded in Datadog

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
