### PR TITLE
Add route and controller for LH API Vet Title 38 Verification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,6 +130,7 @@ app/controllers/v0/prescription_preferences_controller.rb @department-of-veteran
 app/controllers/v0/prescriptions_controller.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/profile/contacts_controller.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/v0/profile/vet_verification_statuses_controller.rb @department-of-veterans-affairs/va-iir @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/rated_disabilities_controller.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/rated_disabilities_discrepancies_controller.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/search_click_tracking_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/profile/vet_verification_statuses_controller.rb
+++ b/app/controllers/v0/profile/vet_verification_statuses_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class VetVerificationStatusesController < ApplicationController
+      service_tag 'profile'
+      before_action { authorize :lighthouse, :access? }
+
+      def show
+        access_token = settings.access_token
+        response = service.get_vet_verification_status(@current_user.icn, access_token.client_id, access_token.rsa_key)
+        response['data']['id'] = ''
+
+        render json: response
+      end
+
+      private
+
+      def service
+        @service ||= VeteranVerification::Service.new
+      end
+
+      def settings
+        Settings.lighthouse.veteran_verification['status']
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,6 +297,7 @@ Rails.application.routes.draw do
 
       # Lighthouse
       resource :direct_deposits, only: %i[show update]
+      resource :vet_verification_status, only: :show
 
       # Vet360 Routes
       resource :addresses, only: %i[create update destroy] do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1074,6 +1074,12 @@ lighthouse:
       access_token:
         client_id: ~
         rsa_key: ~
+      use_mocks: true
+    status:
+      host: https://staging-api.va.gov
+      access_token:
+        client_id: ~
+        rsa_key: ~
       use_mocks: false
   s3:
     uploads_enabled: false

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -31,6 +31,9 @@ module VeteranVerification
       handle_error(e, lighthouse_client_id, endpoint)
     end
 
+    ##
+    # Request a veteran's Title 38 status
+    #   see https://developer.va.gov/explore/api/veteran-service-history-and-eligibility/docs
     def get_vet_verification_status(icn, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
       endpoint = 'status'
       config.get(

--- a/spec/controllers/v0/profile/vet_verification_statuses_controller_spec.rb
+++ b/spec/controllers/v0/profile/vet_verification_statuses_controller_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V0::Profile::VetVerificationStatusesController, type: :controller do
+  let(:user) { create(:user, :loa3, icn: '1012667145V762142') }
+
+  before do
+    sign_in_as(user)
+    allow_any_instance_of(VeteranVerification::Configuration).to receive(:access_token).and_return('blahblech')
+  end
+
+  describe '#show' do
+    context 'when successful' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('lighthouse/veteran_verification/status/200_show_response') do
+          get(:show)
+        end
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns veteran confirmation status' do
+        VCR.use_cassette('lighthouse/veteran_verification/status/200_show_response') do
+          get(:show)
+        end
+
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['data']['attributes']['veteran_status']).to eq('confirmed')
+      end
+
+      it 'removes the Veterans ICN from the response before sending' do
+        VCR.use_cassette('lighthouse/veteran_verification/status/200_show_response') do
+          get(:show)
+        end
+
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['data']['id']).to eq('')
+      end
+    end
+
+    context 'when not authorized' do
+      it 'returns a status of 401' do
+        VCR.use_cassette('lighthouse/veteran_verification/status/401_response') do
+          get(:show)
+        end
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when ICN not found' do
+      let(:user) { create(:user, :loa3, icn: '1012667145V762141') }
+
+      before do
+        sign_in_as(user)
+        allow_any_instance_of(VeteranVerification::Configuration).to receive(:access_token).and_return('blahblech')
+      end
+
+      it 'returns a status of 200' do
+        VCR.use_cassette('lighthouse/veteran_verification/status/200_person_not_found_response') do
+          get(:show)
+        end
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a person_not_found reason' do
+        VCR.use_cassette('lighthouse/veteran_verification/status/200_person_not_found_response') do
+          get(:show)
+        end
+
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['data']['attributes']['veteran_status']).to eq('not confirmed')
+        expect(parsed_body['data']['attributes']['not_confirmed_reason']).to eq('PERSON_NOT_FOUND')
+      end
+    end
+  end
+end

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_person_not_found_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_person_not_found_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762141
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 01 Nov 2024 21:37:28 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Reset:
+      - '33'
+      Ratelimit-Limit:
+      - '120'
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":null,"type":"veteran_status_confirmations","attributes":{"veteran_status":"not
+        confirmed","not_confirmed_reason":"PERSON_NOT_FOUND"}}}'
+  recorded_at: Fri, 01 Nov 2024 21:37:28 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_show_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_show_response.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/status/1012667145V762142
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 01 Nov 2024 17:27:12 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '48'
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Limit:
+      - '120'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"1012667145V762142","type":"veteran_status_confirmations","attributes":{"veteran_status":"confirmed"}}}'
+  recorded_at: Fri, 01 Nov 2024 17:27:12 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary

- This work is not behind a feature toggle.
- This change adds a new route and controller to the `V0::Profile` module in the `app/controllers/v0/profile/vet_verification_statuses_controller.rb` file for getting confirmation of a veteran's Title 38 status. This endpoint returns data from the Lighthouse Veteran Service History and Eligibility API `/status` endpoint, which will be used to determine if a veteran is eligible to view their Proof of Status card. A forthcoming vets-website PR will integrate the data returned into the Veteran Proof of Status feature.
- Documentation and further logging will be added in a forthcoming PR.
- I work on the IIR Product team and we currently own this feature.

## Related issue(s)

- [1138](https://github.com/department-of-veterans-affairs/va-iir/issues/1138)

## Testing done

- [x] *New code is covered by unit tests*
- There is no old behavior, as this is a completely new implementation. Testing will be conducted, once the route is in place, to ensure that the endpoint can be hit with a logged in user and data returned as expected.

## Screenshots


## What areas of the site does it impact?
This change does not impact any areas outside of the newly added files.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

