### PR TITLE
[API-41448] Rescue Lighthouse BackendServiceException

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'claims_api/common/exceptions/lighthouse/backend_service_exception'
 require 'evss/disability_compensation_form/service_exception'
 require 'evss/disability_compensation_form/service'
 require 'evss_service/base'
@@ -42,20 +43,22 @@ module ClaimsApi
 
       queue_flash_updater(auto_claim.flashes, auto_claim_id)
       queue_special_issues_updater(auto_claim.special_issues, auto_claim)
-    rescue ::Common::Exceptions::BackendServiceException => e
-      auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED
-      auto_claim.evss_response = get_errors(e)
-      auto_claim.form_data = orig_form_data
-      auto_claim.save
+    rescue ::ClaimsApi::Common::Exceptions::Lighthouse::BackendServiceException,
+           ::Common::Exceptions::BackendServiceException => e
+      handle_exception(auto_claim:, orig_form_data:, e:)
     rescue => e
-      auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED
-      auto_claim.evss_response = get_errors(e)
-      auto_claim.form_data = orig_form_data
-      auto_claim.save
+      handle_exception(auto_claim:, orig_form_data:, e:)
       raise e
     end
 
     private
+
+    def handle_exception(auto_claim:, orig_form_data:, e:)
+      auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED
+      auto_claim.evss_response = get_errors(e)
+      auto_claim.form_data = orig_form_data
+      auto_claim.save
+    end
 
     def veteran_from_headers(auth_headers)
       vet = ClaimsApi::Veteran.new(

--- a/modules/claims_api/spec/sidekiq/claim_establisher_spec.rb
+++ b/modules/claims_api/spec/sidekiq/claim_establisher_spec.rb
@@ -109,6 +109,16 @@ RSpec.describe ClaimsApi::ClaimEstablisher, type: :job do
 
       expect(claim_with_treatments.form_data['treatments']).to eq(orig_form_data['treatments'])
     end
+
+    it 'rescues a Lighthouse::BackendServiceException and does not raise an error' do
+      evss_service_stub = instance_double('ClaimsApi::EVSSService::Base')
+      allow(ClaimsApi::EVSSService::Base).to receive(:new) { evss_service_stub }
+      allow(evss_service_stub).to receive(:submit).and_raise(
+        ClaimsApi::Common::Exceptions::Lighthouse::BackendServiceException.new(errors)
+      )
+
+      expect { subject.new.perform(claim.id) }.not_to raise_error
+    end
   end
 
   describe 'when an errored job has exhausted its retries' do


### PR DESCRIPTION
## Summary

- Rescue Lighthouse::BackendServiceException in the Claim Establisher. This rescue does not re-raise the exception, thereby avoiding retries.
 
## Related issue(s)

- [API-41448](https://jira.devops.va.gov/browse/API-41448)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

- Claim Establisher

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
