### PR TITLE
[SIMPLE-FORMS] fix: update s3 pre-fetched url logic

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -115,7 +115,7 @@ module SimpleFormsApi
       def s3_upload_file_path(type)
         extension = File.extname(archive_path)
         ext = type == :submission ? '.pdf' : '.zip'
-        build_path(:file, s3_directory_path, archive_path, ext: extension ? nil : ext)
+        build_path(:file, s3_directory_path, File.basename(archive_path), ext: extension ? nil : ext)
       end
 
       def presign_required?

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
     allow(SimpleFormsApi::FormRemediation::SubmissionArchive).to(receive(:new).and_return(submission_archive_double))
     allow(submission_archive_double).to receive(:build!).and_return([local_archive_path, manifest_entry])
     allow(SimpleFormsApi::FormRemediation::Uploader).to receive_messages(new: uploader)
-    allow(uploader).to receive(:get_s3_link).with(local_archive_path).and_return('/s3_url/stuff.pdf')
+    allow(uploader).to receive(:get_s3_link).with(s3_archive_path).and_return('/s3_url/stuff.pdf')
     allow(uploader).to receive_messages(get_s3_file: s3_file, store!: carrier_wave_file)
     allow(Rails.logger).to receive(:info).and_call_original
     allow(Rails.logger).to receive(:error).and_call_original
@@ -153,7 +153,7 @@ RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
 
             describe '#generate_presigned_url' do
               it 'requests the s3 link for the correct file' do
-                expect(uploader).to have_received(:get_s3_link).with(local_archive_path)
+                expect(uploader).to have_received(:get_s3_link).with(s3_archive_path)
               end
             end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR fixes an issue with the Form Remediation solution's S3 integration where the pre-signed URL returned after a successful file upload referenced a temporary file path instead of the actual S3 storage path. The correction ensures that users can reliably access the uploaded PDF via the provided URL.
- The bug caused a `NoSuchKey` error when accessing the pre-signed URL because it incorrectly pointed to a temporary file path.
- The solution involves modifying the `s3_upload_file_path` method to correctly build the S3 file path using the `File.basename(archive_path)`, which references the file in its final S3 location.
- The Veteran-Facing Forms team implemented and maintains this component.

## Related issue(s)

- [Bug - Fix Pre-signed URL Generation for S3 Stored PDFs in Form Remediation](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1811)

## Testing done

- [x] New code is covered by unit tests.
- Prior to the change, the pre-signed URL generated for the uploaded PDF incorrectly referenced a local temporary path, causing a `NoSuchKey` error when accessing the URL.
- Verification steps:
  - Confirm that the uploaded PDF is accessible via the generated pre-signed URL and does not return a `NoSuchKey` error.
  - Review and update unit tests in `s3_client_spec.rb` to ensure that the correct S3 key is used in the pre-signed URL generation process.
  - Run integration tests to verify the end-to-end functionality of file upload and URL generation, ensuring that the response includes a working URL to the PDF in S3.

## What areas of the site does it impact?

This impacts the Veteran-Facing Forms team's form submission process, specifically for generating and accessing pre-signed URLs for PDF downloads from S3 after form submission. No other areas of the site are impacted.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [x] Documentation has been updated (link to documentation).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [ ] Feature/bug has a monitor built into Datadog (if applicable).
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected.
- [ ] I added a screenshot of the developed feature.

## Requested Feedback

Any