### PR TITLE
API-41445-v1-526-validate-bank-name

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
@@ -46,6 +46,7 @@ module ClaimsApi
       # ensure the 'treatment.endDate' is after the 'treatment.startDate'
       # ensure any provided 'treatment.treatedDisabilityNames' match a provided 'disabilities.name'
       validate_form_526_treatments!
+      validate_form_526_direct_depost!
     end
 
     def validate_form_526_current_mailing_address!
@@ -528,6 +529,19 @@ module ClaimsApi
         treatment['center']['name'] = name
 
         treatment
+      end
+    end
+
+    def validate_form_526_direct_depost!
+      direct_deposit = form_attributes['directDeposit']
+      return if direct_deposit.blank?
+
+      bank_name = direct_deposit['bankName']
+      if bank_name.blank?
+        raise ::Common::Exceptions::InvalidFieldValue.new(
+          'directDeposit.bankName',
+          direct_deposit['bankName']
+        )
       end
     end
   end

--- a/modules/claims_api/spec/requests/v1/forms/526_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_spec.rb
@@ -2796,6 +2796,30 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         end
       end
     end
+
+    describe "'directDeposit.bankName" do
+      it 'is required if any other directDeposit values are present' do
+        mock_acg(scopes) do |auth_header|
+          VCR.use_cassette('claims_api/bgs/claims/claims') do
+            VCR.use_cassette('claims_api/brd/countries') do
+              direct_deposit_info = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures',
+                                                    'form_526_direct_deposit.json').read
+              json_data = JSON.parse data
+              params = json_data
+              params['data']['attributes']['directDeposit'] = JSON.parse direct_deposit_info
+              params['data']['attributes']['directDeposit']['bankName'] = ''
+
+              post path, params: params.to_json, headers: headers.merge(auth_header)
+
+              expect(response).to have_http_status(:bad_request)
+              errors = JSON.parse(response.body)['errors']
+              expected_verbiage = '"" is not a valid value for "directDeposit.bankName"'
+              expect(errors.any? { |error| error['detail'].include?(expected_verbiage) }).to be true
+            end
+          end
+        end
+      end
+    end
   end
 
   describe '#526 without flashes or special issues' do


### PR DESCRIPTION
## Summary
* Adds a validation that is any direct deposit values are present then `bankName` must also be present
* Adds test for this scenario

## Related issue(s)
[API-41445](https://jira.devops.va.gov/browse/API-41445)

## Testing done
- [x] *New code is covered by unit tests*

#### Testing Notes
* Sending in `directDeposit` information without the bank name should return
```{
    "errors": [
        {
            "title": "Invalid field value",
            "detail": "\"\" is not a valid value for \"directDeposit.bankName\"",
            "code": "103",
            "status": "400"
        }
    ]
}
```

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
	modified:   modules/claims_api/spec/requests/v1/forms/526_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
