### PR TITLE
Drop benefits intake UUID from form submissions

### DIFF
--- a/db/migrate/20241112135649_drop_benefits_intake_uuid_index_from_form_submissions.rb
+++ b/db/migrate/20241112135649_drop_benefits_intake_uuid_index_from_form_submissions.rb
@@ -1,0 +1,7 @@
+class DropBenefitsIntakeUuidIndexFromFormSubmissions < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+  
+  def change
+    remove_index :form_submissions, name: 'index_form_submissions_on_benefits_intake_uuid', if_exists: true
+  end
+end

--- a/db/migrate/20241112135704_drop_benefits_intake_uuid_from_form_submissions.rb
+++ b/db/migrate/20241112135704_drop_benefits_intake_uuid_from_form_submissions.rb
@@ -1,0 +1,5 @@
+class DropBenefitsIntakeUuidFromFormSubmissions < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :form_submissions, :benefits_intake_uuid, :uuid, if_exists: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_08_144805) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_12_135704) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -791,14 +791,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_08_144805) do
 
   create_table "form_submissions", force: :cascade do |t|
     t.string "form_type", null: false
-    t.uuid "benefits_intake_uuid"
     t.uuid "user_account_id"
     t.bigint "saved_claim_id"
     t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "form_data_ciphertext"
-    t.index ["benefits_intake_uuid"], name: "index_form_submissions_on_benefits_intake_uuid"
     t.index ["saved_claim_id"], name: "index_form_submissions_on_saved_claim_id"
     t.index ["user_account_id"], name: "index_form_submissions_on_user_account_id"
   end


### PR DESCRIPTION
## Summary
This PR removes the `benefits_intake_uuid` and its index from the `form_submissions` table. This follows up on these two PRs:
1. [Write `benefits_intake_uuid` to `form_submission_attempts` table.](https://github.com/department-of-veterans-affairs/vets-api/pull/19015)
2. [Stop saving `benefits_intake_uuid` to Form Submissions.](https://github.com/department-of-veterans-affairs/vets-api/pull/19169)

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=83134444&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1636
