### PR TITLE
[CST] Logging Document upload failure email errors to Sentry

### DIFF
--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -6,6 +6,7 @@ require 'logging/third_party_transaction'
 
 class EVSS::DocumentUpload
   include Sidekiq::Job
+  extend SentryLogging
   extend Logging::ThirdPartyTransaction::MethodWrapper
 
   FILENAME_EXTENSION_MATCHER = /\.\w*$/
@@ -63,6 +64,7 @@ class EVSS::DocumentUpload
     ::Rails.logger.error('EVSS::DocumentUpload exhaustion handler email error',
                          { message: e.message })
     StatsD.increment('silent_failure', tags: DD_ZSF_TAGS)
+    log_exception_to_sentry(e)
   end
 
   def perform(auth_headers, user_uuid, document_hash)

--- a/app/sidekiq/lighthouse/document_upload.rb
+++ b/app/sidekiq/lighthouse/document_upload.rb
@@ -6,6 +6,7 @@ require 'lighthouse/benefits_documents/worker_service'
 
 class Lighthouse::DocumentUpload
   include Sidekiq::Job
+  extend SentryLogging
 
   FILENAME_EXTENSION_MATCHER = /\.\w*$/
   OBFUSCATED_CHARACTER_MATCHER = /[a-zA-Z\d]/
@@ -48,6 +49,7 @@ class Lighthouse::DocumentUpload
     ::Rails.logger.error('Lighthouse::DocumentUpload exhaustion handler email error',
                          { message: e.message })
     StatsD.increment('silent_failure', tags: DD_ZSF_TAGS)
+    log_exception_to_sentry(e)
   end
 
   def self.obscured_filename(original_filename)

--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -3,6 +3,8 @@
 require 'sentry_logging'
 
 module SentryLogging
+  extend self
+
   def log_message_to_sentry(message, level, extra_context = {}, tags_context = {})
     level = normalize_level(level, nil)
     formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"


### PR DESCRIPTION
## Summary
The current error message that we get back when there are errors with the request to VANotify don't include any details about why the emails failed. `e.message` only includes the error code and the service name, but doesn't include any further details. The VANotify module does set these things up as extras for Sentry though, so logging the exception to Sentry makes more fine details available to us. I also considered modifying the VANotify module, but that would require making changes to the `Common::Client::Errors::ClientError` class itself which is used across many different modules and may have ramifications that can't be anticipated.

- *This work is behind a feature toggle (flipper): YES*

## Related issue(s)
department-of-veterans-affairs/va.gov-team/issues/96884

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
