### PR TITLE
Add RSpec tags to direct deposit spec files

### DIFF
--- a/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
@@ -2,7 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe V0::Profile::DirectDepositsController, type: :controller do
+RSpec.describe V0::Profile::DirectDepositsController, feature: :direct_deposit,
+                                                      team: :vfs_authenticated_experience_backend, type: :controller do
   let(:user) { create(:user, :loa3, :accountable, icn: '1012666073V986297') }
 
   before do

--- a/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe V0::Profile::DirectDepositsController, feature: :direct_deposit,
-                                                      team: :vfs_authenticated_experience_backend, type: :controller do
+                                                      team_owner: :vfs_authenticated_experience_backend, type: :controller do
   let(:user) { create(:user, :loa3, :accountable, icn: '1012666073V986297') }
 
   before do

--- a/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits_controller_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe V0::Profile::DirectDepositsController, feature: :direct_deposit,
-                                                      team_owner: :vfs_authenticated_experience_backend, type: :controller do
+                                                      team_owner: :vfs_authenticated_experience_backend,
+                                                      type: :controller do
   let(:user) { create(:user, :loa3, :accountable, icn: '1012666073V986297') }
 
   before do

--- a/spec/mailers/direct_deposit_mailer_spec.rb
+++ b/spec/mailers/direct_deposit_mailer_spec.rb
@@ -2,7 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe DirectDepositMailer, type: [:mailer] do
+RSpec.describe DirectDepositMailer, feature: :direct_deposit,
+                                    team: :vfs_authenticated_experience_backend, type: :mailer do
   subject do
     described_class.build(email, google_analytics_client_id, dd_type).deliver_now
   end

--- a/spec/mailers/direct_deposit_mailer_spec.rb
+++ b/spec/mailers/direct_deposit_mailer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe DirectDepositMailer, feature: :direct_deposit,
-                                    team: :vfs_authenticated_experience_backend, type: :mailer do
+                                    team_owner: :vfs_authenticated_experience_backend, type: :mailer do
   subject do
     described_class.build(email, google_analytics_client_id, dd_type).deliver_now
   end

--- a/spec/serializers/direct_deposits_serializer_spec.rb
+++ b/spec/serializers/direct_deposits_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe DirectDepositsSerializer, feature: :direct_deposit,
-                                   team: :vfs_authenticated_experience_backend, type: :serializer do
+                                   team_owner: :vfs_authenticated_experience_backend, type: :serializer do
   subject { serialize(direct_deposit, serializer_class: described_class) }
 
   let(:direct_deposit) { build(:direct_deposit, :with_payment_account) }

--- a/spec/serializers/direct_deposits_serializer_spec.rb
+++ b/spec/serializers/direct_deposits_serializer_spec.rb
@@ -2,7 +2,8 @@
 
 require 'rails_helper'
 
-describe DirectDepositsSerializer, type: :serializer do
+describe DirectDepositsSerializer, feature: :direct_deposit,
+                                   team: :vfs_authenticated_experience_backend, type: :serializer do
   subject { serialize(direct_deposit, serializer_class: described_class) }
 
   let(:direct_deposit) { build(:direct_deposit, :with_payment_account) }


### PR DESCRIPTION
## Summary
Add `team_owner` and `feature` RSpec tags to direct deposit spec files.

See [this document](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/tutorials/testing/rspec_tags.md) for more information.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/95666

## Testing done
Updates direct deposit spec files.