### PR TITLE
[SIMPLE_FORMS] doc: add rfc detailing tradeoffs of async pdf s3 uploads - PART 2

### DIFF
--- a/modules/simple_forms_api/docs/rfcs/0002-async-s3-pdf-upload.md
+++ b/modules/simple_forms_api/docs/rfcs/0002-async-s3-pdf-upload.md
@@ -54,7 +54,6 @@ Currently, PDFs are generated and uploaded synchronously to the `vff-simple-form
 1. **Status Messaging**:
    1. Display a spinner and "Uploading PDF..." message during the upload.
    1. Once upload completes, replace the message with a download link, allowing users to download their submission PDF.
-
 1. **Polling Logic**:
    1. Implement a polling mechanism to check PDF upload status, ensuring multiple frontend states (e.g., "success", "error", "in-progress") are accurately reflected to the user.
 
@@ -107,15 +106,15 @@ Currently, PDFs are generated and uploaded synchronously to the `vff-simple-form
 ## 5. Impact and Tradeoffs
 
 1. **Increased Complexity**:
-   1. Asynchronous processing with Sidekiq introduces complexity, but alternative solutions (such as one comprehensive frontend call to initiate and check status) simplify the workflow slightly. The proposed solution will considerably increase both front end and back end complexity regardless.
-1. **Wait Times**:
-   1. Although the proposed solution could impact wait times by up to 50%, the wait times are expected to be low as it is. The added complexity may not be worth the reduction in wait time.
-1. **Improved Resilience**:
-   1. Handling the upload asynchronously provides more robust handling of S3 service outages, although internal outages may still impact service availability.
-1. **Scalability**:
-   1. Offloading PDF uploads to Sidekiq will reduce synchronous load on the backend, allowing for better scalability during high-traffic periods.
-1. **Enhanced User Experience**:
-   1. Reduced wait times on the Confirmation page, allowing users quicker access to submission confirmations.
+   1. Asynchronous processing with Sidekiq introduces additional complexity for both the frontend and backend. Tracking job states, handling polling, and managing error notifications create new technical challenges and maintenance overhead.
+1. **User Experience Gains**:
+   1. Although async processing can reduce wait times on the Confirmation page by up to 50%, the current synchronous wait times may already be tolerable. Without concrete metrics showing significant user impact, the added complexity may not justify the gain.
+1. **Resilience vs. Simplicity**:
+   1. While an async solution provides greater resilience to S3 outages, these outages are rare. The current synchronous approach keeps the user experience simpler and more predictable.
+1. **Scalability Benefits**:
+   1. Offloading uploads to Sidekiq reduces backend load during peak times, which could improve scalability. However, scalability concerns may be premature given the current traffic levels.
+1. **Error Handling Limitations**:
+   1. Async workflows can obscure error handling from users, requiring robust retry and monitoring to ensure no failed uploads are missed. A synchronous approach offers more immediate and transparent error feedback.
 
 ## 6. Open Questions
 
@@ -123,7 +122,8 @@ Currently, PDFs are generated and uploaded synchronously to the `vff-simple-form
    1. Would handling both upload initiation and status polling with one API call improve simplicity without reducing functionality? This would prevent frontend polling and maintain a more synchronous user experience.
 1. **S3 Monitoring Interval**:
    1. What interval should the monitoring job use to check for S3 service restoration?
-1. **User Retry Option**: Should users be able to retry failed uploads manually, or should it be fully automated?
+1. **User Retry Option**:
+   1. Should users be able to retry failed uploads manually, or should it be fully automated?
 1. **Persistent Caching**:
    1. Should downloaded PDFs be cached locally on the user's device, or should caching be disabled to avoid repeated requests?
 1. **Job Failure Notification**:

--- a/modules/simple_forms_api/docs/rfcs/0002-async-s3-pdf-upload.md
+++ b/modules/simple_forms_api/docs/rfcs/0002-async-s3-pdf-upload.md
@@ -6,115 +6,141 @@ Transitioning PDF Uploads to Asynchronous Sidekiq Jobs
 
 ## 2. Summary
 
-This document proposes transitioning the PDF upload process from a synchronous workflow to an asynchronous Sidekiq job within the VA.gov platform. By moving to asynchronous processing, we aim to improve user experience on the form submission Confirmation page by reducing wait times, while also enhancing error handling and resilience during S3 outages. The RFC outlines the technical requirements, necessary frontend changes, error-handling strategies, security, and performance considerations for implementing this change.
+This document proposes transitioning the PDF upload process from a synchronous workflow to an asynchronous Sidekiq job within the VA.gov platform. By moving to asynchronous processing, we aim to improve user experience on the form submission Confirmation page by reducing wait times, while also enhancing error handling and resilience during S3 outages. The RFC outlines the technical requirements, necessary frontend changes, error-handling strategies, and other considerations for implementing this change.
 
 ## 3. Background
 
-Currently, PDFs are generated and uploaded synchronously to the `vff-simple-forms` S3 bucket when users submit forms. This process causes delays on the Confirmation page, as users must wait for the upload to complete before accessing their submission PDF. Additionally, any failures during the upload result in immediate user-facing errors, with limited retry or resilience mechanisms in place. This RFC proposes handling the upload asynchronously with Sidekiq, which would enable faster form submissions, provide more robust error handling, and improve the user experience.
+Currently, PDFs are generated and uploaded synchronously to the `vff-simple-forms` S3 bucket when users submit forms. This process can cause delays on the Confirmation page, as users must wait for the upload to complete before accessing their submission PDF. Additionally, any failures during the upload result in immediate user-facing errors, with limited retry or resilience mechanisms in place. This RFC proposes handling the upload asynchronously with Sidekiq, which would enable faster form submissions, provide more robust error handling, and improve the user experience.
 
 ## 4. Proposal
 
 ### 4.1 Asynchronous Upload with Sidekiq
 
-- **Backend Modifications**:
-  - Modify the `UploadsController#submit` action to trigger a Sidekiq job for PDF uploads, allowing form submissions to complete without waiting for the PDF upload.
-  - The Sidekiq job will handle the PDF upload to S3 and return a presigned URL to the backend, where it will be made available for the frontend to display.
-  - Retry Limit: Set to 3 retries in case of transient errors.
-  - Failure Handling: Log errors and notify users if upload fails, without displaying technical error details.
+#### Backend Modifications
 
-- **Frontend Modifications**:
-  - Display a spinner and "Uploading PDF..." message on the Confirmation page during upload.
-  - Once the upload is complete, replace the message with a download link.
-  - In case of a failure, display a user-friendly error message, such as "We couldn't save your form submission. Please try again later."
+1. **UploadsController Modification**:
+   1. Upon form submission, the controller will return a 200 response immediately and trigger a Sidekiq job for PDF uploads. This approach allows form submissions to complete without waiting for the PDF upload to finish.
+   1. The response will include the `benefits_intake_uuid` to help track the submission state. The frontend will use this identifier to poll for upload status.
+1. **New Endpoint for Fetching PDF Status**:
+   1. A new endpoint will allow the frontend to check the status of the PDF upload. This endpoint will handle states such as "pending," "completed," or "failed," and will return a URL for download once the upload completes.
+   1. Alternatively, the frontend could initiate the entire upload and retrieval process, creating a more straightforward lifecycle with one request starting the workflow and another checking for completion.
+1. **Sidekiq Job Specifications**:
+   1. **Retry Limit**: Set to 3 retries in case of transient errors.
+   1. **Error Handling**: Log failures and notify users if upload fails, without displaying technical error details.
+   1. **Pollable State Information**: Sidekiq jobs will need to update a status in the database so the frontend can query the current upload state.
 
-- **Error Handling and Monitoring**:
-  - A dedicated monitoring job will periodically check S3 status during outages, reattempting uploads as S3 becomes available.
-  - Log and alert for both temporary and long-term S3 outages, ensuring users receive timely information.
-  - In the event of temporary files being deleted due to pod lifecycle issues, a call to the SimpleFormsApi::FormRemediation::SubmissionArchive service could hydrate the form submission via the `benefits_intake_uuid` confirmation code. Which could in turn upload the PDF to the S3 Client.
+#### Frontend Modifications
+
+1. **Status Messaging**:
+   1. A loading component on the Confirmation page will display an "Uploading PDF..." message while the upload is in progress.
+   1. Once the upload is complete, the message updates to a download link for the user's PDF.
+1. **User-Friendly Error Messaging**:
+   1. If the upload fails after all retries, the frontend will display a user-friendly error message, such as "We couldn't save your form submission. Please try again later."
+1. **Polling Workflow**:
+   1. The frontend will initiate polling to check for the PDF status using the `benefits_intake_uuid`, ensuring user visibility into the status at each stage (e.g., "submitted," "processing," "complete").
 
 ### 4.2 Technical Specifications
 
 #### Backend (vets-api)
 
-- **Components**:
-  - `SimpleFormsApi::FormRemediation::S3Client`: Modify to support Sidekiq's asynchronous operations.
-  - **Retries and Error Logging**: Configure Sidekiq job retries (3) and log detailed error context for troubleshooting.
+1. **Components**:
+   1. `SimpleFormsApi::FormRemediation::S3Client`: Update to support Sidekiq's asynchronous operations.
+   1. **Retries and Error Logging**: Configure Sidekiq job retries (3) and log detailed error context for troubleshooting.
+1. **New Endpoint**:
+   1. An endpoint will be added to provide the upload status and URL for the PDF download upon completion.
 
 #### Frontend (vets-website)
 
-- **Status Messaging**:
-  - A loading component on the Confirmation page will display an "Uploading PDF..." message while the upload is in progress.
-  - On completion, the message updates to a download link, allowing users to download their submission PDF.
+1. **Status Messaging**:
+   1. Display a spinner and "Uploading PDF..." message during the upload.
+   1. Once upload completes, replace the message with a download link, allowing users to download their submission PDF.
 
-- **User-Friendly Error Messaging**:
-  - If upload fails after all retries, show an error message on the Confirmation page, offering a retry link if needed.
+1. **Polling Logic**:
+   1. Implement a polling mechanism to check PDF upload status, ensuring multiple frontend states (e.g., "success", "error", "in-progress") are accurately reflected to the user.
 
 ### 4.3 Error Handling
 
-- **S3 Outages**:
-  - In the event of an S3 outage, trigger a monitoring job to periodically reattempt uploads once service is restored.
-  - Error handling within the Sidekiq job should include contextual error logging for easier debugging and analysis.
+1. **S3 Outages**:
+   1. In case of an S3 outage, trigger a monitoring job to periodically reattempt uploads once the service is restored.
+   1. Error handling within the Sidekiq job should include contextual error logging for easier debugging and analysis.
 
-- **User Notifications**:
-  - User-friendly messages on the frontend, avoiding technical jargon.
-  - Consider offering a retry button on persistent failures.
+2. **User Notifications**:
+   1. User-friendly messages on the frontend, avoiding technical jargon.
+   1. A retry link may be presented for the user to attempt the upload again in case of prolonged failure.
 
 ### 4.4 Security and Compliance
 
-- **PII and PHI Protection**:
-  - PDFs will continue to be handled in accordance with current PII and PHI standards, with pre-signed URLs provided for secure access.
-  - Scrubbing sensitive data from logs and alerts to ensure compliance.
+1. **PII and PHI Protection**:
+   1. The same PII and PHI handling standards will apply, with no additional persistence beyond necessary retention.
+   1. Sensitive data will be scrubbed from logs to prevent exposure.
 
-- **Performance and Resilience**:
-  - Async processing will reduce frontend wait times by up to 50%, with Sidekiq providing a buffer for heavy loads.
-  - Track Sidekiq performance metrics (job success/failure rates, processing times) to evaluate improvements.
+1. **Performance and Resilience**:
+   1. Async processing is expected to improve frontend wait times by up to 50%, with Sidekiq managing heavy load in the background.
+   1. Track Sidekiq performance metrics (job success/failure rates, processing times) to evaluate improvements.
 
 ### 4.5 Monitoring and Alerting
 
-- **Metrics and Alerts**:
-  - Track key metrics: upload success rates, average processing times, and error rates.
-  - Configure alerts for error rates exceeding thresholds (e.g., >1% error rate in 10 minutes).
-  - Alerts should route to `veteran-facing-forms-notifications` on OCTO DSVA Slack.
-
-- **Escalation Protocol**:
-  - **Tier 1**: Initial alert handled by on-call engineer.
-  - **Tier 2**: Escalate to team lead if unresolved within 30 minutes.
-  - **Tier 3**: Escalate to VFS Platform DevOps if unresolved within 1 hour.
+1. **Metrics and Alerts**:
+   1. Track key metrics like upload success/error rates, average processing times, and threshold-based alerts.
+   1. Configure alerts for error rates exceeding thresholds (e.g., >1% error rate in 10 minutes).
+   1. Alerts should route to `veteran-facing-forms-notifications` on OCTO DSVA Slack.
+1. **Escalation Protocol**:
+   1. **Tier 1**: Initial alert handled by on-call engineer.
+   1. **Tier 2**: Escalate to team lead if unresolved within 30 minutes.
+   1. **Tier 3**: Escalate to VFS Platform DevOps if unresolved within 1 hour.
 
 ### 4.6 DataDog Dashboard
 
-- **Dashboard Setup**:
-  - Display upload success/error rates, average processing times, and alerts summary.
-  - Track metrics historically to identify performance trends and improvement opportunities.
+1. **Dashboard Setup**:
+   1. Display upload success/error rates, average processing times, and alerts summary.
+   1. Track metrics historically to identify performance trends and improvement opportunities.
 
 ### 4.7 Integration with Existing Tools
 
-- **Jenkins Integration**: Ensure automated tests validate the asynchronous upload workflow as part of deployments.
-- **ArgoCD**: Deploy monitoring configurations via CI/CD pipeline to ensure consistency.
-- **Flipper**: Enable feature-flagging to allow controlled rollout of the asynchronous upload process.
+1. **Jenkins Integration**:
+   1. Ensure automated tests validate the asynchronous upload workflow as part of deployments.
+1. **ArgoCD**:
+   1. Deploy monitoring configurations via CI/CD pipeline to ensure consistency.
+1. **Flipper**:
+   1. Enable feature-flagging to allow controlled rollout of the asynchronous upload process.
 
-## 5. Impact
+## 5. Impact and Tradeoffs
 
-- **Enhanced User Experience**: Reduced wait times on the Confirmation page, allowing users quicker access to submission confirmations.
-- **Improved Reliability**: Resilience against S3 outages, with better error-handling and retry mechanisms.
-- **Compliance**: Consistent handling of sensitive data in logs, with pre-signed URLs for secure PDF downloads.
-- **Scalability**: Offloading PDF uploads to Sidekiq will reduce synchronous load on the backend, allowing for better scalability during high-traffic periods.
+1. **Increased Complexity**:
+   1. Asynchronous processing with Sidekiq introduces complexity, but alternative solutions (such as one comprehensive frontend call to initiate and check status) simplify the workflow slightly. The proposed solution will considerably increase both front end and back end complexity regardless.
+1. **Wait Times**:
+   1. Although the proposed solution could impact wait times by up to 50%, the wait times are expected to be low as it is. The added complexity may not be worth the reduction in wait time.
+1. **Improved Resilience**:
+   1. Handling the upload asynchronously provides more robust handling of S3 service outages, although internal outages may still impact service availability.
+1. **Scalability**:
+   1. Offloading PDF uploads to Sidekiq will reduce synchronous load on the backend, allowing for better scalability during high-traffic periods.
+1. **Enhanced User Experience**:
+   1. Reduced wait times on the Confirmation page, allowing users quicker access to submission confirmations.
 
 ## 6. Open Questions
 
-- **S3 Monitoring Interval**: How frequently should the monitoring job check for S3 service restoration?
-- **User Retry Option**: Should users be able to retry failed uploads manually, or should it be fully automated?
-- **Job Failure Notification**: Are additional notifications required in parts of the application beyond the Confirmation page?
+1. **Lifecycle Management with Single API Calls**:
+   1. Would handling both upload initiation and status polling with one API call improve simplicity without reducing functionality? This would prevent frontend polling and maintain a more synchronous user experience.
+1. **S3 Monitoring Interval**:
+   1. What interval should the monitoring job use to check for S3 service restoration?
+1. **User Retry Option**: Should users be able to retry failed uploads manually, or should it be fully automated?
+1. **Persistent Caching**:
+   1. Should downloaded PDFs be cached locally on the user's device, or should caching be disabled to avoid repeated requests?
+1. **Job Failure Notification**:
+   1. Are additional notifications required in parts of the application beyond the Confirmation page?
 
 ## 7. Feedback Request
 
-- Feedback on the proposed async workflow and error-handling strategies.
-- Input on retry and escalation protocols.
-- Suggestions for additional metrics or monitoring improvements.
+1. **Feedback on Complexity vs. Benefits**:
+   1. Is the async approach justified given the low frequency of S3 outages and relatively low traffic volume?
+1. **Error Handling Preferences**:
+   1. Should retry options be handled solely on the backend, or should there be a retry link for users?
+1. **Polling Interval for Status Updates**:
+   1. What is an optimal interval for frontend polling without impacting performance?
 
 ## 8. Appendices/References
 
-- [Architectural Intent Meeting Notes](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91829)
-- [Platform PII Handling Best Practices](https://depo-platform-documentation.scrollhelp.site/developer-docs/coding-best-practices-for-pii)
-- [DataDog Monitoring Guide](https://depo-platform-documentation.scrollhelp.site/developer-docs/get-acquainted-with-datadog)
-- [Platform Performance Monitoring](https://depo-platform-documentation.scrollhelp.site/developer-docs/monitoring-performance)
+1. [Architectural Intent Meeting Notes](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91829)
+1. [Platform PII Handling Best Practices](https://depo-platform-documentation.scrollhelp.site/developer-docs/coding-best-practices-for-pii)
+1. [DataDog Monitoring Guide](https://depo-platform-documentation.scrollhelp.site/developer-docs/get-acquainted-with-datadog)
+1. [Platform Performance Monitoring](https://depo-platform-documentation.scrollhelp.site/developer-docs/monitoring-performance)


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR adds an RFC document proposing the transition of PDF uploads to an asynchronous Sidekiq job rather than the current synchronous method. This RFC outlines the technical requirements, expected benefits, frontend and backend changes, and error-handling strategies to improve user experience and performance.
- Not a bug; this is an RFC to guide future architectural changes.
- Solution: The RFC details the advantages of asynchronous processing, including reduced wait times on the Confirmation page, improved error handling, and resilient handling of S3 outages.
- Team: Veteran-Facing Forms team, responsible for maintaining and implementing this proposal as appropriate.

## Related issue(s)

- [Part 1 of this RFC](https://github.com/department-of-veterans-affairs/vets-api/pull/19135)
- [Discovery - Asynchronous PDF Upload to S3 with Sidekiq](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1626)
- [Architectural Intent Notes](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91829)

## Testing done

- [x] Review completed by relevant stakeholders.

## What areas of the site does it impact?

- This is a documentation update and does not impact site functionality.

## Acceptance criteria

- [x] RFC document added and reviewed by team.
- [x] Documentation aligns with team standards and clearly outlines the proposal and related considerations.

## Requested Feedback

- Please review the RFC for completeness and clarity, especially regarding error-handling strategies and frontend changes.