### PR TITLE
adds feature toggle for exanded classification endpoint traffic

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -76,10 +76,6 @@ features:
   caregiver1010:
     actor_type: user
     description: Enables new features while investigating 1010CG errors
-  expanded_contention_classification:
-    actor_type: user
-    description: Enables the expanded contention classificatier service maintained by the Conditions Team.
-    enable_in_development: true
   hca_browser_monitoring_enabled:
     actor_type: user
     description: Enables browser monitoring for the health care application.
@@ -488,6 +484,10 @@ features:
   disability_526_improved_autosuggestions_add_disabilities_page:
     actor_type: user
     description: enables new version of add disabilities page, with updates to content and search functionality
+    enable_in_development: true
+  disability_526_expanded_contention_classification:
+    actor_type: user
+    description: Enables the expanded contention classification service maintained by the Conditions Team.
     enable_in_development: true
   disability_compensation_flashes:
     actor_type: user

--- a/config/features.yml
+++ b/config/features.yml
@@ -76,6 +76,10 @@ features:
   caregiver1010:
     actor_type: user
     description: Enables new features while investigating 1010CG errors
+  expanded_contention_classification:
+    actor_type: user
+    description: Enables the expanded contention classificatier service maintained by the Conditions Team.
+    enable_in_development: true
   hca_browser_monitoring_enabled:
     actor_type: user
     description: Enables browser monitoring for the health care application.


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): YES
- This PR adds a feature toggle to use to manage traffic to a new endpoint for expanded classification
- The endpoint and logic has not been added, but the feature toggle will be used in future iterations to manage traffic to the endpoint in VRO.

## Related issue(s)

- [#626](https://github.com/orgs/department-of-veterans-affairs/projects/873/views/2?pane=issue&itemId=85258469&issue=department-of-veterans-affairs%7Cvagov-claim-classification%7C626)

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
