### PR TITLE
edm 297 feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1790,3 +1790,9 @@ features:
   fsr_wizard:
     actor_type: user
     description: Used to toggle the FSR wizard
+  gi_comparison_tool_programs_toggle_flag:
+    actor_type: user
+    description: Used to show links to programs page in comparison tool
+  gi_comparison_tool_lce_toggle_flag:
+    actor_type: user
+    description: Used to show lce page in comparison tool


### PR DESCRIPTION
## Summary

- Add feature flag toggles in features.yml file to show and hide access to license, certificates exams and programs pages in comparion tool 
- EDM Team

## Related issue(s)
https://jira.devops.va.gov/browse/EDM-297


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature