### PR TITLE
Raise error if no new or increase disabilities are submitted

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -140,7 +140,6 @@ module V0
     end
 
     def log_failure(claim)
-      # debugger
       StatsD.increment("#{stats_key}.failure")
       raise Common::Exceptions::ValidationErrors, claim
     end

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -166,7 +166,7 @@ module V0
     end
 
     def missing_new_and_increase_disabilities?(saved_claim)
-      if saved_claim.form['updatedRatedDisabilities'].blank? # && saved_claim.form['newPrimaryDisabilities'].blank?
+      if saved_claim.form['updatedRatedDisabilities'].blank? && saved_claim.form['newPrimaryDisabilities'].blank?
         StatsD.increment("#{stats_key}.failure")
         Rails.logger.error(
           'Creating 526 submission: no new or increased disabilities were submitted', user_uuid: @current_user&.uuid

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -118,6 +118,15 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
             expect(response).to match_camelized_response_schema('evss_errors', strict: false)
           end
         end
+
+        it 'returns a 500 when no new or increase disabilities are submitted' do
+          all_claims_form = File.read 'spec/support/disability_compensation_form/all_claims_fe_submission.json'
+          json_object = JSON.parse(all_claims_form)
+          json_object['form526'].delete('newPrimaryDisabilities')
+          updated_form = JSON.generate(json_object)
+          post('/v0/disability_compensation_form/submit_all_claim', params: updated_form, headers:)
+          expect(response).to have_http_status(:internal_server_error)
+        end
       end
 
       context 'with a 401 response' do

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -308,6 +308,7 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
         all_claims_form = File.read 'spec/support/disability_compensation_form/all_claims_fe_submission.json'
         json_object = JSON.parse(all_claims_form)
         json_object['form526'].delete('newPrimaryDisabilities')
+        json_object['form526'].delete('newSecondaryDisabilities')
         updated_form = JSON.generate(json_object)
         post('/v0/disability_compensation_form/submit_all_claim', params: updated_form, headers:)
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -118,15 +118,6 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
             expect(response).to match_camelized_response_schema('evss_errors', strict: false)
           end
         end
-
-        it 'returns a 500 when no new or increase disabilities are submitted' do
-          all_claims_form = File.read 'spec/support/disability_compensation_form/all_claims_fe_submission.json'
-          json_object = JSON.parse(all_claims_form)
-          json_object['form526'].delete('newPrimaryDisabilities')
-          updated_form = JSON.generate(json_object)
-          post('/v0/disability_compensation_form/submit_all_claim', params: updated_form, headers:)
-          expect(response).to have_http_status(:internal_server_error)
-        end
       end
 
       context 'with a 401 response' do
@@ -310,6 +301,15 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
     context 'with invalid json body' do
       it 'returns a 422' do
         post('/v0/disability_compensation_form/submit_all_claim', params: { 'form526' => nil }.to_json, headers:)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns a 422 when no new or increase disabilities are submitted' do
+        all_claims_form = File.read 'spec/support/disability_compensation_form/all_claims_fe_submission.json'
+        json_object = JSON.parse(all_claims_form)
+        json_object['form526'].delete('newPrimaryDisabilities')
+        updated_form = JSON.generate(json_object)
+        post('/v0/disability_compensation_form/submit_all_claim', params: updated_form, headers:)
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end


### PR DESCRIPTION
The PR is a stop-gap fix for a recently encountered [bug](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95368) where somehow users were submitting no NEW or INCREASE disabilities with their 526ez form- even though the frontend explicitly tries to validate against it. Follow up FE fix + investigation ticket for this is [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96290)

The purpose of this fix is to quickly prevent any such claim from going all the way down the submission path and failing there. The user will still see a very generic error for the time being.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Controller-level code that returns failure before the claim is saved and sent down the primary submission path
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
Disability Benefits Experience Team 1 (DBEX-TREX) 🦖
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
https://github.com/department-of-veterans-affairs/va.gov-team/issues/96289
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
![image](https://github.com/user-attachments/assets/0d42b847-f0e0-470a-b5a2-c1caaaf552f4)


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
