### PR TITLE
fix: Only include encrypted records with non-null fields for rotation

### DIFF
--- a/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
+++ b/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
@@ -45,11 +45,11 @@ module KmsKeyRotation
       model = MODELS_FOR_QUERY[model.name] if MODELS_FOR_QUERY.key?(model.name)
 
       model
-        .where.not(encrypted_kms_key: nil)  # Only records with non-NULL encrypted_kms_key
-        .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%")  # Exclude records with current KMS version
+        .where.not(encrypted_kms_key: nil) # Only records with non-NULL encrypted_kms_key
+        .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%") # Exclude records with current KMS version
         .where(
           encrypted_columns.map { |col| model.arel_table[col].not_eq(nil) }
-                           .reduce(:or)       # At least one encrypted field is not NULL
+                           .reduce(:or) # At least one encrypted field is not NULL
         )
         .limit(max_records_per_batch)
         .pluck(model.primary_key)

--- a/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
+++ b/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
@@ -45,14 +45,15 @@ module KmsKeyRotation
       model = MODELS_FOR_QUERY[model.name] if MODELS_FOR_QUERY.key?(model.name)
 
       model
-      .where.not(encrypted_kms_key: nil)  # Include only records with a non-NULL key
-      .where(
-        encrypted_columns.map { |col| model.arel_table[col].not_eq(nil) }
-                        .reduce(:or)       # At least one encrypted field is not NULL
-      )
-      .limit(max_records_per_batch)
-      .pluck(model.primary_key)
-      .map { |id| URI::GID.build(app: GlobalID.app, model_name: model.name, model_id: id).to_s }
+        .where.not(encrypted_kms_key: nil)  # Only records with non-NULL encrypted_kms_key
+        .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%")  # Exclude records with current KMS version
+        .where(
+          encrypted_columns.map { |col| model.arel_table[col].not_eq(nil) }
+                           .reduce(:or)       # At least one encrypted field is not NULL
+        )
+        .limit(max_records_per_batch)
+        .pluck(model.primary_key)
+        .map { |id| URI::GID.build(app: GlobalID.app, model_name: model.name, model_id: id).to_s }
     end
   end
 end

--- a/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
+++ b/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
@@ -46,7 +46,8 @@ module KmsKeyRotation
 
       model
         .where.not(encrypted_kms_key: nil) # Only records with non-NULL encrypted_kms_key
-        .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%") # Exclude records with current KMS version
+        .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%")
+        # Exclude records with current KMS version
         .where(
           encrypted_columns.map { |col| model.arel_table[col].not_eq(nil) }
                            .reduce(:or) # At least one encrypted field is not NULL

--- a/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
+++ b/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
@@ -41,18 +41,10 @@ module KmsKeyRotation
     end
 
     def gids_for_model(model, max_records_per_batch)
-      encrypted_columns = model.lockbox_attributes.keys.map { |col| "#{col}_ciphertext" }
       model = MODELS_FOR_QUERY[model.name] if MODELS_FOR_QUERY.key?(model.name)
-      non_nil_encrypted_fields = encrypted_columns.map { |col| model.arel_table[col].not_eq(nil) }.reduce(:and)
-
       model
         # Exclude records with the current KMS version
         .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%")
-        .or(
-          model
-          .where(encrypted_kms_key: nil) # Include records where `encrypted_kms_key` is nil
-          .where(non_nil_encrypted_fields) # Ensure at least one encrypted field is not nil
-        )
         .limit(max_records_per_batch)
         .pluck(model.primary_key)
         .map { |id| URI::GID.build(app: GlobalID.app, model_name: model.name, model_id: id).to_s }

--- a/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
+++ b/app/sidekiq/kms_key_rotation/batch_initiator_job.rb
@@ -42,6 +42,7 @@ module KmsKeyRotation
 
     def gids_for_model(model, max_records_per_batch)
       model = MODELS_FOR_QUERY[model.name] if MODELS_FOR_QUERY.key?(model.name)
+
       model
         # Exclude records with the current KMS version
         .where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%")


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

### Summary of Changes
We've removed the code filtering out records with a nil encrypted_kms_key from the query. After investigating in the rails console, we found only one record (out of millions) with encrypted data and nil `encrypted_kms_key`, making this condition effectively a no-op.

```
Model AppealsApi::SupplementalClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AppealsApi::NoticeOfDisagreement has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AppealsApi::HigherLevelReview has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model ClaimsApi::SupportingDocument has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model ClaimsApi::PowerOfAttorney has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model ClaimsApi::EvidenceWaiverSubmission has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model CovidVaccine::V0::RegistrationSubmission has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model CovidVaccine::V0::ExpandedRegistrationSubmission has records with nil encrypted_kms_key and non-nil encrypted fields.
Record IDs: [57401]
Model DebtsApi::V0::Form5655Submission has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model HealthQuest::QuestionnaireResponse has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Vye::UserInfo has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Vye::DirectDepositChange has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Vye::AddressChange has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model ClaimsApi::AutoEstablishedClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SignIn::OAuthSession has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model UserCredentialEmail has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SecondaryAppealForm has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model PersonalInformationLog has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model PensionIpfNotification has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model NodNotification has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model InProgressForm has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model GibsNotFoundUser has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model FormSubmissionAttempt has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model FormSubmission has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Form526Submission has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Form1095B has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model EducationStemAutomatedDecision has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model DecisionReviewNotificationAuditLog has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AppealSubmission has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::Vet360::TelephoneTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::Vet360::PermissionTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::Vet360::InitializePersonTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::Vet360::EmailTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::Vet360::AddressTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::VAProfile::TelephoneTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::VAProfile::PermissionTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::VAProfile::InitializePersonTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::VAProfile::EmailTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model AsyncTransaction::VAProfile::AddressTransaction has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model PersistentAttachments::VAForm has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model PersistentAttachments::PensionBurial has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model PersistentAttachments::MilitaryRecords has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model PersistentAttachments::LgyClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model PersistentAttachments::DependencyClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Pensions::SavedClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::VeteranReadinessEmploymentClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::Pension has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::IncomeAndAssets has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::CoeClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::CaregiversAssistanceClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::Ask has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::SupplementalClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::NoticeOfDisagreement has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::HigherLevelReview has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA5495 has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA5490 has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA1995 has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA1990s has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA1990n has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA1990e has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA1990 has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA10203 has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA0994 has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationBenefits::VA0993 has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::DisabilityCompensation::Form526IncreaseOnly has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::DisabilityCompensation::Form526AllClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::EducationCareerCounselingClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::DependencyVerificationClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::DependencyClaim has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SavedClaim::Burial has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Preneeds::PreneedAttachment has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Form1010cg::Attachment has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model DecisionReviewEvidenceAttachment has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model SupportingEvidenceAttachment has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model HCAAttachment has no records with nil encrypted_kms_key and non-nil encrypted fields.
Model Form1010EzrAttachment has no records with nil encrypted_kms_key and non-nil encrypted fields.

```

```
Record IDs: [57401] - The only record - but this service has been deprecated
```



1. **Detective Work**  
   - Shifted the KMS periodic job cron to **5:10 AM**, and observed that the query duration spike followed.

2. **Refined Query to Filter Records with `encrypted_kms_key`**
   - Updated the query to target only records that have an `encrypted_kms_key` value and at least one populated encrypted field. This filters out records with `nil` values in both `encrypted_kms_key` and their encrypted fields, which don’t require rotation.
   - By focusing on records that genuinely need re-encryption, this should significantly reduce the volume of records processed.

3. **Reduced Job Load by Filtering Records in Query**
   - The parent job kicks off child jobs with batches of 100 records, leading to a high volume of jobs, especially for large tables. Now, the refined query is expected to limit the number of records passed to child jobs, reducing the overall job count.
   - This prevents unnecessary processing and minimizes load on the database during job execution.

4. **Connection Pool Optimization**
   - Connection pooling issues were identified as a potential issue, with timeout errors occurring due to the significant runs of re-encryption jobs.
   - By reducing the number of records that require re-encryption, the frequency of connection pool hits is expected to decrease, improving overall database stability and avoiding pool saturation during peak times.

5. **Monitoring Window Adjustment Considerations**
   - The monitor’s duration is set to **30 minutes**, although the actual query spikes occur in shorter bursts of around **10 minutes**. This PR doesn’t directly modify the monitoring duration but addresses the query volume to potentially reduce spikes within the existing window.

### Summary of Counts by Table
Analysis of tables showed a high count of records with `nil` in `encrypted_kms_key` across multiple models:
- `AppealsApi::SupplementalClaim`: 170,234 records with `nil` `encrypted_kms_key`
- `FormSubmissionAttempt`: 111,458 records with `nil` `encrypted_kms_key`
- `AppealSubmission`: 208,391 records with `nil` `encrypted_kms_key`

These records have been excluded from the rotation query by refining the query criteria, focusing on "straggler" records that require re-encryption due to actual changes in `encrypted_kms_key` after KMS key rotation on a yearly basis.

### Expected Outcome
- **Lower Job Count**: By reducing the number of records passed to child jobs, we expect fewer jobs to be enqueued and processed.
- **Reduced Database Load**: Optimizing the query decreases the load on the database, addressing the connection pool timeouts and high query times observed during the re-encryption job.
- **Improved Resource Efficiency**: The updated query filters out non-essential records, focusing on records that genuinely require re-encryption, reducing unnecessary job runs and database strain.

This PR should help prevent connection pool exhaustion and improve performance during key rotation by targeting only necessary records for processing.


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/95678

## Testing done
🥳  - Running this query in prod rails console returns = 0 records (for the above mentioned models/tables) needing rotation! WIN! 🥳 
```
model.where.not(encrypted_kms_key: nil).where.not('encrypted_kms_key LIKE ?', "v#{KmsEncryptedModelPatch.kms_version}:%").count
```

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
