### PR TITLE
API-41807-adjust-slack-filter-for-correct-error-response

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/report_hourly_unsuccessful_submissions.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/report_hourly_unsuccessful_submissions.rb
@@ -77,7 +77,7 @@ module ClaimsApi
 
       unique_errors.each do |ue|
         filtered_error_ids << ue[:id] unless NO_INVESTIGATION_ERROR_TEXT.any? do |text|
-          ue[:evss_response]&.include?(text)
+          ue[:evss_response].to_s&.include?(text)
         end
       end
 

--- a/modules/claims_api/spec/sidekiq/report_hourly_unsuccessful_submissions_spec.rb
+++ b/modules/claims_api/spec/sidekiq/report_hourly_unsuccessful_submissions_spec.rb
@@ -104,25 +104,26 @@ describe ClaimsApi::ReportHourlyUnsuccessfulSubmissions, type: :job do
                                                                                  transaction_id: 'transaction_3',
                                                                                  id: '4')
 
-        FactoryBot.create(:auto_established_claim_va_gov,
-                          :errored,
-                          created_at: 30.seconds.ago,
-                          evss_response: "[{'status'=>'422', " \
-                                         "'title'=>'Backend Service Exception', " \
-                                         "'detail'=>'The Maximum number of EP codes have been " \
-                                         "reached for this benefit type claim code'}]",
-                          transaction_id: 'transaction_4')
+        claim_five = FactoryBot.create(:auto_established_claim_va_gov,
+                                       :errored,
+                                       created_at: 30.seconds.ago,
+                                       evss_response: [{ 'status' => '422',
+                                                         'title' => 'Backend Service Exception',
+                                                         'detail' => 'The Maximum number of EP codes have been ' \
+                                                                     'reached for this benefit type claim code' }],
+                                       transaction_id: 'transaction_4')
 
-        FactoryBot.create(:auto_established_claim_va_gov,
-                          :errored,
-                          created_at: 120.seconds.ago,
-                          evss_response: "[{'status'=>'422', " \
-                                         "'title'=>'Backend Service Exception', " \
-                                         "'detail'=>'Claim could not be established. Retries will fail.'}]",
-                          transaction_id: 'transaction_5')
+        claim_six = FactoryBot.create(:auto_established_claim_va_gov,
+                                      :errored,
+                                      created_at: 120.seconds.ago,
+                                      evss_response: [{ 'status' => '422',
+                                                        'title' => 'Backend Service Exception',
+                                                        'detail' => 'Claim could not be established. ' \
+                                                                    'Retries will fail.' }],
+                                      transaction_id: 'transaction_5')
 
         expected_vagov_claims = [claim_three.id, claim_four.id]
-        expected_absent_values = [claim_one.id, claim_two.id]
+        expected_absent_values = [claim_one.id, claim_two.id, claim_five.id, claim_six.id]
 
         expected_present_values = [
           [],


### PR DESCRIPTION
## Summary
* Adjusts error message data type in test, they are saved as an array not a string
* Adjusts test to actually verify the IDs are not included

## Related issue(s)
[API-41807](https://jira.devops.va.gov/browse/API-41807)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/report_hourly_unsuccessful_submissions.rb
	modified:   modules/claims_api/spec/sidekiq/report_hourly_unsuccessful_submissions_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
