### PR TITLE
[DBX-95173] Normalize 526 failure email flippers

### DIFF
--- a/app/sidekiq/form526_status_polling_job.rb
+++ b/app/sidekiq/form526_status_polling_job.rb
@@ -79,7 +79,7 @@ class Form526StatusPollingJob
   end
 
   def notify_veteran(submission_id)
-    if Flipper.enabled?(:send_backup_submission_polling_failure_email_notice)
+    if Flipper.enabled?(:form526_send_backup_submission_polling_failure_email_notice)
       Form526SubmissionFailureEmailJob.perform_async(submission_id, Time.now.utc.to_s)
     end
   end

--- a/config/features.yml
+++ b/config/features.yml
@@ -629,9 +629,17 @@ features:
     actor_type: user
     description: Enables enqueuing a Form526DocumentUploadFailureEmail if a EVSS::DisabilityCompensationForm::SubmitUploads job exhausts its retries
     enable_in_development: true
+  form526_send_backup_submission_polling_failure_email_notice:
+    actor_type: user
+    description: Enables enqueuing a Form526SubmissionFailureEmailJob if a submission is marked as unprocessable through polling of the Benefits Intake API.
+    enable_in_development: true
+  form526_send_backup_submission_exhaustion_email_notice:
+    actor_type: user
+    description: Enables enqueuing of a Form526SubmissionFailureEmailJob if a submission exhausts it's attempts to upload to the Benefits Intake API.
+    enable_in_development: true
   form526_send_4142_failure_notification:
     actor_type: user
-    description: Enables enqueuing a Form4142DocumentUploadFailureEmail if a SubmitForm4142Job job exhausts its retries
+    description: Enables enqueuing of a Form4142DocumentUploadFailureEmail if a SubmitForm4142Job job exhausts its retries
     enable_in_development: true
   form526_send_0781_failure_notification:
     actor_type: user

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -53,7 +53,7 @@ module Sidekiq
           { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
         )
 
-        if Flipper.enabled?(:send_backup_submission_exhaustion_email_notice)
+        if Flipper.enabled?(:form526_send_backup_submission_exhaustion_email_notice)
           ::Form526SubmissionFailureEmailJob.perform_async(form526_submission_id, Time.now.utc.to_s)
         end
       rescue => e

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
         expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
       end
 
-      context 'when send_backup_submission_exhaustion_email_notice is enabled' do
+      context 'when form526_send_backup_submission_exhaustion_email_notice is enabled' do
         before do
-          Flipper.enable(:send_backup_submission_exhaustion_email_notice)
+          Flipper.enable(:form526_send_backup_submission_exhaustion_email_notice)
         end
 
         it 'remediates the submission via an email notification' do
@@ -70,9 +70,9 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
         end
       end
 
-      context 'when send_backup_submission_exhaustion_email_notice is disabled' do
+      context 'when form526_send_backup_submission_exhaustion_email_notice is disabled' do
         before do
-          Flipper.disable(:send_backup_submission_exhaustion_email_notice)
+          Flipper.disable(:form526_send_backup_submission_exhaustion_email_notice)
         end
 
         it 'does not remediates the submission via an email notification' do

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -140,11 +140,11 @@ RSpec.describe Form526StatusPollingJob, type: :job do
       end
 
       context 'when a failure type response is returned from the API' do
-        context 'when send_backup_submission_exhaustion_email_notice is enabled' do
+        context 'when form526_send_backup_submission_polling_failure_email_notice is enabled' do
           let(:timestamp) { Time.now.utc }
 
           before do
-            Flipper.enable(:send_backup_submission_polling_failure_email_notice)
+            Flipper.enable(:form526_send_backup_submission_polling_failure_email_notice)
           end
 
           it 'enqueues a failure notification email job' do
@@ -173,11 +173,11 @@ RSpec.describe Form526StatusPollingJob, type: :job do
           end
         end
 
-        context 'when send_backup_submission_exhaustion_email_notice is disabled' do
+        context 'when form526_send_backup_submission_polling_failure_email_notice is disabled' do
           let!(:pending_claim_ids) { Form526Submission.pending_backup.pluck(:backup_submitted_claim_id) }
 
           before do
-            Flipper.disable(:send_backup_submission_polling_failure_email_notice)
+            Flipper.disable(:form526_send_backup_submission_polling_failure_email_notice)
           end
 
           it 'does not enqueue a failure notification email job' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Update 526 failure email flipper names to match existing conventions
- add flipper names to config file 

## Related issue(s)

- [Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94173)

## Testing done

- [x] *New code is covered by unit tests*
- Nothing else to test

## What areas of the site does it impact?
526 submission failure via backup path and polling. Zero silent failures

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution 
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature