### PR TITLE
API-41802-handle-empty-unit-name

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
@@ -25,6 +25,8 @@ module ClaimsApi
       validate_service_after_13th_birthday!
       # ensure 'militaryRetiredPay.receiving' and 'militaryRetiredPay.willReceiveInFuture' are not same non-null values
       validate_form_526_service_pay!
+      # ensure an error is avoided if the unit name is not provided
+      validate_form_526_unit_name!
       # ensure 'title10ActivationDate' if provided, is after the earliest servicePeriod.activeDutyBeginDate and on or before the current date # rubocop:disable Layout/LineLength
       validate_form_526_title10_activation_date!
       # ensure 'title10Activation.anticipatedSeparationDate' is in the future
@@ -137,6 +139,12 @@ module ClaimsApi
         'anticipatedSeparationDate',
         title10_anticipated_separation_date
       )
+    end
+
+    def validate_form_526_unit_name!
+      unit_name = form_attributes&.dig('serviceInformation', 'reservesNationalGuardService', 'unitName')
+      unit_name = ' ' if unit_name.empty?
+      form_attributes['serviceInformation']['reservesNationalGuardService']['unitName'] = unit_name
     end
 
     def validate_form_526_submission_claim_date!

--- a/modules/claims_api/spec/requests/v1/forms/526_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_spec.rb
@@ -872,6 +872,25 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
               end
             end
           end
+
+          context "when 'unitName' is empty" do
+            let(:unit_name) { '' }
+
+            it 'returns a successful response' do
+              mock_acg(scopes) do |auth_header|
+                VCR.use_cassette('claims_api/bgs/claims/claims') do
+                  VCR.use_cassette('claims_api/brd/countries') do
+                    par = json_data
+                    par['data']['attributes']['serviceInformation']['reservesNationalGuardService']['unitName'] =
+                      unit_name
+
+                    post path, params: par.to_json, headers: headers.merge(auth_header)
+                    expect(response).to have_http_status(:ok)
+                  end
+                end
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## Summary

- Adds transformation of empty unitName. 
- Adds a corresponding test.


## Related issue(s)

- [API-41802](https://jira.devops.va.gov/browse/API-41802)

## Testing done

- [X] *New code is covered by unit tests*
- hit v1 526 and set unitName to an empty string. You should get a 200

## Screenshots
<img width="907" alt="Screenshot 2024-11-05 at 10 55 04 AM" src="https://github.com/user-attachments/assets/2afeb982-ff03-4961-b9a1-b60e754f2ae6">


## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
	modified:   modules/claims_api/spec/requests/v1/forms/526_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature