### PR TITLE
add silent failure log

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -10,7 +10,7 @@ module IvcChampva
         Datadog::Tracing.trace('Start PEGA Status Update') do
           data = JSON.parse(params.to_json)
 
-          tags = ['service:ivc_champva', "function:#{form_type} form submission to PEGA"]
+          tags = ['service:ivc_champva', 'function:form submission to Pega']
 
           unless data.is_a?(Hash)
             # Log the failure due to invalid JSON format

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -10,7 +10,7 @@ module IvcChampva
         Datadog::Tracing.trace('Start PEGA Status Update') do
           data = JSON.parse(params.to_json)
 
-          tags = ['service:veteran-facing-forms', 'function:form submission to Lighthouse']
+          tags = ['service:ivc_champva', 'function:form submission to Pega']
 
           unless data.is_a?(Hash)
             # Log the failure due to invalid JSON format

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -10,7 +10,7 @@ module IvcChampva
         Datadog::Tracing.trace('Start PEGA Status Update') do
           data = JSON.parse(params.to_json)
 
-          tags = ['service:ivc_champva', 'function:form submission to Pega']
+          tags = ['service:veteran-ivc-champva-forms', 'function:form submission to Pega']
 
           unless data.is_a?(Hash)
             # Log the failure due to invalid JSON format

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -10,7 +10,7 @@ module IvcChampva
         Datadog::Tracing.trace('Start PEGA Status Update') do
           data = JSON.parse(params.to_json)
 
-          tags = ['service:ivc_champva', 'function:form submission to Pega']
+          tags = ['service:ivc_champva', "function:#{form_type} form submission to PEGA"]
 
           unless data.is_a?(Hash)
             # Log the failure due to invalid JSON format
@@ -23,7 +23,6 @@ module IvcChampva
             if valid_keys?(data)
               update_data(data['form_uuid'], data['file_names'], data['status'], data['case_id'])
             else
-              # Log the failure due to invalid keys
               StatsD.increment('silent_failure_avoided_no_confirmation', tags: tags)
               { json: { error_message: 'Invalid JSON keys' }, status: :bad_request }
             end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
Log ZSF for IVC forms

https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/practices/zero-silent-failures/logging-silent-failures.md

Use this log message when your team has identified a silent failure AND has made that failure known to the user via an email notification via VA Notify.

<img width="1301" alt="Screenshot 2024-11-13 at 7 27 54 AM" src="https://github.com/user-attachments/assets/4f8d8e38-854e-4f60-b5cb-958bf94e96fd">



## Testing done
