### PR TITLE
API-30782-hotfix-for-failing-sync-test

### DIFF
--- a/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/526_spec.rb
@@ -4262,9 +4262,17 @@ RSpec.describe 'ClaimsApi::V2::Veterans::526', type: :request do
   describe 'POST #synchronous' do
     let(:veteran_id) { '1012832025V743496' }
     let(:synchronous_path) { "/services/claims/v2/veterans/#{veteran_id}/526/synchronous" }
+    let(:anticipated_separation_date) { 2.days.from_now.strftime('%Y-%m-%d') }
+    let(:active_duty_end_date) { 2.days.from_now.strftime('%Y-%m-%d') }
     let(:data) do
-      Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans', 'disability_compensation',
-                      'form_526_json_api.json').read
+      temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans', 'disability_compensation',
+                             'form_526_json_api.json').read
+      temp = JSON.parse(temp)
+      attributes = temp['data']['attributes']
+      attributes['serviceInformation']['federalActivation']['anticipatedSeparationDate'] = anticipated_separation_date
+      attributes['serviceInformation']['servicePeriods'][-1]['activeDutyEndDate'] = active_duty_end_date
+
+      temp.to_json
     end
     let(:schema) { Rails.root.join('modules', 'claims_api', 'config', 'schemas', 'v2', '526.json').read }
     let(:synchronous_scopes) { %w[system/526.override system/claim.write] }

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
@@ -320,6 +320,9 @@ describe 'DisabilityCompensation', openapi_spec: Rswag::TextHelpers.new.claims_a
       merged_values[:meta] = { transactionId: '00000000-0000-0000-0000-000000000000' }
       parsed_json = JSON.parse(Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
                                                'disability_compensation', 'form_526_json_api.json').read)
+      parsed_json['data']['attributes']['serviceInformation']['federalActivation']['anticipatedSeparationDate'] =
+        2.days.from_now.strftime('%Y-%m-%d')
+
       merged_values[:data] = parsed_json['data']
 
       request_template = JSON.parse(Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
@@ -322,7 +322,8 @@ describe 'DisabilityCompensation', openapi_spec: Rswag::TextHelpers.new.claims_a
                                                'disability_compensation', 'form_526_json_api.json').read)
       parsed_json['data']['attributes']['serviceInformation']['federalActivation']['anticipatedSeparationDate'] =
         2.days.from_now.strftime('%Y-%m-%d')
-
+      parsed_json['data']['attributes']['serviceInformation']['servicePeriods'][-1]['activeDutyEndDate'] =
+        2.days.from_now.strftime('%Y-%m-%d')
       merged_values[:data] = parsed_json['data']
 
       request_template = JSON.parse(Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',


### PR DESCRIPTION
## Summary
* the anticipated separation date was being pulled directly from the JSON api file and was set for 10-31.  Which is today so it no longer is in the future.  This just dynamically sets it 2 days ahead like the rest of the groups.

## Related issue(s)
[API-41632](https://jira.devops.va.gov/browse/API-41632)

## Testing done
- [x] *Adjusted existing test to work correctly tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/spec/requests/v2/veterans/526_spec.rb
	modified:   modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
