### PR TITLE
94148: Rename NodCallbacksController to DecisionReviewNotificationCallbacksController

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -158,8 +158,8 @@ app/controllers/v1/post911_gi_bill_statuses_controller.rb @department-of-veteran
 app/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/supplemental_claims @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/decision_review_evidences_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
+app/controllers/v1/decision_review_notification_callbacks_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/apidocs_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/controllers/v1/nod_callbacks_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/notice_of_disagreements_controller.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/pension_ipf_callbacks_controller.rb @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/sessions_controller.rb  @department-of-veterans-affairs/octo-identity
@@ -1129,7 +1129,7 @@ spec/controllers/v0/veteran_onboardings_controller_spec.rb @department-of-vetera
 spec/controllers/v0/virtual_agent @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/virtual_agent_token_msft_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/virtual_agent_token_nlu_controller_spec.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/controllers/v1/nod_callbacks_controller_spec.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/controllers/v1/decision_review_notification_callbacks_controller_spec.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
 spec/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v1/decision_review_notification_callbacks_controller.rb
+++ b/app/controllers/v1/decision_review_notification_callbacks_controller.rb
@@ -3,7 +3,7 @@
 require 'decision_review_v1/utilities/logging_utils'
 
 module V1
-  class NodCallbacksController < ApplicationController
+  class DecisionReviewNotificationCallbacksController < ApplicationController
     include ActionController::HttpAuthentication::Token::ControllerMethods
     include DecisionReviewV1::Appeals::LoggingUtils
 

--- a/app/controllers/v1/decision_review_notification_callbacks_controller.rb
+++ b/app/controllers/v1/decision_review_notification_callbacks_controller.rb
@@ -84,7 +84,7 @@ module V1
     def authenticate_user_with_token
       authenticate_with_http_token do |token|
         is_authenticated = token == bearer_token_secret
-        Rails.logger.info('NodCallbacksController callback received', is_authenticated:)
+        Rails.logger.info('DecisionReviewNotificationCallbacksController callback received', is_authenticated:)
 
         is_authenticated
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -443,7 +443,7 @@ Rails.application.routes.draw do
     resources :supplemental_claims, only: %i[create show]
 
     scope format: false do
-      resources :nod_callbacks, only: [:create]
+      resources :nod_callbacks, only: [:create], controller: :decision_review_notification_callbacks
       resources :pension_ipf_callbacks, only: [:create]
     end
   end

--- a/spec/controllers/v1/decision_review_notification_callbacks_controller_spec.rb
+++ b/spec/controllers/v1/decision_review_notification_callbacks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe V1::NodCallbacksController, type: :controller do
+RSpec.describe V1::DecisionReviewNotificationCallbacksController, type: :controller do
   let(:notification_id) { SecureRandom.uuid }
   let(:reference) { "NOD-form-#{SecureRandom.uuid}" }
   let(:status) { 'delivered' }


### PR DESCRIPTION
## Summary

This change renames `NodCallbacksController` to `DecisionReviewNotificationCallbacksController` to reflect the real usage of the controller.

This is owned by the Benefits Decision Review team.

## Related issue(s)
#19124
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94148

## Testing done

- [x] *New code is covered by unit tests*
Tested locally and with `rails routes`

## What areas of the site does it impact?
This impacts the `v1/nod_callbacks` route

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
