### PR TITLE
Remove Unused Settings - Part 3

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1561,6 +1561,18 @@ check_in:
   authentication:
     max_auth_retry_limit: 3
     retry_attempt_expiry: 604800 # 7 Days
+  chip_api:
+    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
+    base_path: dev
+    host: vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
+    tmp_api_user: TzY6DFrnjPE8dwxUMbFf9HjbFqRim2MgXpMpMciXJFVohyURUJAc7W99rpFzhfh2B3sVnn4
+    tmp_api_id: 2dcdrrn5zc
+    tmp_api_username: vetsapiTempUser
+    service_name: CHIP-API
+    mock: false
+    key_path: fake_api_path
+    redis_session_prefix: check_in
+    timeout: 30
   chip_api_v2:
     url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
     base_path: dev

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -637,12 +637,7 @@ ask_va_api:
     veis_api_path: eis/vagov.lob.ava/api
     tenant_id: abcdefgh-1234-5678-12345-11e8b8ce491e
     ocp_apim_subscription_key: subscription_key
-    redis_token_expiry: 3540 # 59 minutes
-    mock: true
     service_name: VEIS-API
-  authentication:
-    max_auth_retry_limit: 3
-    retry_attempt_expiry: 604800 # 7 Days
 
 #Settings for Claims Api Module
 claims_api:
@@ -1109,11 +1104,6 @@ vbms:
   server_cert: vbms.aide.oit.va.gov.crt
   environment_directory: /app/secret
   env: test
-
-vet_verification:
-  key_path: modules/veteran_verification/spec/fixtures/verification_test.pem
-  mock_bgs: false
-  mock_bgs_url: false
 
 github_stats:
   username: github-stats-rake
@@ -1607,9 +1597,6 @@ check_in:
     redis_session_prefix: check_in_lorota_v2
     redis_token_expiry: 43200 # 12 Hours
 
-rack:
-  cookie_secret: ~
-
 # Settings for BID Services
 bid:
   awards:
@@ -1698,7 +1685,6 @@ lgy_sahsha:
   base_url: http://www.example.com
   app_id: ~
   api_key: ~
-  mock_coe: false
 
 form526_backup:
   enabled: true
@@ -1738,13 +1724,11 @@ form1095_b:
     aws_access_key_id: ~
     aws_secret_access_key: ~
     bucket: "bucket"
-    enabled: true
     region: "region"
 
 ivc_forms:
   s3:
     bucket: "bucket"
-    enabled: true
     region: "region"
   sidekiq:
     missing_form_status_job:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1561,18 +1561,6 @@ check_in:
   authentication:
     max_auth_retry_limit: 3
     retry_attempt_expiry: 604800 # 7 Days
-  chip_api:
-    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
-    base_path: dev
-    host: vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
-    tmp_api_user: TzY6DFrnjPE8dwxUMbFf9HjbFqRim2MgXpMpMciXJFVohyURUJAc7W99rpFzhfh2B3sVnn4
-    tmp_api_id: 2dcdrrn5zc
-    tmp_api_username: vetsapiTempUser
-    service_name: CHIP-API
-    mock: false
-    key_path: fake_api_path
-    redis_session_prefix: check_in
-    timeout: 30
   chip_api_v2:
     url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
     base_path: dev

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -305,6 +305,18 @@ check_in:
   authentication:
     max_auth_retry_limit: 3
     retry_attempt_expiry: 604800 # 7 Days
+  chip_api:
+    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
+    base_path: dev
+    host: vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
+    tmp_api_user: TzY6DFrnjPE8dwxUMbFf9HjbFqRim2MgXpMpMciXJFVohyURUJAc7W99rpFzhfh2B3sVnn4
+    tmp_api_id: 2dcdrrn5zc
+    tmp_api_username: vetsapiTempUser
+    service_name: CHIP-API
+    mock: false
+    key_path: fake_api_path
+    redis_session_prefix: check_in
+    timeout: 30
   chip_api_v2:
     url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
     base_path: dev

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -364,8 +364,6 @@ dgi:
   vets:
     url: "https://jenkins.ld.afsp.io:32512/vets-service/v1/" # Docker setup for microservice
     mock: false
-rack:
-  cookie_secret: "xxxxx"
 
 bid:
   awards:
@@ -443,12 +441,7 @@ ask_va:
     veis_api_path: veis/vagov.lob.ava/api
     tenant_id: abcdefgh-1234-5678-12345-11e8b8ce491e
     ocp_apim_subscription_key: subscription_key
-    mock: true
-    redis_token_expiry: 3540 # 59 minutes
     service_name: VEIS-API
-  authentication:
-    max_auth_retry_limit: 3
-    retry_attempt_expiry: 604800 # 7 Days
 
 nod_vanotify_status_callback:
   bearer_token: bearer_token_secret

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -305,18 +305,6 @@ check_in:
   authentication:
     max_auth_retry_limit: 3
     retry_attempt_expiry: 604800 # 7 Days
-  chip_api:
-    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
-    base_path: dev
-    host: vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
-    tmp_api_user: TzY6DFrnjPE8dwxUMbFf9HjbFqRim2MgXpMpMciXJFVohyURUJAc7W99rpFzhfh2B3sVnn4
-    tmp_api_id: 2dcdrrn5zc
-    tmp_api_username: vetsapiTempUser
-    service_name: CHIP-API
-    mock: false
-    key_path: fake_api_path
-    redis_session_prefix: check_in
-    timeout: 30
   chip_api_v2:
     url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
     base_path: dev


### PR DESCRIPTION
## Summary

This is part 3 of 3-ish

- Remove settings from `config/settings.yml` and `config/settings/test.yml`
- Checked using:
   - Dot notation
   - Hash access (`[]`, `.dig`, `fetch`)
   - Checked parent key

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95565

## Testing done

- [ ] n/a

## Acceptance criteria

- [x]  Unused settings are removed from `config/settings` files