### PR TITLE
BE | Ask VA Api: Update InquiryPayload and VeteranProfile

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
@@ -9,6 +9,9 @@ module AskVAApi
         class InquiryPayloadError < StandardError; end
         attr_reader :inquiry_params, :inquiry_details, :submitter_profile, :user, :veteran_profile
 
+        UNAUTHENTICATE_ID = '722310000'
+        INQUIRY_SOURCE_AVA_ID = '722310000'
+
         def initialize(inquiry_params:, user: nil)
           @inquiry_params = inquiry_params
           validate_params!
@@ -30,7 +33,7 @@ module AskVAApi
             DependantFirstName: family_member_field(:first)
           }.merge(additional_payload_fields)
 
-          payload[:LevelOfAuthentication] = 'Unauthenticated' if user.nil?
+          payload[:LevelOfAuthentication] = UNAUTHENTICATE_ID if user.nil?
 
           payload
         end
@@ -44,7 +47,7 @@ module AskVAApi
             DependantRelationship: translate_field(:dependent_relationship),
             InquiryAbout: translate_field(:inquiry_about),
             InquiryCategory: inquiry_params[:category_id],
-            InquirySource: '722_310_000',
+            InquirySource: INQUIRY_SOURCE_AVA_ID,
             InquirySubtopic: inquiry_params[:subtopic_id],
             InquirySummary: inquiry_params[:subject],
             InquiryTopic: inquiry_params[:topic_id],

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
@@ -24,7 +24,7 @@ module AskVAApi
         private
 
         def veteran_info
-          inquiry_params[:about_the_veteran]
+          @veteran_info ||= inquiry_params[:about_the_veteran] || {}
         end
 
         def base_profile

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::InquiryPayload do
       let(:authorized_user) { nil }
 
       it 'set LevelOfAuthentication to Unauthenticated' do
-        expect(builder.call[:LevelOfAuthentication]).to eq('Unauthenticated')
+        expect(builder.call[:LevelOfAuthentication]).to eq('722310000')
       end
     end
 

--- a/modules/ask_va_api/spec/support/shared_contexts.rb
+++ b/modules/ask_va_api/spec/support/shared_contexts.rb
@@ -114,7 +114,7 @@ RSpec.shared_context 'shared data' do
       DependantRelationship: nil,
       InquiryAbout: 722_310_001,
       InquiryCategory: '73524deb-d864-eb11-bb24-000d3a579c45',
-      InquirySource: '722_310_000',
+      InquirySource: '722310000',
       InquirySubtopic: '',
       InquirySummary: nil,
       InquiryTopic: 'c0da1728-d91f-ed11-b83c-001dd8069009',


### PR DESCRIPTION
## Summary
• In InquiryPayload, assigned a default LevelOfAuthentication ID for cases where user is nil. This prevents potential null errors when processing unauthenticated users.

• Fixed a nil handling bug in VeteranProfile by adding a check for veteran_info. This ensures the application gracefully handles cases where veteran_info may be missing.

### Bug Reproduction Steps:
• Attempt to access the InquiryPayload and VeteranProfile features with a missing user or veteran_info field, which previously resulted in a null pointer exception.

### Solution Explanation:
• This fix introduces additional checks to manage nil values for user and veteran_info. Assigning a default LevelOfAuthentication ID provides a fallback to ensure continued functionality without throwing errors.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/1463

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
