### PR TITLE
datadog error logs

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -31,14 +31,14 @@ module IvcChampva
             end
 
             render json: response[:json], status: response[:status]
-          rescue Prawn::Errors::IncompatibleStringEncoding
-            raise
-          rescue => e
-            raise Exceptions::ScrubbedUploadsSubmitError.new(params), e
-            Rails.logger.error "Error: #{e.message}"
-            Rails.logger.error e.backtrace.join("\n")
-            render json: { error_message: "Error: #{e.message}" },
-                   status: :internal_server_error
+          end
+        rescue Prawn::Errors::IncompatibleStringEncoding
+          raise
+        rescue => e
+          Rails.logger.error "Error: #{e.message}"
+          Rails.logger.error e.backtrace.join("\n")
+
+          raise Exceptions::ScrubbedUploadsSubmitError.new(params), e
         end
       else
         def submit

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -16,6 +16,11 @@ module IvcChampva
       @form_id = 'vha_10_7959f_1'
     end
 
+    def words_to_remove
+      veteran_ssn + veteran_date_of_birth + veteran_mailing_address + veteran_email +
+        veteran_physical_address + veteran_home_phone
+    end
+
     def metadata
       {
         'veteranFirstName' => @data.dig('veteran', 'full_name', 'first'),
@@ -55,6 +60,44 @@ module IvcChampva
 
     def respond_to_missing?(_)
       true
+    end
+
+    private
+
+    def veteran_ssn
+      [
+        data.dig('veteran', 'ssn')
+      ]
+    end
+
+    def veteran_date_of_birth
+      [
+        data.dig('veteran', 'date_of_birth')
+      ]
+    end
+
+    def veteran_mailing_address
+      [
+        data.dig('veteran', 'mailing_address_string')
+      ]
+    end
+
+    def veteran_email
+      [
+        data.dig('veteran', 'email_address')
+      ]
+    end
+
+    def veteran_physical_address
+      [
+        data.dig('veteran', 'physical_address_string')
+      ]
+    end
+
+    def veteran_home_phone
+      [
+        data.dig('veteran', 'phone_number')
+      ]
     end
   end
 end

--- a/modules/ivc_champva/lib/ivc_champva.rb
+++ b/modules/ivc_champva/lib/ivc_champva.rb
@@ -4,5 +4,57 @@ require 'ivc_champva/engine'
 require 'securerandom'
 
 module IvcChampva
-  # Your code goes here...
+  module Exceptions
+    class ScrubbedUploadsSubmitError < RuntimeError
+      attr_reader :params
+
+      def initialize(params)
+        super
+        @params = params
+      end
+
+      def message
+        scrub_pii(super)
+      end
+
+      private
+
+      def scrub_pii(message)
+        words_to_remove = aggregate_words(JSON.parse(params.to_json))
+
+        case params[:form_number]
+        when '10-7959F-1'
+          words_to_remove += IvcChampva::VHA107959f1.new(params).words_to_remove
+        else
+          return "something has gone wrong with your form, #{params[:form_number]} and the entire " \
+                 'error message has been redacted to keep PII from getting leaked'
+        end
+
+        remove_words(message, words_to_remove)
+      end
+
+      def remove_words(message, words_to_remove)
+        words_to_remove.compact.each do |word|
+          message.gsub!(word, '')
+          message.gsub!(word.upcase, '')
+        end
+
+        message
+      end
+
+      def aggregate_words(parsed_params)
+        words = []
+        parsed_params.each_value do |value|
+          case value
+          when Hash
+            words += aggregate_words(value)
+          when String
+            words += value.split
+          end
+        end
+
+        words.uniq.sort_by(&:length).reverse
+      end
+    end
+  end
 end


### PR DESCRIPTION

## Summary

- *This work is behind a feature toggle (flipper): YES
- This PR enhances datadog monitoring with detailed error messaging in the uploads controller.

<img width="788" alt="Screenshot 2024-11-12 at 10 20 20 AM" src="https://github.com/user-attachments/assets/5a6067e1-690e-4432-8a23-1bcce72a0946">


## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-api/pull/19253


## Testing done
Test is Flipper on and off

## What areas of the site does it impact?
Datadog monitoring and all IVC forms
