### PR TITLE
[10-10G] Update async timeout from 600 to 120

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -176,7 +176,7 @@ form_10_10cg:
       client_id: ~
       client_secret: ~
       timeout: 30
-      async_timeout: 600
+      async_timeout: 120
       auth:
         mock: false
         timeout: ~


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Updating async_timeout setting for mulesoft 10-10CG submission from 600 to 120.
- 10-10 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81842
- Originally set to 600 [in this PR](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46813).

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
