### PR TITLE
[SIMPLE-FORMS] fix: submission failures for form 20-10207

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -221,7 +221,7 @@ module SimpleFormsApi
 
       def upload_pdf_to_s3(id, file_path, metadata, submission, form)
         config = SimpleFormsApi::FormRemediation::Configuration::VffConfig.new
-        attachments = get_form_id == 'vba_20_10207' ? form.attachment_guids : []
+        attachments = get_form_id == 'vba_20_10207' ? form.get_attachments : []
         s3_client = config.s3_client.new(
           config:, type: :submission, id:, submission:, attachments:, file_path:, metadata:
         )

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -113,14 +113,14 @@ module SimpleFormsApi
       PersistentAttachment.where(guid: attachment_guids).map(&:to_pdf)
     end
 
+    private
+
     def attachment_guids
       doc_types = %w[als_documents financial_hardship_documents medal_award_documents pow_documents
                      terminal_illness_documents vsi_documents]
 
       doc_types.flat_map { |type| @data[type]&.pluck('confirmation_code') }.compact
     end
-
-    private
 
     def veteran_ssn
       [

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -107,6 +107,8 @@ module SimpleFormsApi
 
       def process_attachment(attachment_number, file_path)
         config.log_info("Processing attachment ##{attachment_number}: #{file_path}")
+        raise "Attachment file not found: #{file_path}" unless File.exist?(file_path)
+
         create_file("attachment_#{attachment_number}__#{submission_file_name}.pdf", File.read(file_path), 'attachment')
       end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- This PR addresses the issue of document upload errors in the SubmissionArchive service while processing form 20-10207 with attachments.
- Changes include:
  - Adding test coverage for file existence checks
  - Implementing a guard clause to handle missing files
  - Updating the uploads controller to pass the correct attachment file paths instead of UUIDs
- To reproduce the bug, attempt to submit a 20-10207 form with attachments. This should trigger an error during the upload process.
- The solution involves ensuring that the system checks for the existence of the each attachment file before attempting to process it. This prevents errors from occurring when an attachment is missing and provides a clearer error message to the user.
- I work for the Veteran Facing Forms team, which owns the maintenance of this component.

## Related issue(s)

- [Investigate and Resolve Submission Failures for Form 20-10207](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1858)

## Testing done

- [x] New code is covered by unit tests
- Prior to this change, the system would throw an error if a document was uploaded without the corresponding file being present, leading to a poor user experience.
- To verify the changes, follow these steps:
  1. Run the unit tests, there is now no way to reproduce this error with the fix.
OR
  1. Submit a form 20-10207 form successfully with attachments and verify that the submission is processed correctly

## What areas of the site does it impact?

- This change impacts the attachment upload functionality within the SubmissionArchive service, as well as the UploadsController.

## Acceptance criteria

- [x] I fixed unit tests and integration tests for each feature.
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [x] Documentation has been updated (link to documentation).
- [x] No sensitive information is captured in logging, hardcoded, or specs.
- [x] Feature has a monitor built into Datadog.
- [x] I logged into a local build and verified all authenticated routes work as expected.

## Requested Feedback

*I would appreciate feedback on the error handling implementation and whether the test coverage is sufficient. Additionally, if there are any concerns regarding the feature toggle rollout, please let me know.*