### PR TITLE
postman-test container always return success

### DIFF
--- a/postman/Dockerfile
+++ b/postman/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /etc/newman
 
 COPY vets-api.pm-collection.json vets-api.pm-collection.json
 
-ENTRYPOINT newman run vets-api.pm-collection.json --env-var envUnderTest=$API_URL
+ENTRYPOINT newman run vets-api.pm-collection.json -x --env-var envUnderTest=$API_URL


### PR DESCRIPTION


## Summary

- Since the postman test container is run as a postSync process, if it returns failure then the sync process keep re-trying. Changing so the container always succeeds and will rely on datadog monitors to notify of issues

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95636

## Testing done

- confirmed newman command

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
postman test post sync

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
