### PR TITLE
Returning response object instead of just ending function on rails lo…

### DIFF
--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -156,7 +156,7 @@ module CentralMail
       )
 
       payload = payload_hash(lighthouse_service.location)
-      lighthouse_service.upload_doc(**payload)
+      response = lighthouse_service.upload_doc(**payload)
 
       if Flipper.enabled?(POLLING_FLIPPER_KEY)
         form526_submission = Form526Submission.find(@submission_id)
@@ -164,6 +164,7 @@ module CentralMail
         log_info[:form_submission_id] = form_submission_attempt.form_submission.id
       end
       Rails.logger.info('Successful Form4142 Submission to Lighthouse', log_info)
+      response
     end
 
     def generate_metadata


### PR DESCRIPTION
Bug fix for prod issue, 


The `upload_to_lighthouse` method used to return a response object, however since I added logging after what used to be the last line (the return) it was instead returning true (because that is the return of `Rails.logger.info`)



The next line is causing the error in an if condition 

https://github.com/department-of-veterans-affairs/vets-api/blob/270e3ba17dcb1e134d96f1878f3ff27ddcffa43b/app/sidekiq/central_mail/submit_form4142_job.rb#L107




Response is now true instead of an http obj, so that second condition is throwing an error.

So, this would be causing the job to overall fail, even though the job has successfully already sent/uploaded the form. Meaning it is likely sending 14 of these forms for each one submitted.