### PR TITLE
96377: Increase DR Sidekiq jobs retry counts for COLA maintenance

### DIFF
--- a/app/sidekiq/decision_review/form4142_submit.rb
+++ b/app/sidekiq/decision_review/form4142_submit.rb
@@ -10,9 +10,8 @@ module DecisionReview
 
     STATSD_KEY_PREFIX = 'worker.decision_review.form4142_submit'
 
-    # 13 retries equates to roughly 1 day using exponential backoff, which should
-    # be long enough to resolve transient errors like temporary Central Mail outages.
-    sidekiq_options retry: 13
+    # Increasing to 17 retries, approximately 3 days, for ~39 hour COLA maintenance
+    sidekiq_options retry: 17
 
     sidekiq_retries_exhausted do |msg, _ex|
       error_message = msg['error_message']

--- a/app/sidekiq/decision_review/submit_upload.rb
+++ b/app/sidekiq/decision_review/submit_upload.rb
@@ -10,7 +10,8 @@ module DecisionReview
 
     STATSD_KEY_PREFIX = 'worker.decision_review.submit_upload'
 
-    sidekiq_options retry: 13
+    # Increasing to 17 retries, approximately 3 days, for ~39 hour COLA maintenance
+    sidekiq_options retry: 17
 
     sidekiq_retries_exhausted do |msg, _ex|
       error_message = msg['error_message']


### PR DESCRIPTION
## Summary
This PR updates the Decision Review sidekiq jobs to increase the retries in preparation for a ~39 hour COLA maintenance window.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/96377

## Testing done
This is a job configuration change so it does not have unit tests for the retries.

## What areas of the site does it impact?
Decision Review sidekiq jobs related to claims evidence upload and secondary form submissions.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
