### PR TITLE
VACMS-18336: Remove flipper for search_dropdown_component_enabled

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1161,10 +1161,6 @@ features:
     actor_type: user
     description: Enable frontend application and cta for Search Representative application
     enable_in_development: true
-  search_dropdown_component_enabled:
-    actor_type: user
-    description: Enables typeahead 2.0 functionality
-    enable_in_development: true
   search_gov_maintenance:
     actor_type: user
     description: Use when Search.gov system maintenance impacts sitewide search


### PR DESCRIPTION
## Summary
Removes the flipper for the search dropdown component that is not longer in use.

## Related issue(s)
[#18336](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18336)

## Testing done

## Screenshots


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

