### PR TITLE
Retrieve entire pull_request from workflow_run

### DIFF
--- a/.github/workflows/backend-pr-labeler.yml
+++ b/.github/workflows/backend-pr-labeler.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   check-pr-status:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       pr_number: ${{ steps.get_pr_data.outputs.pr_number }}
       pr_draft: ${{ steps.get_pr_data.outputs.pr_draft }}
@@ -33,12 +35,23 @@ jobs:
             echo "pr_draft=${{ github.event.pull_request_review.pull_request.draft }}" >> $GITHUB_OUTPUT
             echo "pr_labels=$(echo '${{ toJSON(github.event.pull_request_review.pull_request.labels.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
             echo "pr_requested_teams=$(echo '${{ toJSON(github.event.pull_request_review.pull_request.requested_teams.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_run" ]] && [[ "${{ toJSON(github.event.workflow_run.pull_requests) }}" != "[]" ]]; then
-            echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
-            echo "pr_draft=${{ github.event.workflow_run.pull_requests[0].draft }}" >> $GITHUB_OUTPUT
-            echo "pr_labels=$(echo '${{ toJSON(github.event.workflow_run.pull_requests[0].labels.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
-            echo "pr_requested_teams=$(echo '${{ toJSON(github.event.workflow_run.pull_requests[0].requested_teams.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+          elif ${{ github.event_name == 'workflow_run' }} && ${{ toJSON(github.event.workflow_run.pull_requests) != '[]' }}; then
+            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+            echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+            
+            # Fetch PR details from GitHub API
+            PR_INFO=$(gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER} --jq '{
+              draft: .draft,
+              labels: [.labels[].name],
+              requested_teams: [.requested_teams[].slug]
+            }')
+            
+            # Extract and store individual fields
+            echo "pr_draft=$(echo "$PR_INFO" | jq -r '.draft')" >> $GITHUB_OUTPUT
+            echo "pr_labels=$(echo "$PR_INFO" | jq -c '.labels')" >> $GITHUB_OUTPUT
+            echo "pr_requested_teams=$(echo "$PR_INFO" | jq -c '.requested_teams')" >> $GITHUB_OUTPUT
           else
+            echo "event_name: ${{ github.event_name }}"
             echo "Pull Request not successfully retrieved."
             exit 1
           fi


### PR DESCRIPTION
## Summary

- The pull request object nested in the workflow run doesn't contain enough info, so this requires making a call to retrieve the whole PR to get the draft status, labels, and teams.