### PR TITLE
Burial 91426 SavedClaim::Burial#benefits_claimed returning nil

### DIFF
--- a/app/models/saved_claim/burial.rb
+++ b/app/models/saved_claim/burial.rb
@@ -84,5 +84,6 @@ class SavedClaim::Burial < CentralMailClaim
     claimed << 'Burial Allowance' if parsed_form['burialAllowance']
     claimed << 'Plot Allowance' if parsed_form['plotAllowance']
     claimed << 'Transportation' if parsed_form['transportation']
+    claimed
   end
 end

--- a/spec/models/saved_claim/burial_spec.rb
+++ b/spec/models/saved_claim/burial_spec.rb
@@ -64,4 +64,39 @@ RSpec.describe SavedClaim::Burial do
       expect(instance.email).to eq('foo@foo.com')
     end
   end
+
+  describe '#benefits_claimed' do
+    it 'returns a full array of values' do
+      benefits_claimed = instance_v2.benefits_claimed
+      expected = ['Burial Allowance', 'Plot Allowance', 'Transportation']
+
+      expect(benefits_claimed.length).to eq(3)
+      expect(benefits_claimed).to eq(expected)
+    end
+
+    it 'returns at least an empty array' do
+      form = instance_v2.parsed_form
+
+      form = form.merge({ 'transportation' => false })
+      claim = FactoryBot.build(:burial_claim_v2, form: form.to_json)
+      benefits_claimed = claim.benefits_claimed
+      expected = ['Burial Allowance', 'Plot Allowance']
+      expect(benefits_claimed.length).to eq(2)
+      expect(benefits_claimed).to eq(expected)
+
+      form = form.merge({ 'plotAllowance' => false })
+      claim = FactoryBot.build(:burial_claim_v2, form: form.to_json)
+      benefits_claimed = claim.benefits_claimed
+      expected = ['Burial Allowance']
+      expect(benefits_claimed.length).to eq(1)
+      expect(benefits_claimed).to eq(expected)
+
+      form = form.merge({ 'burialAllowance' => false })
+      claim = FactoryBot.build(:burial_claim_v2, form: form.to_json)
+      benefits_claimed = claim.benefits_claimed
+      expected = []
+      expect(benefits_claimed.length).to eq(0)
+      expect(benefits_claimed).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

benefits_claim model function returning nil if last checked value was false

## Related issue(s)

[Trigger Pension and Burial Action Needed email notification](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91426)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
burial

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
