### PR TITLE
Prevent silent failure logging when 4142 mailer is sent

### DIFF
--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -76,6 +76,11 @@ module CentralMail
       if Flipper.enabled?(:form526_send_4142_failure_notification)
         EVSS::DisabilityCompensationForm::Form4142DocumentUploadFailureEmail.perform_async(form526_submission_id)
       end
+      # NOTE: do NOT add any additional code here between the failure email being enqueued and the rescue block.
+      # The mailer prevents an upload from failing silently, since we notify the veteran and provide a workaround.
+      # The rescue will catch any errors in the sidekiq_retries_exhausted block and mark a "silent failure".
+      # This shouldn't happen if an email was sent; there should be no code here to throw an additional exception.
+      # The mailer should be the last thing that can fail.
     rescue => e
       cl = caller_locations.first
       call_location = Logging::CallLocation.new(ZSF_DD_TAG_FUNCTION, cl.path, cl.lineno)


### PR DESCRIPTION


## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)*

Ensures the veteran-facing failure mailer we send when a 4142 document fails to upload for a Form 526 is the last thing that can raise an exception in the upload job's `sidekiq_retries_exhausted` block.

(I missed updating this job in [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/19394), same change)

- *(Which team do you work for, does your team own the maintenance of this component?)*

Disability benefits team 2, yes we own the maintenance


## Testing done

N/A documentation change CI will catch anything



## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). N/A
- [ ]  No error nor warning in the console. N/A
- [ ]  Events are being sent to the appropriate logging solution N/A
- [ ]  Documentation has been updated (link to documentation) N/A
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs N/A
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [ ]  I added a screenshot of the developed feature N/A
