### PR TITLE
[10-10EZ/10-10EZR] Temporarily disable BGS call for the COLA update weekend

### DIFF
--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -19,6 +19,12 @@ module V0
     before_action(only: :rating_info) { authorize(:hca_disability_rating, :access?) }
 
     def rating_info
+      if Flipper.enabled?(:hca_disable_bgs_service)
+        # Return 0 when not calling the actual BGS::Service
+        render json: HCARatingInfoSerializer.new({ user_percent_of_disability: 0 })
+        return
+      end
+
       service = BGS::Service.new(current_user)
       disability_rating = service.find_rating_data[:disability_rating_record][:service_connected_combined_degree]
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -79,6 +79,9 @@ features:
   hca_browser_monitoring_enabled:
     actor_type: user
     description: Enables browser monitoring for the health care application.
+  hca_disable_bgs_service:
+    actor_type: user
+    description: Do not call the BGS Service when this is turned on. Instead return 0 for rating.
   hca_enrollment_status_override_enabled:
     actor_type: user
     description: Enables override of enrollment status for a user, to allow multiple submissions with same user.

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
     let(:current_user) { build(:ch33_dd_user) }
 
     before do
-      Flipper.disable(:hca_disable_bgs_service)
+      allow(Flipper).to receive(:enabled?).with(:hca_disable_bgs_service).and_return(false)
       sign_in_as(current_user)
     end
 
@@ -31,7 +31,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
     context 'hca_disable_bgs_service enabled' do
       before do
-        Flipper.enable(:hca_disable_bgs_service)
+        allow(Flipper).to receive(:enabled?).with(:hca_disable_bgs_service).and_return(true)
       end
 
       it 'does not call the BGS Service and returns the rating info as 0' do

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
         Flipper.enable(:hca_disable_bgs_service)
       end
 
-      it 'returns the rating info as 0' do
-        VCR.use_cassette('bgs/service/find_rating_data', VCR::MATCH_EVERYTHING) do
-          get(rating_info_v0_health_care_applications_path)
-        end
+      it 'does not call the BGS Service and returns the rating info as 0' do
+        expect_any_instance_of(BGS::Service).not_to receive(:find_rating_data)
+
+        get(rating_info_v0_health_care_applications_path)
 
         expect(JSON.parse(response.body)['data']['attributes']).to eq(
           { 'user_percent_of_disability' => 0 }

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
     let(:current_user) { build(:ch33_dd_user) }
 
     before do
+      Flipper.disable(:hca_disable_bgs_service)
       sign_in_as(current_user)
     end
 
@@ -26,6 +27,22 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
       expect(JSON.parse(response.body)['data']['attributes']).to eq(
         { 'user_percent_of_disability' => 100 }
       )
+    end
+
+    context 'hca_disable_bgs_service enabled' do
+      before do
+        Flipper.enable(:hca_disable_bgs_service)
+      end
+
+      it 'returns the rating info as 0' do
+        VCR.use_cassette('bgs/service/find_rating_data', VCR::MATCH_EVERYTHING) do
+          get(rating_info_v0_health_care_applications_path)
+        end
+
+        expect(JSON.parse(response.body)['data']['attributes']).to eq(
+          { 'user_percent_of_disability' => 0 }
+        )
+      end
     end
 
     context 'User not found' do


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Added a flipper toggle to our `/rating_info` endpoint that allows the endpoint to return a 0 be default instead of calling the underlying BGS service. This will be turned on during a planned BGS outage to prevent calls to the service. Veterans will receive a 0 from this endpoint, but the forms allow them to add their own information later. 
- 10-10 Health Apps
- Flipper toggle `hca_disable_bgs_service`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97030

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10EZ and 10-10EZR

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
