### PR TITLE
Run Staging check too

### DIFF
--- a/.github/workflows/deploy_delay_notifications.yml
+++ b/.github/workflows/deploy_delay_notifications.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
       - name: Check deployment status for staging
-        if: ${{ env.latest_sha != '' && env.staging_deployed_sha != '' }}
+        if: always() && ${{ env.latest_sha != '' && env.staging_deployed_sha != '' }}
         id: check-staging-status
         run: |
           latest_sha=${{ env.latest_sha }}


### PR DESCRIPTION
## Summary

- The failure is preventing the staging step from running. Adding `always()` will allow it to run to, assuming the other condition is true.