### PR TITLE
Prevent Form 526 silent failure logging when failure email is sent

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
@@ -76,6 +76,11 @@ module EVSS
         if Flipper.enabled?(:form526_send_0781_failure_notification)
           EVSS::DisabilityCompensationForm::Form0781DocumentUploadFailureEmail.perform_async(form526_submission_id)
         end
+        # NOTE: do NOT add any additional code here between the failure email being enqueued and the rescue block.
+        # The mailer prevents an upload from failing silently, since we notify the veteran and provide a workaround.
+        # The rescue will catch any errors in the sidekiq_retries_exhausted block and mark a "silent failure".
+        # This shouldn't happen if an email was sent; there should be no code here to throw an additional exception.
+        # The mailer should be the last thing that can fail.
       rescue => e
         cl = caller_locations.first
         call_location = Logging::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)

--- a/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
@@ -45,17 +45,22 @@ module EVSS
 
         StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
 
-        if Flipper.enabled?(:form526_send_document_upload_failure_notification)
-          guid = upload_data['confirmationCode']
-          Form526DocumentUploadFailureEmail.perform_async(form526_submission_id, guid)
-        end
-
         if Flipper.enabled?(:disability_compensation_use_api_provider_for_submit_veteran_upload)
           submission = Form526Submission.find(form526_submission_id)
 
           provider = api_upload_provider(submission, upload_data['attachmentId'], nil)
           provider.log_uploading_job_failure(self, error_class, error_message)
         end
+
+        if Flipper.enabled?(:form526_send_document_upload_failure_notification)
+          guid = upload_data['confirmationCode']
+          Form526DocumentUploadFailureEmail.perform_async(form526_submission_id, guid)
+        end
+        # NOTE: do NOT add any additional code here between the failure email being enqueued and the rescue block.
+        # The mailer prevents an upload from failing silently, since we notify the veteran and provide a workaround.
+        # The rescue will catch any errors in the sidekiq_retries_exhausted block and mark a "silent failure".
+        # This shouldn't happen if an email was sent; there should be no code here to throw an additional exception.
+        # The mailer should be the last thing that can fail.
       rescue => e
         cl = caller_locations.first
         call_location = Logging::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): 
NO

- *(Summarize the changes that have been made to the platform)*

Ensures the veteran-facing failure mailer we send when a document fails to upload for a Form 526 is the last thing that can raise an exception in an upload job's `sidekiq_retries_exhausted` block. Moves the order of the code in one job and adds a note to two jobs so no new code can get added in this area.


- *(Which team do you work for, does your team own the maintenance of this component?)*

Disability Benefits team 2, we own the maintenance of this component



## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/96216

## Testing done

- [X] *New code is covered by unit tests*


## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). N/A
- [X]  No error nor warning in the console. N/A
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
