### PR TITLE
Add representation-management to Datadog service catalog

### DIFF
--- a/datadog-service-catalog/datadog-service-catalog.yml
+++ b/datadog-service-catalog/datadog-service-catalog.yml
@@ -215,7 +215,7 @@ tier: '1'
 description: Supplemental Claims application
 lifecycle: production
 contacts:
-  - name: '#benefits-decision-reviews'
+  - name: "#benefits-decision-reviews"
     type: slack
     contact: https://dsva.slack.com/archives/C5AGLBNRK
 links:
@@ -246,7 +246,7 @@ dd-service: avs
 team: After Visit Summary
 description: Displays after visit summaries to veterans.
 contacts:
-  - name: '#after-visit-summary'
+  - name: "#after-visit-summary"
     type: slack
     contact: https://dsva.slack.com/archives/C04UBETRY8N
 integrations: {}
@@ -259,7 +259,7 @@ tier: '1'
 description: disability benefits application
 lifecycle: production
 contacts:
-  - name: '#benefits-disability'
+  - name: "#benefits-disability"
     type: slack
     contact: https://dsva.slack.com/archives/C04KW0B46N5
 links:
@@ -293,7 +293,7 @@ team: vfs-websites
 tier: '1'
 description: VA.gov homepage.
 contacts:
-  - name: '#sitewide-public-websites'
+  - name: "#sitewide-public-websites"
     type: slack
     contact: https://dsva.slack.com/archives/C52CL1PKQ
 tags:
@@ -434,7 +434,7 @@ tier: '1'
 description: Veteran medical appointment scheduling service.
 lifecycle: production
 contacts:
-  - name: '#appointments-team'
+  - name: "#appointments-team"
     type: slack
     contact: https://dsva.slack.com/archives/CMNQT72LX
 type: web

--- a/datadog-service-catalog/datadog-service-catalog.yml
+++ b/datadog-service-catalog/datadog-service-catalog.yml
@@ -1,5 +1,41 @@
 ---
 schema-version: v2.2
+dd-service: representation-management
+team: benefits
+application: Accredited Representation Management
+tier: '1'
+lifecycle: production
+contacts:
+  - name: benefits-representation-management
+    type: slack
+    contact: https://dsva.slack.com/archives/C05L6HSJLHM
+description: 'For details, visit: https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/accredited-representation-management'
+links:
+  - name: ARM in vets-api
+    type: repo
+    provider: github
+    url: https://github.com/department-of-veterans-affairs/vets-api/tree/master/modules/representation_management
+  - name: Appoint a Representative Frontend
+    type: repo
+    provider: github
+    url: https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/representative-appoint
+  - name: Find a Representative Frontend
+    type: repo
+    provider: github
+    url: https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/representative-search
+  - name: Representative Status Widget
+    type: repo
+    provider: github
+    url: https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/static-pages/representative-status
+tags:
+  - representation-management
+type: web
+languages:
+  - ruby
+  - javascript
+integrations: {}
+---
+schema-version: v2.2
 dd-service: accredited-representative-portal
 team: benefits
 application: Accredited Representative Portal
@@ -179,7 +215,7 @@ tier: '1'
 description: Supplemental Claims application
 lifecycle: production
 contacts:
-  - name: "#benefits-decision-reviews"
+  - name: '#benefits-decision-reviews'
     type: slack
     contact: https://dsva.slack.com/archives/C5AGLBNRK
 links:
@@ -210,7 +246,7 @@ dd-service: avs
 team: After Visit Summary
 description: Displays after visit summaries to veterans.
 contacts:
-  - name: "#after-visit-summary"
+  - name: '#after-visit-summary'
     type: slack
     contact: https://dsva.slack.com/archives/C04UBETRY8N
 integrations: {}
@@ -223,7 +259,7 @@ tier: '1'
 description: disability benefits application
 lifecycle: production
 contacts:
-  - name: "#benefits-disability"
+  - name: '#benefits-disability'
     type: slack
     contact: https://dsva.slack.com/archives/C04KW0B46N5
 links:
@@ -257,7 +293,7 @@ team: vfs-websites
 tier: '1'
 description: VA.gov homepage.
 contacts:
-  - name: "#sitewide-public-websites"
+  - name: '#sitewide-public-websites'
     type: slack
     contact: https://dsva.slack.com/archives/C52CL1PKQ
 tags:
@@ -398,7 +434,7 @@ tier: '1'
 description: Veteran medical appointment scheduling service.
 lifecycle: production
 contacts:
-  - name: "#appointments-team"
+  - name: '#appointments-team'
     type: slack
     contact: https://dsva.slack.com/archives/CMNQT72LX
 type: web


### PR DESCRIPTION
Resolves https://github.com/orgs/department-of-veterans-affairs/projects/1180/views/5?pane=issue&itemId=81409364&issue=department-of-veterans-affairs%7Cva.gov-team%7C93851

## Summary
- This PR adds the `representation-management` service to `datadog-service-catalog/datadog-service-catalog.yml`

## Related issue(s)
- https://github.com/orgs/department-of-veterans-affairs/projects/1180/views/5?pane=issue&itemId=81409364&issue=department-of-veterans-affairs%7Cva.gov-team%7C93851

## Testing done
NA

## Screenshots
NA

## What areas of the site does it impact?
Datadog services catalog

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
NA