### PR TITLE
API-40398: Add `benefits_require_gateway_origin` Feature Flag to 

### DIFF
--- a/modules/appeals_api/config/flipper/enabled_features.yml
+++ b/modules/appeals_api/config/flipper/enabled_features.yml
@@ -1,4 +1,5 @@
 common:
+  - benefits_require_gateway_origin
   - decision_review_hlr_email
   - decision_review_nod_email
   - decision_review_sc_email

--- a/modules/vba_documents/config/flipper/enabled_features.yml
+++ b/modules/vba_documents/config/flipper/enabled_features.yml
@@ -1,4 +1,5 @@
 common:
+  - benefits_require_gateway_origin
 development:
 staging:
 sandbox:


### PR DESCRIPTION
## Summary
This work is behind a feature toggle (flipper): No

This PR adds the `benefits_require_gateway_origin` feature flag to the list of enabled feature flags for all environments, so that the `AppealsAPI::FlipperStatusAlert` and `VBADocuments::FlipperStatusAlert` jobs will send a Slack alert if the `benefits_require_gateway_origin` is found not to be enabled.

The `benefits_require_gateway_origin` feature flag has already been enabled in all deployed environments.

The `va_forms` module also uses this feature flag, but since all traffic for that API has been migrated to the LHDI platform and we will be removing the module from `vets-api` in the near future, I have not added the flag to the VA Forms `enabled_features.yml` config.

My team (Lighthouse Banana Peels) owns the `appeals_api` and `vba_documents` modules.

## Related issue(s)
[API-40398](https://jira.devops.va.gov/browse/API-40398)

## Testing done
- [x] New code is covered by unit tests

I ran the jobs locally to ensure that the config was still valid. The code was already covered by unit tests.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `AppealsAPI::FlipperStatusAlert` and `VBADocuments::FlipperStatusAlert` jobs only.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A, config change only
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
