### PR TITLE
[SIMPLE-FORMS] fix: update s3 client logic to properly set pre-signed url

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
@@ -70,7 +70,7 @@ module SimpleFormsApi
       def build_path(path_type, base_dir, *path_segments, ext: '.pdf')
         file_ext = path_type == :file ? ext : ''
         path = Pathname.new(base_dir.to_s).join(*path_segments)
-        path = path.to_s + file_ext unless file_ext.empty?
+        path = path.to_s + file_ext if file_ext.present?
         path.to_s
       end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- This PR includes updates to the S3 client logic, added test coverage is in this PR.
- Fixes a bug
- These updates resolve issues with S3 Client pre-signed url generation
- Team: Veteran Facing Forms team, maintenance of this component is handled by our team.
- No feature toggle introduced

## Related issue(s)

- [Implement S3 PDF Storage and Pre-Signed URL Generation for Successful Submissions](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1622)
- [Epic: Enable PDF Access, Storage, and Download Functionality for Submitted Forms](https://github.com/department-of-veterans-affairs/VA.gov-team-forms#1620)

## Testing done

- [x] New code is covered by unit tests (additional coverage in another PR).
- No flipper involved, so flipper testing is not required.

## What areas of the site does it impact?

- This impacts the VFF team's S3 client operations. No other areas are expected to be impacted.

## Requested Feedback

- None required; changes are straightforward.
