### PR TITLE
[SIMPLE-FORMS] fix: update s3 client pre-signed url generation logic and add test coverage

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
@@ -70,7 +70,7 @@ module SimpleFormsApi
       def build_path(path_type, base_dir, *path_segments, ext: '.pdf')
         file_ext = path_type == :file ? ext : ''
         path = Pathname.new(base_dir.to_s).join(*path_segments)
-        path = path.to_s + file_ext unless file_ext.empty?
+        path = path.to_s + file_ext if file_ext.present?
         path.to_s
       end
 

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 require 'simple_forms_api/form_remediation/configuration/vff_config'
 
+# rubocop:disable Metrics/ModuleLength
 module SimpleFormsApi
   module FormRemediation
     RSpec.describe S3Client do
@@ -202,3 +203,4 @@ module SimpleFormsApi
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -4,203 +4,197 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 require 'simple_forms_api/form_remediation/configuration/vff_config'
 
-# rubocop:disable Metrics/ModuleLength
-module SimpleFormsApi
-  module FormRemediation
-    RSpec.describe S3Client do
-      include FileUtilities
+RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
+  include SimpleFormsApi::FormRemediation::FileUtilities
 
-      # Initial form data setup
-      let(:form_type) { '20-10207' }
-      let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
-      let(:form_data) do
-        Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read
+  # Initial form data setup
+  let(:form_type) { '20-10207' }
+  let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
+  let(:form_data) do
+    Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read
+  end
+
+  # Params setup
+  let(:attachments) { Array.new(5) { Rails.root.join(fixtures_path, 'doctors-note.pdf') } }
+  let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+  let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
+  let(:config) { SimpleFormsApi::FormRemediation::Configuration::VffConfig.new }
+  let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
+  let(:metadata) do
+    {
+      'veteranFirstName' => 'John',
+      'veteranLastName' => 'Veteran',
+      'fileNumber' => '222773333',
+      'zipCode' => '12345',
+      'source' => 'VA Platform Digital Forms',
+      'docType' => form_type,
+      'businessLine' => 'CMP'
+    }
+  end
+  let(:default_args) { { id: benefits_intake_uuid, config:, type: } }
+  let(:hydrated_submission_args) { default_args.merge(submission:, file_path:, attachments:, metadata:) }
+
+  # Mock file paths
+  let(:submission_file_name) { unique_file_name(form_type, benefits_intake_uuid) }
+  let(:s3_archive_dir) { "#{type}/#{dated_directory_name(form_type)}" }
+  let(:s3_archive_path) { "#{s3_archive_dir}/#{submission_file_name}.#{type == :remediation ? 'zip' : 'pdf'}" }
+  let(:local_archive_dir) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
+  let(:local_archive_path) do
+    "#{local_archive_dir}/#{submission_file_name}.#{type == :remediation ? 'zip' : 'pdf'}"
+  end
+
+  # Doubles and mocks
+  let(:submission_archive_double) { instance_double(SimpleFormsApi::FormRemediation::SubmissionArchive) }
+  let(:uploader) { instance_double(SimpleFormsApi::FormRemediation::Uploader) }
+  let(:carrier_wave_file) { instance_double(CarrierWave::SanitizedFile) }
+  let(:file_double) { instance_double(File, read: 'content') }
+  let(:s3_file) { instance_double(Aws::S3::Object) }
+
+  let(:manifest_entry) do
+    [
+      submission.created_at,
+      form_type,
+      benefits_intake_uuid,
+      metadata['fileNumber'],
+      metadata['veteranFirstName'],
+      metadata['veteranLastName']
+    ]
+  end
+
+  before do
+    allow(FileUtils).to receive(:mkdir_p).and_return(true)
+    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+    allow(File).to receive(:directory?).with(local_archive_path).and_return(false)
+    allow(File).to receive(:directory?).with(a_string_including('-manifest')).and_return(false)
+    allow(File).to receive(:open).with(local_archive_path).and_yield(file_double)
+    allow(File).to receive(:open).with(a_string_including('-manifest')).and_yield(file_double)
+    allow(CarrierWave::SanitizedFile).to receive(:new).with(file_double).and_return(carrier_wave_file)
+    allow(CSV).to receive(:open).and_return(true)
+    allow(SimpleFormsApi::FormRemediation::SubmissionArchive).to(receive(:new).and_return(submission_archive_double))
+    allow(submission_archive_double).to receive(:build!).and_return([local_archive_path, manifest_entry])
+    allow(SimpleFormsApi::FormRemediation::Uploader).to receive_messages(new: uploader)
+    allow(uploader).to receive(:get_s3_link).with(local_archive_path).and_return('/s3_url/stuff.pdf')
+    allow(uploader).to receive_messages(get_s3_file: s3_file, store!: carrier_wave_file)
+    allow(Rails.logger).to receive(:info).and_call_original
+    allow(Rails.logger).to receive(:error).and_call_original
+  end
+
+  %i[submission remediation].each do |archive_type|
+    describe "when archiving a #{archive_type}" do
+      let(:type) { archive_type }
+
+      describe '.fetch_presigned_url' do
       end
 
-      # Params setup
-      let(:attachments) { Array.new(5) { Rails.root.join(fixtures_path, 'doctors-note.pdf') } }
-      let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
-      let(:benefits_intake_uuid) { submission.benefits_intake_uuid }
-      let(:config) { Configuration::VffConfig.new }
-      let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
-      let(:metadata) do
-        {
-          'veteranFirstName' => 'John',
-          'veteranLastName' => 'Veteran',
-          'fileNumber' => '222773333',
-          'zipCode' => '12345',
-          'source' => 'VA Platform Digital Forms',
-          'docType' => form_type,
-          'businessLine' => 'CMP'
-        }
-      end
-      let(:default_args) { { id: benefits_intake_uuid, config:, type: } }
-      let(:hydrated_submission_args) { default_args.merge(submission:, file_path:, attachments:, metadata:) }
+      describe '#initialize' do
+        subject(:new) { described_class.new(id: benefits_intake_uuid, type:, config:) }
 
-      # Mock file paths
-      let(:submission_file_name) { unique_file_name(form_type, benefits_intake_uuid) }
-      let(:s3_archive_dir) { "#{type}/#{dated_directory_name(form_type)}" }
-      let(:s3_archive_path) { "#{s3_archive_dir}/#{submission_file_name}.#{type == :remediation ? 'zip' : 'pdf'}" }
-      let(:local_archive_dir) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
-      let(:local_archive_path) do
-        "#{local_archive_dir}/#{submission_file_name}.#{type == :remediation ? 'zip' : 'pdf'}"
-      end
-
-      # Doubles and mocks
-      let(:submission_archive_double) { instance_double(SubmissionArchive) }
-      let(:uploader) { instance_double(Uploader) }
-      let(:carrier_wave_file) { instance_double(CarrierWave::SanitizedFile) }
-      let(:file_double) { instance_double(File, read: 'content') }
-      let(:s3_file) { instance_double(Aws::S3::Object) }
-
-      let(:manifest_entry) do
-        [
-          submission.created_at,
-          form_type,
-          benefits_intake_uuid,
-          metadata['fileNumber'],
-          metadata['veteranFirstName'],
-          metadata['veteranLastName']
-        ]
-      end
-
-      before do
-        allow(FileUtils).to receive(:mkdir_p).and_return(true)
-        allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
-        allow(File).to receive(:directory?).with(local_archive_path).and_return(false)
-        allow(File).to receive(:directory?).with(a_string_including('-manifest')).and_return(false)
-        allow(File).to receive(:open).with(local_archive_path).and_yield(file_double)
-        allow(File).to receive(:open).with(a_string_including('-manifest')).and_yield(file_double)
-        allow(CarrierWave::SanitizedFile).to receive(:new).with(file_double).and_return(carrier_wave_file)
-        allow(CSV).to receive(:open).and_return(true)
-        allow(SubmissionArchive).to(receive(:new).and_return(submission_archive_double))
-        allow(submission_archive_double).to receive(:build!).and_return([local_archive_path, manifest_entry])
-        allow(Uploader).to receive_messages(new: uploader)
-        allow(uploader).to receive(:get_s3_link).with(local_archive_path).and_return('/s3_url/stuff.pdf')
-        allow(uploader).to receive_messages(get_s3_file: s3_file, store!: carrier_wave_file)
-        allow(Rails.logger).to receive(:info).and_call_original
-        allow(Rails.logger).to receive(:error).and_call_original
-      end
-
-      %i[submission remediation].each do |archive_type|
-        describe "when archiving a #{archive_type}" do
-          let(:type) { archive_type }
-
-          describe '.fetch_presigned_url' do
+        context 'when initialized with a valid benefits_intake_uuid' do
+          it 'successfully completes initialization' do
+            expect { new }.not_to raise_exception
           end
+        end
+      end
 
-          describe '#initialize' do
-            subject(:new) { described_class.new(id: benefits_intake_uuid, type:, config:) }
+      describe '#upload' do
+        shared_examples 's3 client acts as expected' do
+          context 'when no errors occur' do
+            before { upload }
 
-            context 'when initialized with a valid benefits_intake_uuid' do
-              it 'successfully completes initialization' do
-                expect { new }.not_to raise_exception
+            it 'logs "uploading" notification' do
+              expect(Rails.logger).to have_received(:info).with(
+                { message: "Uploading #{type}: #{benefits_intake_uuid} to S3 bucket" }
+              )
+            end
+
+            describe '#log_initialization' do
+              it 'logs s3 client initialization notification' do
+                expect(Rails.logger).to have_received(:info).with(
+                  { message: "Initialized S3Client for #{type} with ID: #{benefits_intake_uuid}" }
+                )
+              end
+            end
+
+            describe '#build_archive!' do
+              it 'initializes the submission archive' do
+                expect(SimpleFormsApi::FormRemediation::SubmissionArchive).to have_received(:new)
+              end
+
+              it 'builds the submission archive' do
+                expect(submission_archive_double).to have_received(:build!)
+              end
+            end
+
+            describe '#upload_to_s3' do
+              it 'opens the correct file path(s) and creates/stores sanitized file(s)' do
+                expect(File).to have_received(:open).with(local_archive_path).once
+                expect(File).to have_received(:open).with(a_string_including('-manifest')).once if type == :remediation
+
+                times = type == :remediation ? 2 : 1
+                expect(CarrierWave::SanitizedFile).to have_received(:new).with(file_double).exactly(times).times
+                expect(uploader).to have_received(:store!).with(carrier_wave_file).exactly(times).times
+              end
+            end
+
+            describe '#update_manifest'
+            describe '#build_s3_manifest_path'
+            describe '#download_manifest'
+            describe '#write_and_upload_manifest'
+
+            describe '#s3_uploader' do
+              it 'initializes uploader with correct directory' do
+                expect(SimpleFormsApi::FormRemediation::Uploader).to have_received(:new).with(
+                  config:, directory: s3_archive_dir
+                )
+              end
+            end
+
+            describe '#s3_directory_path'
+
+            describe '#generate_presigned_url' do
+              it 'requests the s3 link for the correct file' do
+                expect(uploader).to have_received(:get_s3_link).with(local_archive_path)
+              end
+            end
+
+            describe '#s3_upload_file_path'
+            describe '#presign_required?'
+            describe '#manifest_required?'
+
+            describe '#cleanup!' do
+              it 'logs clean up notification' do
+                expect(Rails.logger).to have_received(:info).with(
+                  { message: "Cleaning up path: #{local_archive_path}" }
+                )
               end
             end
           end
 
-          describe '#upload' do
-            shared_examples 's3 client acts as expected' do
-              context 'when no errors occur' do
-                before { upload }
+          context 'when an error occurs' do
+            before { allow(File).to receive(:directory?).and_raise('oops') }
 
-                it 'logs "uploading" notification' do
-                  expect(Rails.logger).to have_received(:info).with(
-                    { message: "Uploading #{type}: #{benefits_intake_uuid} to S3 bucket" }
-                  )
-                end
-
-                describe '#log_initialization' do
-                  it 'logs s3 client initialization notification' do
-                    expect(Rails.logger).to have_received(:info).with(
-                      { message: "Initialized S3Client for #{type} with ID: #{benefits_intake_uuid}" }
-                    )
-                  end
-                end
-
-                describe '#build_archive!' do
-                  it 'initializes the submission archive' do
-                    expect(SubmissionArchive).to have_received(:new)
-                  end
-
-                  it 'builds the submission archive' do
-                    expect(submission_archive_double).to have_received(:build!)
-                  end
-                end
-
-                describe '#upload_to_s3' do
-                  it 'opens the correct file path(s) and creates/stores sanitized file(s)' do
-                    expect(File).to have_received(:open).with(local_archive_path).once
-                    if type == :remediation
-                      expect(File).to have_received(:open).with(a_string_including('-manifest')).once
-                    end
-
-                    times = type == :remediation ? 2 : 1
-                    expect(CarrierWave::SanitizedFile).to have_received(:new).with(file_double).exactly(times).times
-                    expect(uploader).to have_received(:store!).with(carrier_wave_file).exactly(times).times
-                  end
-                end
-
-                describe '#update_manifest'
-                describe '#build_s3_manifest_path'
-                describe '#download_manifest'
-                describe '#write_and_upload_manifest'
-
-                describe '#s3_uploader' do
-                  it 'initializes uploader with correct directory' do
-                    expect(Uploader).to have_received(:new).with(config:, directory: s3_archive_dir)
-                  end
-                end
-
-                describe '#s3_directory_path'
-
-                describe '#generate_presigned_url' do
-                  it 'requests the s3 link for the correct file' do
-                    expect(uploader).to have_received(:get_s3_link).with(local_archive_path)
-                  end
-                end
-
-                describe '#s3_upload_file_path'
-                describe '#presign_required?'
-                describe '#manifest_required?'
-
-                describe '#cleanup!' do
-                  it 'logs clean up notification' do
-                    expect(Rails.logger).to have_received(:info).with(
-                      { message: "Cleaning up path: #{local_archive_path}" }
-                    )
-                  end
-                end
-              end
-
-              context 'when an error occurs' do
-                before { allow(File).to receive(:directory?).and_raise('oops') }
-
-                it 'raises the error' do
-                  expect { upload }.to raise_exception(RuntimeError, 'oops')
-                end
-              end
-            end
-
-            context 'when initialized with a valid id' do
-              let(:archive_instance) { described_class.new(**default_args) }
-
-              subject(:upload) { archive_instance.upload }
-
-              include_examples 's3 client acts as expected'
-            end
-
-            context 'when initialized with valid submission data' do
-              let(:archive_instance) { described_class.new(**hydrated_submission_args) }
-
-              subject(:upload) { archive_instance.upload }
-
-              include_examples 's3 client acts as expected'
+            it 'raises the error' do
+              expect { upload }.to raise_exception(RuntimeError, 'oops')
             end
           end
+        end
+
+        context 'when initialized with a valid id' do
+          subject(:upload) { archive_instance.upload }
+
+          let(:archive_instance) { described_class.new(**default_args) }
+
+          include_examples 's3 client acts as expected'
+        end
+
+        context 'when initialized with valid submission data' do
+          subject(:upload) { archive_instance.upload }
+
+          let(:archive_instance) { described_class.new(**hydrated_submission_args) }
+
+          include_examples 's3 client acts as expected'
         end
       end
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -99,7 +99,7 @@ module SimpleFormsApi
           end
 
           describe '#upload' do
-            shared_examples 'thing' do
+            shared_examples 's3 client acts as expected' do
               context 'when no errors occur' do
                 before { upload }
 
@@ -179,7 +179,7 @@ module SimpleFormsApi
 
               subject(:upload) { archive_instance.upload }
 
-              include_examples 'thing'
+              include_examples 's3 client acts as expected'
             end
 
             context 'when initialized with valid submission data' do
@@ -187,7 +187,7 @@ module SimpleFormsApi
 
               subject(:upload) { archive_instance.upload }
 
-              include_examples 'thing'
+              include_examples 's3 client acts as expected'
             end
           end
         end

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -4,183 +4,182 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 require 'simple_forms_api/form_remediation/configuration/vff_config'
 
-# rubocop:disable Metrics/ModuleLength
-module SimpleFormsApi
-  module FormRemediation
-    RSpec.describe SubmissionArchive do
-      include FileUtilities
+RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
+  include SimpleFormsApi::FormRemediation::FileUtilities
 
-      let(:form_type) { '20-10207' }
-      let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
-      let(:form_data) do
-        Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read
-      end
-      let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
-      let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
-      let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
-      let(:benefits_intake_uuid) { submission&.benefits_intake_uuid }
-      let(:metadata) do
-        {
-          veteranFirstName: 'John',
-          veteranLastName: 'Veteran',
-          fileNumber: '321540987',
-          zipCode: '12345',
-          source: 'VA Platform Digital Forms',
-          docType: '20-10207',
-          businessLine: 'CMP'
-        }
-      end
-      let(:submission_file_path) { unique_file_name(form_type, benefits_intake_uuid) }
-      let(:new_submission_instance) { instance_double(SubmissionRemediationData) }
-      let(:hydrated_submission_instance) do
-        instance_double(SubmissionRemediationData, submission:, file_path:, attachments:, metadata:)
-      end
-      let(:config) { Configuration::VffConfig.new }
-      let(:temp_file_path) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
-      let(:default_args) { { id: benefits_intake_uuid, config:, type: } }
-      let(:hydrated_submission_args) { default_args.merge(submission:, file_path:, attachments:, metadata:) }
+  let(:form_type) { '20-10207' }
+  let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
+  let(:form_data) do
+    Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read
+  end
+  let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
+  let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
+  let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+  let(:benefits_intake_uuid) { submission&.benefits_intake_uuid }
+  let(:metadata) do
+    {
+      veteranFirstName: 'John',
+      veteranLastName: 'Veteran',
+      fileNumber: '321540987',
+      zipCode: '12345',
+      source: 'VA Platform Digital Forms',
+      docType: '20-10207',
+      businessLine: 'CMP'
+    }
+  end
+  let(:submission_file_path) { unique_file_name(form_type, benefits_intake_uuid) }
+  let(:new_submission_instance) { instance_double(SimpleFormsApi::FormRemediation::SubmissionRemediationData) }
+  let(:hydrated_submission_instance) do
+    instance_double(SimpleFormsApi::FormRemediation::SubmissionRemediationData, submission:, file_path:, attachments:,
+                                                                                metadata:)
+  end
+  let(:config) { SimpleFormsApi::FormRemediation::Configuration::VffConfig.new }
+  let(:temp_file_path) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
+  let(:default_args) { { id: benefits_intake_uuid, config:, type: } }
+  let(:hydrated_submission_args) { default_args.merge(submission:, file_path:, attachments:, metadata:) }
 
-      before do
-        allow(FormSubmission).to receive(:find_by).and_return(submission)
-        allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
-        allow(SubmissionRemediationData).to receive(:new).and_return(new_submission_instance)
-        allow(new_submission_instance).to receive_messages(hydrate!: hydrated_submission_instance)
-        allow(File).to receive_messages(write: true, directory?: true)
-        allow(CSV).to receive(:open).and_return(true)
-        allow(FileUtils).to receive(:mkdir_p).and_return(true)
-      end
+  before do
+    allow(FormSubmission).to receive(:find_by).and_return(submission)
+    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+    allow(SimpleFormsApi::FormRemediation::SubmissionRemediationData).to(
+      receive(:new).and_return(new_submission_instance)
+    )
+    allow(new_submission_instance).to receive_messages(hydrate!: hydrated_submission_instance)
+    allow(File).to receive_messages(write: true, directory?: true)
+    allow(CSV).to receive(:open).and_return(true)
+    allow(FileUtils).to receive(:mkdir_p).and_return(true)
+  end
 
-      %i[submission remediation].each do |archive_type|
-        describe "when archiving a #{archive_type}" do
-          let(:type) { archive_type }
+  %i[submission remediation].each do |archive_type|
+    describe "when archiving a #{archive_type}" do
+      let(:type) { archive_type }
 
-          describe '#initialize' do
-            subject(:archive_instance) { described_class.new(**args) }
+      describe '#initialize' do
+        subject(:archive_instance) { described_class.new(**args) }
 
-            context 'when initialized with a valid id' do
-              let(:args) { default_args }
+        context 'when initialized with a valid id' do
+          let(:args) { default_args }
 
-              it 'successfully completes initialization' do
-                expect { archive_instance }.not_to raise_exception
-              end
+          it 'successfully completes initialization' do
+            expect { archive_instance }.not_to raise_exception
+          end
 
-              context 'when no id is passed' do
-                let(:benefits_intake_uuid) { nil }
+          context 'when no id is passed' do
+            let(:benefits_intake_uuid) { nil }
 
-                it 'raises an exception' do
-                  expect { archive_instance }.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
-                end
-              end
-
-              context 'when no config is passed' do
-                let(:config) { nil }
-
-                it 'raises an exception' do
-                  expect { archive_instance }.to raise_exception(NoConfigurationError, 'No configuration was provided')
-                end
-              end
-            end
-
-            context 'when initialized with valid hydrated submission data' do
-              let(:args) { hydrated_submission_args }
-
-              it 'successfully completes initialization' do
-                expect { archive_instance }.not_to raise_exception
-              end
-
-              context 'when no submission is passed' do
-                let(:submission) { nil }
-                let(:benefits_intake_uuid) { 'random-letters-n-numbers' }
-
-                it 'successfully completes initialization' do
-                  expect { archive_instance }.not_to raise_exception
-                end
-
-                context 'when no id is passed' do
-                  let(:benefits_intake_uuid) { nil }
-
-                  it 'raises an exception' do
-                    expect { archive_instance }.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
-                  end
-                end
-              end
+            it 'raises an exception' do
+              expect { archive_instance }.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
             end
           end
 
-          describe '#build!' do
-            let(:file_name) { "#{temp_file_path}/#{submission_file_path}.#{type == :remediation ? 'zip' : 'pdf'}" }
+          context 'when no config is passed' do
+            let(:config) { nil }
 
-            before do
-              allow(archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
-                s3_dir = build_path(:dir, parent_dir, 'remediation')
-                s3_file_path = build_path(:file, s3_dir, filename, ext: '.zip')
-                build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
-              end
-              build_archive
-            end
-
-            shared_examples 'successfully built submission archive' do
-              it 'builds the file path correctly' do
-                expect(build_archive.first).to include(file_name)
-              end
-
-              it 'builds the manifest entry correctly' do
-                expect(build_archive.second).to eq(
-                  [
-                    submission.created_at,
-                    form_type,
-                    benefits_intake_uuid,
-                    metadata['fileNumber'],
-                    metadata['veteranFirstName'],
-                    metadata['veteranLastName']
-                  ]
-                )
-              end
-
-              it 'writes the submission pdf file' do
-                expect(File).to have_received(:write).with(
-                  "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-                )
-              end
-
-              it 'writes the attachment files' do
-                attachments.each_with_index do |_, i|
-                  expect(File).to have_received(:write).with(
-                    "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-                  )
-                end
-              end
-
-              it 'zips the directory when necessary' do
-                if type == :submission
-                  expect(archive_instance).not_to have_received(:zip_directory!)
-                else
-                  expect(archive_instance).to have_received(:zip_directory!).with(
-                    config.parent_dir, "#{temp_file_path}/", submission_file_path
-                  )
-                end
-              end
-            end
-
-            context 'when initialized with a valid id' do
-              let(:archive_instance) { described_class.new(**default_args) }
-
-              subject(:build_archive) { archive_instance.build! }
-
-              include_examples 'successfully built submission archive'
-            end
-
-            context 'when initialized with valid submission data' do
-              let(:archive_instance) { described_class.new(**hydrated_submission_args) }
-
-              subject(:build_archive) { archive_instance.build! }
-
-              include_examples 'successfully built submission archive'
+            it 'raises an exception' do
+              expect { archive_instance }.to(
+                raise_exception(SimpleFormsApi::FormRemediation::NoConfigurationError, 'No configuration was provided')
+              )
             end
           end
+        end
+
+        context 'when initialized with valid hydrated submission data' do
+          let(:args) { hydrated_submission_args }
+
+          it 'successfully completes initialization' do
+            expect { archive_instance }.not_to raise_exception
+          end
+
+          context 'when no submission is passed' do
+            let(:submission) { nil }
+            let(:benefits_intake_uuid) { 'random-letters-n-numbers' }
+
+            it 'successfully completes initialization' do
+              expect { archive_instance }.not_to raise_exception
+            end
+
+            context 'when no id is passed' do
+              let(:benefits_intake_uuid) { nil }
+
+              it 'raises an exception' do
+                expect { archive_instance }.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
+              end
+            end
+          end
+        end
+      end
+
+      describe '#build!' do
+        let(:file_name) { "#{temp_file_path}/#{submission_file_path}.#{type == :remediation ? 'zip' : 'pdf'}" }
+
+        before do
+          allow(archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
+            s3_dir = build_path(:dir, parent_dir, 'remediation')
+            s3_file_path = build_path(:file, s3_dir, filename, ext: '.zip')
+            build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
+          end
+          build_archive
+        end
+
+        shared_examples 'successfully built submission archive' do
+          it 'builds the file path correctly' do
+            expect(build_archive.first).to include(file_name)
+          end
+
+          it 'builds the manifest entry correctly' do
+            expect(build_archive.second).to eq(
+              [
+                submission.created_at,
+                form_type,
+                benefits_intake_uuid,
+                metadata['fileNumber'],
+                metadata['veteranFirstName'],
+                metadata['veteranLastName']
+              ]
+            )
+          end
+
+          it 'writes the submission pdf file' do
+            expect(File).to have_received(:write).with(
+              "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+            )
+          end
+
+          it 'writes the attachment files' do
+            attachments.each_with_index do |_, i|
+              expect(File).to have_received(:write).with(
+                "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+              )
+            end
+          end
+
+          it 'zips the directory when necessary' do
+            if type == :submission
+              expect(archive_instance).not_to have_received(:zip_directory!)
+            else
+              expect(archive_instance).to have_received(:zip_directory!).with(
+                config.parent_dir, "#{temp_file_path}/", submission_file_path
+              )
+            end
+          end
+        end
+
+        context 'when initialized with a valid id' do
+          subject(:build_archive) { archive_instance.build! }
+
+          let(:archive_instance) { described_class.new(**default_args) }
+
+          include_examples 'successfully built submission archive'
+        end
+
+        context 'when initialized with valid submission data' do
+          subject(:build_archive) { archive_instance.build! }
+
+          let(:archive_instance) { described_class.new(**hydrated_submission_args) }
+
+          include_examples 'successfully built submission archive'
         end
       end
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -4,253 +4,214 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 require 'simple_forms_api/form_remediation/configuration/vff_config'
 
-RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
-  include SimpleFormsApi::FormRemediation::FileUtilities
+module SimpleFormsApi
+  module FormRemediation
+    RSpec.describe SubmissionArchive do
+      include FileUtilities
 
-  let(:form_type) { '20-10207' }
-  let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
-  let(:form_data) { Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read }
-  let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
-  let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
-  let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
-  let(:type) { :remediation }
-  let(:benefits_intake_uuid) { submission&.benefits_intake_uuid }
-  let(:metadata) do
-    {
-      veteranFirstName: 'John',
-      veteranLastName: 'Veteran',
-      fileNumber: '321540987',
-      zipCode: '12345',
-      source: 'VA Platform Digital Forms',
-      docType: '20-10207',
-      businessLine: 'CMP'
-    }
-  end
-  let(:submission_file_path) do
-    [Time.zone.today.strftime('%-m.%d.%y'), 'form', form_type, 'vagov', benefits_intake_uuid].join('_')
-  end
-  let(:new_submission_instance) { instance_double(SimpleFormsApi::FormRemediation::SubmissionRemediationData) }
-  let(:hydrated_submission_instance) do
-    instance_double(
-      SimpleFormsApi::FormRemediation::SubmissionRemediationData, submission:, file_path:, attachments:, metadata:
-    )
-  end
-  let(:config) { SimpleFormsApi::FormRemediation::Configuration::VffConfig.new }
-  let(:id_archive_instance) { described_class.new(id: benefits_intake_uuid, config:, type:) }
-  let(:data_archive_instance) do
-    described_class.new(id: benefits_intake_uuid, config:, submission:, file_path:, attachments:, metadata:, type:)
-  end
-  let(:temp_file_path) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
+      let(:form_type) { '20-10207' }
+      let(:fixtures_path) { 'modules/simple_forms_api/spec/fixtures' }
+      let(:form_data) do
+        Rails.root.join(fixtures_path, 'form_json', 'vba_20_10207_with_supporting_documents.json').read
+      end
+      let(:file_path) { Rails.root.join(fixtures_path, 'pdfs', 'vba_20_10207-completed.pdf') }
+      let(:attachments) { Array.new(5) { fixture_file_upload('doctors-note.pdf', 'application/pdf').path } }
+      let(:submission) { create(:form_submission, :pending, form_type:, form_data:) }
+      let(:benefits_intake_uuid) { submission&.benefits_intake_uuid }
+      let(:metadata) do
+        {
+          veteranFirstName: 'John',
+          veteranLastName: 'Veteran',
+          fileNumber: '321540987',
+          zipCode: '12345',
+          source: 'VA Platform Digital Forms',
+          docType: '20-10207',
+          businessLine: 'CMP'
+        }
+      end
+      let(:submission_file_path) { unique_file_name(form_type, benefits_intake_uuid) }
+      let(:new_submission_instance) { instance_double(SubmissionRemediationData) }
+      let(:hydrated_submission_instance) do
+        instance_double(SubmissionRemediationData, submission:, file_path:, attachments:, metadata:)
+      end
+      let(:config) { Configuration::VffConfig.new }
+      let(:temp_file_path) { Rails.root.join('tmp', 'random-letters-n-numbers-archive').to_s }
 
-  before do
-    allow(FormSubmission).to receive(:find_by).and_return(submission)
-    allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
-    allow(SimpleFormsApi::FormRemediation::SubmissionRemediationData).to(
-      receive(:new).and_return(new_submission_instance)
-    )
-    allow(new_submission_instance).to receive_messages(hydrate!: hydrated_submission_instance)
-    allow(File).to receive_messages(write: true, directory?: true)
-    allow(CSV).to receive(:open).and_return(true)
-    allow(FileUtils).to receive(:mkdir_p).and_return(true)
-    allow(id_archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
-      s3_dir = build_path(:dir, parent_dir, 'remediation')
-      s3_file_path = build_path(:file, s3_dir, filename, ext: '.zip')
-      build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
-    end
-    allow(data_archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
-      s3_dir = build_path(:dir, parent_dir, 'remediation')
-      s3_file_path = build_path(:file, s3_dir, filename, ext: '.zip')
-      build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
-    end
-  end
-
-  describe '#initialize' do
-    context 'when initialized with a valid id' do
-      subject(:new) { id_archive_instance }
-
-      it 'successfully completes initialization' do
-        expect { new }.not_to raise_exception
+      before do
+        allow(FormSubmission).to receive(:find_by).and_return(submission)
+        allow(SecureRandom).to receive(:hex).and_return('random-letters-n-numbers')
+        allow(SubmissionRemediationData).to receive(:new).and_return(new_submission_instance)
+        allow(new_submission_instance).to receive_messages(hydrate!: hydrated_submission_instance)
+        allow(File).to receive_messages(write: true, directory?: true)
+        allow(CSV).to receive(:open).and_return(true)
+        allow(FileUtils).to receive(:mkdir_p).and_return(true)
       end
 
-      context 'when no id is passed' do
-        it 'raises an exception' do
-          expect { described_class.new(id: nil, config:, type:) }.to(
-            raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
-          )
-        end
-      end
+      %i[submission remediation].each do |type|
+        describe "when archiving a #{type}" do
+          let(:default_args) { { id: benefits_intake_uuid, config:, type: } }
+          let(:hydrated_submission_args) { default_args.merge(submission:, file_path:, attachments:, metadata:) }
 
-      context 'when no config is passed' do
-        it 'raises an exception' do
-          expect { described_class.new(id: benefits_intake_uuid, config: nil, type:) }.to(
-            raise_exception(SimpleFormsApi::FormRemediation::NoConfigurationError, 'No configuration was provided')
-          )
-        end
-      end
-    end
+          describe '#initialize' do
+            context 'when initialized with a valid id' do
+              subject(:new) { described_class.new(**default_args) }
 
-    context 'when initialized with valid hydrated submission data' do
-      subject(:new) { data_archive_instance }
+              it 'successfully completes initialization' do
+                expect { new }.not_to raise_exception
+              end
 
-      it 'successfully completes initialization' do
-        expect { new }.not_to raise_exception
-      end
+              context 'when no id is passed' do
+                let(:benefits_intake_uuid) { nil }
 
-      context 'when no submission is passed' do
-        let(:submission) { nil }
-        let(:benefits_intake_uuid) { 'random-letters-n-numbers' }
+                it 'raises an exception' do
+                  expect { new }.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
+                end
+              end
 
-        it 'successfully completes initialization' do
-          expect { new }.not_to raise_exception
-        end
+              context 'when no config is passed' do
+                let(:config) { nil }
 
-        context 'when no id is passed' do
-          it 'raises an exception' do
-            expect do
-              described_class.new(id: nil, config:, submission:, file_path:, attachments:, metadata:, type:)
-            end.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
-          end
-        end
-      end
-    end
-  end
+                it 'raises an exception' do
+                  expect { new }.to raise_exception(NoConfigurationError, 'No configuration was provided')
+                end
+              end
+            end
 
-  describe '#build!' do
-    let(:zip_file_path) { "#{temp_file_path}/#{submission_file_path}.zip" }
+            context 'when initialized with valid hydrated submission data' do
+              subject(:new) { described_class.new(**hydrated_submission_args) }
 
-    before { build_archive }
+              it 'successfully completes initialization' do
+                expect { new }.not_to raise_exception
+              end
 
-    context 'when archiving a remediation package' do
-      context 'when initialized with a valid id' do
-        subject(:build_archive) { id_archive_instance.build! }
+              context 'when no submission is passed' do
+                let(:submission) { nil }
+                let(:benefits_intake_uuid) { 'random-letters-n-numbers' }
 
-        it 'builds the zip path correctly' do
-          expect(build_archive[0]).to include(zip_file_path)
-        end
+                it 'successfully completes initialization' do
+                  expect { new }.not_to raise_exception
+                end
 
-        it 'builds the manifest entry correctly' do
-          expect(build_archive[1]).to eq(
-            [
-              submission.created_at,
-              form_type,
-              benefits_intake_uuid,
-              metadata['fileNumber'],
-              metadata['veteranFirstName'],
-              metadata['veteranLastName']
-            ]
-          )
-        end
+                context 'when no id is passed' do
+                  let(:benefits_intake_uuid) { nil }
 
-        it 'writes the submission pdf file' do
-          expect(File).to have_received(:write).with(
-            "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-          )
-        end
-
-        it 'writes the attachment files' do
-          attachments.each_with_index do |_, i|
-            expect(File).to have_received(:write).with(
-              "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-            )
-          end
-        end
-
-        it 'zips the directory' do
-          expect(id_archive_instance).to have_received(:zip_directory!).with(
-            config.parent_dir,
-            a_string_including('/tmp/random-letters-n-numbers-archive/'),
-            a_string_including(submission_file_path)
-          )
-        end
-      end
-
-      context 'when initialized with valid submission data' do
-        subject(:build_archive) { data_archive_instance.build! }
-
-        it 'builds the zip path correctly' do
-          expect(build_archive[0]).to include(zip_file_path)
-        end
-
-        it 'builds the manifest entry correctly' do
-          expect(build_archive[1]).to eq(
-            [
-              submission.created_at,
-              form_type,
-              benefits_intake_uuid,
-              metadata['fileNumber'],
-              metadata['veteranFirstName'],
-              metadata['veteranLastName']
-            ]
-          )
-        end
-
-        it 'writes the submission pdf file' do
-          expect(File).to have_received(:write).with(
-            "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-          )
-        end
-
-        it 'writes the attachment files' do
-          attachments.each_with_index do |_, i|
-            expect(File).to have_received(:write).with(
-              "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-            )
-          end
-        end
-
-        it 'zips the directory' do
-          expect(data_archive_instance).to have_received(:zip_directory!).with(
-            config.parent_dir,
-            a_string_including('/tmp/random-letters-n-numbers-archive/'),
-            a_string_including(submission_file_path)
-          )
-        end
-      end
-
-      context 'when archiving a submission' do
-        let(:type) { :submission }
-
-        context 'when initialized with a valid id' do
-          subject(:build_archive) { id_archive_instance.build! }
-
-          it 'builds the pdf path correctly' do
-            expect(build_archive[0]).to include(submission_file_path)
+                  it 'raises an exception' do
+                    expect { new }.to raise_exception(RuntimeError, 'No benefits_intake_uuid was provided')
+                  end
+                end
+              end
+            end
           end
 
-          it 'builds the manifest entry' do
-            expect(build_archive[1]).not_to eq(nil)
-          end
+          describe '#build!' do
+            let(:file_name) { "#{temp_file_path}/#{submission_file_path}.#{type == :remediation ? 'zip' : 'pdf'}" }
 
-          it 'writes the submission pdf file' do
-            expect(File).to have_received(:write).with(
-              "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-            )
-          end
+            before do
+              allow(archive_instance).to receive(:zip_directory!) do |parent_dir, temp_dir, filename|
+                s3_dir = build_path(:dir, parent_dir, 'remediation')
+                s3_file_path = build_path(:file, s3_dir, filename, ext: '.zip')
+                build_local_path_from_s3(s3_dir, s3_file_path, temp_dir)
+              end
+              build_archive
+            end
 
-          it 'does not zip the directory' do
-            expect(id_archive_instance).not_to have_received(:zip_directory!)
-          end
-        end
+            context 'when initialized with a valid id' do
+              let(:archive_instance) { described_class.new(**default_args) }
 
-        context 'when initialized with valid submission data' do
-          subject(:build_archive) { data_archive_instance.build! }
+              subject(:build_archive) { archive_instance.build! }
 
-          it 'builds the pdf path correctly' do
-            expect(build_archive[0]).to include(submission_file_path)
-          end
+              it 'builds the file path correctly' do
+                expect(build_archive[0]).to include(file_name)
+              end
 
-          it 'builds the manifest entry' do
-            expect(build_archive[1]).not_to eq(nil)
-          end
+              it 'builds the manifest entry correctly' do
+                expect(build_archive[1]).to eq(
+                  [
+                    submission.created_at,
+                    form_type,
+                    benefits_intake_uuid,
+                    metadata['fileNumber'],
+                    metadata['veteranFirstName'],
+                    metadata['veteranLastName']
+                  ]
+                )
+              end
 
-          it 'writes the submission pdf file' do
-            expect(File).to have_received(:write).with(
-              "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
-            )
-          end
+              it 'writes the submission pdf file' do
+                expect(File).to have_received(:write).with(
+                  "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+                )
+              end
 
-          it 'does not zip the directory' do
-            expect(data_archive_instance).not_to have_received(:zip_directory!)
+              it 'writes the attachment files' do
+                attachments.each_with_index do |_, i|
+                  expect(File).to have_received(:write).with(
+                    "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+                  )
+                end
+              end
+
+              it 'zips the directory when necessary' do
+                if type == :submission
+                  expect(archive_instance).not_to have_received(:zip_directory!)
+                else
+                  expect(archive_instance).to have_received(:zip_directory!).with(
+                    config.parent_dir,
+                    a_string_including('/tmp/random-letters-n-numbers-archive/'),
+                    a_string_including(submission_file_path)
+                  )
+                end
+              end
+            end
+
+            context 'when initialized with valid submission data' do
+              let(:archive_instance) { described_class.new(**hydrated_submission_args) }
+
+              subject(:build_archive) { archive_instance.build! }
+
+              it 'builds the file path correctly' do
+                expect(build_archive[0]).to include(file_name)
+              end
+
+              it 'builds the manifest entry correctly' do
+                expect(build_archive[1]).to eq(
+                  [
+                    submission.created_at,
+                    form_type,
+                    benefits_intake_uuid,
+                    metadata['fileNumber'],
+                    metadata['veteranFirstName'],
+                    metadata['veteranLastName']
+                  ]
+                )
+              end
+
+              it 'writes the submission pdf file' do
+                expect(File).to have_received(:write).with(
+                  "#{temp_file_path}/#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+                )
+              end
+
+              it 'writes the attachment files' do
+                attachments.each_with_index do |_, i|
+                  expect(File).to have_received(:write).with(
+                    "#{temp_file_path}/attachment_#{i + 1}__#{submission_file_path}.pdf", a_string_starting_with('%PDF')
+                  )
+                end
+              end
+
+              it 'zips the directory when necessary' do
+                if type == :submission
+                  expect(archive_instance).not_to have_received(:zip_directory!)
+                else
+                  expect(archive_instance).to have_received(:zip_directory!).with(
+                    config.parent_dir,
+                    a_string_including('/tmp/random-letters-n-numbers-archive/'),
+                    a_string_including(submission_file_path)
+                  )
+                end
+              end
+            end
           end
         end
       end

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 require 'simple_forms_api/form_remediation/configuration/vff_config'
 
+# rubocop:disable Metrics/ModuleLength
 module SimpleFormsApi
   module FormRemediation
     RSpec.describe SubmissionArchive do
@@ -47,17 +48,6 @@ module SimpleFormsApi
         allow(File).to receive_messages(write: true, directory?: true)
         allow(CSV).to receive(:open).and_return(true)
         allow(FileUtils).to receive(:mkdir_p).and_return(true)
-      end
-
-      def expected_manifest_entry
-        [
-          submission.created_at,
-          form_type,
-          benefits_intake_uuid,
-          metadata['fileNumber'],
-          metadata['veteranFirstName'],
-          metadata['veteranLastName']
-        ]
       end
 
       %i[submission remediation].each do |archive_type|
@@ -131,11 +121,20 @@ module SimpleFormsApi
 
             shared_examples 'successfully built submission archive' do
               it 'builds the file path correctly' do
-                expect(build_archive[0]).to include(file_name)
+                expect(build_archive.first).to include(file_name)
               end
 
               it 'builds the manifest entry correctly' do
-                expect(build_archive[1]).to eq(expected_manifest_entry)
+                expect(build_archive.second).to eq(
+                  [
+                    submission.created_at,
+                    form_type,
+                    benefits_intake_uuid,
+                    metadata['fileNumber'],
+                    metadata['veteranFirstName'],
+                    metadata['veteranLastName']
+                  ]
+                )
               end
 
               it 'writes the submission pdf file' do
@@ -157,9 +156,7 @@ module SimpleFormsApi
                   expect(archive_instance).not_to have_received(:zip_directory!)
                 else
                   expect(archive_instance).to have_received(:zip_directory!).with(
-                    config.parent_dir,
-                    a_string_including('/tmp/random-letters-n-numbers-archive/'),
-                    a_string_including(submission_file_path)
+                    config.parent_dir, "#{temp_file_path}/", submission_file_path
                   )
                 end
               end
@@ -186,3 +183,4 @@ module SimpleFormsApi
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- This PR includes updates to the S3 client logic, and added test coverage.
- Fixes a bug
- These updates resolve issues with S3 Client pre-signed url generation
- Team: Veteran Facing Forms team, maintenance of this component is handled by our team.
- No feature toggle introduced

## Related issue(s)

- [Implement S3 PDF Storage and Pre-Signed URL Generation for Successful Submissions](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1622)
- [Epic: Enable PDF Access, Storage, and Download Functionality for Submitted Forms](https://github.com/department-of-veterans-affairs/VA.gov-team-forms#1620)

## Testing done

- [x] New code is covered by unit tests.
- No flipper involved, so flipper testing is not required.

## What areas of the site does it impact?

- This impacts the VFF team's S3 client operations. No other areas are expected to be impacted.

## Requested Feedback

- None required; changes are straightforward.
