### PR TITLE
#95981 monitor notification status

### DIFF
--- a/app/controllers/v1/nod_callbacks_controller.rb
+++ b/app/controllers/v1/nod_callbacks_controller.rb
@@ -24,7 +24,7 @@ module V1
       'SC' => 'supplemental-claims'
     }.freeze
 
-    VALID_FUNCTION_TYPES = %w[form evidence].freeze
+    VALID_FUNCTION_TYPES = %w[form evidence secondary_form].freeze
 
     def create
       return render json: nil, status: :not_found unless enabled?

--- a/spec/controllers/v1/nod_callbacks_controller_spec.rb
+++ b/spec/controllers/v1/nod_callbacks_controller_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe V1::NodCallbacksController, type: :controller do
 
         post(:create, params:, as: :json)
       end
+
+      context 'when the reference is for a secondary form' do
+        let(:reference) { "SC-secondary_form-#{SecureRandom.uuid}" }
+        let(:tags) { ['service:supplemental-claims', 'function: secondary_form submission to Lighthouse'] }
+
+        it 'sends a silent_failure_avoided statsd metric' do
+          expect(StatsD).to receive(:increment).with('silent_failure_avoided', tags:)
+          expect(Rails.logger).not_to receive(:error)
+
+          post(:create, params:, as: :json)
+        end
+      end
     end
 
     context 'the reference appeal_type is invalid' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Add another function type to the callbacks controller so it can parse references from secondary form emails and log silent_failure_avoided for those emails
- Decision Reviews, yes

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95981

## Testing done

- [x] *New code is covered by unit tests*
- Controller only recognized emails about forms and evidence, now also recognizes emails about secondary forms
- Trigger notification emailed for failed SecondaryAppealForm, see it deliver succesfully, see the callback controller create a record of that success and log it as silent_failure_avoided

## What areas of the site does it impact?
Backend handling of VA Notify callbacks about email status

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
