### PR TITLE
API-41803 Add transform for empty disabilities

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -71,6 +71,7 @@ module ClaimsApi
       form_data['disabilities'] = transform_disability_approximate_begin_dates
       form_data['disabilities'] = massage_invalid_disability_names
       form_data['disabilities'] = remove_special_issues_from_secondary_disabilities
+      form_data['disabilities'] = remove_empty_disability_elements
       form_data['treatments'] = transform_treatment_dates if treatments?
       form_data['treatments'] = transform_treatment_center_names if treatments?
       form_data['serviceInformation'] = transform_service_branch
@@ -476,6 +477,28 @@ module ClaimsApi
 
           secondary
         end
+      end
+      disabilities
+    end
+
+    # remove any empty disability objects to prevent further processing errors
+    def remove_empty_disability_elements
+      disabilities = form_data['disabilities']
+      return if disabilities.blank?
+
+      disabilities.each_with_index do |disability, index|
+        if disability['specialIssues'].presence ||
+           disability['ratedDisabilityId'].presence ||
+           disability['diagnosticCode'].presence ||
+           disability['classificationCode'].presence ||
+           disability['approximateBeginDate'].presence ||
+           disability['serviceRelevance'].presence ||
+           disability['secondaryDisabilities'].presence
+          next
+        end
+
+        disability_name = disability['name']
+        disabilities.delete_at(index) if disability_name == '' && disability['disabilityActionType'].presence
       end
       disabilities
     end

--- a/modules/claims_api/spec/models/auto_establish_claim_spec.rb
+++ b/modules/claims_api/spec/models/auto_establish_claim_spec.rb
@@ -530,6 +530,27 @@ RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
         expect(phone_number).to eq('555')
       end
     end
+
+    context 'removes empty disabilities having only empty string name and disabilityActionType' do
+      let(:temp_form_data) do
+        pending_record.form_data.tap do |data|
+          data['disabilities'] = [{
+            'disabilityActionType' => 'NEW',
+            'name' => ''
+          }]
+        end
+      end
+      let(:payload) { JSON.parse(pending_record.to_internal) }
+      let(:disabilities) { payload['form526']['disabilities'] }
+
+      before do
+        pending_record.form_data = temp_form_data
+      end
+
+      it 'removes the disability' do
+        expect(disabilities).to eq([])
+      end
+    end
   end
 
   describe 'evss_id_by_token' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates AutoEstablishedClaim.to_internal to add a transformation method for "empty" disabilities encountered in production support recently, where the disability object has only a name set to an empty string, and a disabilityActionType, but no other attributes.
- Transformation tests submitted disabilities and removes those considered "empty" in v1 526 submissions.

## Related issue(s)

[API-41803](https://jira.devops.va.gov/browse/API-41803)

## Testing done

- [x] *New code is covered by unit tests*
- Previous handling did not detect this disability scenario, such that when the form_data was transformed and sent to EVSS docker, it resulted in an EVSS owing to the blank disability name.
- Submit a v1 526 submission ({{uri}}/services/claims/v1/forms/526) having an "empty" disability, and confirm that the transformed data has the empty disability removed.
- Disabilities not considered empty are not removed.
- Example disabilities section with an empty disability included:
```
"disabilities": [
                {
                    "ratedDisabilityId": "1100583",
                    "diagnosticCode": 9999,
                    "disabilityActionType": "NEW",
                    "name": "PTSD (post traumatic stress disorder)",
                    "specialIssues": [
                        "Fully Developed Claim",
                        "PTSD/2"
                    ],
                    "secondaryDisabilities": [
                        {
                            "name": "PTSD personal trauma",
                            "disabilityActionType": "SECONDARY",
                            "serviceRelevance": "Caused by a service-connected disability\\nLengthy description"
                        }
                    ]
                },
                {
                    "disabilityActionType": "NEW",
                    "name": ""
                }
            ],

```

## What areas of the site does it impact?
modules/claims_api/app/models/claims_api/auto_established_claim.rb
modules/claims_api/spec/models/auto_establish_claim_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

