### PR TITLE
Fix namespacing on 526 doc upload polling job chron register

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -61,7 +61,7 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   mgr.register('0 1 * * 1', 'BenefitsIntakeRemediationStatusJob')
 
   # Update Lighthouse526DocumentUpload statuses according to Lighthouse Benefits Documents service tracking
-  mgr.register('15 * * * *', 'Form526DocumentUploadPollingJob')
+  mgr.register('15 * * * *', 'Lighthouse::Form526DocumentUploadPollingJob')
 
   # Updates status of FormSubmissions per call to Lighthouse Benefits Intake API
   mgr.register('0 3 * * *', 'Form526StatusPollingJob')


### PR DESCRIPTION



## Summary

- *This work is behind a feature toggle (flipper): YES/NO*

NO

- *(Summarize the changes that have been made to the platform)*

Updates the chron job registration for the `Lighthouse::Form526DocumentUploadPollingJob` to properly namespace the job. It was missing the `Lighthouse::` module name

It was discovered in launching the [BDD Instruction migration](https://github.com/department-of-veterans-affairs/va.gov-team/issues/90361) that polling records for Lighthouse weren't getting updated; furthermore there was no log of the job ever running.

I'm pretty sure this is the cause but will need to merge in prod to validate it.


## Testing done

- [X] *New code is covered by unit tests* N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). N/A
- [ ]  No error nor warning in the console. N/A
- [ ]  Events are being sent to the appropriate logging solution N/A
- [ ]  Documentation has been updated (link to documentation) N/A
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected