### PR TITLE
Add correct Datadog service tag to FlagAccreditedRepresentativesController

### DIFF
--- a/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/flag_accredited_representatives_controller.rb
@@ -3,7 +3,7 @@
 module RepresentationManagement
   module V0
     class FlagAccreditedRepresentativesController < ApplicationController
-      service_tag 'lighthouse-veteran'
+      service_tag 'representation-management'
       before_action :feature_enabled
       skip_before_action :authenticate
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/93851


## Summary
- This PR adds the correct Datadog service tag to `FlagAccreditedRepresentativesController`

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93851

## Testing done
NA

## Screenshots
NA

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
NA
