### PR TITLE
Add new Vet Verification Service method for LH API request

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -248,6 +248,12 @@ lighthouse:
         client_id: abc123456
         rsa_key: path/to/key
       use_mocks: false
+    status:
+      host: https://sandbox-api.va.gov
+      access_token:
+        client_id: ~
+        rsa_key: ~
+      use_mocks: false
   benefits_claims:
     host: https://sandbox-api.va.gov
     aud_claim_url: https://deptva-eval.okta.com/oauth2/ausi3u00gw66b9Ojk2p7/v1/token

--- a/lib/lighthouse/veteran_verification/configuration.rb
+++ b/lib/lighthouse/veteran_verification/configuration.rb
@@ -9,7 +9,7 @@ module VeteranVerification
   class Configuration < Common::Client::Configuration::REST
     self.read_timeout = Settings.lighthouse.veteran_verification.timeout || 20
 
-    API_SCOPES = %w[disability_rating.read].freeze
+    API_SCOPES = %w[disability_rating.read veteran_status.read].freeze
     VETERAN_VERIFICATION_PATH = 'services/veteran_verification/v2'
     TOKEN_PATH = 'oauth2/veteran-verification/system/v1/token'
 

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -31,6 +31,18 @@ module VeteranVerification
       handle_error(e, lighthouse_client_id, endpoint)
     end
 
+    def get_vet_verification_status(icn, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
+      endpoint = 'status'
+      config.get(
+        "#{endpoint}/#{icn}",
+        lighthouse_client_id,
+        lighthouse_rsa_key_path,
+        options
+      ).body
+    rescue => e
+      handle_error(e, lighthouse_client_id, endpoint)
+    end
+
     def handle_error(error, lighthouse_client_id, endpoint)
       Lighthouse::ServiceException.send_error(
         error,

--- a/spec/lib/lighthouse/veteran_verification/service_spec.rb
+++ b/spec/lib/lighthouse/veteran_verification/service_spec.rb
@@ -49,6 +49,44 @@ RSpec.describe VeteranVerification::Service do
           end.to raise_error Common::Exceptions::ServiceError
         end
       end
+
+      describe 'when requesting status' do
+        let(:icn) { '1012667145V762142' }
+
+        it 'retrieves veteran confirmation status from the Lighthouse API' do
+          VCR.use_cassette('lighthouse/veteran_verification/status/200_response') do
+            response = @service.get_vet_verification_status(icn, '', '')
+            expect(response['data']['id']).to eq('1012667145V762142')
+            expect(response['data']['type']).to eq('veteran_status_confirmations')
+            expect(response['data']['attributes']['veteran_status']).to eq('confirmed')
+          end
+        end
+
+        it 'retrieves veteran not confirmed status from the Lighthouse API' do
+          VCR.use_cassette('lighthouse/veteran_verification/status/200_not_confirmed_response') do
+            response = @service.get_vet_verification_status('1012666182V203559', '', '')
+            expect(response['data']['id']).to eq('1012666182V203559')
+            expect(response['data']['attributes']['veteran_status']).to eq('not confirmed')
+            expect(response['data']['attributes']).to have_key('not_confirmed_reason')
+          end
+        end
+
+        Lighthouse::ServiceException::ERROR_MAP.except(404, 422, 499, 501).each do |status, error_class|
+          it "throws a #{status} error if Lighthouse sends it back" do
+            expect do
+              test_error(
+                "lighthouse/veteran_verification/status/#{status}_response"
+              )
+            end.to raise_error error_class
+          end
+
+          def test_error(cassette_path)
+            VCR.use_cassette(cassette_path) do
+              @service.get_vet_verification_status(icn, '', '')
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_not_confirmed_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_not_confirmed_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<LIGHTHOUSE_DIRECT_DEPOSIT_HOST>/services/veteran_verification/v2/status/1012666182V203559"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 19:06:24 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '38'
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Limit:
+      - '120'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"1012666182V203559","type":"veteran_status_confirmations","attributes":{"veteran_status":"not
+        confirmed","not_confirmed_reason":"NOT_TITLE_38"}}}'
+  recorded_at: Thu, 31 Oct 2024 19:06:24 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_response.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 30 Oct 2024 23:02:03 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Reset:
+      - '58'
+      Ratelimit-Limit:
+      - '120'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"1012667145V762142","type":"veteran_status_confirmations","attributes":{"veteran_status":"confirmed"}}}'
+  recorded_at: Wed, 30 Oct 2024 23:02:03 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/400_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/400_response.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:08:59 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '1'
+      X-Ratelimit-Remaining-Minute:
+      - '113'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '113'
+      Ratelimit-Limit:
+      - '120'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+  "title": "Bad Request",
+  "detail": "Bad Request",
+  "code": "400",
+  "status": "400"
+}'
+  recorded_at: Thu, 31 Oct 2024 18:08:59 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/401_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/401_response.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: Not Authorized
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:08:58 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '114'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '114'
+      Ratelimit-Reset:
+      - '2'
+      Ratelimit-Limit:
+      - '120'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "{ \n  \"status\": 401,\n  \"error\": \"Invalid token.\"\n}\n"
+  recorded_at: Thu, 31 Oct 2024 18:08:58 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/403_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/403_response.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:08:57 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '115'
+      Ratelimit-Limit:
+      - '120'
+      Ratelimit-Remaining:
+      - '115'
+      Ratelimit-Reset:
+      - '3'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+  "status": "403",
+  "error": "Token not granted requested scope.",
+  "path": "/veteran_verification/v2/status"
+}'
+  recorded_at: Thu, 31 Oct 2024 18:08:57 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/413_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/413_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 413
+      message: Payload too large
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:08:51 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '118'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '118'
+      Ratelimit-Reset:
+      - '9'
+      Ratelimit-Limit:
+      - '120'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+  "message": "Request size limit exceeded"
+}'
+  recorded_at: Thu, 31 Oct 2024 18:08:51 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/429_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/429_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 429
+      message: Too many requests
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:09:01 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '59'
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Limit:
+      - '120'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+  "message": "API rate limit exceeded"
+}'
+  recorded_at: Thu, 31 Oct 2024 18:09:01 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/500_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/500_response.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:09:03 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '57'
+      X-Ratelimit-Remaining-Minute:
+      - '117'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '117'
+      Ratelimit-Limit:
+      - '120'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '
+      {
+  "title": "Internal server error",
+  "detail": "Internal server error",
+  "code": "500",
+  "status": "500"
+}'
+  recorded_at: Thu, 31 Oct 2024 18:09:03 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/502_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/502_response.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 502
+      message: Bad Gateway
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:08:54 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '117'
+      Ratelimit-Reset:
+      - '6'
+      Ratelimit-Limit:
+      - '120'
+      X-Ratelimit-Remaining-Minute:
+      - '117'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+  "errors": [
+    {
+      "title": "Bad Gateway",
+      "detail": "Upstream Request Error.",
+      "code": "502",
+      "status": "502"
+    }
+  ]
+}'
+  recorded_at: Thu, 31 Oct 2024 18:08:54 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/503_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/503_response.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 503
+      message: Service Unavailable
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:08:56 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '116'
+      Ratelimit-Reset:
+      - '5'
+      Ratelimit-Limit:
+      - '120'
+      X-Ratelimit-Remaining-Minute:
+      - '116'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+  "errors": [
+    {
+      "title": "Service Unavailable",
+      "detail": "Backend Service Unavailable.",
+      "code": "503",
+      "status": "503"
+    }
+  ]
+}'
+  recorded_at: Thu, 31 Oct 2024 18:08:55 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/504_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/504_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 504
+      message: Gateway Timeout
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 18:08:42 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      Ratelimit-Limit:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Reset:
+      - '18'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Www-Authenticate:
+      - Bearer
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+  "message": "The server took too long to respond"
+}'
+  recorded_at: Thu, 31 Oct 2024 18:08:42 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary

- This work is not behind a feature toggle.
- This change adds a new method to the `VeteranVerification` module in the `lib/lighthouse/veteran_verification/service.rb` file for getting confirmation of veteran status. This method makes a request to the Lighthouse Veteran Service History and Eligibility API /status endpoint. A later PR will put this behind a new vets-api endpoint, which will be ready for vets-website to integrate into the Veteran Proof of Status feature.
- Documentation and further logging will be added in a later PR.
- I work on the IIR Product team and we currently own this feature.

## Related issue(s)

- [1139](https://github.com/department-of-veterans-affairs/va-iir/issues/1139)

## Testing done

- [x] *New code is covered by unit tests*
- There is no old behavior, as this is a completely new implementation. Testing will be conducted, once the route is in place, to ensure that the endpoint can be hit with a logged in user and data returned as expected.

## Screenshots


## What areas of the site does it impact?
This change impacts the `VeteranVerification` module service and config, as the new method was added and config slightly adjusted to allow for this new method.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

