### PR TITLE
Move periodic job run to 5:10 window

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -207,7 +207,7 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   mgr.register('0 2,9,16 * * 1-5', 'VBADocuments::FlipperStatusAlert')
 
   # Rotates Lockbox/KMS record keys and _ciphertext fields every October 12th (when the KMS key auto-rotate)
-  mgr.register('10 1 * * *', 'KmsKeyRotation::BatchInitiatorJob')
+  mgr.register('10 5 * * *', 'KmsKeyRotation::BatchInitiatorJob')
 
   # Updates veteran representatives address attributes (including lat, long, location, address fields, email address, phone number) # rubocop:disable Layout/LineLength
   mgr.register('0 3 * * *', 'Representatives::QueueUpdates')


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

After merging [this change yesterday](https://github.com/department-of-veterans-affairs/vets-api/pull/19116), we noticed a [shift in the alert window](https://vagov.ddog-gov.com/monitors/199084). It's split between two windows, but does overlap with the window where the KMS job runs. While [some logs indicate record rotation failures](https://vagov.ddog-gov.com/logs?query=service%3Avets-api%20env%3Aeks-prod%20host%3A%2Avets%5C-api%5C-sidekiq%2A%2A%20status%3Aerror%20%22%2ADecryption%20failed%2A%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Casc&viz=stream&from_ts=1730265180000&to_ts=1730267100000&live=false), there’s also [a job failure that might be skewing the results](https://vagov.ddog-gov.com/logs?query=service%3Avets-api%20env%3Aeks-prod%20host%3A%2Avets%5C-api%5C-sidekiq%2A%2A%20status%3Aerror%20%40exception.cause.message%3A%22undefined%20method%20%60status%27%20for%20true%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZLb3ldo8NfCbQAAAAAAAAAYAAAAAEFaTGIzbHctQUFEUUZpTTJZaFJUb3dBTwAAACQAAAAAMDE5MmRiZTYtZjdiYy00MjE2LWJhNWYtMDdkNDFkNmUxMTY1&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Casc&viz=stream&from_ts=1730265240000&to_ts=1730266860000&live=false). To better understand the behavior, I want to move this job to a lower traffic window and observe if the alert window shifts accordingly.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95678
## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x] Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
