### PR TITLE
Remove v0/veteran_confirmation endpoint request and test

### DIFF
--- a/postman/vets-api.pm-collection.json
+++ b/postman/vets-api.pm-collection.json
@@ -146,43 +146,6 @@
 					"response": []
 				},
 				{
-					"name": "/v0/backend_statuses/{service}",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Endpoint returns valid backend status object\", function () {",
-									"    if (pm.response.code != 200) { return };",
-									"    var responseBody = pm.response.json();",
-									"    pm.expect(responseBody).to.have.property('data');",
-									"});",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{vets_api_env}}//v0/backend_statuses/gibs",
-							"host": [
-								"{{vets_api_env}}"
-							],
-							"path": [
-								"",
-								"v0",
-								"backend_statuses",
-								"gibs"
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "/v0/forms",
 					"event": [
 						{

--- a/postman/vets-api.pm-collection.json
+++ b/postman/vets-api.pm-collection.json
@@ -5,7 +5,7 @@
 		"description": "This collection of tests is designed to be able to run against any `vets-api` environment from production to development due to the complete absence of authenticated endpoint testing.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "30919894",
-		"_collection_link": "https://vagov-prt.postman.co/workspace/My-Workspace~185144e6-e8c9-422f-8b0d-4419d7c6241f/collection/30919894-01f8fb9c-b9c0-48e8-8304-681931b023fc?action=share&source=collection_link&creator=30919894"
+		"_collection_link": "https://vagov-prt.postman.co/workspace/185144e6-e8c9-422f-8b0d-4419d7c6241f/collection/30919894-01f8fb9c-b9c0-48e8-8304-681931b023fc?action=share&source=collection_link&creator=30919894"
 	},
 	"item": [
 		{
@@ -140,6 +140,43 @@
 							"path": [
 								"v0",
 								"backend_statuses"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/v0/backend_statuses/{service}",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Endpoint returns valid backend status object\", function () {",
+									"    if (pm.response.code != 200) { return };",
+									"    var responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('data');",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{vets_api_env}}//v0/backend_statuses/gibs",
+							"host": [
+								"{{vets_api_env}}"
+							],
+							"path": [
+								"",
+								"v0",
+								"backend_statuses",
+								"gibs"
 							]
 						}
 					},
@@ -751,57 +788,6 @@
 								"appeals",
 								"v0",
 								"upstream_healthcheck"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/services/veteran_confirmation/v0/health",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Response status code is 200\", function () {",
-									"  pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response has the required fields - status, components, and groups\", function () {",
-									"    const responseData = pm.response.json();",
-									"    ",
-									"    pm.expect(responseData).to.be.an('object');",
-									"    pm.expect(responseData).to.have.property('status');",
-									"    pm.expect(responseData).to.have.property('components');",
-									"    pm.expect(responseData).to.have.property('groups');",
-									"});",
-									"",
-									"",
-									"pm.test(\"Status should be UP\", function () {",
-									"    const responseData = pm.response.json();",
-									"    ",
-									"    pm.expect(responseData.status).to.be.a('string').and.to.have.lengthOf.at.least(1, \"Status should not be empty\");",
-									"    pm.expect(responseData.status).to.deep.equal('UP');",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{vets_api_env}}/services/veteran_confirmation/v0/health",
-							"host": [
-								"{{vets_api_env}}"
-							],
-							"path": [
-								"services",
-								"veteran_confirmation",
-								"v0",
-								"health"
 							]
 						}
 					},


### PR DESCRIPTION
As stated by Derek Brown, this endpoint is deprecated and is slated for removal from vets-api.  As such, removing the test from the Postman collection will ensure that no failures occur due to its disuse and eventual removal.


## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*

- *This work has been done by the Platform Reliability Team in support of the Product Team*

## Related issue(s)

https://dsva.slack.com/archives/C013VCQKSE7/p1730925246985469


## What areas of the site does it impact?
*Nothing user-facing*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).

