### PR TITLE
expand logs to check for passworded pdfs

### DIFF
--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -42,7 +42,7 @@ module FormAttachmentCreate
     end
   rescue => e
     log_message_to_sentry(
-      'form attachment error 1',
+      'form attachment error 1 - validate class',
       :info,
       phase: 'FAC_validate',
       klass: filtered_params[:file_data].class.name,
@@ -55,8 +55,10 @@ module FormAttachmentCreate
     form_attachment.set_file_data!(filtered_params[:file_data], filtered_params[:password])
   rescue => e
     log_message_to_sentry(
-      'form attachment error 2',
+      'form attachment error 2 - save to cloud',
       :info,
+      has_pass: filtered_params[:password].present?,
+      ext: File.extname(filtered_params[:file_data]).last(5),
       phase: 'FAC_cloud',
       exception: e.message
     )
@@ -67,7 +69,7 @@ module FormAttachmentCreate
     form_attachment.save!
   rescue => e
     log_message_to_sentry(
-      'form attachment error 3',
+      'form attachment error 3 - save to db',
       :info,
       phase: 'FAC_db',
       errors: form_attachment.errors,

--- a/spec/concerns/form_attachment_create_spec.rb
+++ b/spec/concerns/form_attachment_create_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe FormAttachmentCreate, type: :controller do
           debug_timestamp: anything
         )
         expect(@controller).to receive(:log_message_to_sentry).with(
-          'form attachment error 1',
+          'form attachment error 1 - validate class',
           :info,
           phase: 'FAC_validate',
           klass: 'String',
@@ -102,8 +102,10 @@ RSpec.describe FormAttachmentCreate, type: :controller do
           debug_timestamp: anything
         )
         expect(@controller).to receive(:log_message_to_sentry).with(
-          'form attachment error 2',
+          'form attachment error 2 - save to cloud',
           :info,
+          has_pass: false,
+          ext: File.extname(file_data).last(5),
           phase: 'FAC_cloud',
           exception: 'Unprocessable Entity'
         )
@@ -128,7 +130,7 @@ RSpec.describe FormAttachmentCreate, type: :controller do
           debug_timestamp: anything
         )
         expect(@controller).to receive(:log_message_to_sentry).with(
-          'form attachment error 3',
+          'form attachment error 3 - save to db',
           :info,
           phase: 'FAC_db',
           errors: 'error text',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO*
- Expand logging to track whether the file has a password, and its extension.
- To avoid accidentally introducing PII/PHI in the logs, we're only logging the last 5 characters of the extension. Maybe over-prudent, but we're filtering out the filename for a reason.
- 10-10 Health Enrollment EZ/CG team

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92139
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93581

## Testing done
- [x] *New code is covered by unit tests*
- Fill out EZ form, upload a file for e.g. Discharge Papers, confirm that the new data appears in the log when the CarrierWave call fails.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*10-10EZ file uploads

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
