### PR TITLE
Add :failure_notification_sent_at to SecondaryAppealForm

### DIFF
--- a/db/migrate/20241029143650_add_failure_notification_sent_at_to_secondary_appeal_form.rb
+++ b/db/migrate/20241029143650_add_failure_notification_sent_at_to_secondary_appeal_form.rb
@@ -1,0 +1,5 @@
+class AddFailureNotificationSentAtToSecondaryAppealForm < ActiveRecord::Migration[7.1]
+  def change
+    add_column :secondary_appeal_forms, :failure_notification_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_23_222045) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_29_143650) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1107,6 +1107,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_222045) do
     t.datetime "delete_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "failure_notification_sent_at"
     t.index ["appeal_submission_id"], name: "index_secondary_appeal_forms_on_appeal_submission_id"
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Add a column to the SecondaryAppealForm table to track when a failure notification has been sent
- Decision Reviews team, yes

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95980

## Testing done

- [ ] *New code is covered by unit tests*
- Migration only, no new code

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Only adding a new column to a table for future work

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
