### PR TITLE
[DBEX] refactor 0781 failure email logging & monitoring

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
@@ -118,7 +118,7 @@ module EVSS
 
         zsf_monitor.log_silent_failure_avoided(
           log_info.merge(email_confirmation_id: email_response&.id),
-          submission.user_account_id,
+          submission&.user_account_id,
           call_location:
         )
       end

--- a/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
@@ -69,10 +69,10 @@ module EVSS
       end
 
       def perform(form526_submission_id)
-        submission = form526_submission(form526_submission_id)
+        submission = Form526Submission.find(form526_submission_id)
 
         with_tracking('Form0781DocumentUploadFailureEmail', submission.saved_claim_id, form526_submission_id) do
-          send_notification_mailer(form526_submission_id)
+          send_notification_mailer(submission)
         end
       rescue => e
         retryable_error_handler(e)
@@ -87,59 +87,40 @@ module EVSS
         raise error
       end
 
-      def send_notification_mailer(form526_submission_id)
-        email_address = @form526_submission.veteran_email_address
-        first_name = @form526_submission.get_first_name
-        date_submitted = @form526_submission.format_creation_time_for_mailers
+      def send_notification_mailer(submission)
+        email_address = submission.veteran_email_address
+        first_name = submission.get_first_name
+        date_submitted = submission.format_creation_time_for_mailers
+
+        notify_service_bd = Settings.vanotify.services.benefits_disability
+        notify_client = VaNotify::Service.new(notify_service_bd.api_key)
+        template_id = notify_service_bd.template_id.form0781_upload_failure_notification_template_id
 
         notify_response = notify_client.send_email(
           email_address:,
-          template_id: mailer_template_id,
-          personalisation: {
-            first_name:,
-            date_submitted:
-          }
+          template_id:,
+          personalisation: { first_name:, date_submitted: }
         )
 
-        log_mailer_dispatch(form526_submission_id, notify_response)
+        log_info = { form526_submission_id: submission.id, timestamp: Time.now.utc }
+
+        log_mailer_dispatch(submission, log_info, notify_response)
       end
 
-      def log_mailer_dispatch(form526_submission_id, email_response = {})
+      def log_mailer_dispatch(submission, log_info, email_response = {})
         StatsD.increment("#{STATSD_METRIC_PREFIX}.success")
 
-        log_info = { form526_submission_id:, timestamp: Time.now.utc }
         Rails.logger.info('Form0781DocumentUploadFailureEmail notification dispatched', log_info)
+
+        cl = caller_locations.first
+        call_location = ZeroSilentFailures::Monitor::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)
+        zsf_monitor = ZeroSilentFailures::Monitor.new(Form526Submission::ZSF_DD_TAG_SERVICE)
 
         zsf_monitor.log_silent_failure_avoided(
           log_info.merge(email_confirmation_id: email_response&.id),
-          @form526_submission&.user_account_id,
+          submission.user_account_id,
           call_location:
         )
-      end
-
-      def form526_submission(form526_submission_id)
-        @form526_submission ||= Form526Submission.find(form526_submission_id)
-      end
-
-      def mailer_template_id
-        notify_service_bd.template_id.form0781_upload_failure_notification_template_id
-      end
-
-      def notify_client
-        @notify_client ||= VaNotify::Service.new(notify_service_bd.api_key)
-      end
-
-      def notify_service_bd
-        @notify_service_bd ||= Settings.vanotify.services.benefits_disability
-      end
-
-      def zsf_monitor
-        ZeroSilentFailures::Monitor.new(Form526Submission::ZSF_DD_TAG_SERVICE)
-      end
-
-      def call_location
-        cl = caller_locations.first
-        ZeroSilentFailures::Monitor::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): ~YES~/NO*
- *(Summarize the changes that have been made to the platform)*
  - Removes unnecessary memoization and methods in `Form0781DocumentUploadFailureEmail` (from https://github.com/department-of-veterans-affairs/vets-api/pull/19081) based on feedback received in https://github.com/department-of-veterans-affairs/vets-api/pull/19097
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)*
  - Logs messages identified as failures, which are made known to the user via email notification from VA Notify
  - Increments metrics to capture an issue
  - Supports logging and metrics requirements set by VA stakeholders
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95092
- https://github.com/department-of-veterans-affairs/vets-api/pull/19081

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
- Impacts logging and metrics data recorded in Datadog

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
