### PR TITLE
[10-10CG] Update log from debug to error

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -33,7 +33,7 @@ module V0
       end
     rescue => e
       unless e.is_a?(Common::Exceptions::ValidationErrors) || e.is_a?(::Form1010cg::Service::InvalidVeteranStatus)
-        Rails.logger.debug('CaregiverAssistanceClaim: error submitting claim',
+        Rails.logger.error('CaregiverAssistanceClaim: error submitting claim',
                            { saved_claim_guid: @claim.guid, error: e })
       end
       raise e

--- a/spec/requests/v0/caregivers_assistance_claims_spec.rb
+++ b/spec/requests/v0/caregivers_assistance_claims_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
   before do
     allow_any_instance_of(Form1010cg::Auditor).to receive(:record)
     allow_any_instance_of(Form1010cg::Auditor).to receive(:record_caregivers)
-    allow(Rails.logger).to receive(:debug)
+    allow(Rails.logger).to receive(:error)
   end
 
   describe 'POST /v0/caregivers_assistance_claims' do
@@ -65,7 +65,7 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
           end
 
           it 'logs the error and re-raises it' do
-            expect(Rails.logger).to receive(:debug).with(
+            expect(Rails.logger).to receive(:error).with(
               'CaregiverAssistanceClaim: error submitting claim',
               { saved_claim_guid: claim.guid, error: kind_of(StandardError) }
             )
@@ -84,7 +84,7 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
         end
 
         it 'returns backend service exception' do
-          expect(Rails.logger).not_to receive(:debug).with(
+          expect(Rails.logger).not_to receive(:error).with(
             'CaregiverAssistanceClaim: error submitting claim',
             { saved_claim_guid: claim.guid, error: instance_of(Form1010cg::Service::InvalidVeteranStatus) }
           )
@@ -114,7 +114,7 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
                                                                                claim_guid: claim.guid,
                                                                                errors: hash_including('#/': be_present)
                                                                              ))
-        expect(Rails.logger).not_to receive(:debug).with(
+        expect(Rails.logger).not_to receive(:error).with(
           'CaregiverAssistanceClaim: error submitting claim',
           { saved_claim_guid: claim.guid,
             error: instance_of(Common::Exceptions::ValidationErrors) }
@@ -161,7 +161,7 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
       end
 
       it 'logs the error and re-raises it' do
-        expect(Rails.logger).to receive(:debug).with(
+        expect(Rails.logger).to receive(:error).with(
           'CaregiverAssistanceClaim: error submitting claim',
           { saved_claim_guid: claim.guid, error: kind_of(StandardError) }
         )


### PR DESCRIPTION

## Summary

- This work is behind a feature toggle (flipper): NO
- Added new log statement for when the caregivers create endpoint raises an exception. It was original set as a debug log, but I realized in production we have `config.log_level = :info` so these logs won't be saved. This changes the log to an error so I can see the results of the logs in production. 
- 10-10 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95897

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
10-10 CG

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

