### PR TITLE
95932: Update Pensions monitor

### DIFF
--- a/modules/pensions/lib/pensions/monitor.rb
+++ b/modules/pensions/lib/pensions/monitor.rb
@@ -27,8 +27,16 @@ module Pensions
     # @param e [ActiveRecord::RecordNotFound]
     #
     def track_show404(confirmation_number, current_user, e)
-      Rails.logger.error('21P-527EZ submission not found',
-                         { confirmation_number:, user_uuid: current_user&.uuid, message: e&.message })
+      additional_context = {
+        confirmation_number:,
+        user_account_uuid: current_user&.user_account_uuid,
+        message: e&.message,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('error', '21P-527EZ submission not found', CLAIM_STATS_KEY, additional_context,
+                    call_location: caller_locations.first)
     end
 
     ##
@@ -40,8 +48,16 @@ module Pensions
     # @param e [Error]
     #
     def track_show_error(confirmation_number, current_user, e)
-      Rails.logger.error('21P-527EZ fetching submission failed',
-                         { confirmation_number:, user_uuid: current_user&.uuid, message: e&.message })
+      additional_context = {
+        confirmation_number:,
+        user_account_uuid: current_user&.user_account_uuid,
+        message: e&.message,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('error', '21P-527EZ fetching submission failed', CLAIM_STATS_KEY, additional_context,
+                    call_location: caller_locations.first)
     end
 
     ##
@@ -52,10 +68,15 @@ module Pensions
     # @param current_user [User]
     #
     def track_create_attempt(claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.attempt")
-      Rails.logger.info('21P-527EZ submission to Sidekiq begun',
-                        { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
-                          statsd: "#{CLAIM_STATS_KEY}.attempt" })
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: current_user&.user_account_uuid,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('info', '21P-527EZ submission to Sidekiq begun', "#{CLAIM_STATS_KEY}.attempt", additional_context,
+                    call_location: caller_locations.first)
     end
 
     ##
@@ -68,11 +89,17 @@ module Pensions
     # @param e [Error]
     #
     def track_create_validation_error(in_progress_form, claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.validation_error")
-      Rails.logger.error('21P-527EZ submission validation error',
-                         { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
-                           in_progress_form_id: in_progress_form&.id, errors: claim&.errors&.errors,
-                           statsd: "#{CLAIM_STATS_KEY}.validation_error" })
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: current_user&.user_account_uuid,
+        in_progress_form_id: in_progress_form&.id,
+        errors: claim&.errors&.errors,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('error', '21P-527EZ submission validation error', "#{CLAIM_STATS_KEY}.validation_error",
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -85,11 +112,18 @@ module Pensions
     # @param e [Error]
     #
     def track_create_error(in_progress_form, claim, current_user, e = nil)
-      StatsD.increment("#{CLAIM_STATS_KEY}.failure")
-      Rails.logger.error('21P-527EZ submission to Sidekiq failed',
-                         { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
-                           in_progress_form_id: in_progress_form&.id, errors: claim&.errors&.errors,
-                           message: e&.message, statsd: "#{CLAIM_STATS_KEY}.failure" })
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: current_user&.user_account_uuid,
+        in_progress_form_id: in_progress_form&.id,
+        errors: claim&.errors&.errors,
+        message: e&.message,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('error', '21P-527EZ submission to Sidekiq failed', "#{CLAIM_STATS_KEY}.failure", additional_context,
+                    call_location: caller_locations.first)
     end
 
     ##
@@ -101,14 +135,16 @@ module Pensions
     # @param current_user [User]
     #
     def track_create_success(in_progress_form, claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.success")
-      context = {
+      additional_context = {
         confirmation_number: claim&.confirmation_number,
-        user_uuid: current_user&.uuid,
+        user_account_uuid: current_user&.user_account_uuid,
         in_progress_form_id: in_progress_form&.id,
-        statsd: "#{CLAIM_STATS_KEY}.success"
+        tags: {
+          form_id: '21P-527EZ'
+        }
       }
-      Rails.logger.info('21P-527EZ submission to Sidekiq success', context)
+      track_request('info', '21P-527EZ submission to Sidekiq success', "#{CLAIM_STATS_KEY}.success",
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -120,11 +156,17 @@ module Pensions
     # @param e [Error]
     #
     def track_process_attachment_error(in_progress_form, claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.process_attachment_error")
-      Rails.logger.error('21P-527EZ process attachment error',
-                         { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
-                           in_progress_form_id: in_progress_form&.id, errors: claim&.errors&.errors,
-                           statsd: "#{CLAIM_STATS_KEY}.process_attachment_error" })
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: current_user&.user_account_uuid,
+        in_progress_form_id: in_progress_form&.id,
+        errors: claim&.errors&.errors,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('error', '21P-527EZ process attachment error', "#{CLAIM_STATS_KEY}.process_attachment_error",
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -133,17 +175,20 @@ module Pensions
     #
     # @param claim [Pension::SavedClaim]
     # @param lighthouse_service [BenefitsIntake::Service]
-    # @param user_uuid [UUID]
+    # @param user_account_uuid [UUID]
     #
-    def track_submission_begun(claim, lighthouse_service, user_uuid)
-      StatsD.increment("#{SUBMISSION_STATS_KEY}.begun")
-      Rails.logger.info('Lighthouse::PensionBenefitIntakeJob submission to LH begun',
-                        {
-                          claim_id: claim&.id,
-                          benefits_intake_uuid: lighthouse_service&.uuid,
-                          confirmation_number: claim&.confirmation_number,
-                          user_uuid:
-                        })
+    def track_submission_begun(claim, lighthouse_service, user_account_uuid)
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid:,
+        claim_id: claim&.id,
+        benefits_intake_uuid: lighthouse_service&.uuid,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('info', 'Lighthouse::PensionBenefitIntakeJob submission to LH begun',
+                    "#{SUBMISSION_STATS_KEY}.begun", additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -152,19 +197,23 @@ module Pensions
     #
     # @param claim [Pension::SavedClaim]
     # @param lighthouse_service [BenefitsIntake::Service]
-    # @param user_uuid [UUID]
+    # @param user_account_uuid [UUID]
     # @param upload [Hash] lighthouse upload data
     #
-    def track_submission_attempted(claim, lighthouse_service, user_uuid, upload)
-      StatsD.increment("#{SUBMISSION_STATS_KEY}.attempt")
-      Rails.logger.info('Lighthouse::PensionBenefitIntakeJob submission to LH attempted', {
-                          claim_id: claim&.id,
-                          benefits_intake_uuid: lighthouse_service&.uuid,
-                          confirmation_number: claim&.confirmation_number,
-                          user_uuid:,
-                          file: upload[:file],
-                          attachments: upload[:attachments]
-                        })
+    def track_submission_attempted(claim, lighthouse_service, user_account_uuid, upload)
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid:,
+        claim_id: claim&.id,
+        benefits_intake_uuid: lighthouse_service&.uuid,
+        file: upload[:file],
+        attachments: upload[:attachments],
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('info', 'Lighthouse::PensionBenefitIntakeJob submission to LH attempted',
+                    "#{SUBMISSION_STATS_KEY}.attempt", additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -173,16 +222,20 @@ module Pensions
     #
     # @param claim [Pension::SavedClaim]
     # @param lighthouse_service [BenefitsIntake::Service]
-    # @param user_uuid [UUID]
+    # @param user_account_uuid [UUID]
     #
-    def track_submission_success(claim, lighthouse_service, user_uuid)
-      StatsD.increment("#{SUBMISSION_STATS_KEY}.success")
-      Rails.logger.info('Lighthouse::PensionBenefitIntakeJob submission to LH succeeded', {
-                          claim_id: claim&.id,
-                          benefits_intake_uuid: lighthouse_service&.uuid,
-                          confirmation_number: claim&.confirmation_number,
-                          user_uuid:
-                        })
+    def track_submission_success(claim, lighthouse_service, user_account_uuid)
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid:,
+        claim_id: claim&.id,
+        benefits_intake_uuid: lighthouse_service&.uuid,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('info', 'Lighthouse::PensionBenefitIntakeJob submission to LH succeeded',
+                    "#{SUBMISSION_STATS_KEY}.success", additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -191,18 +244,22 @@ module Pensions
     #
     # @param claim [Pension::SavedClaim]
     # @param lighthouse_service [BenefitsIntake::Service]
-    # @param user_uuid [UUID]
+    # @param user_account_uuid [UUID]
     # @param e [Error]
     #
-    def track_submission_retry(claim, lighthouse_service, user_uuid, e)
-      StatsD.increment("#{SUBMISSION_STATS_KEY}.failure")
-      Rails.logger.warn('Lighthouse::PensionBenefitIntakeJob submission to LH failed, retrying', {
-                          claim_id: claim&.id,
-                          benefits_intake_uuid: lighthouse_service&.uuid,
-                          confirmation_number: claim&.confirmation_number,
-                          user_uuid:,
-                          message: e&.message
-                        })
+    def track_submission_retry(claim, lighthouse_service, user_account_uuid, e)
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid:,
+        claim_id: claim&.id,
+        benefits_intake_uuid: lighthouse_service&.uuid,
+        message: e&.message,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('warn', 'Lighthouse::PensionBenefitIntakeJob submission to LH failed, retrying',
+                    "#{SUBMISSION_STATS_KEY}.failure", additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -215,16 +272,18 @@ module Pensions
     def track_submission_exhaustion(msg, claim = nil)
       user_account_uuid = msg['args'].length <= 1 ? nil : msg['args'][1]
       additional_context = {
-        form_id: claim&.form_id,
-        claim_id: msg['args'].first,
         confirmation_number: claim&.confirmation_number,
-        message: msg
+        user_account_uuid: user_account_uuid,
+        claim_id: msg['args'].first,
+        form_id: claim&.form_id,
+        message: msg,
+        tags: {
+          form_id: '21P-527EZ'
+        }
       }
       log_silent_failure(additional_context, user_account_uuid, call_location: caller_locations.first)
-
-      StatsD.increment("#{SUBMISSION_STATS_KEY}.exhausted")
-      Rails.logger.error('Lighthouse::PensionBenefitIntakeJob submission to LH exhausted!',
-                         user_uuid: user_account_uuid, **additional_context)
+      track_request('error', 'Lighthouse::PensionBenefitIntakeJob submission to LH exhausted!',
+                    "#{SUBMISSION_STATS_KEY}.exhausted", additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -233,17 +292,23 @@ module Pensions
     #
     # @param claim [Pension::SavedClaim]
     # @param lighthouse_service [LighthouseService]
-    # @param user_uuid [String]
+    # @param user_account_uuid [String]
     # @param e [Exception]
     #
-    def track_send_confirmation_email_failure(claim, lighthouse_service, user_uuid, e)
-      Rails.logger.warn('Lighthouse::PensionBenefitIntakeJob send_confirmation_email failed', {
-                          claim_id: claim&.id,
-                          benefits_intake_uuid: lighthouse_service&.uuid,
-                          confirmation_number: claim&.confirmation_number,
-                          user_uuid:,
-                          message: e&.message
-                        })
+    def track_send_confirmation_email_failure(claim, lighthouse_service, user_account_uuid, e)
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid:,
+        claim_id: claim&.id,
+        benefits_intake_uuid: lighthouse_service&.uuid,
+        message: e&.message,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+
+      track_request('warn', 'Lighthouse::PensionBenefitIntakeJob send_confirmation_email failed', CLAIM_STATS_KEY,
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -252,19 +317,22 @@ module Pensions
     #
     # @param claim [Pension::SavedClaim]
     # @param lighthouse_service [BenefitsIntake::Service]
-    # @param user_uuid [UUID]
+    # @param user_account_uuid [UUID]
     # @param e [Error]
     #
-    def track_file_cleanup_error(claim, lighthouse_service, user_uuid, e)
-      StatsD.increment("#{SUBMISSION_STATS_KEY}.cleanup_failed")
-      Rails.logger.error('Lighthouse::PensionBenefitIntakeJob cleanup failed',
-                         {
-                           claim_id: claim&.id,
-                           benefits_intake_uuid: lighthouse_service&.uuid,
-                           confirmation_number: claim&.confirmation_number,
-                           user_uuid:,
-                           error: e&.message
-                         })
+    def track_file_cleanup_error(claim, lighthouse_service, user_account_uuid, e)
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid:,
+        claim_id: claim&.id,
+        benefits_intake_uuid: lighthouse_service&.uuid,
+        error: e&.message,
+        tags: {
+          form_id: '21P-527EZ'
+        }
+      }
+      track_request('error', 'Lighthouse::PensionBenefitIntakeJob cleanup failed',
+                    "#{SUBMISSION_STATS_KEY}.cleanup_failed", additional_context, call_location: caller_locations.first)
     end
   end
 end

--- a/modules/pensions/spec/lib/pensions/monitor_spec.rb
+++ b/modules/pensions/spec/lib/pensions/monitor_spec.rb
@@ -20,11 +20,20 @@ RSpec.describe Pensions::Monitor do
         log = '21P-527EZ submission not found'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          message: monitor_error.message
+          user_account_uuid: current_user.user_account_uuid,
+          message: monitor_error.message,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(Rails.logger).to receive(:error).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          claim_stats_key,
+          payload,
+          anything
+        )
 
         monitor.track_show404(claim.confirmation_number, current_user, monitor_error)
       end
@@ -35,11 +44,20 @@ RSpec.describe Pensions::Monitor do
         log = '21P-527EZ fetching submission failed'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          message: monitor_error.message
+          user_account_uuid: current_user.user_account_uuid,
+          message: monitor_error.message,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(Rails.logger).to receive(:error).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          claim_stats_key,
+          payload,
+          anything
+        )
 
         monitor.track_show_error(claim.confirmation_number, current_user, monitor_error)
       end
@@ -50,12 +68,19 @@ RSpec.describe Pensions::Monitor do
         log = '21P-527EZ submission to Sidekiq begun'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          statsd: "#{claim_stats_key}.attempt"
+          user_account_uuid: current_user.user_account_uuid,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.attempt")
-        expect(Rails.logger).to receive(:info).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'info',
+          log,
+          "#{claim_stats_key}.attempt",
+          payload,
+          anything
+        )
 
         monitor.track_create_attempt(claim, current_user)
       end
@@ -66,14 +91,21 @@ RSpec.describe Pensions::Monitor do
         log = '21P-527EZ submission validation error'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
           errors: [], # mock claim does not have `errors`
-          statsd: "#{claim_stats_key}.validation_error"
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.validation_error")
-        expect(Rails.logger).to receive(:error).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{claim_stats_key}.validation_error",
+          payload,
+          anything
+        )
 
         monitor.track_create_validation_error(ipf, claim, current_user)
       end
@@ -84,14 +116,21 @@ RSpec.describe Pensions::Monitor do
         log = '21P-527EZ process attachment error'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
           errors: [], # mock claim does not have `errors`
-          statsd: "#{claim_stats_key}.process_attachment_error"
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.process_attachment_error")
-        expect(Rails.logger).to receive(:error).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{claim_stats_key}.process_attachment_error",
+          payload,
+          anything
+        )
 
         monitor.track_process_attachment_error(ipf, claim, current_user)
       end
@@ -102,15 +141,22 @@ RSpec.describe Pensions::Monitor do
         log = '21P-527EZ submission to Sidekiq failed'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
           errors: [], # mock claim does not have `errors`
           message: monitor_error.message,
-          statsd: "#{claim_stats_key}.failure"
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.failure")
-        expect(Rails.logger).to receive(:error).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{claim_stats_key}.failure",
+          payload,
+          anything
+        )
 
         monitor.track_create_error(ipf, claim, current_user, monitor_error)
       end
@@ -121,14 +167,21 @@ RSpec.describe Pensions::Monitor do
         log = '21P-527EZ submission to Sidekiq success'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
-          statsd: "#{claim_stats_key}.success"
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
         claim.form_start_date = Time.zone.now
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.success")
-        expect(Rails.logger).to receive(:info).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'info',
+          log,
+          "#{claim_stats_key}.success",
+          payload,
+          anything
+        )
 
         monitor.track_create_success(ipf, claim, current_user)
       end
@@ -141,11 +194,19 @@ RSpec.describe Pensions::Monitor do
           claim_id: claim.id,
           benefits_intake_uuid: lh_service.uuid,
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid
+          user_account_uuid: current_user.uuid,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.begun")
-        expect(Rails.logger).to receive(:info).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'info',
+          log,
+          "#{submission_stats_key}.begun",
+          payload,
+          anything
+        )
 
         monitor.track_submission_begun(claim, lh_service, current_user.uuid)
       end
@@ -163,13 +224,21 @@ RSpec.describe Pensions::Monitor do
           claim_id: claim.id,
           benefits_intake_uuid: lh_service.uuid,
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.uuid,
           file: upload[:file],
-          attachments: upload[:attachments]
+          attachments: upload[:attachments],
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.attempt")
-        expect(Rails.logger).to receive(:info).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'info',
+          log,
+          "#{submission_stats_key}.attempt",
+          payload,
+          anything
+        )
 
         monitor.track_submission_attempted(claim, lh_service, current_user.uuid, upload)
       end
@@ -182,11 +251,19 @@ RSpec.describe Pensions::Monitor do
           claim_id: claim.id,
           benefits_intake_uuid: lh_service.uuid,
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid
+          user_account_uuid: current_user.uuid,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.success")
-        expect(Rails.logger).to receive(:info).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'info',
+          log,
+          "#{submission_stats_key}.success",
+          payload,
+          anything
+        )
 
         monitor.track_submission_success(claim, lh_service, current_user.uuid)
       end
@@ -199,12 +276,20 @@ RSpec.describe Pensions::Monitor do
           claim_id: claim.id,
           benefits_intake_uuid: lh_service.uuid,
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          message: monitor_error.message
+          user_account_uuid: current_user.uuid,
+          message: monitor_error.message,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.failure")
-        expect(Rails.logger).to receive(:warn).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'warn',
+          log,
+          "#{submission_stats_key}.failure",
+          payload,
+          anything
+        )
 
         monitor.track_submission_retry(claim, lh_service, current_user.uuid, monitor_error)
       end
@@ -218,13 +303,23 @@ RSpec.describe Pensions::Monitor do
         payload = {
           form_id: claim.form_id,
           claim_id: claim.id,
+          user_account_uuid: current_user.uuid,
           confirmation_number: claim.confirmation_number,
-          message: msg
+          message: msg,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
         expect(monitor).to receive(:log_silent_failure).with(payload, current_user.uuid, anything)
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted")
-        expect(Rails.logger).to receive(:error).with(log, user_uuid: current_user.uuid, **payload)
+
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{submission_stats_key}.exhausted",
+          payload,
+          anything
+        )
 
         monitor.track_submission_exhaustion(msg, claim)
       end
@@ -237,11 +332,20 @@ RSpec.describe Pensions::Monitor do
           claim_id: claim.id,
           benefits_intake_uuid: lh_service.uuid,
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          message: monitor_error.message
+          user_account_uuid: current_user.uuid,
+          message: monitor_error.message,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(Rails.logger).to receive(:warn).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'warn',
+          log,
+          claim_stats_key,
+          payload,
+          anything
+        )
 
         monitor.track_send_confirmation_email_failure(claim, lh_service, current_user.uuid, monitor_error)
       end
@@ -254,11 +358,20 @@ RSpec.describe Pensions::Monitor do
           claim_id: claim.id,
           benefits_intake_uuid: lh_service.uuid,
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          error: monitor_error.message
+          user_account_uuid: current_user.uuid,
+          error: monitor_error.message,
+          tags: {
+            form_id: '21P-527EZ'
+          }
         }
 
-        expect(Rails.logger).to receive(:error).with(log, payload)
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{submission_stats_key}.cleanup_failed",
+          payload,
+          anything
+        )
 
         monitor.track_file_cleanup_error(claim, lh_service, current_user.uuid, monitor_error)
       end


### PR DESCRIPTION
Now that we have the general classes in place refactor the existing class and functions used in pension (and income-and-assets) to be reusable from other form submission workflows


## Summary

- Refactor `Pensions::Monitor` to use new generalized method
- Update unit tests

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95932

## Testing done

- [ ] *New code is covered by unit tests*
