### PR TITLE
95932: Update Burials monitor

### DIFF
--- a/lib/burials/monitor.rb
+++ b/lib/burials/monitor.rb
@@ -26,8 +26,16 @@ module Burials
     # @param e [ActiveRecord::RecordNotFound]
     #
     def track_show404(confirmation_number, current_user, e)
-      Rails.logger.error('21P-530EZ submission not found',
-                         { confirmation_number:, user_uuid: current_user&.uuid, message: e&.message })
+      additional_context = {
+        confirmation_number:,
+        user_account_uuid: current_user&.user_account_uuid,
+        message: e&.message,
+        tags: {
+          form_id: '21P-530EZ'
+        }
+      }
+      track_request('error', '21P-530EZ submission not found', CLAIM_STATS_KEY, additional_context,
+                    call_location: caller_locations.first)
     end
 
     ##
@@ -39,8 +47,16 @@ module Burials
     # @param e [Error]
     #
     def track_show_error(confirmation_number, current_user, e)
-      Rails.logger.error('21P-530EZ fetching submission failed',
-                         { confirmation_number:, user_uuid: current_user&.uuid, message: e&.message })
+      additional_context = {
+        confirmation_number:,
+        user_account_uuid: current_user&.user_account_uuid,
+        message: e&.message,
+        tags: {
+          form_id: '21P-530EZ'
+        }
+      }
+      track_request('error', '21P-530EZ fetching submission failed', CLAIM_STATS_KEY, additional_context,
+                    call_location: caller_locations.first)
     end
 
     ##
@@ -51,10 +67,15 @@ module Burials
     # @param current_user [User]
     #
     def track_create_attempt(claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.attempt")
-      Rails.logger.info('21P-530EZ submission to Sidekiq begun',
-                        { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
-                          statsd: "#{CLAIM_STATS_KEY}.attempt" })
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: current_user&.user_account_uuid,
+        tags: {
+          form_id: '21P-530EZ'
+        }
+      }
+      track_request('error', '21P-530EZ submission to Sidekiq begun', "#{CLAIM_STATS_KEY}.attempt", additional_context,
+                    call_location: caller_locations.first)
     end
 
     ##
@@ -67,11 +88,17 @@ module Burials
     # @param e [Error]
     #
     def track_create_validation_error(in_progress_form, claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.validation_error")
-      Rails.logger.error('21P-530EZ submission validation error',
-                         { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
-                           in_progress_form_id: in_progress_form&.id, errors: claim&.errors&.errors,
-                           statsd: "#{CLAIM_STATS_KEY}.validation_error" })
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: current_user&.user_account_uuid,
+        in_progress_form_id: in_progress_form&.id,
+        errors: claim&.errors&.errors,
+        tags: {
+          form_id: '21P-530EZ'
+        }
+      }
+      track_request('error', '21P-530EZ submission validation error', "#{CLAIM_STATS_KEY}.validation_error",
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -84,11 +111,18 @@ module Burials
     # @param e [Error]
     #
     def track_create_error(in_progress_form, claim, current_user, e = nil)
-      StatsD.increment("#{CLAIM_STATS_KEY}.failure")
-      Rails.logger.error('21P-530EZ submission to Sidekiq failed',
-                         { confirmation_number: claim&.confirmation_number, user_uuid: current_user&.uuid,
-                           in_progress_form_id: in_progress_form&.id, errors: claim&.errors&.errors,
-                           message: e&.message, statsd: "#{CLAIM_STATS_KEY}.failure" })
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: current_user&.user_account_uuid,
+        in_progress_form_id: in_progress_form&.id,
+        errors: claim&.errors&.errors,
+        message: e&.message,
+        tags: {
+          form_id: '21P-530EZ'
+        }
+      }
+      track_request('error', '21P-530EZ submission to Sidekiq failed', "#{CLAIM_STATS_KEY}.failure",
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -100,14 +134,17 @@ module Burials
     # @param current_user [User]
     #
     def track_create_success(in_progress_form, claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.success")
-      context = {
+      additional_context = {
         confirmation_number: claim&.confirmation_number,
-        user_uuid: current_user&.uuid,
+        user_account_uuid: current_user&.user_account_uuid,
         in_progress_form_id: in_progress_form&.id,
-        statsd: "#{CLAIM_STATS_KEY}.success"
+        errors: claim&.errors&.errors,
+        tags: {
+          form_id: '21P-530EZ'
+        }
       }
-      Rails.logger.info('21P-530EZ submission to Sidekiq success', context)
+      track_request('info', '21P-530EZ submission to Sidekiq success', "#{CLAIM_STATS_KEY}.success",
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -119,15 +156,17 @@ module Burials
     # @param current_user [User]
     #
     def track_process_attachment_error(in_progress_form, claim, current_user)
-      StatsD.increment("#{CLAIM_STATS_KEY}.process_attachment_error")
-      context = {
+      additional_context = {
         confirmation_number: claim&.confirmation_number,
-        user_uuid: current_user&.uuid,
+        user_account_uuid: current_user&.user_account_uuid,
         in_progress_form_id: in_progress_form&.id,
         errors: claim&.errors&.errors,
-        statsd: "#{CLAIM_STATS_KEY}.process_attachment_error"
+        tags: {
+          form_id: '21P-530EZ'
+        }
       }
-      Rails.logger.error('21P-530EZ process attachment error', context)
+      track_request('error', '21P-530EZ process attachment error', "#{CLAIM_STATS_KEY}.process_attachment_error",
+                    additional_context, call_location: caller_locations.first)
     end
 
     ##
@@ -140,16 +179,19 @@ module Burials
     def track_submission_exhaustion(msg, claim = nil)
       user_account_uuid = msg['args'].length <= 1 ? nil : msg['args'][1]
       additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid: user_account_uuid,
         form_id: claim&.form_id,
         claim_id: msg['args'].first,
-        confirmation_number: claim&.confirmation_number,
-        message: msg
+        message: msg,
+        tags: {
+          form_id: '21P-530EZ'
+        }
       }
       log_silent_failure(additional_context, user_account_uuid, call_location: caller_locations.first)
 
-      StatsD.increment("#{SUBMISSION_STATS_KEY}.exhausted")
-      Rails.logger.error('Lighthouse::SubmitBenefitsIntakeClaim Burial 21P-530EZ submission to LH exhausted!',
-                         user_uuid: user_account_uuid, **additional_context)
+      track_request('error', 'Lighthouse::SubmitBenefitsIntakeClaim Burial 21P-530EZ submission to LH exhausted!',
+                    "#{SUBMISSION_STATS_KEY}.exhausted", additional_context, call_location: caller_locations.first)
     end
   end
 end

--- a/spec/lib/burials/monitor_spec.rb
+++ b/spec/lib/burials/monitor_spec.rb
@@ -5,27 +5,34 @@ require_relative '../../../lib/burials/monitor'
 
 RSpec.describe Burials::Monitor do
   let(:monitor) { described_class.new }
-  let(:claim_stats_key) { described_class::CLAIM_STATS_KEY }
-  let(:submission_stats_key) { described_class::SUBMISSION_STATS_KEY }
   let(:claim) { create(:burial_claim_v2) }
   let(:ipf) { create(:in_progress_form) }
+  let(:claim_stats_key) { described_class::CLAIM_STATS_KEY }
+  let(:submission_stats_key) { described_class::SUBMISSION_STATS_KEY }
 
   context 'with all params supplied' do
     let(:current_user) { create(:user) }
     let(:monitor_error) { create(:monitor_error) }
-    let(:lh_service) { OpenStruct.new(uuid: 'uuid') }
 
     describe '#track_show404' do
       it 'logs a not found error' do
         log = '21P-530EZ submission not found'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          message: monitor_error.message
+          user_account_uuid: current_user.user_account_uuid,
+          message: monitor_error.message,
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
 
-        expect(Rails.logger).to receive(:error).with(log, payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          claim_stats_key,
+          payload,
+          anything
+        )
         monitor.track_show404(claim.confirmation_number, current_user, monitor_error)
       end
     end
@@ -35,12 +42,20 @@ RSpec.describe Burials::Monitor do
         log = '21P-530EZ fetching submission failed'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          message: monitor_error.message
+          user_account_uuid: current_user.user_account_uuid,
+          message: monitor_error.message,
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
 
-        expect(Rails.logger).to receive(:error).with(log, payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          claim_stats_key,
+          payload,
+          anything
+        )
         monitor.track_show_error(claim.confirmation_number, current_user, monitor_error)
       end
     end
@@ -50,13 +65,19 @@ RSpec.describe Burials::Monitor do
         log = '21P-530EZ submission to Sidekiq begun'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
-          statsd: "#{claim_stats_key}.attempt"
+          user_account_uuid: current_user.user_account_uuid,
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.attempt")
-        expect(Rails.logger).to receive(:info).with(log, payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{claim_stats_key}.attempt",
+          payload,
+          anything
+        )
         monitor.track_create_attempt(claim, current_user)
       end
     end
@@ -66,15 +87,21 @@ RSpec.describe Burials::Monitor do
         log = '21P-530EZ submission validation error'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
-          errors: [], # mock claim does not have `errors`
-          statsd: "#{claim_stats_key}.validation_error"
+          errors: [],
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.validation_error")
-        expect(Rails.logger).to receive(:error).with(log, payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{claim_stats_key}.validation_error",
+          payload,
+          anything
+        )
         monitor.track_create_validation_error(ipf, claim, current_user)
       end
     end
@@ -84,15 +111,21 @@ RSpec.describe Burials::Monitor do
         log = '21P-530EZ process attachment error'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
-          errors: [], # mock claim does not have `errors`
-          statsd: "#{claim_stats_key}.process_attachment_error"
+          errors: [],
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.process_attachment_error")
-        expect(Rails.logger).to receive(:error).with(log, payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{claim_stats_key}.process_attachment_error",
+          payload,
+          anything
+        )
         monitor.track_process_attachment_error(ipf, claim, current_user)
       end
     end
@@ -102,16 +135,22 @@ RSpec.describe Burials::Monitor do
         log = '21P-530EZ submission to Sidekiq failed'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
-          errors: [], # mock claim does not have `errors`
+          errors: [],
           message: monitor_error.message,
-          statsd: "#{claim_stats_key}.failure"
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.failure")
-        expect(Rails.logger).to receive(:error).with(log, payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{claim_stats_key}.failure",
+          payload,
+          anything
+        )
         monitor.track_create_error(ipf, claim, current_user, monitor_error)
       end
     end
@@ -121,35 +160,49 @@ RSpec.describe Burials::Monitor do
         log = '21P-530EZ submission to Sidekiq success'
         payload = {
           confirmation_number: claim.confirmation_number,
-          user_uuid: current_user.uuid,
+          user_account_uuid: current_user.user_account_uuid,
           in_progress_form_id: ipf.id,
-          statsd: "#{claim_stats_key}.success"
+          errors: [],
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
-        claim.form_start_date = Time.zone.now
 
-        expect(StatsD).to receive(:increment).with("#{claim_stats_key}.success")
-        expect(Rails.logger).to receive(:info).with(log, payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'info',
+          log,
+          "#{claim_stats_key}.success",
+          payload,
+          anything
+        )
         monitor.track_create_success(ipf, claim, current_user)
       end
     end
 
     describe '#track_submission_exhaustion' do
       it 'logs sidekiq job exhaustion' do
-        msg = { 'args' => [claim.id, current_user.uuid] }
-
         log = 'Lighthouse::SubmitBenefitsIntakeClaim Burial 21P-530EZ submission to LH exhausted!'
+        msg = { 'args' => [claim.id, current_user.uuid] }
+        user_account_uuid = msg['args'].length <= 1 ? nil : msg['args'][1]
         payload = {
+          confirmation_number: claim.confirmation_number,
+          user_account_uuid: user_account_uuid,
           form_id: claim.form_id,
           claim_id: claim.id,
-          confirmation_number: claim.confirmation_number,
-          message: msg
+          message: msg,
+          tags: {
+            form_id: '21P-530EZ'
+          }
         }
 
         expect(monitor).to receive(:log_silent_failure).with(payload, current_user.uuid, anything)
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted")
-        expect(Rails.logger).to receive(:error).with(log, user_uuid: current_user.uuid, **payload)
-
+        expect_any_instance_of(Logging::Monitor).to receive(:track_request).with(
+          'error',
+          log,
+          "#{submission_stats_key}.exhausted",
+          payload,
+          anything
+        )
         monitor.track_submission_exhaustion(msg, claim)
       end
     end


### PR DESCRIPTION
Now that we have the general classes in place refactor the existing class and functions used in pension (and income-and-assets) to be reusable from other form submission workflows


## Summary

- Refactor `Burials::Monitor` to use new generalized method
- Update unit tests

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95932

## Testing done

- [ ] *New code is covered by unit tests*
