### PR TITLE
EZR: Add ZSF logging

### DIFF
--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -9,6 +9,10 @@ module HCA
     extend SentryLogging
     VALIDATION_ERROR = HCA::SOAPParser::ValidationError
     STATSD_KEY_PREFIX = 'api.1010ezr'
+    DD_ZSF_TAGS = [
+      'service:healthcare-application',
+      'function: 10-10EZR async form submission'
+    ].freeze
 
     # 14 retries was decided on because it's the closest to a 24-hour time span based on
     # Sidekiq's backoff formula: https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry
@@ -56,6 +60,7 @@ module HCA
         api_key
       )
       StatsD.increment("#{STATSD_KEY_PREFIX}.submission_failure_email_sent")
+      StatsD.increment('silent_failure_avoided_no_confirmation', tags: DD_ZSF_TAGS)
     end
 
     def perform(encrypted_form, user_uuid)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*

Adds [additional logging[(https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/practices/zero-silent-failures/logging-silent-failures.md) required for the ZSF initiative.

## Related issue(s)

[95506](https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/95506)

## Testing done

- [x] *New code is covered by unit tests*
- [ ] Ensure logging metric appears in DD in staging

## What areas of the site does it impact?
Form 10-10 EZR

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
