### PR TITLE
Adjust so worklow_run only performs on PR Code Checks

### DIFF
--- a/.github/workflows/backend-pr-labeler.yml
+++ b/.github/workflows/backend-pr-labeler.yml
@@ -35,21 +35,29 @@ jobs:
             echo "pr_draft=${{ github.event.pull_request_review.pull_request.draft }}" >> $GITHUB_OUTPUT
             echo "pr_labels=$(echo '${{ toJSON(github.event.pull_request_review.pull_request.labels.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
             echo "pr_requested_teams=$(echo '${{ toJSON(github.event.pull_request_review.pull_request.requested_teams.*.name) }}' | jq -c '.')" >> $GITHUB_OUTPUT
-          elif ${{ github.event_name == 'workflow_run' }} && ${{ toJSON(github.event.workflow_run.pull_requests) != '[]' }}; then
-            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
-            echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          elif ${{ github.event_name == 'workflow_run' }}; then
+            if ${{ github.event.workflow_run.event == 'push' }}; then
+              echo "Workflow was triggered by push to ${{ github.event.workflow_run.head_branch }}. Labeling not required."
+              exit 0
+            elif ${{ toJSON(github.event.workflow_run.pull_requests) != '[]' }}; then
+              PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+              echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
             
-            # Fetch PR details from GitHub API
-            PR_INFO=$(gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER} --jq '{
-              draft: .draft,
-              labels: [.labels[].name],
-              requested_teams: [.requested_teams[].slug]
-            }')
-            
-            # Extract and store individual fields
-            echo "pr_draft=$(echo "$PR_INFO" | jq -r '.draft')" >> $GITHUB_OUTPUT
-            echo "pr_labels=$(echo "$PR_INFO" | jq -c '.labels')" >> $GITHUB_OUTPUT
-            echo "pr_requested_teams=$(echo "$PR_INFO" | jq -c '.requested_teams')" >> $GITHUB_OUTPUT
+              # Fetch PR details from GitHub API
+              PR_INFO=$(gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER} --jq '{
+                draft: .draft,
+                labels: [.labels[].name],
+                requested_teams: [.requested_teams[].slug]
+              }')
+              
+              # Extract and store individual fields
+              echo "pr_draft=$(echo "$PR_INFO" | jq -r '.draft')" >> $GITHUB_OUTPUT
+              echo "pr_labels=$(echo "$PR_INFO" | jq -c '.labels')" >> $GITHUB_OUTPUT
+              echo "pr_requested_teams=$(echo "$PR_INFO" | jq -c '.requested_teams')" >> $GITHUB_OUTPUT
+            else
+              echo "Workflow run has no associated pull requests. Labeling not performed."
+              exit 0
+            fi
           else
             echo "event_name: ${{ github.event_name }}"
             echo "Pull Request not successfully retrieved."


### PR DESCRIPTION
## Summary

- work_flow run was failing because Code Checks runs both on PRs AND pushes to master. Now workflow will exit if there isn't a pull_request, and not throw an error