### PR TITLE
MHV-62174 Handle patient not found

### DIFF
--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -82,6 +82,11 @@ module MedicalRecords
                                     search: { parameters: { identifier: } },
                                     headers: { 'Cache-Control': 'no-cache' }
                                   })
+
+      # MHV will return a 202 if and only if the patient does not exist. It will not return 202 for
+      # multiple patients found.
+      raise MedicalRecords::PatientNotFound if result.response[:code] == 202
+
       resource = result.resource
       handle_api_errors(result) if resource.nil?
       resource

--- a/spec/lib/medical_records/client_spec.rb
+++ b/spec/lib/medical_records/client_spec.rb
@@ -79,6 +79,16 @@ describe MedicalRecords::Client do
         end
       end
     end
+
+    context 'when the patient is not found', :vcr do
+      it 'gets a patient by identifer', :vcr do
+        VCR.use_cassette 'mr_client/get_a_patient_by_identifier_not_found' do
+          expect do
+            client.get_patient_by_identifier(client.fhir_client, patient_id)
+          end.to raise_error(MedicalRecords::PatientNotFound)
+        end
+      end
+    end
   end
 
   it 'gets a list of allergies', :vcr do

--- a/spec/lib/medical_records/client_spec.rb
+++ b/spec/lib/medical_records/client_spec.rb
@@ -44,11 +44,11 @@ describe MedicalRecords::Client do
 
     it 'adds adds a custom header to bypass FHIR server cache', :vcr do
       VCR.use_cassette 'mr_client/get_a_patient_by_identifier' do
-      client.get_patient_by_identifier(client.fhir_client, patient_id)
-      expect(
-        a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
-      ).to have_been_made.at_least_once
-    end
+        client.get_patient_by_identifier(client.fhir_client, patient_id)
+        expect(
+          a_request(:any, //).with(headers: { 'Cache-Control' => 'no-cache' })
+        ).to have_been_made.at_least_once
+      end
     end
 
     context 'when the redaction feature toggle is enabled', :vcr do

--- a/spec/support/vcr_cassettes/mr_client/get_a_patient_by_identifier_hapi_1363.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_patient_by_identifier_hapi_1363.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: "<MHV_MR_HOST>/fhir/Patient?identifier=12345"
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/fhir+json
+        User-Agent:
+          - Ruby FHIR Client
+        Accept-Charset:
+          - utf-8
+        Authorization: Bearer <TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Host:
+          - localhost:2003
+    response:
+      status:
+        code: 500
+        message: ""
+      headers:
+        Date:
+          - Thu, 28 Sep 2023 18:36:15 GMT
+        Content-Type:
+          - application/fhir+json;charset=UTF-8
+        Transfer-Encoding:
+          - chunked
+        X-Powered-By:
+          - HAPI FHIR 6.2.2 REST Server (FHIR Server; FHIR 4.0.1/R4)
+        X-Request-Id:
+          - d2627c3d159be1e9d944fbfb77fe9e2c
+        Last-Modified:
+          - Thu, 28 Sep 2023 18:36:15 GMT
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "resourceType": "OperationOutcome",
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><tr><td style=\"font-weight: bold;\">ERROR</td><td>[]</td><td><pre>HAPI-1363: Either No patient or multiple patient found</pre></td>\n\t\t\t</tr>\n\t\t</table>\n\t</div>"
+            },
+            "issue": [
+              {
+                "severity": "error",
+                "code": "processing",
+                "diagnostics": "HAPI-1363: Either No patient or multiple patient found"
+              }
+            ]
+          }
+    recorded_at: Thu, 28 Sep 2023 18:36:15 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/vcr_cassettes/mr_client/get_a_patient_by_identifier_not_found.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_patient_by_identifier_not_found.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: "<MHV_MR_HOST>/fhir/Patient?identifier=12345"
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/fhir+json
+        User-Agent:
+          - Ruby FHIR Client
+        Accept-Charset:
+          - utf-8
+        Authorization: Bearer <TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Host:
+          - localhost:2003
+    response:
+      status:
+        code: 202
+        message: ""
+      headers:
+        Date:
+          - Thu, 28 Sep 2023 18:36:15 GMT
+        Content-Type:
+          - application/fhir+json;charset=UTF-8
+        Transfer-Encoding:
+          - chunked
+        X-Powered-By:
+          - HAPI FHIR 6.2.2 REST Server (FHIR Server; FHIR 4.0.1/R4)
+        X-Request-Id:
+          - d2627c3d159be1e9d944fbfb77fe9e2c
+        Last-Modified:
+          - Thu, 28 Sep 2023 18:36:15 GMT
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+              "resourceType": "OperationOutcome",
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><tr><td style=\"font-weight: bold;\">ERROR</td><td>[]</td><td>No Patient found</td></tr></table></div>"
+              },
+              "issue": [
+                  {
+                      "severity": "error",
+                      "code": "processing",
+                      "diagnostics": "No Patient found"
+                  }
+              ]
+          }
+    recorded_at: Thu, 28 Sep 2023 18:36:15 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

- MHV backend will no longer throw an error for Patient Not Found. Instead it will return a 202.
- For a time, VA.gov will need to handle both error cases (the 202, plus the original HAPI-1363 error that is being deprecated).

## Related issue(s)

### [MHV-62174](https://jira.devops.va.gov/browse/MHV-62174) - Update vets-api to handle 202 from MHV when no patient found ###

> Update vets-api to handle 202 from MHV when no patient found
> 
> Currently when "No patient found" or "Multiple patient found," MHV is sending back the same 500 error. Muazzam is updating this to split out these errors ([MHV-60266](https://jira.devops.va.gov/browse/MHV-60266)). In the future:
> 
> "Multiple patients found" will continue to return 500
> "No patient found" will now return a 202 with an Observation record
> 
> We need to now update vets-api in two ways:
> 
> When we get that particular 500, return an error to the frontend
> When we get the 202, handle things appropriately (throw a PatientNotFound error which will return a 202 to vets-website.
> 
> User Story:  As a MR user, I want to have a better understanding of the errors I receive.
> 
> Feature Flag Y/N ? N
> 
> DataDog Analytics  Y/N ? N
> 
> Manual Testing Y/N ? N
> 
> Automated Testing Y/N ? N
> 
> Accessibility Testing Y/N ? N
> 
> UCD Validation Y/N N
> 
> Acceptance Criteria:
> 
> AC1 Vets API has been updated to match Muazzam's work
> 
> AC2
> 
> AC3
> 
> AC4
> 
> Links to UCD:
> 
> Figma Link:
> 
> Other Design Notes:

## Testing done

- Added more comprehensive spec tests to test BOTH conditions, top to bottom.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
