### PR TITLE
[VI-739] Updating token exchanged session attributes so that exchanged session has proper expiration times

### DIFF
--- a/app/services/sign_in/session_spawner.rb
+++ b/app/services/sign_in/session_spawner.rb
@@ -76,7 +76,7 @@ module SignIn
         refresh_token_hash:,
         parent_refresh_token_hash:,
         anti_csrf_token:,
-        last_regeneration_time: refresh_creation,
+        last_regeneration_time:,
         user_attributes: JSON.parse(user_attributes)
       )
     end
@@ -106,7 +106,11 @@ module SignIn
     end
 
     def refresh_expiration_time
-      @refresh_expiration_time ||= refresh_creation + client_config.refresh_token_duration
+      @refresh_expiration_time ||= last_regeneration_time + client_config.refresh_token_duration
+    end
+
+    def last_regeneration_time
+      @last_regeneration_time ||= Time.zone.now
     end
 
     def get_hash(object)

--- a/spec/services/sign_in/session_spawner_spec.rb
+++ b/spec/services/sign_in/session_spawner_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe SignIn::SessionSpawner do
   describe '#perform' do
     subject { session_spawner.perform }
 
-    let(:current_session) { create(:oauth_session, handle: current_session_handle, user_verification:) }
+    let(:current_session) do
+      create(:oauth_session, handle: current_session_handle, user_verification:, refresh_creation:)
+    end
+    let(:refresh_creation) { 5.minutes.ago }
     let(:current_session_handle) { 'edd4c2fc-d776-4596-8dce-71a9848e15e0' }
     let(:user_uuid) { current_session.user_verification.backing_credential_identifier }
     let(:user_verification) { create(:user_verification, locked:) }
@@ -24,6 +27,10 @@ RSpec.describe SignIn::SessionSpawner do
     let(:access_token_attributes) { %w[first_name last_name email all_emails] }
     let(:enforced_terms) { nil }
     let(:device_sso) { false }
+
+    before { Timecop.freeze(Time.zone.now.floor) }
+
+    after { Timecop.return }
 
     context 'expected credential_lock validation' do
       let(:locked) { false }
@@ -84,7 +91,8 @@ RSpec.describe SignIn::SessionSpawner do
       let(:expected_token_uuid) { SecureRandom.uuid }
       let(:expected_parent_token_uuid) { SecureRandom.uuid }
       let(:expected_user_uuid) { user_uuid }
-      let(:expected_expiration_time) { expected_created_time + refresh_token_duration }
+      let(:expected_last_regeneration_time) { Time.zone.now }
+      let(:expected_expiration_time) { expected_last_regeneration_time + refresh_token_duration }
       let(:expected_user_attributes) { JSON.parse(current_session.user_attributes) }
       let(:expected_double_hashed_parent_refresh_token) do
         Digest::SHA256.hexdigest(parent_refresh_token_hash)
@@ -214,7 +222,7 @@ RSpec.describe SignIn::SessionSpawner do
                anti_csrf_token: expected_anti_csrf_token)
       end
       let(:expected_parent_refresh_token_hash) { Digest::SHA256.hexdigest(parent_refresh_token.to_json) }
-      let(:expected_last_regeneration_time) { current_session.refresh_creation }
+      let(:expected_last_regeneration_time) { Time.zone.now }
 
       before do
         allow(SecureRandom).to receive_messages(hex: stubbed_random_number, uuid: expected_handle)


### PR DESCRIPTION
## Summary

- This PR updates the token expirations for a token exchanged session so that it properly expires based off the creation of the new session, not the creation of the original session. This was causing an issue where token expirations were set in the past when an exchanged session happened more than 30 minutes after the creation of the original session

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-739

## Testing done

- [ ] Authenticated with a client that can utilize token exchange
- [ ] Created a new session with token exchange and noted the expiration time for the cookies that were created
- [ ] Refreshed the original session
- [ ] Created another new section with token exchange, and noted that the expiration time was properly updated (should be set to 30 minutes in the future when I performed the token exchange)


## What areas of the site does it impact?
Authentication - Token Exchange

## Acceptance criteria

- [ ]  Authenticate with token exchange client following instructions from: https://github.com/department-of-veterans-affairs/vets-api/pull/16832
- [ ] Confirm that cookie expiration from token exchange is set to 30 minutes in the future from when token exchange is called, not 30 minutes from when the original session is created
