### PR TITLE
[API-40542] Create POA Request - Return Proc ID

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -59,7 +59,7 @@ module ClaimsApi
           render json: res, status: :ok
         end
 
-        def request_representative
+        def create
           # validate target veteran exists
           target_veteran
 
@@ -81,10 +81,11 @@ module ClaimsApi
 
           # skip the BGS API calls in lower environments to prevent 3rd parties from creating data in external systems
           unless Flipper.enabled?(:lighthouse_claims_v2_poa_requests_skip_bgs)
-            ClaimsApi::PowerOfAttorneyRequestService::Orchestrator.new(target_veteran.participant_id,
-                                                                       bgs_form_attributes.deep_symbolize_keys,
-                                                                       user_profile&.profile&.participant_id,
-                                                                       :poa).submit_request
+            res = ClaimsApi::PowerOfAttorneyRequestService::Orchestrator.new(target_veteran.participant_id,
+                                                                             bgs_form_attributes.deep_symbolize_keys,
+                                                                             user_profile&.profile&.participant_id,
+                                                                             :poa).submit_request
+            form_attributes['procId'] = res['procId']
           end
 
           # return only the form information consumers provided

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -17357,7 +17357,8 @@
                         "SICKLE_CELL",
                         "HIV",
                         "ALCOHOLISM"
-                      ]
+                      ],
+                      "procId": "3857415"
                     }
                   }
                 },
@@ -17638,6 +17639,11 @@
                             "consentAddressChange": {
                               "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
                               "type": "boolean"
+                            },
+                            "procId": {
+                              "description": "The process ID of the new Power of Attorney request.",
+                              "type": "string",
+                              "example": "12345"
                             }
                           }
                         }

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -51,7 +51,7 @@ ClaimsApi::Engine.routes.draw do
         post '/:veteranId/2122a', to: 'individual#submit'
         get '/:veteranId/power-of-attorney/:id', to: 'base#status'
         # Power of Attorney Requests
-        post '/:veteranId/power-of-attorney-requests', to: 'request#create'
+        post '/:veteranId/power-of-attorney-request', to: 'request#create'
         post '/power-of-attorney-requests', to: 'request#index'
         post '/power-of-attorney-requests/decide', to: 'request#decide'
       end

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -50,8 +50,8 @@ ClaimsApi::Engine.routes.draw do
         post '/:veteranId/2122a/validate', to: 'individual#validate'
         post '/:veteranId/2122a', to: 'individual#submit'
         get '/:veteranId/power-of-attorney/:id', to: 'base#status'
-        post '/:veteranId/power-of-attorney-request', to: 'request#request_representative'
         # Power of Attorney Requests
+        post '/:veteranId/power-of-attorney-requests', to: 'request#create'
         post '/power-of-attorney-requests', to: 'request#index'
         post '/power-of-attorney-requests/decide', to: 'request#decide'
       end

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -124,6 +124,136 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
     end
   end
 
+  describe '#create' do
+    let(:scopes) { %w[claim.write] }
+    let(:form_attributes) do
+      {
+        veteran: {
+          service_number: '123678453',
+          service_branch: 'ARMY',
+          address: {
+            address_line1: '2719 Hyperion Ave',
+            address_line2: 'Apt 2',
+            city: 'Los Angeles',
+            country: 'USA',
+            state_code: 'CA',
+            zip_code: '92264',
+            zip_code_suffix: '0200'
+          },
+          phone: {
+            area_code: '555',
+            phone_number: '5551234'
+          },
+          email: 'test@test.com',
+          insurance_number: '1234567890'
+        },
+        poa: {
+          poa_code: '003',
+          registration_number: '12345',
+          job_title: 'MyJob'
+        },
+        record_consent: true,
+        consent_address_change: true,
+        consent_limits: %w[
+          DRUG_ABUSE
+          SICKLE_CELL
+          HIV
+          ALCOHOLISM
+        ]
+      }
+    end
+    let(:veteran_id) { '1012667145V762142' }
+    let(:representative_data) do
+      {
+        'poa' => {
+          'firstName' => 'John',
+          'lastName' => 'Doe'
+        }
+      }
+    end
+    let(:terminate_existing_requests) do
+      instance_double(ClaimsApi::PowerOfAttorneyRequestService::TerminateExistingRequests)
+    end
+    let(:create_request) do
+      instance_double(ClaimsApi::PowerOfAttorneyRequestService::CreateRequest)
+    end
+    let(:create_request_response) do
+      {
+        'addressLine1' => '2719 Hyperion Ave',
+        'addressLine2' => 'Apt 2',
+        'addressLine3' => nil,
+        'changeAddressAuth' => 'true',
+        'city' => 'Los Angeles',
+        'claimantPtcpntId' => '185953',
+        'claimantRelationship' => nil,
+        'formTypeCode' => '21-22',
+        'insuranceNumbers' => '1234567890',
+        'limitationAlcohol' => 'true',
+        'limitationDrugAbuse' => 'true',
+        'limitationHIV' => 'true',
+        'limitationSCA' => 'true',
+        'organizationName' => nil,
+        'otherServiceBranch' => nil,
+        'phoneNumber' => '5555551234',
+        'poaCode' => '003',
+        'postalCode' => '92264',
+        'procId' => '3857415',
+        'representativeFirstName' => nil,
+        'representativeLastName' => nil,
+        'representativeLawFirmOrAgencyName' => nil,
+        'representativeTitle' => 'MyJob',
+        'representativeType' => 'Recognized Veterans Service Organization',
+        'section7332Auth' => 'true',
+        'serviceBranch' => 'Army',
+        'serviceNumber' => '123678453',
+        'state' => 'CA',
+        'vdcStatus' => 'Submitted',
+        'veteranPtcpntId' => '185953',
+        'acceptedBy' => nil,
+        'claimantFirstName' => 'TAMARA',
+        'claimantLastName' => 'ELLIS',
+        'claimantMiddleName' => nil,
+        'declinedBy' => nil,
+        'declinedReason' => nil,
+        'secondaryStatus' => nil,
+        'veteranFirstName' => 'TAMARA',
+        'veteranLastName' => 'ELLIS',
+        'veteranMiddleName' => nil,
+        'veteranSSN' => '796130115',
+        'veteranVAFileNumber' => '00123456'
+      }
+    end
+
+    before do
+      allow_any_instance_of(ClaimsApi::FormSchemas).to receive(:validate!).and_return(nil)
+      allow_any_instance_of(described_class).to receive(:validate_accredited_representative)
+        .with(anything, anything)
+        .and_return(nil)
+      allow_any_instance_of(described_class).to receive(:validate_accredited_organization)
+        .with(anything)
+        .and_return(nil)
+      allow_any_instance_of(described_class).to receive(:representative_data).and_return(representative_data)
+      Flipper.disable(:lighthouse_claims_v2_poa_requests_skip_bgs)
+      allow(ClaimsApi::PowerOfAttorneyRequestService::TerminateExistingRequests).to receive(:new)
+        .with(anything)
+        .and_return(terminate_existing_requests)
+      allow(terminate_existing_requests).to receive(:call).and_return(nil)
+      allow(ClaimsApi::PowerOfAttorneyRequestService::CreateRequest).to receive(:new)
+        .with(anything, anything, anything, anything)
+        .and_return(create_request)
+      allow(create_request).to receive(:call).and_return(create_request_response)
+    end
+
+    it 'returns a created status and procId in the response' do
+      mock_ccg(scopes) do |auth_header|
+        create_request_with(veteran_id:, form_attributes:, auth_header:)
+
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)['data']['attributes']['procId']).to eq('3857415')
+      end
+    end
+  end
+
   def index_request_with(poa_codes:, auth_header:)
     post v2_veterans_power_of_attorney_requests_path,
          params: { data: { attributes: { poaCodes: poa_codes } } }.to_json,
@@ -133,6 +263,12 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
   def decide_request_with(proc_id:, decision:, auth_header:)
     post v2_veterans_power_of_attorney_requests_decide_path,
          params: { data: { attributes: { procId: proc_id, decision: } } }.to_json,
+         headers: auth_header
+  end
+
+  def create_request_with(veteran_id:, form_attributes:, auth_header:)
+    post "/services/claims/v2/veterans/#{veteran_id}/power-of-attorney-request",
+         params: { data: { attributes: form_attributes } }.to_json,
          headers: auth_header
   end
 end

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/power_of_attorney_request_spec.rb
@@ -168,30 +168,6 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::PowerOfAttorneyRequest', type: :
             end
           end
         end
-
-        context 'lighthouse_claims_v2_poa_requests_skip_bgs disabled' do
-          before do
-            Flipper.disable(:lighthouse_claims_v2_poa_requests_skip_bgs)
-          end
-
-          it 'responds with created status and the original request body' do
-            VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
-              mock_ccg(scopes) do |auth_header|
-                # the final return from BGS does not matter at this point in time, the calls need only to succeed
-                allow_any_instance_of(ClaimsApi::PowerOfAttorneyRequestService::Orchestrator)
-                  .to receive(:submit_request)
-                  .and_return(true)
-
-                post request_path, params: request_body, headers: auth_header
-
-                response_body = JSON.parse(response.body)
-
-                expect(response).to have_http_status(:created)
-                expect(response_body).to eq(JSON.parse(request_body))
-              end
-            end
-          end
-        end
       end
     end
 

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -987,7 +987,10 @@ describe 'PowerOfAttorney',
           after do |example|
             example.metadata[:response][:content] = {
               'application/json' => {
-                example: JSON.parse(response.body, symbolize_names: true)
+                example: JSON.parse(response.body, symbolize_names: true).tap do |json|
+                  json[:data][:attributes]
+                    .merge!(procId: '3857415')
+                end
               }
             }
           end

--- a/spec/support/schemas/claims_api/v2/veterans/power_of_attorney/request_representative/submit.json
+++ b/spec/support/schemas/claims_api/v2/veterans/power_of_attorney/request_representative/submit.json
@@ -267,6 +267,11 @@
             "consentAddressChange": {
               "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
               "type": "boolean"
+            },
+            "procId": {
+              "description": "The process ID of the new Power of Attorney request.",
+              "type": "string",
+              "example": "12345"
             }
           }
         }


### PR DESCRIPTION
## Summary

- Add the newly created `procId` returned by BGS to the `/veterans/:id/power-of-attorney-request` response.
- Update docs (staging only) to reflect the above.

## Related issue(s)

- [API-40542](https://jira.devops.va.gov/browse/API-40542)

## Testing done

- [x] *New code is covered by unit tests*

**Testing steps**

1. Disable the `lighthouse_claims_v2_poa_requests_skip_bgs` feature flag.
1. Connect to BGS and manually send the following request:
   
   ```
   curl --location 'http://localhost:3000/services/claims/v2/veterans/1012667145V762142/power-of-attorney-request' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer *****' \
   --data-raw '{
       "data": {
           "attributes": {
               "veteran": {
                   "serviceNumber": "123678453",
                   "serviceBranch": "ARMY",
                   "address": {
                       "addressLine1": "2719 Hyperion Ave",
                       "addressLine2": "Apt 2",
                       "city": "Los Angeles",
                       "country": "USA",
                       "stateCode": "CA",
                       "zipCode": "92264",
                       "zipCodeSuffix": "0200"
                   },
                   "phone": {
                       "areaCode": "555",
                       "phoneNumber": "5551234"
                   },
                   "email": "test@test.com",
                   "insuranceNumber": "1234567890"
               },
               "poa": {
                   "poaCode": "003",
                   "registrationNumber": "12345",
                   "jobTitle": "MyJob"
               },
               "recordConsent": true,
               "consentAddressChange": true,
               "consentLimits": [
                   "DRUG_ABUSE",
                   "SICKLE_CELL",
                   "HIV",
                   "ALCOHOLISM"
               ]
           }
       }
   }'
   ```
1. Observe a successful response (including the newly added `procId`).

## Screenshots

![proc-id-response](https://github.com/user-attachments/assets/a7cf4279-9787-417b-ac25-86e488a9d38f)
![proc-id-response-schema](https://github.com/user-attachments/assets/f74c2d51-8cd6-4413-bf45-471d350ffae3)


## What areas of the site does it impact?

- Power of attorney requests
- Docs

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A