### PR TITLE
Removing to support other team model change

### DIFF
--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -244,7 +244,6 @@ module CentralMail
       if form_submission.blank?
         form_submission = FormSubmission.create(
           form_type: FORM4142_FORMSUBMISSION_TYPE, # form526_form4142
-          benefits_intake_uuid: lighthouse_service.uuid,
           form_data: '{}', # we have this already in the Form526Submission.form['form4142']
           user_account: form526_submission.user_account,
           saved_claim: form526_submission.saved_claim


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO

This change is to make the FormSubmission objects not have a benefits intake uuid, this is being abstracted out by another team. Removing to support.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94144



