### PR TITLE
[VI-716] - Only create MHV account async during SiS auth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -456,6 +456,18 @@ class User < Common::RedisStore
     @relationships ||= get_relationships_array
   end
 
+  def create_mhv_account_async
+    return unless can_create_mhv_account?
+
+    MHV::AccountCreatorJob.perform_async(user_verification_id)
+  end
+
+  def can_create_mhv_account?
+    return false unless Flipper.enabled?(:mhv_account_creation_after_login, user_account)
+
+    loa3? && va_patient? && !needs_accepted_terms_of_use
+  end
+
   private
 
   def mpi_profile

--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -20,7 +20,6 @@ module Login
       Login::UserAcceptableVerifiedCredentialUpdater.new(user_account: @current_user.user_account).perform
       update_account_login_stats(login_type)
       id_mismatch_validations
-      create_mhv_account
 
       if Settings.test_user_dashboard.env == 'staging'
         TestUserDashboard::UpdateUser.new(current_user).call(Time.current)
@@ -53,13 +52,6 @@ module Login
         error_data.merge!(identity_value:, mpi_value:) unless error_message.include?('SSN')
         Rails.logger.warn("[SessionsController version:v1] #{error_message}", error_data)
       end
-    end
-
-    def create_mhv_account
-      return unless current_user.loa3?
-      return unless Flipper.enabled?(:mhv_account_creation_after_login, current_user.user_account)
-
-      MHV::AccountCreatorJob.perform_async(current_user.user_verification_id)
     end
   end
 end

--- a/app/services/sign_in/user_loader.rb
+++ b/app/services/sign_in/user_loader.rb
@@ -31,20 +31,13 @@ module SignIn
       current_user.session_handle = access_token.session_handle
       current_user.save && user_identity.save
       current_user.invalidate_mpi_cache
-      create_mhv_account
+      current_user.create_mhv_account_async
 
       current_user
     end
 
     def validate_account_and_session
       raise Errors::SessionNotFoundError.new message: 'Invalid Session Handle' unless session
-    end
-
-    def create_mhv_account
-      return unless current_user.loa3?
-      return unless Flipper.enabled?(:mhv_account_creation_after_login, user_account)
-
-      MHV::AccountCreatorJob.perform_async(user_verification.id)
     end
 
     def user_attributes

--- a/app/sidekiq/mhv/account_creator_job.rb
+++ b/app/sidekiq/mhv/account_creator_job.rb
@@ -8,11 +8,11 @@ module MHV
 
     sidekiq_options retry: false
 
-    def perform(id)
-      user_verification = UserVerification.find(id)
+    def perform(user_verification_id)
+      user_verification = UserVerification.find(user_verification_id)
       MHV::UserAccount::Creator.new(user_verification:, break_cache: true).perform
     rescue ActiveRecord::RecordNotFound
-      Rails.logger.error("MHV AccountCreatorJob failed: UserVerification not found for id #{id}")
+      Rails.logger.error("MHV AccountCreatorJob failed: UserVerification not found for id #{user_verification_id}")
     end
   end
 end

--- a/spec/services/login/after_login_actions_spec.rb
+++ b/spec/services/login/after_login_actions_spec.rb
@@ -206,46 +206,5 @@ RSpec.describe Login::AfterLoginActions do
         it_behaves_like 'identity-mpi id validation'
       end
     end
-
-    context 'when creating an MHV account' do
-      let(:user) { create(:user, :loa3, idme_uuid:) }
-      let!(:user_verification) { create(:idme_user_verification, idme_uuid:) }
-      let!(:user_account) { user_verification.user_account }
-      let(:idme_uuid) { 'some-idme-uuid' }
-      let(:enabled) { true }
-
-      before do
-        allow(MHV::AccountCreatorJob).to receive(:perform_async)
-        allow(Flipper).to receive(:enabled?).with(:mhv_account_creation_after_login, user_account).and_return(enabled)
-      end
-
-      shared_examples 'a non-enqueued MHV::AccountCreatorJob' do
-        it 'does not enqueue an MHV::AccountCreatorJob' do
-          described_class.new(user).perform
-          expect(MHV::AccountCreatorJob).not_to have_received(:perform_async)
-        end
-      end
-
-      context 'when the user is LOA3' do
-        context 'when :mhv_account_creation_after_login is enabled' do
-          it 'enqueues an MHV::AccountCreatorJob' do
-            described_class.new(user).perform
-            expect(MHV::AccountCreatorJob).to have_received(:perform_async).with(user_verification.id)
-          end
-        end
-
-        context 'when :mhv_account_creation_after_login is disabled' do
-          let(:enabled) { false }
-
-          it_behaves_like 'a non-enqueued MHV::AccountCreatorJob'
-        end
-      end
-
-      context 'when the user is not LOA3' do
-        let(:user) { create(:user) }
-
-        it_behaves_like 'a non-enqueued MHV::AccountCreatorJob'
-      end
-    end
   end
 end


### PR DESCRIPTION
## Summary

- Only create MHV user account async during SiS auth

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-716

## Testing 
- Login with SiS and make sure a `MHV::AccountCreatorJob` job is enqueued - http://localhost:3000/sidekiq/queues/default

## What areas of the site does it impact?
MHV Account creation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

