### PR TITLE
[10-10CG] Remove caregiver1010 flipper toggle logic

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -43,15 +43,11 @@ module V0
       client_file_name = file_name_for_pdf(@claim.veteran_data)
       file_contents    = File.read(source_file_path)
 
-      File.delete(source_file_path) if !Flipper.enabled?(:caregiver1010) && File.exist?(source_file_path)
-
       auditor.record(:pdf_download)
 
       send_data file_contents, filename: client_file_name, type: 'application/pdf', disposition: 'attachment'
     ensure
-      if Flipper.enabled?(:caregiver1010) && (source_file_path && File.exist?(source_file_path))
-        File.delete(source_file_path)
-      end
+      File.delete(source_file_path) if source_file_path && File.exist?(source_file_path)
     end
 
     def facilities


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Removed usage of `caregiver1010` flipper toggle and usage in the `CaregiversAssistanceClaimsController` download_pdf.
- 10-10 Health Apps

## Related issue(s)

- Original added as part of investigating https://github.com/department-of-veterans-affairs/va.gov-team/issues/93581

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
