### PR TITLE
Add check-pr-status job to BE PR Labeler

### DIFF
--- a/.github/workflows/backend-pr-labeler.yml
+++ b/.github/workflows/backend-pr-labeler.yml
@@ -2,6 +2,8 @@ name: Backend PR Labeler
 on:
   pull_request:
     types: [opened, reopened, review_requested, review_request_removed, ready_for_review, converted_to_draft, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
   workflow_run:
     workflows: 
       - "Code Checks"
@@ -9,7 +11,78 @@ on:
 jobs:
   check-pr-status:
     runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.get_pr_data.outputs.pr_number }}
+      pr_draft: ${{ steps.get_pr_data.outputs.pr_draft }}
+      pr_labels: ${{ steps.get_pr_data.outputs.pr_labels }}
+      pr_requested_teams: ${{ steps.get_pr_data.outputs.pr_requested_teams }}
+      test_status: ${{ steps.get_code_checks_conclusion.outputs.test_status }}
+      exempt: ${{ steps.check_exemption.outputs.exempt }}
+      failures_detected: ${{ steps.audit_pr_labels.outputs.failures_detected }}
     steps:
-      - name: Say Hi
+      - name: Get pull_request data
+        id: get_pr_data
         run: |
-          echo "Hi"
+          if ${{ github.event_name == 'pull_request'}}; then
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "pr_draft=${{ github.event.pull_request.draft }}" >> $GITHUB_OUTPUT
+            echo "pr_labels=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+            echo "pr_requested_teams=$(echo '${{ toJSON(github.event.pull_request.requested_teams.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+          elif ${{ github.event_name == 'pull_request_review' }}; then
+            echo "pr_number=${{ github.event.pull_request_review.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "pr_draft=${{ github.event.pull_request_review.pull_request.draft }}" >> $GITHUB_OUTPUT
+            echo "pr_labels=$(echo '${{ toJSON(github.event.pull_request_review.pull_request.labels.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+            echo "pr_requested_teams=$(echo '${{ toJSON(github.event.pull_request_review.pull_request.requested_teams.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]] && [[ "${{ toJSON(github.event.workflow_run.pull_requests) }}" != "[]" ]]; then
+            echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
+            echo "pr_draft=${{ github.event.workflow_run.pull_requests[0].draft }}" >> $GITHUB_OUTPUT
+            echo "pr_labels=$(echo '${{ toJSON(github.event.workflow_run.pull_requests[0].labels.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+            echo "pr_requested_teams=$(echo '${{ toJSON(github.event.workflow_run.pull_requests[0].requested_teams.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+          else
+            echo "Pull Request not successfully retrieved."
+            exit 1
+          fi
+
+      - name: Echo PR data
+        run: |
+          echo "pr_number: ${{ steps.get_pr_data.outputs.pr_number }}"
+          echo "pr_draft: ${{ steps.get_pr_data.outputs.pr_draft }}"
+          echo "pr_labels: ${{ steps.get_pr_data.outputs.pr_labels }}"
+          echo "pr_labels: ${{ fromJson(steps.get_pr_data.outputs.pr_labels)[0] }}"
+          echo "pr_requested_teams: ${{ steps.get_pr_data.outputs.pr_requested_teams }}"
+          echo "pr_requested_teams: ${{ fromJSON(steps.get_pr_data.outputs.pr_requested_teams)[0] }}"
+
+      - name: Get Code Checks result
+        if: github.event_name == 'workflow_run'
+        run: |
+          echo "test_status=${{ github.event.workflow_run.conclusion }}" >> $GITHUB_OUTPUT
+          echo "test_status: ${{ github.event.workflow_run.conclusion }}"
+
+      - name: Check for exemption
+        id: check_exemption
+        run: |
+          if ${{ contains(fromJSON(steps.get_pr_data.outputs.pr_requested_teams), 'backend-review-group') }}; then
+            echo "exempt=false" >> $GITHUB_OUTPUT
+            echo "PR requires backend approval."
+          else
+            echo "exempt=true" >> $GITHUB_OUTPUT
+            echo "PR is exempt from backend approval."
+          fi
+
+      - name: Check for failure labels
+        id: audit_pr_labels
+        env:
+          labels: ${{ steps.get_pr_data.outputs.pr_labels }}
+        run: |
+          if \
+            ${{ contains(env.labels, 'code-health-failure') }} ||\
+            ${{ contains(env.labels, 'codeowners-addition-failure') }} ||\
+            ${{ contains(env.labels, 'codeowners-delete-failure') }} ||\
+            ${{ contains(env.labels, 'lint-failure') }} ||\
+            ${{ contains(env.labels, 'test-failure') }} ; then
+            echo "failures_detected=true" >> $GITHUB_OUTPUT
+            echo "Failure labels detected."
+          else
+            echo "failures_detected=false" >> $GITHUB_OUTPUT
+            echo "No failure labels detected."
+          fi


### PR DESCRIPTION
## Summary

- Adding the check-pr-status job from my working branch so that I can test that it works when triggered by Code Checks

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/19126