### PR TITLE
API-41520 PoaVBMSUploadJob BD refactor

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/poa_vbms_upload_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_vbms_upload_job.rb
@@ -20,8 +20,8 @@ module ClaimsApi
       auth_headers = power_of_attorney.auth_headers
 
       if Flipper.enabled?(:lighthouse_claims_api_poa_use_bd)
-        benefits_doc_api.upload(claim: power_of_attorney, pdf_path: file_path, action:, doc_type: 'L075',
-                                pctpnt_vet_id: auth_headers['participant_id'])
+        benefits_doc_upload(poa: power_of_attorney, pdf_path: file_path, action:, doc_type: 'L075',
+                            ptcpnt_vet_id: auth_headers['participant_id'])
       else
         upload_to_vbms(power_of_attorney, file_path)
       end
@@ -60,6 +60,15 @@ module ClaimsApi
     end
 
     private
+
+    def benefits_doc_upload(poa:, pdf_path:, doc_type:, action:, ptcpnt_vet_id:)
+      if Flipper.enabled? :claims_api_poa_uploads_bd_refactor
+        PoaDocumentService.new.create_upload(poa:, pdf_path:, action:, doc_type:)
+      else
+        benefits_doc_api.upload(claim: poa, pdf_path:, action:, doc_type: 'L075',
+                                pctpnt_vet_id: ptcpnt_vet_id)
+      end
+    end
 
     def benefits_doc_api
       ClaimsApi::BD.new

--- a/modules/claims_api/spec/sidekiq/poa_vbms_upload_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_vbms_upload_job_spec.rb
@@ -225,9 +225,10 @@ RSpec.describe ClaimsApi::PoaVBMSUploadJob, type: :job do
     let(:pdf_path) { 'some/path' }
     let(:doc_type) { 'L075' }
 
-    context 'when the bd upload feature flag is enabled' do
+    context 'when the bd upload feature flag is enabled and BD refactor flag is disabled' do
       before do
         allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_poa_use_bd).and_return true
+        allow(Flipper).to receive(:enabled?).with(:claims_api_poa_uploads_bd_refactor).and_return false
       end
 
       it 'calls the benefits document API with doc_type L075' do
@@ -257,6 +258,26 @@ RSpec.describe ClaimsApi::PoaVBMSUploadJob, type: :job do
           power_of_attorney.reload
           expect(power_of_attorney.status).to eq(ClaimsApi::PowerOfAttorney::ERRORED)
           expect(power_of_attorney.vbms_error_message).to eq(e.message)
+        end
+      end
+
+      context 'when the BD upload refactor feature flag is enabled' do
+        before do
+          allow(Flipper).to receive(:enabled?).with(:claims_api_poa_uploads_bd_refactor).and_return true
+        end
+
+        it 'calls the PoaDocumentService before calling BD' do
+          allow_any_instance_of(BGS::PersonWebService)
+            .to receive(:find_by_ssn).and_return({ file_nbr: '123456789' })
+          allow_any_instance_of(BGS::VetRecordWebService).to receive(:update_birls_record)
+            .and_return({ return_code: 'BMOD0001' })
+          expect_any_instance_of(ClaimsApi::PoaDocumentService).to receive(:create_upload).with(
+            poa: power_of_attorney,
+            pdf_path: anything,
+            doc_type: 'L075',
+            action: 'put'
+          )
+          subject.new.perform(power_of_attorney.id, 'put')
         end
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Updates PoaVBMSUploadJob to add feature flag to determine whether to use refactored BD upload_document logic via PoaDocumentService.

## Related issue(s)

[API-41520](https://jira.devops.va.gov/browse/API-41520)

## Testing done

- [x] *New code is covered by unit tests*
- Prior POA v1 put 2122/:id logic used ClaimsApi::BD service methods to handle logic specific to the doc type and generate the appropriate upload body for submission to BD /upload.
- New code uses PoaDocumentService and DocumentServiceBase classes to handle logic specific to the L075 doc type and generate the appropriate upload body for submission to BD /upload, using new ClaimsApi::BD service method upload_document to simply submit the upload body to BD /upload.
- New logic requires the following flipper to be enabled:
Flipper.enable :claims_api_poa_uploads_bd_refactor
Tested POA v1 put submissions with and without flipper enabled and confirmed BD /upload success.


## What areas of the site does it impact?
POA v1 put 2122/:id submissions

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

