### PR TITLE
[API-41444] v1 526 validation - changeOfAddress beginningDate before endingDate

### DIFF
--- a/modules/claims_api/spec/requests/v1/forms/526_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_spec.rb
@@ -549,6 +549,108 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
                 end
               end
             end
+
+            context 'when the endingDate is not provided' do
+              let(:json_data) { JSON.parse data }
+              let(:change_of_address) do
+                {
+                  beginningDate: 1.month.from_now.to_date.to_s,
+                  addressChangeType: value,
+                  addressLine1: '1234 Couch Street',
+                  city: 'New York City',
+                  state: 'NY',
+                  type: 'DOMESTIC',
+                  zipFirstFive: '12345',
+                  country: 'USA'
+                }
+              end
+
+              it 'raises an exception that endingDate is not valid' do
+                mock_acg(scopes) do |auth_header|
+                  VCR.use_cassette('claims_api/brd/intake_sites') do
+                    VCR.use_cassette('claims_api/brd/countries') do
+                      par = json_data
+                      par['data']['attributes']['veteran']['changeOfAddress'] = change_of_address
+                      par['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyEndDate'] =
+                        '2007-08-01'
+
+                      post path, params: par.to_json, headers: headers.merge(auth_header)
+                      expect(response).to have_http_status(:bad_request)
+                    end
+                  end
+                end
+              end
+            end
+
+            context 'when the beginningDate is after the endingDate' do
+              let(:json_data) { JSON.parse data }
+              let(:change_of_address) do
+                {
+                  beginningDate: 1.month.from_now.to_date.to_s,
+                  endingDate: 1.month.ago.to_date.to_s,
+                  addressChangeType: value,
+                  addressLine1: '1234 Couch Street',
+                  city: 'New York City',
+                  state: 'NY',
+                  type: 'DOMESTIC',
+                  zipFirstFive: '12345',
+                  country: 'USA'
+                }
+              end
+
+              it 'raises an exception that endingDate is not valid' do
+                mock_acg(scopes) do |auth_header|
+                  VCR.use_cassette('claims_api/brd/intake_sites') do
+                    VCR.use_cassette('claims_api/brd/countries') do
+                      par = json_data
+                      par['data']['attributes']['veteran']['changeOfAddress'] = change_of_address
+                      par['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyEndDate'] =
+                        '2007-08-01'
+
+                      post path, params: par.to_json, headers: headers.merge(auth_header)
+                      expect(response).to have_http_status(:bad_request)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        context 'when addressChangeType is PERMANENT' do
+          let(:value) { 'PERMANENT' }
+
+          context 'when the endingDate is provided' do
+            let(:json_data) { JSON.parse data }
+            let(:change_of_address) do
+              {
+                beginningDate: 1.month.from_now.to_date.to_s,
+                endingDate: 2.months.from_now.to_date.to_s,
+                addressChangeType: value,
+                addressLine1: '1234 Couch Street',
+                city: 'New York City',
+                state: 'NY',
+                type: 'DOMESTIC',
+                zipFirstFive: '12345',
+                country: 'USA'
+              }
+            end
+
+            it 'raises an exception that endingDate is not valid' do
+              mock_acg(scopes) do |auth_header|
+                VCR.use_cassette('claims_api/brd/intake_sites') do
+                  VCR.use_cassette('claims_api/brd/countries') do
+                    par = json_data
+                    par['data']['attributes']['veteran']['changeOfAddress'] = change_of_address
+                    par['data']['attributes']['serviceInformation']['servicePeriods'][0]['activeDutyEndDate'] =
+                      '2007-08-01'
+
+                    post path, params: par.to_json, headers: headers.merge(auth_header)
+                    expect(response).to have_http_status(:bad_request)
+                  end
+                end
+              end
+            end
           end
         end
 


### PR DESCRIPTION
## Summary

Add the following validations to v1 /526 `changeOfAddress` field:
- _if_ the address change is **temporary**:
   - _and_ the `endingDate` is not present, raise an exception;
   - _and_ the `beginningDate` and `endingDate` are not in chronological order, raise an exception.
- _if_ the address change is **permanent**:
   - _and_ the `endingDate` is present, raise an exception. 

## Related issue(s)

[API-41444](https://jira.devops.va.gov/browse/API-41444)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

v1 526 validation

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A