### PR TITLE
[API-40054] update poa decide enums

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -44,7 +44,7 @@ module ClaimsApi
           unless decision && %w[accepted declined].include?(normalize(decision))
             raise ::Common::Exceptions::ParameterMissing.new(
               'decision',
-              detail: 'decision is required and must be either "accepted" or "declined"'
+              detail: 'decision is required and must be either "ACCEPTED" or "DECLINED"'
             )
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -350,8 +350,8 @@
                             "type": "string",
                             "description": "The decision of the request.",
                             "enum": [
-                              "approved",
-                              "declined"
+                              "ACCEPTED",
+                              "DECLINED"
                             ]
                           },
                           "declinedReason": {
@@ -368,7 +368,7 @@
                   "data": {
                     "attributes": {
                       "procId": "76529",
-                      "decision": "accepted",
+                      "decision": "ACCEPTED",
                       "declinedReason": null
                     }
                   }

--- a/modules/claims_api/config/schemas/v2/power_of_attorney_requests/param/decision/post.json
+++ b/modules/claims_api/config/schemas/v2/power_of_attorney_requests/param/decision/post.json
@@ -29,8 +29,8 @@
               "type": "string",
               "description": "The decision of the request.",
               "enum": [
-                "approved",
-                "declined"
+                "ACCEPTED",
+                "DECLINED"
               ]
             },
             "declinedReason": {

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -78,12 +78,12 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
       end
     end
 
-    context 'when decision is not accepted or declined' do
+    context 'when decision is not ACCEPTED or DECLINED' do
       before do
         allow(subject).to receive(:form_attributes).and_return({ 'procId' => '76529', 'decision' => 'invalid' })
       end
 
-      it 'raises a ParameterMissing error if decision is not accepted or declined' do
+      it 'raises a ParameterMissing error' do
         expect do
           subject.decide
         end.to raise_error(Common::Exceptions::ParameterMissing)
@@ -92,7 +92,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
     context 'when procId is present and valid and decision is accepted' do
       let(:proc_id) { '76529' }
-      let(:decision) { 'accepted' }
+      let(:decision) { 'ACCEPTED' }
 
       it 'updates the secondaryStatus and returns a hash containing the ACC code' do
         mock_ccg(scopes) do |auth_header|
@@ -110,7 +110,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
     context 'when procId is present but invalid' do
       let(:proc_id) { '1' }
-      let(:decision) { 'accepted' }
+      let(:decision) { 'ACCEPTED' }
 
       it 'raises an error' do
         mock_ccg(scopes) do |auth_header|

--- a/modules/claims_api/spec/requests/v2/power_of_attorney_requests/decisions/create/rswag_spec.rb
+++ b/modules/claims_api/spec/requests/v2/power_of_attorney_requests/decisions/create/rswag_spec.rb
@@ -44,7 +44,7 @@ describe 'PowerOfAttorney', metadata do
         'data' => {
           'attributes' => {
             'procId' => '76529',
-            'decision' => 'accepted',
+            'decision' => 'ACCEPTED',
             'declinedReason' => nil
           }
         }


### PR DESCRIPTION
## Summary

- All caps POA `/decide` decision enums.
- Fix typo in docs (staging only) from `approved` → `ACCEPTED`.

## Related issue(s)

[API-40054](https://jira.devops.va.gov/browse/API-40054)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

<img width="899" alt="decide-example" src="https://github.com/user-attachments/assets/f56dfffb-d3c0-4c51-b6bd-3880654b8d3c">

<img width="1138" alt="decide-schema" src="https://github.com/user-attachments/assets/5eb26226-c98b-423b-a54b-20aa291fd75f">

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

N/A
