### PR TITLE
96419: Add email notifications for DR jobs sidekiq retries exhausted

### DIFF
--- a/app/sidekiq/decision_review/failure_notification_email_job.rb
+++ b/app/sidekiq/decision_review/failure_notification_email_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
+require 'decision_review_v1/utilities/constants'
 
 module DecisionReview
   class FailureNotificationEmailJob
@@ -13,27 +14,6 @@ module DecisionReview
       SavedClaim::HigherLevelReview
       SavedClaim::SupplementalClaim
     ].freeze
-
-    TEMPLATE_IDS = Settings.vanotify.services.benefits_decision_review.template_id
-
-    FORM_TEMPLATE_IDS = {
-      'HLR' => TEMPLATE_IDS.higher_level_review_form_error_email,
-      'NOD' => TEMPLATE_IDS.notice_of_disagreement_form_error_email,
-      'SC' => TEMPLATE_IDS.supplemental_claim_form_error_email
-    }.freeze
-
-    EVIDENCE_TEMPLATE_IDS = {
-      'NOD' => TEMPLATE_IDS.notice_of_disagreement_evidence_error_email,
-      'SC' => TEMPLATE_IDS.supplemental_claim_evidence_error_email
-    }.freeze
-
-    SECONDARY_FORM_TEMPLATE_ID = TEMPLATE_IDS.supplemental_claim_secondary_form_error_email
-
-    APPEAL_TYPE_TO_SERVICE_MAP = {
-      'HLR' => 'higher-level-review',
-      'NOD' => 'board-appeal',
-      'SC' => 'supplemental-claims'
-    }.freeze
 
     ERROR_STATUS = 'error'
 
@@ -115,8 +95,8 @@ module DecisionReview
         appeal_type = submission.type_of_appeal
         reference = "#{appeal_type}-form-#{submission.submitted_appeal_uuid}"
 
-        response = send_email_with_vanotify(submission, nil, submission.created_at, FORM_TEMPLATE_IDS[appeal_type],
-                                            reference)
+        response = send_email_with_vanotify(submission, nil, submission.created_at,
+                                            DecisionReviewV1::FORM_TEMPLATE_IDS[appeal_type], reference)
         submission.update(failure_notification_sent_at: DateTime.now)
 
         record_form_email_send_successful(submission, response.id)
@@ -134,7 +114,7 @@ module DecisionReview
         reference = "#{appeal_type}-evidence-#{upload.lighthouse_upload_id}"
 
         response = send_email_with_vanotify(submission, upload.masked_attachment_filename, upload.created_at,
-                                            EVIDENCE_TEMPLATE_IDS[appeal_type], reference)
+                                            DecisionReviewV1::EVIDENCE_TEMPLATE_IDS[appeal_type], reference)
         upload.update(failure_notification_sent_at: DateTime.now)
 
         record_evidence_email_send_successful(upload, response.id)
@@ -151,7 +131,7 @@ module DecisionReview
         response = send_email_with_vanotify(form.appeal_submission,
                                             nil,
                                             form.created_at,
-                                            SECONDARY_FORM_TEMPLATE_ID,
+                                            DecisionReviewV1::SECONDARY_FORM_TEMPLATE_ID,
                                             reference)
         form.update(failure_notification_sent_at: DateTime.now)
 
@@ -167,7 +147,8 @@ module DecisionReview
       Rails.logger.info('DecisionReview::FailureNotificationEmailJob form email queued', params)
       StatsD.increment("#{STATSD_KEY_PREFIX}.form.email_queued", tags: ["appeal_type:#{appeal_type}"])
 
-      tags = ["service:#{APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}", 'function: form submission to Lighthouse']
+      tags = ["service:#{DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}",
+              'function: form submission to Lighthouse']
       StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
     end
 
@@ -188,7 +169,8 @@ module DecisionReview
       Rails.logger.info('DecisionReview::FailureNotificationEmailJob secondary form email queued', params)
       StatsD.increment("#{STATSD_KEY_PREFIX}.secondary_form.email_queued", tags: ["appeal_type:#{appeal_type}"])
 
-      tags = ["service:#{APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}", 'function: secondary form submission to Lighthouse']
+      tags = ["service:#{DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}",
+              'function: secondary form submission to Lighthouse']
       StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
     end
 
@@ -215,7 +197,8 @@ module DecisionReview
       Rails.logger.info('DecisionReview::FailureNotificationEmailJob evidence email queued', params)
       StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.email_queued", tags: ["appeal_type:#{appeal_type}"])
 
-      tags = ["service:#{APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}", 'function: evidence submission to Lighthouse']
+      tags = ["service:#{DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}",
+              'function: evidence submission to Lighthouse']
       StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
     end
 

--- a/app/sidekiq/decision_review/submit_upload.rb
+++ b/app/sidekiq/decision_review/submit_upload.rb
@@ -18,14 +18,25 @@ module DecisionReview
       message = 'DecisionReview::SubmitUpload retries exhausted'
       job_id = msg['jid']
       appeal_submission_upload_id = msg['args'].first
-      appeal_submission = AppealSubmissionUpload.find(appeal_submission_upload_id).appeal_submission
-      service_name = DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_submission.type_of_appeal]
 
+      upload = AppealSubmissionUpload.find(appeal_submission_upload_id)
+      submission = upload.appeal_submission
+
+      service_name = DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[submission.type_of_appeal]
       tags = ["service:#{service_name}", 'function: evidence submission to Lighthouse']
       StatsD.increment('silent_failure', tags:)
 
       ::Rails.logger.error({ error_message:, message:, appeal_submission_upload_id:, job_id: })
       StatsD.increment("#{STATSD_KEY_PREFIX}.permanent_error")
+
+      begin
+        response = send_notification_email(upload, submission)
+        upload.update(failure_notification_sent_at: DateTime.now)
+
+        record_email_send_successful(upload, submission, response.id)
+      rescue => e
+        record_email_send_failure(upload, submission, e)
+      end
     end
 
     # Make a request to Lighthouse to get the URL where we can upload the file,
@@ -152,5 +163,48 @@ module DecisionReview
                                                appeal_submission_upload_id:)
       upload_url_response
     end
+
+    def self.send_notification_email(upload, submission)
+      appeal_type = submission.type_of_appeal
+      reference = "#{appeal_type}-evidence-#{upload.lighthouse_upload_id}"
+
+      email_address = submission.current_email_address
+      template_id = DecisionReviewV1::EVIDENCE_TEMPLATE_IDS[appeal_type]
+      personalisation = {
+        first_name: submission.get_mpi_profile.given_names[0],
+        filename: upload.masked_attachment_filename,
+        date_submitted: upload.created_at.strftime('%B %d, %Y')
+      }
+
+      service = ::VaNotify::Service.new(Settings.vanotify.services.benefits_decision_review.api_key)
+      service.send_email({ email_address:, template_id:, personalisation:, reference: })
+    end
+    private_class_method :send_notification_email
+
+    def self.record_email_send_successful(upload, submission, notification_id)
+      appeal_type = submission.type_of_appeal
+      params = { submitted_appeal_uuid: submission.submitted_appeal_uuid,
+                 appeal_submission_upload_id: upload.id,
+                 appeal_type:,
+                 notification_id: }
+      Rails.logger.info('DecisionReview::SubmitUpload retries exhausted email queued', params)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.retries_exhausted.email_queued")
+
+      tags = ["service:#{DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}",
+              'function: evidence submission to Lighthouse']
+      StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
+    end
+    private_class_method :record_email_send_successful
+
+    def self.record_email_send_failure(upload, submission, e)
+      appeal_type = submission.type_of_appeal
+      params = { submitted_appeal_uuid: submission.submitted_appeal_uuid,
+                 appeal_submission_upload_id: upload.id,
+                 appeal_type:,
+                 message: e.message }
+      Rails.logger.error('DecisionReview::SubmitUpload retries exhausted email error', params)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.retries_exhausted.email_error", tags: ["appeal_type:#{appeal_type}"])
+    end
+    private_class_method :record_email_send_failure
   end
 end

--- a/lib/decision_review_v1/utilities/constants.rb
+++ b/lib/decision_review_v1/utilities/constants.rb
@@ -23,6 +23,21 @@ module DecisionReviewV1
   GET_CONTESTABLE_ISSUES_RESPONSE_SCHEMA =
     VetsJsonSchema::SCHEMAS.fetch 'DECISION-REVIEW-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1'
 
+  TEMPLATE_IDS = Settings.vanotify.services.benefits_decision_review.template_id
+
+  FORM_TEMPLATE_IDS = {
+    'HLR' => TEMPLATE_IDS.higher_level_review_form_error_email,
+    'NOD' => TEMPLATE_IDS.notice_of_disagreement_form_error_email,
+    'SC' => TEMPLATE_IDS.supplemental_claim_form_error_email
+  }.freeze
+
+  EVIDENCE_TEMPLATE_IDS = {
+    'NOD' => TEMPLATE_IDS.notice_of_disagreement_evidence_error_email,
+    'SC' => TEMPLATE_IDS.supplemental_claim_evidence_error_email
+  }.freeze
+
+  SECONDARY_FORM_TEMPLATE_ID = TEMPLATE_IDS.supplemental_claim_secondary_form_error_email
+
   APPEAL_TYPE_TO_SERVICE_MAP = {
     'HLR' => 'higher-level-review',
     'NOD' => 'board-appeal',

--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -12,10 +12,40 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
     Sidekiq::Testing.inline!(&example)
   end
 
+  let(:notification_id) { SecureRandom.uuid }
+  let(:vanotify_service) do
+    service = instance_double(VaNotify::Service)
+
+    response = instance_double(Notifications::Client::ResponseNotification, id: notification_id)
+    allow(service).to receive(:send_email).and_return(response)
+
+    service
+  end
+
+  let(:user_uuid) { create(:user, :loa3, ssn: '212222112').uuid }
+  let(:mpi_profile) { build(:mpi_profile, vet360_id: Faker::Number.number) }
+  let(:find_profile_response) { create(:find_profile_response, profile: mpi_profile) }
+  let(:mpi_service) do
+    service = instance_double(MPI::Service, find_profile_by_identifier: nil)
+    allow(service).to receive(:find_profile_by_identifier).with(identifier: user_uuid, identifier_type: anything)
+                                                          .and_return(find_profile_response)
+    service
+  end
+
+  let(:email_address) { 'testuser@test.com' }
+  let(:emails) { build(:email, email_address:) }
+  let(:person) { build(:person, emails:) }
+  let(:person_response) { instance_double(VAProfile::ContactInformation::PersonResponse, person:) }
+
+  before do
+    allow(VaNotify::Service).to receive(:new).and_return(vanotify_service)
+    allow(MPI::Service).to receive(:new).and_return(mpi_service)
+  end
+
   describe 'perform' do
     let(:submitted_appeal_uuid) { 'e076ea91-6b99-4912-bffc-a8318b9b403f' }
     let(:appeal_submission) do
-      create(:appeal_submission, :with_one_upload, submitted_appeal_uuid:)
+      create(:appeal_submission, :with_one_upload, submitted_appeal_uuid:, type_of_appeal: 'SC')
     end
     let(:user) { build(:user, :loa3) }
     let(:request_body) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV') }
@@ -50,18 +80,33 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
         end
       end
 
-      it 'increments statsd when job fails permanently' do
-        msg = {
-          'jid' => 'job_id',
-          'args' => [appeal_submission.id, 'encrypted_payload', submitted_appeal_uuid],
-          'error_message' => 'An error occurred for sidekiq job'
-        }
+      context 'when job fails permanently' do
+        let(:msg) do
+          {
+            'jid' => 'job_id',
+            'args' => [appeal_submission.id, 'encrypted_payload', submitted_appeal_uuid],
+            'error_message' => 'An error occurred for sidekiq job'
+          }
+        end
+        let(:tags) { ['service:supplemental-claims', 'function: secondary form submission to Lighthouse'] }
 
-        tags = ['service:supplemental-claims-4142', 'function: 21-4142 PDF submission to Lighthouse']
+        it 'increments statsd correctly when email is sent' do
+          expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }
+            .to trigger_statsd_increment('worker.decision_review.form4142_submit.permanent_error')
+            .and trigger_statsd_increment('silent_failure', tags:)
+            .and trigger_statsd_increment('silent_failure_avoided_no_confirmation', tags:)
+            .and trigger_statsd_increment('worker.decision_review.form4142_submit.retries_exhausted.email_queued')
+        end
 
-        expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }
-          .to trigger_statsd_increment('worker.decision_review.form4142_submit.permanent_error')
-          .and trigger_statsd_increment('silent_failure', tags:)
+        it 'increments statsd correctly for an error when sending an email' do
+          expect(vanotify_service).to receive(:send_email).and_raise('Failed to send email')
+
+          expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }
+            .to trigger_statsd_increment('worker.decision_review.form4142_submit.permanent_error')
+            .and trigger_statsd_increment('silent_failure', tags:)
+            .and trigger_statsd_increment('worker.decision_review.form4142_submit.retries_exhausted.email_error',
+                                          tags: ['appeal_type:SC'])
+        end
       end
     end
   end

--- a/spec/sidekiq/decision_review/submit_upload_spec.rb
+++ b/spec/sidekiq/decision_review/submit_upload_spec.rb
@@ -10,6 +10,36 @@ RSpec.describe DecisionReview::SubmitUpload, type: :job do
     Sidekiq::Testing.inline!(&example)
   end
 
+  let(:notification_id) { SecureRandom.uuid }
+  let(:vanotify_service) do
+    service = instance_double(VaNotify::Service)
+
+    response = instance_double(Notifications::Client::ResponseNotification, id: notification_id)
+    allow(service).to receive(:send_email).and_return(response)
+
+    service
+  end
+
+  let(:user_uuid) { create(:user, :loa3, ssn: '212222112').uuid }
+  let(:mpi_profile) { build(:mpi_profile, vet360_id: Faker::Number.number) }
+  let(:find_profile_response) { create(:find_profile_response, profile: mpi_profile) }
+  let(:mpi_service) do
+    service = instance_double(MPI::Service, find_profile_by_identifier: nil)
+    allow(service).to receive(:find_profile_by_identifier).with(identifier: user_uuid, identifier_type: anything)
+                                                          .and_return(find_profile_response)
+    service
+  end
+
+  let(:email_address) { 'testuser@test.com' }
+  let(:emails) { build(:email, email_address:) }
+  let(:person) { build(:person, emails:) }
+  let(:person_response) { instance_double(VAProfile::ContactInformation::PersonResponse, person:) }
+
+  before do
+    allow(VaNotify::Service).to receive(:new).and_return(vanotify_service)
+    allow(MPI::Service).to receive(:new).and_return(mpi_service)
+  end
+
   describe 'perform' do
     let(:appeal_submission) do
       create(:appeal_submission, :with_one_upload, submitted_appeal_uuid: 'e076ea91-6b99-4912-bffc-a8318b9b403f')
@@ -241,18 +271,34 @@ RSpec.describe DecisionReview::SubmitUpload, type: :job do
         end
       end
 
-      it 'increments statsd when job fails permanently' do
-        msg = {
-          'jid' => 'job_id',
-          'args' => [appeal_submission_upload.id],
-          'error_message' => 'An error occurred for sidekiq job'
-        }
+      context 'when job fails permanently' do
+        let(:msg) do
+          {
+            'jid' => 'job_id',
+            'args' => [appeal_submission_upload.id],
+            'error_message' => 'An error occurred for sidekiq job'
+          }
+        end
 
-        tags = ['service:board-appeal', 'function: evidence submission to Lighthouse']
+        let(:tags) { ['service:board-appeal', 'function: evidence submission to Lighthouse'] }
 
-        expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }
-          .to trigger_statsd_increment('worker.decision_review.submit_upload.permanent_error')
-          .and trigger_statsd_increment('silent_failure', tags:)
+        it 'increments statsd correctly when email is sent' do
+          expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }
+            .to trigger_statsd_increment('worker.decision_review.submit_upload.permanent_error')
+            .and trigger_statsd_increment('silent_failure', tags:)
+            .and trigger_statsd_increment('silent_failure_avoided_no_confirmation', tags:)
+            .and trigger_statsd_increment('worker.decision_review.submit_upload.retries_exhausted.email_queued')
+        end
+
+        it 'increments statsd correctly when an error occurs while sending out an email' do
+          expect(vanotify_service).to receive(:send_email).and_raise('Failed to send email')
+
+          expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }
+            .to trigger_statsd_increment('worker.decision_review.submit_upload.permanent_error')
+            .and trigger_statsd_increment('silent_failure', tags:)
+            .and trigger_statsd_increment('worker.decision_review.submit_upload.retries_exhausted.email_error',
+                                          tags: ['appeal_type:NOD'])
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
This adds email notification functionality to the DR jobs when all sidekiq retries are exhausted.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/96419
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94461

## Testing done

- [x] *New code is covered by unit tests*
Tested locally and via spec test.

## What areas of the site does it impact?
`DecisionReview::SubmitUpload` and `DecisionReview::Form4142Submit` jobs, StatsD

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
