### PR TITLE
83846 disability benefits migrate 0781 a uploads to lighthouse

### DIFF
--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -230,6 +230,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
 
       context 'when a submission has a 0781 form' do
         it 'successfully uploads the 0781 document to Lighthouse' do
+          submission.update!(form_json: form0781_only)
+
           allow_any_instance_of(described_class)
             .to receive(:generate_stamp_pdf)
             .with(parsed_0781_form, submission.submitted_claim_id, '21-0781')

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -229,6 +229,9 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
           document_type: 'L229'
         )
       end
+      let(:expected_statsd_metrics_prefix) do
+        'worker.evss.submit_form0781.lighthouse_supplemental_document_upload_provider'
+      end
 
       before do
         Flipper.enable(:disability_compensation_upload_0781_to_lighthouse)
@@ -247,36 +250,127 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
       end
 
       context 'when a submission has both 0781 and 0781a' do
-        it 'uploads both documents to Lighthouse' do
-          # 0781
-          allow_any_instance_of(described_class)
-            .to receive(:generate_stamp_pdf)
-            .with(parsed_0781_form, submission.submitted_claim_id, '21-0781')
-            .and_return(path_to_0781_fixture)
+        context 'when the request is successful' do
+          it 'uploads both documents to Lighthouse' do
+            # 0781
+            allow_any_instance_of(described_class)
+              .to receive(:generate_stamp_pdf)
+              .with(parsed_0781_form, submission.submitted_claim_id, '21-0781')
+              .and_return(path_to_0781_fixture)
 
-          allow_any_instance_of(LighthouseSupplementalDocumentUploadProvider)
-            .to receive(:generate_upload_document)
-            .and_return(lighthouse_0781_document)
+            allow_any_instance_of(LighthouseSupplementalDocumentUploadProvider)
+              .to receive(:generate_upload_document)
+              .and_return(lighthouse_0781_document)
 
-          expect(BenefitsDocuments::Form526::UploadSupplementalDocumentService)
-            .to receive(:call)
-            .with(File.read(path_to_0781_fixture), lighthouse_0781a_document)
+            expect(BenefitsDocuments::Form526::UploadSupplementalDocumentService)
+              .to receive(:call)
+              .with(File.read(path_to_0781_fixture), lighthouse_0781a_document)
 
-          # 0781a
-          allow_any_instance_of(described_class)
-            .to receive(:generate_stamp_pdf)
-            .with(parsed_0781a_form, submission.submitted_claim_id, '21-0781a')
-            .and_return(path_to_0781a_fixture)
+            # 0781a
+            allow_any_instance_of(described_class)
+              .to receive(:generate_stamp_pdf)
+              .with(parsed_0781a_form, submission.submitted_claim_id, '21-0781a')
+              .and_return(path_to_0781a_fixture)
 
-          allow_any_instance_of(LighthouseSupplementalDocumentUploadProvider)
-            .to receive(:generate_upload_document)
-            .and_return(lighthouse_0781a_document)
+            allow_any_instance_of(LighthouseSupplementalDocumentUploadProvider)
+              .to receive(:generate_upload_document)
+              .and_return(lighthouse_0781a_document)
 
-          expect(BenefitsDocuments::Form526::UploadSupplementalDocumentService)
-            .to receive(:call)
-            .with(File.read(path_to_0781a_fixture), lighthouse_0781a_document)
+            expect(BenefitsDocuments::Form526::UploadSupplementalDocumentService)
+              .to receive(:call)
+              .with(File.read(path_to_0781a_fixture), lighthouse_0781a_document)
 
-          perform_upload
+            perform_upload
+          end
+
+          it 'logs the upload attempt with the correct job prefix' do
+            expect(StatsD).to receive(:increment).with(
+              "#{expected_statsd_metrics_prefix}.upload_attempt"
+            ).twice # For 0781 and 0781a
+            perform_upload
+          end
+
+          it 'increments the correct StatsD success metric' do
+            expect(StatsD).to receive(:increment).with(
+              "#{expected_statsd_metrics_prefix}.upload_success"
+            ).twice # For 0781 and 0781a
+
+            perform_upload
+          end
+
+          it 'creates a pending Lighthouse526DocumentUpload record for the submission so we can poll Lighthouse later' do
+            upload_attributes = {
+              aasm_state: 'pending',
+              form526_submission_id: submission.id,
+              lighthouse_document_request_id: lighthouse_request_id
+            }
+
+            expect(Lighthouse526DocumentUpload.where(**upload_attributes).count).to eq(0)
+
+            perform_upload
+            expect(Lighthouse526DocumentUpload.where(**upload_attributes)
+            .where(document_type: 'Form 0781').count).to eq(1)
+            expect(Lighthouse526DocumentUpload.where(**upload_attributes)
+            .where(document_type: 'Form 0781a').count).to eq(1)
+          end
+        end
+
+        context 'when Lighthouse returns an error response' do
+          let(:error_response_body) do
+            # From vcr_cassettes/lighthouse/benefits_claims/documents/lighthouse_form_526_document_upload_400.yml
+            {
+              'errors' => [
+                {
+                  'detail' => 'Something broke',
+                  'status' => 400,
+                  'title' => 'Bad Request',
+                  'instance' => Faker::Internet.uuid
+                }
+              ]
+            }
+          end
+
+          before do
+            allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
+              .and_return(faraday_response)
+
+            allow(faraday_response).to receive(:body).and_return(error_response_body)
+          end
+
+          it 'logs the Lighthouse error response' do
+            expect(Rails.logger).to receive(:error).with(
+              'LighthouseSupplementalDocumentUploadProvider upload failed',
+              {
+                class: 'LighthouseSupplementalDocumentUploadProvider',
+                submission_id: submission.submitted_claim_id,
+                user_uuid: submission.user_uuid,
+                va_document_type_code: 'L228',
+                primary_form: 'Form526',
+                lighthouse_error_response: error_response_body
+              }
+            )
+            expect(Rails.logger).to receive(:error).with(
+              'LighthouseSupplementalDocumentUploadProvider upload failed',
+              {
+                class: 'LighthouseSupplementalDocumentUploadProvider',
+                submission_id: submission.submitted_claim_id,
+                user_uuid: submission.user_uuid,
+                va_document_type_code: 'L229',
+                primary_form: 'Form526',
+                lighthouse_error_response: error_response_body
+              }
+            )
+
+            perform_upload
+          end
+
+          it 'increments the correct status failure metric' do
+            expect(StatsD).to receive(:increment).with(
+              "#{expected_statsd_metrics_prefix}.upload_failure"
+            ).twice # For 0781 and 0781a
+
+            perform_upload
+          end
         end
       end
 
@@ -335,6 +429,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
         )
       end
       let(:client_stub) { instance_double(EVSS::DocumentsService) }
+      let(:expected_statsd_metrics_prefix) { 'worker.evss.submit_form0781.evss_supplemental_document_upload_provider' }
 
       before do
         Flipper.disable(:disability_compensation_upload_0781_to_lighthouse)
@@ -362,12 +457,44 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
       end
 
       context 'when a submission has both 0781 and 0781a' do
-        it 'uploads both documents to EVSS' do
-          expect(client_stub).to receive(:upload).with(File.read(path_to_0781_fixture), evss_claim_0781_document)
+        context 'when the request is successful' do
+          it 'uploads both documents to EVSS' do
+            expect(client_stub).to receive(:upload).with(File.read(path_to_0781_fixture), evss_claim_0781_document)
 
-          expect(client_stub).to receive(:upload).with(File.read(path_to_0781a_fixture), evss_claim_0781a_document)
+            expect(client_stub).to receive(:upload).with(File.read(path_to_0781a_fixture), evss_claim_0781a_document)
 
-          perform_upload
+            perform_upload
+          end
+
+          it 'logs the upload attempt with the correct job prefix' do
+            allow(client_stub).to receive(:upload)
+            expect(StatsD).to receive(:increment).with(
+              "#{expected_statsd_metrics_prefix}.upload_attempt"
+            ).twice # For 0781 and 0781a
+
+            perform_upload
+          end
+
+          it 'increments the correct StatsD success metric' do
+            allow(client_stub).to receive(:upload)
+            expect(StatsD).to receive(:increment).with(
+              "#{expected_statsd_metrics_prefix}.upload_success"
+            ).twice # For 0781 and 0781a
+
+            perform_upload
+          end
+        end
+
+        context 'when an upload raises an EVSS response error' do
+          it 'logs an upload error' do
+            allow(client_stub).to receive(:upload).and_raise(EVSS::ErrorMiddleware::EVSSError)
+            expect_any_instance_of(EVSSSupplementalDocumentUploadProvider).to receive(:log_upload_failure)
+
+            expect do
+              subject.perform_async(submission.id)
+              described_class.drain
+            end.to raise_error(EVSS::ErrorMiddleware::EVSSError)
+          end
         end
       end
 
@@ -386,18 +513,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
           expect(client_stub).to receive(:upload).with(File.read(path_to_0781a_fixture), evss_claim_0781a_document)
 
           perform_upload
-        end
-      end
-
-      context 'when an upload raises an EVSS response error' do
-        it 'logs an upload error' do
-          allow(client_stub).to receive(:upload).and_raise(EVSS::ErrorMiddleware::EVSSError)
-          expect_any_instance_of(EVSSSupplementalDocumentUploadProvider).to receive(:log_upload_failure)
-
-          expect do
-            subject.perform_async(submission.id)
-            described_class.drain
-          end.to raise_error(EVSS::ErrorMiddleware::EVSSError)
         end
       end
     end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -230,8 +230,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
 
       context 'when a submission has a 0781 form' do
         it 'successfully uploads the 0781 document to Lighthouse' do
-          submission.update!(form_json: form0781_only)
-
           allow_any_instance_of(described_class)
             .to receive(:generate_stamp_pdf)
             .with(parsed_0781_form, submission.submitted_claim_id, '21-0781')


### PR DESCRIPTION
This PR is a follow-up to #19186, which is the base PR that will allow us to progressively transition uploading 0781 forms to the new Lighthouse Documents Benefits API. This PR only adds specs to test the multiple conditions of uploading the 0781 and 0781a forms. The submit0781 job processes both forms 0781 and 0781a, if present.

All new behavior is hidden behind a killswitch flipper, `disability_compensation_use_api_provider_for_0781_uploads`, which will only use the API provider if turned on.

If the killswitch is enabled, the API Provider Factory itself will decide if we use the Lighthouse or EVSS provider client for the uploads, based on the status of the `disability_compensation_upload_0781_to_lighthouse` flipper.

## Summary

- *This work is behind a feature toggle (flipper): YES (described above)
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
Disability Benefits team 2, aka Carbs; yes we do own the maintenance of these components
- *(If introducing a flipper, what is the success criteria being targeted?)*
A certain amount of submissions will fail on upload to Lighthouse just as they do to EVSS now - it's the same underlying system; however we will be on the look out for new errors that expose bugs on our side or in Lighthouse's benefits documents API.

## Related issue(s)

- Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/83846
- Previous PR: https://github.com/department-of-veterans-affairs/vets-api/pull/19186

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
This feature will be tested extensively on staging before release. It will be rolled out incrementally based on a percentage of production users, starting at 1%. All 0781 upload attempts will be logged and monitored.


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) Not yet, but we have a ticket to do this [issue #95698](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95698)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

This is a lot of lines, but it is all within one spec file with considerable test setup and descriptions.
