### PR TITLE
Add MHV error codes to MHV account error responses

### DIFF
--- a/app/services/mhv/user_account/errors.rb
+++ b/app/services/mhv/user_account/errors.rb
@@ -3,10 +3,34 @@
 module MHV
   module UserAccount
     module Errors
-      class UserAccountError < StandardError; end
+      class UserAccountError < StandardError
+        def as_json
+          message.split(',').map { |m| { title: class_name, detail: m.strip } }
+        end
+
+        private
+
+        def class_name
+          self.class.name.demodulize.underscore.humanize
+        end
+      end
+
       class CreatorError < UserAccountError; end
+
       class ValidationError < UserAccountError; end
-      class MHVClientError < UserAccountError; end
+
+      class MHVClientError < UserAccountError
+        attr_accessor :body
+
+        def initialize(message, body = nil)
+          super(message)
+          @body = body
+        end
+
+        def as_json
+          [{ title: message, detail: body[:message], code: body[:errorCode] }]
+        end
+      end
     end
   end
 end

--- a/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
+++ b/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
@@ -55,13 +55,9 @@ describe V0::User::MHVUserAccountsController, type: :controller do
 
     context 'when there is an error retrieving the MHV account' do
       shared_examples 'an unprocessable entity' do
-        let(:expected_log_payload) { { error_message: expected_error_message } }
+        let(:expected_log_payload) { { errors: expected_errors } }
         let(:expected_log_message) { '[User][MHVUserAccountsController] show error' }
-        let(:expected_response_body) do
-          {
-            errors: expected_error_message.split(',').map { |m| { detail: m.strip } }
-          }.as_json
-        end
+        let(:expected_response_body) { { errors: expected_errors }.as_json }
 
         it 'returns an unprocessable entity' do
           get :show
@@ -77,35 +73,25 @@ describe V0::User::MHVUserAccountsController, type: :controller do
         end
       end
 
-      context 'when there is an MHV client error' do
-        let(:expected_error_message) { 'some client error' }
-
-        before do
-          allow(mhv_client).to receive(:create_account).and_raise(Common::Client::Errors::ClientError,
-                                                                  expected_error_message)
-        end
-
-        it_behaves_like 'an unprocessable entity'
-      end
-
       context 'when the user does not have an ICN' do
         let(:icn) { nil }
-        let(:expected_error_message) { 'ICN must be present' }
+        let(:expected_errors) { [{ title: 'Validation error', detail: 'ICN must be present' }] }
 
         it_behaves_like 'an unprocessable entity'
       end
 
       context 'when the user does not have an email' do
         let(:user_credential_email) { nil }
-        let(:expected_error_message) { 'Email must be present' }
+        let(:expected_errors) { [{ title: 'Validation error', detail: 'Email must be present' }] }
 
         it_behaves_like 'an unprocessable entity'
       end
 
       context 'when the user does not have a terms of use agreement' do
         let(:terms_of_use_agreement) { nil }
-        let(:expected_error_message) do
-          "Current terms of use agreement must be present, Current terms of use agreement must be 'accepted'"
+        let(:expected_errors) do
+          [{ title: 'Validation error', detail: 'Current terms of use agreement must be present' },
+           { title: 'Validation error', detail: "Current terms of use agreement must be 'accepted'" }]
         end
 
         it_behaves_like 'an unprocessable entity'
@@ -113,9 +99,37 @@ describe V0::User::MHVUserAccountsController, type: :controller do
 
       context 'when the user has not accepted the terms of use agreement' do
         let(:terms_of_use_response) { 'declined' }
-        let(:expected_error_message) { "Current terms of use agreement must be 'accepted'" }
+        let(:expected_errors) do
+          [{ title: 'Validation error', detail: "Current terms of use agreement must be 'accepted'" }]
+        end
 
         it_behaves_like 'an unprocessable entity'
+      end
+
+      context 'when there is an MHV client error' do
+        let(:mhv_error_body) { { errorCode: mhv_error_code, message: mhv_error_message } }
+        let(:mhv_error_code) { 'some-code' }
+        let(:mhv_error_message) { 'some-error-message' }
+
+        let(:client_error_message) { 'some-client-error' }
+
+        let(:expected_errors) { [{ title: client_error_message, detail: mhv_error_message, code: mhv_error_code }] }
+
+        before do
+          allow(mhv_client).to receive(:create_account)
+            .and_raise(Common::Client::Errors::ClientError.new(client_error_message, 400, mhv_error_body))
+        end
+
+        context 'when the response_body has a code and message' do
+          it_behaves_like 'an unprocessable entity'
+        end
+
+        context 'when the response_body does not have a code and message' do
+          let(:mhv_error_code) { nil }
+          let(:mhv_error_message) { nil }
+
+          it_behaves_like 'an unprocessable entity'
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

This passes along the error codes and messages we receive from MHV

```json
{
  "errors": [
    {
      "title": "The server responded with status 400",
      "detail": "ICN provided is not the Primary ICN",
      "code": "802"
    }
  ]
}
```

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-743

## Testing 

- Difficult to test locally but we can mock a response 
- add this to beginning of lib/mhv/account_creation/service.rb#create_account
   ```ruby
   def create_account(icn:, email:, tou_occurred_at:, break_cache: false)
     raise  Common::Client::Errors::ClientError.new("The server responded with status 400", 400, {errorCode: 805, message: "Deactivated Account found in MHV for ICN"} )
     ...
   end
   ```
- Sign-in
- go to http://localhost:3000/v0/user/mhv_user_account and you should see an error message with the code and message from MHV
   ```json
   {
    "errors": [
      {
        "title": "The server responded with status 400",
        "detail": "Deactivated Account found in MHV for ICN",
        "code": 805
      }
    ]
  }
   ```

## What areas of the site does it impact?
MHV Account Creation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

