### PR TITLE
[DBX-94173] fix timestamp string bug in 526 failure email

### DIFF
--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -76,7 +76,7 @@ class Form526StatusPollingJob
 
   def notify_veteran(submission_id)
     if Flipper.enabled?(:send_backup_submission_polling_failure_email_notice)
-      Form526SubmissionFailureEmailJob.perform_async(submission_id, Time.now.utc)
+      Form526SubmissionFailureEmailJob.perform_async(submission_id, Time.now.utc.to_s)
     end
   end
 end

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -60,7 +60,7 @@ class Form526SubmissionFailureEmailJob
 
   def perform(submission_id, date_of_failure = Time.now.utc.to_s)
     @submission = Form526Submission.find(submission_id)
-    @date_of_failure = Time.new(date_of_failure)
+    @date_of_failure = Time.zone.parse(date_of_failure)
     send_email
     track_remedial_action
     log_success

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -58,9 +58,9 @@ class Form526SubmissionFailureEmailJob
     raise e
   end
 
-  def perform(submission_id, date_of_failure = Time.now.utc)
+  def perform(submission_id, date_of_failure = Time.now.utc.to_s)
     @submission = Form526Submission.find(submission_id)
-    @date_of_failure = date_of_failure
+    @date_of_failure = Time.new(date_of_failure)
     send_email
     track_remedial_action
     log_success
@@ -106,11 +106,11 @@ class Form526SubmissionFailureEmailJob
       date_submitted: submission.format_creation_time_for_mailers,
       forms_submitted: list_forms_submitted.presence || 'None',
       files_submitted: list_files_submitted.presence || 'None',
-      date_of_failure:
+      date_of_failure: parsed_date_of_failure
     }
   end
 
-  def date_of_failure
+  def parsed_date_of_failure
     @date_of_failure.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.')
   end
 

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -54,7 +54,7 @@ module Sidekiq
         )
 
         if Flipper.enabled?(:send_backup_submission_exhaustion_email_notice)
-          ::Form526SubmissionFailureEmailJob.perform_async(form526_submission_id, Time.now.utc)
+          ::Form526SubmissionFailureEmailJob.perform_async(form526_submission_id, Time.now.utc.to_s)
         end
       rescue => e
         ::Rails.logger.error(

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
             args = { 'jid' => form526_job_status.job_id, 'args' => [form526_submission.id] }
             subject.within_sidekiq_retries_exhausted_block(args) do
               expect(Form526SubmissionFailureEmailJob)
-                .to receive(:perform_async).with(form526_submission.id, timestamp)
+                .to receive(:perform_async).with(form526_submission.id, timestamp.to_s)
             end
           end
         end
@@ -81,7 +81,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
             subject.within_sidekiq_retries_exhausted_block(args) do
               expect(Form526SubmissionFailureEmailJob)
                 .not_to receive(:perform_async)
-                .with(form526_submission.id, timestamp)
+                .with(form526_submission.id, timestamp.to_s)
             end
           end
         end

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -159,14 +159,14 @@ RSpec.describe Form526StatusPollingJob, type: :job do
                 .and_return(response)
 
               expect(Form526SubmissionFailureEmailJob)
-                .not_to receive(:perform_async).with(backup_submission_a.id, timestamp)
+                .not_to receive(:perform_async).with(backup_submission_a.id, timestamp.to_s)
               expect(Form526SubmissionFailureEmailJob)
-                .not_to receive(:perform_async).with(backup_submission_b.id, timestamp)
+                .not_to receive(:perform_async).with(backup_submission_b.id, timestamp.to_s)
 
               expect(Form526SubmissionFailureEmailJob)
-                .to receive(:perform_async).once.ordered.with(backup_submission_c.id, timestamp)
+                .to receive(:perform_async).once.ordered.with(backup_submission_c.id, timestamp.to_s)
               expect(Form526SubmissionFailureEmailJob)
-                .to receive(:perform_async).once.ordered.with(backup_submission_d.id, timestamp)
+                .to receive(:perform_async).once.ordered.with(backup_submission_d.id, timestamp.to_s)
 
               Form526StatusPollingJob.new.perform
             end

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   end
 
   describe '#perform' do
+
     context 'when a user has additional form and files with their submission' do
       let!(:form526_submission) { create(:form526_submission, :with_uploads_and_ancillary_forms) }
 
@@ -40,11 +41,22 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
         }
       end
 
+      context 'when a timestamp is not passed' do
+        it 'marks the current time as the date_of_failure' do
+          Timecop.freeze(timestamp) do
+            expect(email_service).to receive(:send_email).with(expected_params)
+
+            subject.perform_async(form526_submission.id)
+            subject.drain
+          end
+        end
+      end
+
       it 'dispatches a failure notification email with the expected params' do
         Timecop.freeze(timestamp) do
           expect(email_service).to receive(:send_email).with(expected_params)
 
-          subject.perform_async(form526_submission.id)
+          subject.perform_async(form526_submission.id, timestamp.to_s)
           subject.drain
         end
       end
@@ -85,7 +97,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
         Timecop.freeze(timestamp) do
           expect(email_service).to receive(:send_email).with(expected_params)
 
-          subject.perform_async(form526_submission.id)
+          subject.perform_async(form526_submission.id, timestamp.to_s)
           subject.drain
         end
       end
@@ -117,7 +129,7 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
         Timecop.freeze(timestamp) do
           expect(email_service).to receive(:send_email).with(expected_params)
 
-          subject.perform_async(form526_submission.id)
+          subject.perform_async(form526_submission.id, timestamp.to_s)
           subject.drain
         end
       end

--- a/spec/sidekiq/form526_submission_failure_email_job_spec.rb
+++ b/spec/sidekiq/form526_submission_failure_email_job_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Form526SubmissionFailureEmailJob, type: :job do
   end
 
   describe '#perform' do
-
     context 'when a user has additional form and files with their submission' do
       let!(:form526_submission) { create(:form526_submission, :with_uploads_and_ancillary_forms) }
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
-  BUG FIX: Sidekiq converts all incomming arguments to strings. This was an oversight in the previous PR but caught in testing. This PR updates the Job to handle incomming timestamps as strings (or nil)

## Related issue(s)

- [Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94173)

## Testing done

- [x] *New code is covered by unit tests*
- Prior to the change, the job  expected a ruby Time object or nil
- After the change, the job expects a timestamp as a string

We were not able to test the built in Sidekiq behavior until this change was actually merged. Previous tests [outlined in this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/19108) only tested the object, not the Sidekiq enqueuing / argument parsing behavior. 

The new code has been validated with step through tests in a staging command line to the extent possible. This iterative testing in staging is the purpose of this ticket. error log that alerted us to this problem [can be seen here](https://vagov.ddog-gov.com/logs?query=Form526SubmissionFailureEmailJob&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1730226071070&to_ts=1730229671070&live=true)

## What areas of the site does it impact?
526 failure emails, zero silent failures

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

