### PR TITLE
VaNotify - Update callback default params

### DIFF
--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -18,7 +18,7 @@ module VaNotify
     def initialize(api_key, callback_options = {})
       overwrite_client_networking
       @notify_client ||= Notifications::Client.new(api_key, client_url)
-      @callback_options = callback_options
+      @callback_options = callback_options || {}
     rescue => e
       handle_error(e)
     end

--- a/modules/va_notify/spec/lib/service_spec.rb
+++ b/modules/va_notify/spec/lib/service_spec.rb
@@ -129,6 +129,21 @@ describe VaNotify::Service do
           end
         end
 
+        it 'without nil passed in as callback data' do
+          subject = VaNotify::Service.new(test_api_key, nil)
+
+          VCR.use_cassette('va_notify/success_email') do
+            allow(Flipper).to receive(:enabled?).with(:va_notify_notification_creation).and_return(true)
+
+            subject.send_email(send_email_parameters)
+            expect(VANotify::Notification.count).to eq(1)
+            notification = VANotify::Notification.first
+            expect(notification.source_location).to include('modules/va_notify/spec/lib/service_spec.rb')
+            expect(notification.callback).to eq(nil)
+            expect(notification.metadata).to eq(nil)
+          end
+        end
+
         it 'with callback data' do
           VCR.use_cassette('va_notify/success_email') do
             subject = described_class.new(test_api_key, { callback: 'TestCallback', metadata: 'optional_metadata' })


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): YES
- *(Summarize the changes that have been made to the platform)* Updates so that notification creation (behind feature flag) always defaults to a hash.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)* VA Notify - yes, my team owns this module
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vanotify-team/issues/1411

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
