### PR TITLE
[SIMPLE-FORMS] doc: update form_submission_pdf_backups.md

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/docs/form_submission_pdf_backups.md
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/docs/form_submission_pdf_backups.md
@@ -2,10 +2,6 @@
 
 This documentation covers the setup and usage of the PDF upload/download solution, designed to handle individual form submissions as PDF files within an AWS S3 bucket.
 
-The following image depicts how this solution is architected:
-
-![Error Remediation Architecture](./error_remediation_architecture.png)
-
 ---
 
 ## Table of Contents
@@ -82,15 +78,7 @@ By default, the solution uses the `:benefits_intake_uuid` identifier to query `F
 
 ### Individual Processing
 
-To handle a single PDF upload for a form submission, instantiate the `S3Client` directly with the appropriate configuration and submission ID:
-
-```ruby
-config = YourTeamsConfig.new
-client = SimpleFormsApi::FormRemediation::S3Client.new(config:, id: <YOUR_SUBMISSION_ID>)
-client.upload
-```
-
-For backup purposes, specify `type: :submission` during initialization. This ensures that only the original form PDF is uploaded and a presigned URL is generated:
+To handle a single PDF upload for a form submission, instantiate the `S3Client` directly with the appropriate configuration and submission ID. For backup purposes, specify `type: :submission` during initialization. This ensures that only the original form PDF is uploaded and a presigned URL is generated:
 
 ```ruby
 config = YourTeamsConfig.new
@@ -108,10 +96,11 @@ Each component of this solution can be extended or customized to meet team requi
 2. Create subclasses for required functionality.
 3. Register the subclass in your configuration:
 
+Extending the uploader:
 ```ruby
 # frozen_string_literal: true
 
-require 'simple_forms_api/form_remediation/configuration/base'
+require 'simple_forms_api/form_remediation/uploader'
 
 class NewUploader < SimpleFormsApi::FormRemediation::Uploader
   def size_range
@@ -120,6 +109,7 @@ class NewUploader < SimpleFormsApi::FormRemediation::Uploader
 end
 ```
 
+Using the new uploader within your own team's configuration:
 ```ruby
 # frozen_string_literal: true
 
@@ -136,6 +126,7 @@ class NewConfig < SimpleFormsApi::FormRemediation::Configuration::Base
 end
 ```
 
+Instantiate the client with your team's configuration:
 ```ruby
 config = NewConfig.new
 client = SimpleFormsApi::FormRemediation::S3Client.new(config:, id: <YOUR_SUBMISSION_ID>, type: :submission)

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/docs/form_submission_pdf_backups.md
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/docs/form_submission_pdf_backups.md
@@ -13,6 +13,7 @@ This documentation covers the setup and usage of the PDF upload/download solutio
     - [Configuration](#configuration)
   - [Usage](#usage)
     - [Individual Processing](#individual-processing)
+    - [S3 Pre-Signed URL Retrieval](#s3-pre-signed-url-retrieval)
   - [Extending Functionality](#extending-functionality)
     - [Overrideable Classes](#overrideable-classes)
     - [Directory and File Structure](#directory-and-file-structure)
@@ -86,6 +87,15 @@ client = SimpleFormsApi::FormRemediation::S3Client.new(config:, id: <YOUR_SUBMIS
 client.upload
 ```
 
+### S3 Pre-Signed URL Retrieval
+
+To handle a single PDF download for an already archived form submission, call the `fetch_presigned_url` class method on the `S3Client` class with the appropriate configuration and submission ID:
+
+```ruby
+config = YourTeamsConfig.new
+SimpleFormsApi::FormRemediation::S3Client.fetch_presigned_url(<YOUR_SUBMISSION_ID>, config:)
+```
+
 ---
 
 ## Extending Functionality
@@ -97,6 +107,7 @@ Each component of this solution can be extended or customized to meet team requi
 3. Register the subclass in your configuration:
 
 Extending the uploader:
+
 ```ruby
 # frozen_string_literal: true
 
@@ -110,6 +121,7 @@ end
 ```
 
 Using the new uploader within your own team's configuration:
+
 ```ruby
 # frozen_string_literal: true
 
@@ -127,6 +139,7 @@ end
 ```
 
 Instantiate the client with your team's configuration:
+
 ```ruby
 config = NewConfig.new
 client = SimpleFormsApi::FormRemediation::S3Client.new(config:, id: <YOUR_SUBMISSION_ID>, type: :submission)


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR provides minor changes to the PDF backup documentation which clarify and streamline some of the information.
- I work for the Veteran Facing Forms team, which owns the maintenance of these documents.
- Since this work is not behind a feature toggle, there are no specific success criteria related to a flipper.

## Related issue(s)

- [Improve Documentation Clarity and Organization for PDF Download and Form Remediation](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1840)

## Testing done

- To verify the changes, reviewers should:
  1. Ensure that the PDF download instructions are clearly separated and easy to follow.
  2. Confirm that the documentation is accessible and correctly formatted.

## What areas of the site does it impact?

- This change impacts the documentation section of the Platform, specifically the areas related to PDF downloads and form remediation. The code touched only involves documentation files, so no other areas of the site are directly affected.

## Acceptance criteria

- [x] Clear, step-by-step instructions for PDF download implementation are available and easy to locate.
- [ ] Documentation is moved to the official Platform documentation repository.
- [x] No error nor warning in the console.
- [x] Documentation has been updated.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.

## Requested Feedback

I would appreciate feedback on the clarity and organization of the new documentation structure. Are the PDF download instructions easy to follow? Is there anything else that could be improved to enhance user understanding? Thank you!
