### PR TITLE
MHV-63968: CCD download date param parsed and modified headers fixed

### DIFF
--- a/lib/medical_records/bb_internal/client.rb
+++ b/lib/medical_records/bb_internal/client.rb
@@ -112,9 +112,9 @@ module BBInternal
     # @return - Continuity of Care Document in XML format
     #
     def get_download_ccd(date)
-      token_headers['Accept'] = 'application/xml'
-
-      response = perform(:get, "bluebutton/healthsummary/#{date}/fileFormat/XML/ccdType/XML", nil, token_headers)
+      modified_headers = token_headers.dup
+      modified_headers['Accept'] = 'application/xml'
+      response = perform(:get, "bluebutton/healthsummary/#{date}/fileFormat/XML/ccdType/XML", nil, modified_headers)
       response.body
     end
 

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/ccd_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/ccd_controller.rb
@@ -15,6 +15,7 @@ module MyHealth
         # @param generated_datetime [String] date receieved from get_generate_ccd call property dateGenerated
         # @return [XML] Continuity of Care Document
         def download
+          generated_datetime = params[:date]
           resource = bb_client.get_download_ccd(generated_datetime)
           send_data resource, type: 'application/xml'
         end


### PR DESCRIPTION
## Summary
- Added parameter parsing to the CCD download endpoint in the ccd_controller
- Fixed the headers to be modified appropriately so that Accept is set to application/xml
- These changes were left behind when this PR was created: https://jira.devops.va.gov/browse/MHV-63375?devStatusDetailDialog=pullrequest

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-63968

> ### CCD download returning a 406
> Download CCD endpoint is returning a 406 locally
> 

## Testing done
No additional tests needed

## Screenshots
no UI changes

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria
Download CCD endpoint not returning a 406
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
