### PR TITLE
Remove Unused Settings - Part 4

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -188,7 +188,6 @@ form_10_10cg:
       aws_access_key_id: my-aws-key-id
       aws_secret_access_key: my-aws-access-key
       bucket: my-bucket
-      enabled: true
       region: us-gov-west-1
 
 vbs:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1678,7 +1678,6 @@ sidekiq:
   github_team: ~
   github_oauth_key: ~
   github_oauth_secret: ~
-  github_api_key: ~
 
 flipper:
   mute_logs: false
@@ -1686,7 +1685,6 @@ flipper:
   github_team: ~
   github_oauth_key: ~
   github_oauth_secret: ~
-  github_api_key: ~
 
 lgy:
   base_url: http://www.example.com
@@ -1755,7 +1753,6 @@ coverband:
   github_team: ~
   github_oauth_key: ~
   github_oauth_secret: ~
-  github_api_key: ~
 
 dogstatsd:
   enabled: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -13,9 +13,6 @@ betamocks:
   cache_dir: /cache # via docker; e.g. make up or make console
   services_config: config/betamocks/services_config.yml
 
-saml_ssoe:
-  idme_authn_context: https://eauth.va.gov/csp?Select=idme3
-
 account:
   enabled: true
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -129,7 +129,6 @@ flipper:
   github_team: 0000000
   github_oauth_key: xxx000
   github_oauth_secret: 000xxx
-  github_api_key: ~
 
 va_forms:
   drupal_username: ~

--- a/lib/flipper/README.md
+++ b/lib/flipper/README.md
@@ -22,7 +22,6 @@ flipper:
   github_team: <see below>
   github_oauth_key: <see below>
   github_oauth_secret: <see below>
-  github_api_key: <see below>
 ```
 
 `github_team` - to give yourself access, provide the id of a team that you belong to (i.e. `backend-review-group`). You can retrieve the id via the github API:
@@ -33,5 +32,3 @@ curl -H "Authorization: token <personal_access_token>" https://api.github.com/or
 [Creating a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 
 `github_oauth_key`/`github_oauth_secret` - These reference the Client ID and Client Secret for the associated Github OAuth App. There are separate apps for each app using github authentication (Flipper, Sidekiq, Coverband, etc) AND for each environment INCLUDING a Test App for use with localhost, `va.gov-flipper-oauth-local-test`. The credentials are stored in the parameter store under `/dsva-vagov/vets-api/local-dev/flipper/github-oauth-key` and `/github-oauth-secret`, respectively. 
-
-`github_api_key` - This is the API key used across all OAuth apps. You can retrieve this from the Parameter store, located at `/dsva-vagov/vets-api/common/sidekiq/github-api-key`


### PR DESCRIPTION
## Summary

This is part 4 of 3-ish

- Remove settings from `config/settings.yml` and `config/settings/development.yml`
- Checked using:
   - Dot notation
   - Hash access (`[]`, `.dig`, `fetch`)
   - Checked parent key
- Added comments for difficult to find Settings (willing to remove if undesirable)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95565

## Testing done

- [ ] n/a

## Acceptance criteria

- [x]  Unused settings are removed from `config/settings` files