### PR TITLE
[API-41395] Add suffix matching to poa code validation

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/claims_user.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/claims_user.rb
@@ -2,6 +2,9 @@
 
 module ClaimsApi
   class ClaimsUser
+    attr_reader :uuid
+    attr_accessor :first_name, :last_name, :middle_name, :email, :suffix
+
     def initialize(id)
       @uuid = id
       @identifier = UserIdentifier.new(id)
@@ -26,9 +29,6 @@ module ClaimsApi
     def loa
       @identifier.loa
     end
-
-    attr_reader :uuid
-    attr_accessor :first_name, :last_name, :middle_name, :email
 
     def authn_context
       'authn'

--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -65,35 +65,19 @@ module ClaimsApi
       # @param poa_code [String] poa code to match to @current_user
       #
       # @return [Boolean] True if valid poa code, False if not
-      def valid_poa_code_for_current_user?(poa_code) # rubocop:disable Metrics/MethodLength
+      def valid_poa_code_for_current_user?(poa_code)
         return false if @current_user.first_name.nil? || @current_user.last_name.nil?
 
-        reps = ::Veteran::Service::Representative.all_for_user(first_name: @current_user.first_name,
-                                                               last_name: @current_user.last_name)
+        reps_by_first_and_last_name = ::Veteran::Service::Representative.all_for_user(
+          first_name: @current_user.first_name,
+          last_name: @current_user.last_name
+        )
 
-        return false if reps.blank?
-
-        if reps.count > 1
-          if @current_user.middle_name.blank?
-            raise ::Common::Exceptions::Unauthorized, detail: 'Ambiguous VSO Representative Results'
-          else
-            middle_initial = @current_user.middle_name[0]
-            reps = ::Veteran::Service::Representative.all_for_user(first_name: @current_user.first_name,
-                                                                   last_name: @current_user.last_name,
-                                                                   middle_initial:)
-
-            if reps.blank? || reps.count > 1
-              reps = ::Veteran::Service::Representative.all_for_user(first_name: @current_user.first_name,
-                                                                     last_name: @current_user.last_name,
-                                                                     poa_code:)
-            end
-
-            raise ::Common::Exceptions::Unauthorized, detail: 'VSO Representative Not Found' if reps.blank?
-            raise ::Common::Exceptions::Unauthorized, detail: 'Ambiguous VSO Representative Results' if reps.count > 1
-          end
-        end
-
-        reps.first.poa_codes.include?(poa_code)
+        exactly_one_rep_match?(reps_by_first_and_last_name, poa_code) ||
+          find_by_suffix(poa_code) ||
+          find_by_middle_initial(poa_code) ||
+          find_by_poa_code(poa_code) ||
+          handle_not_found(reps_by_first_and_last_name)
       end
 
       #
@@ -114,6 +98,47 @@ module ClaimsApi
 
       def poa_code_in_organization?(poa_code)
         ::Veteran::Service::Organization.find_by(poa: poa_code).present?
+      end
+
+      private
+
+      def exactly_one_rep_match?(reps, poa_code)
+        reps.first.poa_codes.include?(poa_code) if reps.count == 1
+      end
+
+      def find_by_suffix(poa_code)
+        return false if @current_user.suffix.blank?
+
+        last_name_with_suffix = "#{@current_user.last_name} #{@current_user.suffix}"
+        reps_by_suffix = ::Veteran::Service::Representative.all_for_user(first_name: @current_user.first_name,
+                                                                         last_name: last_name_with_suffix)
+
+        exactly_one_rep_match?(reps_by_suffix, poa_code)
+      end
+
+      def find_by_middle_initial(poa_code)
+        return false if @current_user.middle_name.blank?
+
+        middle_initial = @current_user.middle_name[0]
+        reps_by_middle_initial = ::Veteran::Service::Representative.all_for_user(first_name: @current_user.first_name,
+                                                                                 last_name: @current_user.last_name,
+                                                                                 middle_initial:)
+
+        exactly_one_rep_match?(reps_by_middle_initial, poa_code)
+      end
+
+      def find_by_poa_code(poa_code)
+        reps_by_poa_code = ::Veteran::Service::Representative.all_for_user(first_name: @current_user.first_name,
+                                                                           last_name: @current_user.last_name,
+                                                                           poa_code:)
+
+        exactly_one_rep_match?(reps_by_poa_code, poa_code)
+      end
+
+      def handle_not_found(reps)
+        raise ::Common::Exceptions::Unauthorized, detail: 'Ambiguous VSO Representative Results' if reps.count > 1
+
+        false
       end
     end
   end

--- a/modules/claims_api/app/controllers/concerns/claims_api/token_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/token_validation.rb
@@ -104,6 +104,8 @@ module ClaimsApi
         claims_user.first_name_last_name(first_name, last_name)
         middle_name = mpi_profile&.profile&.given_names&.second
         claims_user.middle_name = middle_name unless middle_name.nil?
+        suffix = mpi_profile&.profile&.suffix
+        claims_user.suffix = suffix unless suffix.nil?
       end
       claims_user
     end

--- a/modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb
+++ b/modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb
@@ -10,6 +10,7 @@ class FakeController < ApplicationController
     @current_user = ClaimsApi::ClaimsUser.new('test')
     @current_user.first_name_last_name('John', 'Doe')
     @current_user.middle_name = 'Alexander'
+    @current_user.suffix = 'III'
   end
 end
 
@@ -95,8 +96,22 @@ describe FakeController do
         end
 
         it 'raises "Ambiguous VSO Representative Results"' do
-          expect { subject.valid_poa_code_for_current_user?(poa_code) }.to raise_error(Common::Exceptions::Unauthorized)
+          expect do
+            subject.valid_poa_code_for_current_user?(poa_code)
+          end.to raise_error(Common::Exceptions::Unauthorized)
         end
+      end
+    end
+
+    context 'when the repʼs last name includes a suffix that matches the current userʼs suffix' do
+      before do
+        create(:representative, representative_id: '12345', first_name:, last_name: "#{last_name} III",
+                                poa_codes: ['091'], phone:)
+      end
+
+      it 'finds the rep and returns true' do
+        res = subject.valid_poa_code_for_current_user?(poa_code)
+        expect(res).to eq(true)
       end
     end
   end

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -29,11 +29,10 @@ module Veteran
       def self.all_for_user(first_name:, last_name:, middle_initial: nil, poa_code: nil)
         return [] if first_name.nil? || last_name.nil?
 
-        representatives = get_representatives(first_name, last_name)
-
-        representatives = representatives&.where('? = ANY(poa_codes)', poa_code) if poa_code
-
-        representatives&.select { |rep| matching_middle_initial(rep, middle_initial) }
+        representatives = where('lower(first_name) = ? AND lower(last_name) = ?', first_name&.downcase,
+                                last_name&.downcase)
+        representatives = representatives.where('? = ANY(poa_codes)', poa_code) if poa_code
+        representatives.select { |rep| matching_middle_initial(rep, middle_initial) }
       end
 
       #
@@ -110,29 +109,6 @@ module Veteran
         %i[address email phone_number].each_with_object({}) do |field, diff|
           diff["#{field}_changed"] = field == :address ? address_changed?(rep_data) : send(field) != rep_data[field]
         end
-      end
-
-      def self.get_suffixes(first_name, last_name)
-        first_suffix = first_name.split.last if first_name.split.count > 1
-        last_suffix = last_name.split.last if last_name.split.count > 1
-        [first_suffix, last_suffix]
-      end
-
-      def self.get_representatives(first_name, last_name)
-        suffixes = get_suffixes(first_name, last_name)
-
-        representatives = where('lower(first_name) = ? AND lower(last_name) = ?', first_name&.downcase,
-                                last_name&.downcase)
-
-        if representatives.blank? && suffixes.any?
-          # check without suffix
-          first_name = first_name.delete(suffixes[0]).strip if suffixes[0].present?
-          last_name = last_name.delete(suffixes[1]).strip if suffixes[1].present?
-
-          representatives = where('lower(first_name) = ? AND lower(last_name) = ?', first_name&.downcase,
-                                  last_name&.downcase)
-        end
-        representatives
       end
 
       private

--- a/modules/veteran/spec/models/veteran/service/representative_spec.rb
+++ b/modules/veteran/spec/models/veteran/service/representative_spec.rb
@@ -69,22 +69,6 @@ describe Veteran::Service::Representative, type: :model do
                  poa_code: '016'
                )).to eq([])
       end
-
-      it 'can find a user with a suffix' do
-        expect(Veteran::Service::Representative.all_for_user(
-          first_name: identity.first_name,
-          last_name: "#{identity.last_name} III",
-          poa_code: 'A1Q'
-        ).first.poa_codes).to include('A1Q')
-      end
-
-      it 'can find a user with a suffix on the first name' do
-        expect(Veteran::Service::Representative.all_for_user(
-          first_name: "#{identity.first_name} Esq",
-          last_name: identity.last_name,
-          poa_code: 'A1Q'
-        ).first.poa_codes).to include('A1Q')
-      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Revert #19017.
- Add `suffix` to `ClaimsUser` (i.e., `@current_user`) attributes.
- Set the `@current_user`ʼs `suffix` to the suffix received from MPI, if any.
- Refactor POA code validation. Include suffix lookup to disambiguate representatives.
   - Relax the validation to include the suffix matching _in addition to_ the other matching (e.g., middle name). i.e., increase the chances of a successful POA code validation.

## Related issue(s)

[API-41395](https://jira.devops.va.gov/browse/API-41395)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

- ClaimsUser attributes
- POA verification
- Token validation

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Do we want to do any normalization around the suffix (e.g., strip punctuation/spaces)?