### PR TITLE
94148: Add reference value to DR failure email job and handling to callback controller

### DIFF
--- a/app/controllers/v1/nod_callbacks_controller.rb
+++ b/app/controllers/v1/nod_callbacks_controller.rb
@@ -18,31 +18,31 @@ module V1
 
     DELIVERED_STATUS = 'delivered'
 
+    APPEAL_TYPE_TO_SERVICE_MAP = {
+      'HLR' => 'higher-level-review',
+      'NOD' => 'board-appeal',
+      'SC' => 'supplemental-claims'
+    }.freeze
+
+    VALID_FUNCTION_TYPES = %w[form evidence].freeze
+
     def create
       return render json: nil, status: :not_found unless enabled?
 
       payload = JSON.parse(request.body.string)
       status = payload['status']&.downcase
+      reference = payload['reference']
 
       StatsD.increment("#{STATSD_KEY_PREFIX}.received", tags: { status: })
+      send_silent_failure_avoided_metric(reference) if status == DELIVERED_STATUS
 
-      if status == DELIVERED_STATUS
-        tags = ['service:supplemental-claim', 'function: form or evidence submission to Lighthouse']
-        StatsD.increment('silent_failure_avoided', tags:)
-      end
-
-      begin
-        DecisionReviewNotificationAuditLog.create!(notification_id: payload['id'],
-                                                   reference: payload['reference'],
-                                                   status:,
-                                                   payload:)
-      rescue ActiveRecord::RecordInvalid => e
-        log_formatted(**log_params(payload, false), params: { exception_message: e.message })
-        return render json: { message: 'failed' }
-      end
+      DecisionReviewNotificationAuditLog.create!(notification_id: payload['id'], reference:, status:, payload:)
 
       log_formatted(**log_params(payload, true))
       render json: { message: 'success' }
+    rescue => e
+      log_formatted(**log_params(payload, false), params: { exception_message: e.message })
+      render json: { message: 'failed' }
     end
 
     private
@@ -60,6 +60,21 @@ module V1
           status: payload['status']
         }
       }
+    end
+
+    def send_silent_failure_avoided_metric(reference)
+      service_name, function_type = parse_reference_value(reference)
+      tags = ["service:#{service_name}", "function: #{function_type} submission to Lighthouse"]
+      StatsD.increment('silent_failure_avoided', tags:)
+    rescue => e
+      Rails.logger.error('Failed to send silent_failure_avoided metric', params: { reference:, message: e.message })
+    end
+
+    def parse_reference_value(reference)
+      appeal_type, function_type = reference.split('-')
+      raise 'Invalid function_type' unless VALID_FUNCTION_TYPES.include? function_type
+
+      [APPEAL_TYPE_TO_SERVICE_MAP.fetch(appeal_type.upcase), function_type]
     end
 
     def authenticate_header

--- a/app/sidekiq/decision_review/failure_notification_email_job.rb
+++ b/app/sidekiq/decision_review/failure_notification_email_job.rb
@@ -76,7 +76,7 @@ module DecisionReview
       end
     end
 
-    def send_email_with_vanotify(submission, filename, created_at)
+    def send_email_with_vanotify(submission, filename, created_at, template_id, reference)
       email_address = submission.current_email
       personalisation = {
         first_name: submission.get_mpi_profile.given_names[0],
@@ -84,16 +84,18 @@ module DecisionReview
         date_submitted: created_at.strftime('%B %d, %Y')
       }
 
-      appeal_type = submission.type_of_appeal
-      template_id = filename.nil? ? FORM_TEMPLATE_IDS[appeal_type] : EVIDENCE_TEMPLATE_IDS[appeal_type]
-      vanotify_service.send_email({ email_address:, template_id:, personalisation: })
+      vanotify_service.send_email({ email_address:, template_id:, personalisation:, reference: })
     end
 
     def send_form_emails
       StatsD.increment("#{STATSD_KEY_PREFIX}.form.processing_records", submissions.size)
 
       submissions.each do |submission|
-        response = send_email_with_vanotify(submission, nil, submission.created_at)
+        appeal_type = submission.type_of_appeal
+        reference = "#{appeal_type}-form-#{submission.submitted_appeal_uuid}"
+
+        response = send_email_with_vanotify(submission, nil, submission.created_at, FORM_TEMPLATE_IDS[appeal_type],
+                                            reference)
         submission.update(failure_notification_sent_at: DateTime.now)
 
         record_form_email_send_successful(submission, response.id)
@@ -106,9 +108,12 @@ module DecisionReview
       StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.processing_records", submission_uploads.size)
 
       submission_uploads.each do |upload|
-        response = send_email_with_vanotify(upload.appeal_submission,
-                                            upload.masked_attachment_filename,
-                                            upload.created_at)
+        submission = upload.appeal_submission
+        appeal_type = submission.type_of_appeal
+        reference = "#{appeal_type}-evidence-#{upload.lighthouse_upload_id}"
+
+        response = send_email_with_vanotify(submission, upload.masked_attachment_filename, upload.created_at,
+                                            EVIDENCE_TEMPLATE_IDS[appeal_type], reference)
         upload.update(failure_notification_sent_at: DateTime.now)
 
         record_evidence_email_send_successful(upload, response.id)

--- a/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
             filename: nil
           }
         end
+        let(:reference) { "SC-form-#{guid1}" }
 
         before do
           SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}', metadata: '{"status":"error"}')
@@ -119,14 +120,17 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
 
             expect(vanotify_service).to have_received(:send_email).with({ email_address:,
                                                                           personalisation:,
+                                                                          reference:,
                                                                           template_id: 'fake_sc_template_id' })
 
             expect(vanotify_service).not_to have_received(:send_email).with({ email_address: anything,
                                                                               personalisation: anything,
+                                                                              reference: anything,
                                                                               template_id: 'fake_nod_template_id' })
 
             expect(vanotify_service).not_to have_received(:send_email).with({ email_address: anything,
                                                                               personalisation: anything,
+                                                                              reference: anything,
                                                                               template_id: 'fake_hlr_template_id' })
 
             logger_params = [
@@ -228,7 +232,6 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
             date_submitted: created_at.strftime('%B %d, %Y')
           }
         end
-
         let(:personalisation2) do
           {
             first_name: mpi_profile2.given_names[0],
@@ -236,6 +239,8 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
             date_submitted: created_at.strftime('%B %d, %Y')
           }
         end
+        let(:reference) { "NOD-evidence-#{upload_guid1}" }
+        let(:reference2) { "NOD-evidence-#{upload_guid5}" }
 
         before do
           SavedClaim::NoticeOfDisagreement.create(guid: guid1, form: '{}', metadata: metadata1.to_json)
@@ -286,10 +291,12 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
 
             expect(vanotify_service).to have_received(:send_email).with({ email_address:,
                                                                           template_id: 'fake_nod_evidence_template_id',
+                                                                          reference:,
                                                                           personalisation: })
 
             expect(vanotify_service).to have_received(:send_email).with({ email_address: email_address2,
                                                                           template_id: 'fake_nod_evidence_template_id',
+                                                                          reference: reference2,
                                                                           personalisation: personalisation2 })
 
             upload1 = AppealSubmissionUpload.find_by(lighthouse_upload_id: upload_guid1)


### PR DESCRIPTION
## Summary
This PR updates the FailureNotificationEmailJob to include details in the `reference` field that is available for VANotify send_email. The callback handler will be able to use the `reference` field to accurately report the service name and function for `silent_failure_avoided` StatsD metrics.

This feature is behind the nod_callbacks_endpoint flipper flag.

This is owned by the Benefits Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94148

## Testing done

- [x] *New code is covered by unit tests*
Tested locally and also spec tests

## What areas of the site does it impact?
This impacts the FailureNotificationEmailJob, VANotify and the NodCallbacks endpoint

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
