### PR TITLE
Change sidekiq retries to 16

### DIFF
--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -11,7 +11,9 @@ module BGS
 
     attr_reader :claim, :user, :user_uuid, :saved_claim_id, :vet_info, :icn
 
-    sidekiq_options retry: 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16
 
     sidekiq_retries_exhausted do |msg, _error|
       user_uuid, icn, saved_claim_id, encrypted_vet_info, encrypted_user_struct_hash = msg['args']

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -11,7 +11,9 @@ module BGS
 
     attr_reader :claim, :user, :user_uuid, :saved_claim_id, :vet_info, :icn
 
-    sidekiq_options retry: 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16
 
     sidekiq_retries_exhausted do |msg, _error|
       user_uuid, icn, saved_claim_id, encrypted_vet_info = msg['args']

--- a/app/sidekiq/central_mail/submit_central_form686c_job.rb
+++ b/app/sidekiq/central_mail/submit_central_form686c_job.rb
@@ -15,7 +15,9 @@ module CentralMail
     FORM_ID = '686C-674'
     FORM_ID_674 = '21-674'
     STATSD_KEY_PREFIX = 'worker.submit_686c_674_backup_submission'
-    RETRY = 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    RETRY = 16
 
     attr_reader :claim, :form_path, :attachment_paths
 

--- a/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form0781_document_upload_failure_email.rb
@@ -9,8 +9,9 @@ module EVSS
       STATSD_METRIC_PREFIX = 'api.form_526.veteran_notifications.form0781_upload_failure_email'
       ZSF_DD_TAG_FUNCTION = '526_form_0781_failure_email_queuing'
 
-      # retry for one day
-      sidekiq_options retry: 14
+      # retry for  2d 1h 47m 12s
+      # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+      sidekiq_options retry: 16
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']

--- a/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form4142_document_upload_failure_email.rb
@@ -9,8 +9,9 @@ module EVSS
       STATSD_METRIC_PREFIX = 'api.form_526.veteran_notifications.form4142_upload_failure_email'
       ZSF_DD_TAG_FUNCTION  = '526_form_4142_upload_failure_email_sending'
 
-      # retry for one day
-      sidekiq_options retry: 14
+      # retry for  2d 1h 47m 12s
+      # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+      sidekiq_options retry: 16
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']

--- a/app/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email.rb
+++ b/app/sidekiq/evss/disability_compensation_form/form526_document_upload_failure_email.rb
@@ -9,8 +9,9 @@ module EVSS
       STATSD_METRIC_PREFIX = 'api.form_526.veteran_notifications.document_upload_failure_email'
       ZSF_DD_TAG_FUNCTION = '526_evidence_upload_failure_email_queuing'
 
-      # retry for one day
-      sidekiq_options retry: 14
+      # retry for  2d 1h 47m 12s
+      # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+      sidekiq_options retry: 16
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -15,10 +15,9 @@ module EVSS
       attr_accessor :submission_id
 
       # Sidekiq has built in exponential back-off functionality for retries
-      # A max retry attempt of 15 will result in a run time of ~36 hours
-      # Changed from 15 -> 14 ~ Jan 19, 2023
-      # This change reduces the run-time from ~36 hours to ~24 hours
-      RETRY = 14
+      # retry for  2d 1h 47m 12s
+      # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+      RETRY = 16
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526'
 
       wrap_with_logging(

--- a/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
@@ -8,8 +8,9 @@ module EVSS
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526_upload'
       ZSF_DD_TAG_FUNCTION = '526_evidence_upload_failure_email_queuing'
 
-      # retry for one day
-      sidekiq_options retry: 14
+      # retry for  2d 1h 47m 12s
+      # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+      sidekiq_options retry: 16
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']

--- a/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
+++ b/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
@@ -12,8 +12,9 @@ module EVSS
       BDD_INSTRUCTIONS_DOCUMENT_TYPE = 'L023'
       BDD_INSTRUCTIONS_FILE_NAME = 'BDD_Instructions.pdf'
 
-      # retry for one day
-      sidekiq_options retry: 14
+      # retry for  2d 1h 47m 12s
+      # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+      sidekiq_options retry: 16
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']

--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -31,7 +31,7 @@ class EVSS::DocumentUpload
   )
 
   # retry for one day
-  sidekiq_options retry: 14, queue: 'low'
+  sidekiq_options retry: 16, queue: 'low'
   # Set minimum retry time to ~1 hour
   sidekiq_retry_in do |count, _exception|
     rand(3600..3660) if count < 9

--- a/app/sidekiq/evss/request_decision.rb
+++ b/app/sidekiq/evss/request_decision.rb
@@ -2,8 +2,9 @@
 
 class EVSS::RequestDecision
   include Sidekiq::Job
-
-  sidekiq_options retry: 14
+  # retry for  2d 1h 47m 12s
+  # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+  sidekiq_options retry: 16
 
   def perform(auth_headers, evss_id)
     client = EVSS::ClaimsService.new(auth_headers)

--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -9,7 +9,9 @@ module Form1010cg
     include Sidekiq::MonitoredWorker
     include SentryLogging
 
-    sidekiq_options retry: 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16
 
     sidekiq_retries_exhausted do |msg, _e|
       StatsD.increment("#{STATSD_KEY_PREFIX}failed_no_retries_left", tags: ["claim_id:#{msg['args'][0]}"])

--- a/app/sidekiq/form526_submission_failure_email_job.rb
+++ b/app/sidekiq/form526_submission_failure_email_job.rb
@@ -20,7 +20,9 @@ class Form526SubmissionFailureEmailJob
     'form8940' => 'VA Form 21-8940'
   }.freeze
 
-  sidekiq_options retry: 14
+  # retry for  2d 1h 47m 12s
+  # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+  sidekiq_options retry: 16
 
   sidekiq_retries_exhausted do |msg, _ex|
     job_id = msg['jid']

--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -14,9 +14,9 @@ module HCA
       'function: 10-10EZR async form submission'
     ].freeze
 
-    # 14 retries was decided on because it's the closest to a 24-hour time span based on
-    # Sidekiq's backoff formula: https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry
-    sidekiq_options retry: 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16
 
     sidekiq_retries_exhausted do |msg, _e|
       parsed_form = decrypt_form(msg['args'][0])

--- a/app/sidekiq/hca/submission_job.rb
+++ b/app/sidekiq/hca/submission_job.rb
@@ -2,7 +2,9 @@
 
 module HCA
   class SubmissionJob < BaseSubmissionJob
-    sidekiq_options retry: 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16
 
     sidekiq_retries_exhausted do |msg, _e|
       health_care_application = HealthCareApplication.find(msg['args'][2])

--- a/app/sidekiq/lighthouse/create_intent_to_file_job.rb
+++ b/app/sidekiq/lighthouse/create_intent_to_file_job.rb
@@ -22,9 +22,10 @@ module Lighthouse
       '21P-527EZ' => 'pension'
     }.freeze
 
-    # retry for one day
+    # retry for 2d 1h 47m 12s
     # exhausted attempts will be logged in intent_to_file_queue_exhaustions table
-    sidekiq_options retry: 14, queue: 'low'
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16, queue: 'low'
     sidekiq_retries_exhausted do |msg, error|
       ::Rails.logger.info("Create Intent to File Job exhausted all retries for in_progress_form_id: #{msg['args'][0]}")
 

--- a/app/sidekiq/lighthouse/document_upload.rb
+++ b/app/sidekiq/lighthouse/document_upload.rb
@@ -15,8 +15,9 @@ class Lighthouse::DocumentUpload
   NOTIFY_SETTINGS = Settings.vanotify.services.benefits_management_tools
   MAILER_TEMPLATE_ID = NOTIFY_SETTINGS.template_id.evidence_submission_failure_email
 
-  # retry for one day
-  sidekiq_options retry: 14, queue: 'low'
+  # retry for  2d 1h 47m 12s
+  # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+  sidekiq_options retry: 16, queue: 'low'
   # Set minimum retry time to ~1 hour
   sidekiq_retry_in do |count, _exception|
     rand(3600..3660) if count < 9

--- a/app/sidekiq/lighthouse/income_and_assets_intake_job.rb
+++ b/app/sidekiq/lighthouse/income_and_assets_intake_job.rb
@@ -13,8 +13,9 @@ module Lighthouse
 
     INCOME_AND_ASSETS_SOURCE = 'app/sidekiq/lighthouse/income_and_assets_intake_job.rb'
 
-    # retry for one day
-    sidekiq_options retry: 14, queue: 'low'
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16, queue: 'low'
     sidekiq_retries_exhausted do |msg|
       ia_monitor = IncomeAndAssets::Submissions::Monitor.new
       begin

--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -19,9 +19,9 @@ module Lighthouse
     FOREIGN_POSTALCODE = '00000'
     STATSD_KEY_PREFIX = 'worker.lighthouse.submit_benefits_intake_claim'
 
-    # Sidekiq has built in exponential back-off functionality for retries
-    # A max retry attempt of 14 will result in a run time of ~25 hours
-    RETRY = 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    RETRY = 16
 
     sidekiq_options retry: RETRY
 

--- a/app/sidekiq/lighthouse/submit_career_counseling_job.rb
+++ b/app/sidekiq/lighthouse/submit_career_counseling_job.rb
@@ -5,7 +5,9 @@ require 'pcpg/monitor'
 module Lighthouse
   class SubmitCareerCounselingJob
     include Sidekiq::Job
-    RETRY = 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    RETRY = 16
 
     STATSD_KEY_PREFIX = 'worker.lighthouse.submit_career_counseling_job'
 

--- a/app/sidekiq/va_notify_dd_email_job.rb
+++ b/app/sidekiq/va_notify_dd_email_job.rb
@@ -5,7 +5,9 @@ require 'sentry_logging'
 class VANotifyDdEmailJob
   include Sidekiq::Job
   extend SentryLogging
-  sidekiq_options retry: 14
+  # retry for  2d 1h 47m 12s
+  # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+  sidekiq_options retry: 16
 
   STATSD_ERROR_NAME = 'worker.direct_deposit_confirmation_email.error'
   STATSD_SUCCESS_NAME = 'worker.direct_deposit_confirmation_email.success'

--- a/app/sidekiq/va_notify_email_job.rb
+++ b/app/sidekiq/va_notify_email_job.rb
@@ -3,7 +3,9 @@
 class VANotifyEmailJob
   include Sidekiq::Job
   include SentryLogging
-  sidekiq_options retry: 14
+  # retry for  2d 1h 47m 12s
+  # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+  sidekiq_options retry: 16
 
   def perform(email, template_id, personalisation = nil)
     notify_client = VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)

--- a/app/sidekiq/vbms/submit_dependents_pdf_job.rb
+++ b/app/sidekiq/vbms/submit_dependents_pdf_job.rb
@@ -6,7 +6,9 @@ module VBMS
     include Sidekiq::Job
     include SentryLogging
 
-    sidekiq_options retry: 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16
     attr_reader :claim
 
     sidekiq_retries_exhausted do |msg, error|

--- a/app/sidekiq/vre/create_ch31_submissions_report_job.rb
+++ b/app/sidekiq/vre/create_ch31_submissions_report_job.rb
@@ -9,8 +9,9 @@ module VRE
     STATSD_KEY_PREFIX = 'worker.vre.create_ch31_submissions_report_job'
 
     # Sidekiq has built in exponential back-off functionality for retries
-    # A max retry attempt of 14 will result in a run time of ~25 hours
-    RETRY = 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    RETRY = 16
 
     sidekiq_options retry: RETRY
 

--- a/app/sidekiq/vre/submit1900_job.rb
+++ b/app/sidekiq/vre/submit1900_job.rb
@@ -8,7 +8,9 @@ module VRE
     include SentryLogging
 
     STATSD_KEY_PREFIX = 'worker.vre.submit_1900_job'
-    RETRY = 14
+    # retry for  2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    RETRY = 16
 
     sidekiq_options retry: RETRY
 

--- a/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
+++ b/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
@@ -27,8 +27,9 @@ module Pensions
     # `source` attribute for upload metadata
     PENSION_SOURCE = __FILE__
 
-    # retry for one day
-    sidekiq_options retry: 14, queue: 'low'
+    # retry for 2d 1h 47m 12s
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    sidekiq_options retry: 16, queue: 'low'
 
     # retry exhaustion
     sidekiq_retries_exhausted do |msg|

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Form1010cg::SubmissionJob do
   end
 
   it 'has a retry count of 14' do
-    expect(described_class.get_sidekiq_options['retry']).to eq(14)
+    expect(described_class.get_sidekiq_options['retry']).to eq(16)
   end
 
   it 'defines #notify' do


### PR DESCRIPTION
## Summary
In response to new standards and the upcoming COLA outage, all sidekiq retries should be set to 16.

retry for  2d 1h 47m 12s
https://github.com/sidekiq/sidekiq/wiki/Error-Handling
  
https://dsva.slack.com/archives/C053U7BUT27/p1730909263999689?thread_ts=1730731734.405619&cid=C053U7BUT27

## Testing done

- [ X ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
