### PR TITLE
MHV-62902: BBMI email notification setting status api created

### DIFF
--- a/lib/medical_records/bb_internal/client.rb
+++ b/lib/medical_records/bb_internal/client.rb
@@ -127,6 +127,15 @@ module BBInternal
       response.body
     end
 
+    # Retrieves the BBMI notification setting for the user.
+    # @return [Hash] containing:
+    #   - flag [Boolean]: Indicates whether the BBMI notification setting is enabled (true) or disabled (false)
+    #
+    def get_bbmi_notification_setting
+      response = perform(:get, 'usermgmt/notification/bbmi', nil, token_headers)
+      response.body
+    end
+
     private
 
     ##

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/bbmi_notification_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/bbmi_notification_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module MyHealth
+  module V1
+    module MedicalRecords
+      class BbmiNotificationController < MrController
+        # Retrieves the BBMI notification setting
+        # @return [JSON] BBMI notification setting
+        def status
+          resource = bb_client.get_bbmi_notification_setting
+          render json: resource
+        end
+      end
+    end
+  end
+end

--- a/modules/my_health/config/routes.rb
+++ b/modules/my_health/config/routes.rb
@@ -23,6 +23,9 @@ MyHealth::Engine.routes.draw do
           get :download, to: 'ccd#download'
         end
       end
+      resources :bbmi_notification, only: [] do
+        get :status, on: :collection
+      end
       resources :military_service, only: %i[index]
       resources :imaging, only: %i[index], defaults: { format: :json } do
         get 'request', on: :member, action: :request_download

--- a/spec/lib/medical_records/bb_internal/client_spec.rb
+++ b/spec/lib/medical_records/bb_internal/client_spec.rb
@@ -157,4 +157,16 @@ describe BBInternal::Client do
       end
     end
   end
+
+  describe '#get_bbmi_notification_setting' do
+    it 'retrieves the BBMI notification setting' do
+      VCR.use_cassette 'mr_client/bb_internal/get_bbmi_notification_setting' do
+        notification_setting = client.get_bbmi_notification_setting
+
+        expect(notification_setting).to be_a(Hash)
+        expect(notification_setting).to have_key('flag')
+        expect(notification_setting['flag']).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/support/vcr_cassettes/mr_client/bb_internal/get_bbmi_notification_setting.yml
+++ b/spec/support/vcr_cassettes/mr_client/bb_internal/get_bbmi_notification_setting.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<MHV_MR_HOST>/mhvapi/v1/usermgmt/notification/bbmi"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Token: "<SESSION_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Tue, 05 Nov 2024 23:39:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: '{"flag":true}'
+  recorded_at: Tue, 05 Nov 2024 23:39:54 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary
New API endpoint created to get bbmi email notification setting

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-62902

> ### Retrieve backend notification settings to determine which content to display for image notification
> Description
> Retrieve backend notification settings to determine which content to display for image notification. 
> 
> Front end will either say, you'll get an email notification or, if you want one, here's where to go to turn that on. 
> 
> Haritha, Elwood Gary might know, start w mike/muazzam. 
> 
> Goal: Find notification setting in MHV API and implement it for vets-api. 
> 
> User Story: As a Medical Images team, we want to determine what the user has set the imaging notification setting to, in order tov display the correct content for retrieving images.

## Testing done
Test created for new bb internal client method for getting the setting

## Screenshots
No UI changes

## What areas of the site does it impact?
MHV medical records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

