### PR TITLE
Stop saving benefits_intake_uuid to form submission spec factory

### DIFF
--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -4,11 +4,8 @@ FactoryBot.define do
   factory :form_submission do
     form_type { '21-4142' }
     form_data { '{}' }
-    benefits_intake_uuid { nil }
 
     trait :pending do
-      benefits_intake_uuid { nil }
-
       form_submission_attempts { create_list(:form_submission_attempt, 1, :pending) }
     end
 


### PR DESCRIPTION
## Summary
This PR fixes an omission where I was saving a field as `nil` instead of just omitting it altogether. In a followup PR we'll remove this field from the model/table altogether.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=83134444&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1636
