### PR TITLE
Add feature flag to notify on 4142 failure

### DIFF
--- a/app/models/appeal_submission.rb
+++ b/app/models/appeal_submission.rb
@@ -56,13 +56,13 @@ class AppealSubmission < ApplicationRecord
     end
   end
 
-  def current_email
+  def current_email_address
     va_profile = ::VAProfile::ContactInformation::Service.get_person(get_mpi_profile.vet360_id.to_s)&.person
     raise 'Failed to fetch VA profile' if va_profile.nil?
 
     current_emails = va_profile.emails.select { |email| email.effective_end_date.nil? }
     email = current_emails.first&.email_address
-    raise 'Failed to retrieve email' if email.nil?
+    raise 'Failed to retrieve email address' if email.nil?
 
     email
   end

--- a/app/sidekiq/decision_review/failure_notification_email_job.rb
+++ b/app/sidekiq/decision_review/failure_notification_email_job.rb
@@ -77,7 +77,7 @@ module DecisionReview
     end
 
     def send_email_with_vanotify(submission, filename, created_at, template_id, reference)
-      email_address = submission.current_email
+      email_address = submission.current_email_address
       personalisation = {
         first_name: submission.get_mpi_profile.given_names[0],
         filename:,

--- a/config/features.yml
+++ b/config/features.yml
@@ -420,6 +420,10 @@ features:
     actor_type: user
     description: Enable saving record of 4142 forms submitted to Lighthouse as part of a Supplemental Claim
     enable_in_development: true
+  decision_review_notify_4142_failures:
+    actor_type: user
+    description: Enable sending an email if a 4142 submission is not successful in Lighthouse
+    enable_in_development: true
   dependency_verification:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.

--- a/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
 
       context 'when an error occurs during form processing' do
         let(:email_address) { nil }
-        let(:message) { 'Failed to retrieve email' }
+        let(:message) { 'Failed to retrieve email address' }
 
         before do
           SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}', metadata: '{"status":"error"}')


### PR DESCRIPTION
- minor method name change for clarity

## Summary

- *This work is behind a feature toggle (flipper): NO* -adds the Flipper
- Add a new Flipper for sending 4142 failure notification emails
- Minor change to method name `.current_email` -> `.current_email_address`
- Decision Reviews team, yes

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95980

## Testing done

- [X] *New code is covered by unit tests*
- Method name was slightly ambiguous - no behavior changes

## What areas of the site does it impact?
Background job to notify about silent failures - no new behavior yet

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature