### PR TITLE
Don't build PE on merge to master

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,6 +1,9 @@
 name: Build And Publish Preview Environment
 run-name: Build And Publish Preview Environment
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - master
 permissions: write-all
 jobs:
   build-and-publish:


### PR DESCRIPTION
## Summary
This PR prevents preview environments from being built when a PR is merged into the `master` branch. It's my understanding that preview envs are designed to be used during the code review process and once the code is merged, a new preview environment wouldn't really be necessary. 

While on Backend support, I'm often looking at the list of [commits into master](https://github.com/department-of-veterans-affairs/vets-api/commits/master/) to make sure the code is passing its code-checks workflow. Whenever I see the :x: (see screenshot below), I click on it to see if it's the code-checks workflow. Oftentimes it's the build-and-publish workflow, which is distracting.
<img width="406" alt="image" src="https://github.com/user-attachments/assets/9209b754-4e2d-4336-a9a4-1031e1c432e9">

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75910
- [GitHub workflow docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-branches-and-tags)

## Testing done
I will keep an eye on merges and PRs to make sure PEs are created in PRs and not on merge to master. 

## What areas of the site does it impact?
Preview Envs being created after a commit is pushed to master (i.e. merged)