### PR TITLE
[VI-740] SSOe: add MHV account creation after login

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -408,7 +408,8 @@ module V1
     end
 
     def after_login_actions
-      Login::AfterLoginActions.new(@current_user).perform
+      client_id = url_service.tracker.payload_attr(:application)
+      Login::AfterLoginActions.new(@current_user, client_id).perform
       log_persisted_session_and_warnings
     end
 

--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -6,10 +6,11 @@ module Login
   class AfterLoginActions
     include Accountable
 
-    attr_reader :current_user
+    attr_reader :current_user, :client_id
 
-    def initialize(user)
+    def initialize(user, client_id)
       @current_user = user
+      @client_id = client_id
     end
 
     def perform
@@ -20,6 +21,7 @@ module Login
       Login::UserAcceptableVerifiedCredentialUpdater.new(user_account: @current_user.user_account).perform
       update_account_login_stats(login_type)
       id_mismatch_validations
+      create_mhv_account
 
       if Settings.test_user_dashboard.env == 'staging'
         TestUserDashboard::UpdateUser.new(current_user).call(Time.current)
@@ -28,6 +30,12 @@ module Login
     end
 
     private
+
+    def create_mhv_account
+      return if client_id.in?(SAML::URLService::SKIP_MHV_ACCOUNT_CREATION_CLIENTS)
+
+      current_user.create_mhv_account_async
+    end
 
     def login_type
       @login_type ||= current_user.identity.sign_in[:service_name]

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -105,11 +105,19 @@ module SAML
     end
 
     def terms_of_use_url
-      if Settings.review_instance_slug.present?
-        "http://#{Settings.review_instance_slug}.review.vetsgov-internal/terms-of-use"
-      else
-        "#{base_redirect_url}/terms-of-use"
+      current_application = @tracker&.payload_attr(:application)
+
+      base_url = if Settings.review_instance_slug.present?
+                   "http://#{Settings.review_instance_slug}.review.vetsgov-internal/terms-of-use"
+                 else
+                   "#{base_redirect_url}/terms-of-use"
+                 end
+
+      if current_application.in?(SKIP_MHV_ACCOUNT_CREATION_CLIENTS)
+        base_url = add_query(base_url, { skip_mhv_account_creation: true })
       end
+
+      base_url
     end
 
     def client_redirect_target

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -26,6 +26,7 @@ module SAML
     MOBILE_CLIENT_ID = 'mobile'
     UNIFIED_SIGN_IN_CLIENTS = %w[vaweb mhv myvahealth ebenefits vamobile vaoccmobile].freeze
     TERMS_OF_USE_DECLINED_PATH = '/terms-of-use/declined'
+    SKIP_MHV_ACCOUNT_CREATION_CLIENTS = %w[mhv].freeze
 
     attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :tracker
 

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -527,10 +527,20 @@ RSpec.describe V1::SessionsController, type: :controller do
             allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
           end
 
-          it 'redirects to terms of use page' do
-            expect(call_endpoint).to redirect_to(
-              'http://127.0.0.1:3001/terms-of-use?redirect_url=http%3A%2F%2F127.0.0.1%3A3001%2Fauth%2Flogin%2Fcallback'
-            )
+          context 'when the application is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+            it 'redirects to terms of use page' do
+              expect(call_endpoint).to redirect_to(
+                'http://127.0.0.1:3001/terms-of-use?redirect_url=http%3A%2F%2F127.0.0.1%3A3001%2Fauth%2Flogin%2Fcallback'
+              )
+            end
+          end
+
+          context 'when the application is in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+            let(:application) { 'mhv' }
+
+            it 'redirects to terms of use page with skip_mhv_account_creation query param' do
+              expect(call_endpoint).to redirect_to(a_string_including('skip_mhv_account_creation=true'))
+            end
           end
         end
 
@@ -570,10 +580,20 @@ RSpec.describe V1::SessionsController, type: :controller do
             allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
           end
 
-          it 'redirects to terms of use page' do
-            expect(call_endpoint).to redirect_to(
-              'http://127.0.0.1:3001/terms-of-use?redirect_url=http%3A%2F%2F127.0.0.1%3A3001%2Fauth%2Flogin%2Fcallback'
-            )
+          context 'when the application is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+            it 'redirects to terms of use page' do
+              expect(call_endpoint).to redirect_to(
+                'http://127.0.0.1:3001/terms-of-use?redirect_url=http%3A%2F%2F127.0.0.1%3A3001%2Fauth%2Flogin%2Fcallback'
+              )
+            end
+          end
+
+          context 'when the application is in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+            let(:application) { 'mhv' }
+
+            it 'redirects to terms of use page with skip_mhv_account_creation query param' do
+              expect(call_endpoint).to redirect_to(a_string_including('skip_mhv_account_creation=true'))
+            end
           end
         end
 

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -613,6 +613,28 @@ RSpec.describe SAML::PostURLService do
             let(:expected_log_message) { 'Redirecting to /terms-of-use' }
             let(:expected_log_payload) { { type: :ssoe } }
 
+            shared_examples 'terms of use redirected url' do
+              it 'has a login redirect url as a parameter embedded in review instance terms of use page' do
+                expect(subject.terms_of_use_redirect_url)
+                  .to eq("#{base_url}/terms-of-use?#{expected_redirect_url_param}")
+              end
+
+              it 'logs expected message and payload' do
+                expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+                subject.terms_of_use_redirect_url
+              end
+
+              context 'and tracker application is within SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+                let(:application) { SAML::URLService::SKIP_MHV_ACCOUNT_CREATION_CLIENTS.first }
+                let(:skip_mhv_account_creation_param) { 'skip_mhv_account_creation=true' }
+
+                it 'appends skip_mhv_account_creation query parameter' do
+                  expect(subject.terms_of_use_redirect_url)
+                    .to eq("#{base_url}/terms-of-use?#{expected_redirect_url_param}&#{skip_mhv_account_creation_param}")
+                end
+              end
+            end
+
             context 'when associated terms of use redirect user cache object exists' do
               let(:cache_key) { "terms_of_use_redirect_user_#{user.uuid}" }
               let(:enabled_clients) { application }
@@ -628,31 +650,17 @@ RSpec.describe SAML::PostURLService do
 
                 context 'and authentication is occuring on a review instance' do
                   let(:review_instance_slug) { 'some-review-instance-slug' }
-                  let(:review_instance_url) { "#{review_instance_slug}.review.vetsgov-internal" }
+                  let(:base_url) { "http://#{review_instance_slug}.review.vetsgov-internal" }
 
                   before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
 
-                  it 'has a login redirect url as a parameter embedded in review instance terms of use page' do
-                    expect(subject.terms_of_use_redirect_url)
-                      .to eq("http://#{review_instance_url}/terms-of-use?#{expected_redirect_url_param}")
-                  end
-
-                  it 'logs expected message and payload' do
-                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
-                    subject.terms_of_use_redirect_url
-                  end
+                  it_behaves_like 'terms of use redirected url'
                 end
 
                 context 'and authentication is not occurring on a review instance' do
-                  it 'has a login redirect url as a parameter embedded in terms of use page with success' do
-                    expect(subject.terms_of_use_redirect_url)
-                      .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
-                  end
+                  let(:base_url) { values[:base_redirect] }
 
-                  it 'logs expected message and payload' do
-                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
-                    subject.terms_of_use_redirect_url
-                  end
+                  it_behaves_like 'terms of use redirected url'
                 end
               end
 
@@ -678,46 +686,25 @@ RSpec.describe SAML::PostURLService do
 
                 context 'and authentication is occuring on a review instance' do
                   let(:review_instance_slug) { 'some-review-instance-slug' }
-                  let(:review_instance_url) { "#{review_instance_slug}.review.vetsgov-internal" }
+                  let(:base_url) { "http://#{review_instance_slug}.review.vetsgov-internal" }
 
                   before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
 
-                  it 'has a login redirect url as a parameter embedded in review instance terms of use page' do
-                    expect(subject.terms_of_use_redirect_url)
-                      .to eq("http://#{review_instance_url}/terms-of-use?#{expected_redirect_url_param}")
-                  end
-
-                  it 'logs expected message and payload' do
-                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
-                    subject.terms_of_use_redirect_url
-                  end
+                  it_behaves_like 'terms of use redirected url'
                 end
 
                 context 'and authentication is not occurring on a review instance' do
-                  it 'has a login redirect url as a parameter embedded in terms of use page with success' do
-                    expect(subject.terms_of_use_redirect_url)
-                      .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
-                  end
+                  let(:base_url) { values[:base_redirect] }
 
-                  it 'logs expected message and payload' do
-                    expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
-                    subject.terms_of_use_redirect_url
-                  end
+                  it_behaves_like 'terms of use redirected url'
                 end
               end
 
               context 'when tracker application is nil' do
                 let(:application) { nil }
+                let(:base_url) { values[:base_redirect] }
 
-                it 'has a login redirect url as a parameter embedded in terms of use page with success' do
-                  expect(subject.terms_of_use_redirect_url)
-                    .to eq("#{values[:base_redirect]}/terms-of-use?#{expected_redirect_url_param}")
-                end
-
-                it 'logs expected message and payload' do
-                  expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
-                  subject.terms_of_use_redirect_url
-                end
+                it_behaves_like 'terms of use redirected url'
               end
 
               context 'when tracker application is not within Settings.terms_of_use.enabled_clients' do

--- a/spec/services/login/after_login_actions_spec.rb
+++ b/spec/services/login/after_login_actions_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Login::AfterLoginActions do
   describe '#perform' do
+    let(:client_id) { 'some-client-id' }
+
     context 'creating credential email' do
       let(:user) { create(:user, email:, idme_uuid:) }
       let!(:user_verification) { create(:idme_user_verification, idme_uuid:) }
@@ -11,7 +13,7 @@ RSpec.describe Login::AfterLoginActions do
       let(:email) { 'some-email' }
 
       it 'creates a user credential email with expected attributes' do
-        expect { described_class.new(user).perform }.to change(UserCredentialEmail, :count)
+        expect { described_class.new(user, client_id).perform }.to change(UserCredentialEmail, :count)
         user_credential_email = user.user_verification.user_credential_email
         expect(user_credential_email.credential_email).to eq(email)
       end
@@ -28,7 +30,7 @@ RSpec.describe Login::AfterLoginActions do
       after { Timecop.return }
 
       it 'creates a user acceptable verified credential with expected attributes' do
-        expect { described_class.new(user).perform }.to change(UserAcceptableVerifiedCredential, :count)
+        expect { described_class.new(user, client_id).perform }.to change(UserAcceptableVerifiedCredential, :count)
         user_avc = UserAcceptableVerifiedCredential.find_by(user_account: user.user_account)
         expect(user_avc.idme_verified_credential_at).to eq(expected_avc_at)
       end
@@ -45,7 +47,7 @@ RSpec.describe Login::AfterLoginActions do
 
       it 'does not call TUD account checkout' do
         expect_any_instance_of(TestUserDashboard::UpdateUser).not_to receive(:call)
-        described_class.new(user).perform
+        described_class.new(user, client_id).perform
       end
     end
 
@@ -60,7 +62,7 @@ RSpec.describe Login::AfterLoginActions do
 
       it 'calls TUD account checkout' do
         expect_any_instance_of(TestUserDashboard::UpdateUser).to receive(:call)
-        described_class.new(user).perform
+        described_class.new(user, client_id).perform
       end
     end
 
@@ -73,17 +75,17 @@ RSpec.describe Login::AfterLoginActions do
 
       context 'with non-existent login stats record' do
         it 'creates an account_login_stats record' do
-          expect { described_class.new(user).perform }.to \
+          expect { described_class.new(user, client_id).perform }.to \
             change(AccountLoginStat, :count).by(1)
         end
 
         it 'updates the correct login stats column' do
-          described_class.new(user).perform
+          described_class.new(user, client_id).perform
           expect(AccountLoginStat.last.send("#{login_type_stat}_at")).not_to be_nil
         end
 
         it 'updates the current_verification column' do
-          described_class.new(user).perform
+          described_class.new(user, client_id).perform
           expect(AccountLoginStat.last.current_verification).to eq('loa1')
         end
 
@@ -91,7 +93,7 @@ RSpec.describe Login::AfterLoginActions do
           login_type = 'something_invalid'
           allow_any_instance_of(UserIdentity).to receive(:sign_in).and_return(service_name: login_type)
 
-          expect { described_class.new(user).perform }.not_to \
+          expect { described_class.new(user, client_id).perform }.not_to \
             change(AccountLoginStat, :count)
         end
       end
@@ -105,7 +107,7 @@ RSpec.describe Login::AfterLoginActions do
         end
 
         it 'does not create another record' do
-          expect { described_class.new(user).perform }.not_to \
+          expect { described_class.new(user, client_id).perform }.not_to \
             change(AccountLoginStat, :count)
         end
 
@@ -113,7 +115,7 @@ RSpec.describe Login::AfterLoginActions do
           stat = AccountLoginStat.last
 
           expect do
-            described_class.new(user).perform
+            described_class.new(user, client_id).perform
             stat.reload
           end.to change(stat, :myhealthevet_at)
         end
@@ -124,7 +126,7 @@ RSpec.describe Login::AfterLoginActions do
           stat = AccountLoginStat.last
 
           expect do
-            described_class.new(user).perform
+            described_class.new(user, client_id).perform
             stat.reload
           end.not_to change(stat, :myhealthevet_at)
 
@@ -134,7 +136,7 @@ RSpec.describe Login::AfterLoginActions do
         it 'triggers sentry error if update fails' do
           allow_any_instance_of(AccountLoginStat).to receive(:update!).and_raise('Failure!')
           expect_any_instance_of(described_class).to receive(:log_error)
-          described_class.new(user).perform
+          described_class.new(user, client_id).perform
         end
       end
 
@@ -143,7 +145,7 @@ RSpec.describe Login::AfterLoginActions do
 
         it 'triggers sentry error message' do
           expect_any_instance_of(described_class).to receive(:no_account_log_message)
-          expect { described_class.new(user).perform }.not_to \
+          expect { described_class.new(user, client_id).perform }.not_to \
             change(AccountLoginStat, :count)
         end
       end
@@ -166,7 +168,7 @@ RSpec.describe Login::AfterLoginActions do
       shared_examples 'identity-mpi id validation' do
         it 'logs a warning when Identity & MPI values conflict' do
           expect(Rails.logger).to receive(:warn).at_least(:once).with(expected_error_message, expected_error_data)
-          described_class.new(loa3_user).perform
+          described_class.new(loa3_user, client_id).perform
         end
       end
 
@@ -204,6 +206,32 @@ RSpec.describe Login::AfterLoginActions do
         let(:validation_id) { 'MHV Correlation ID' }
 
         it_behaves_like 'identity-mpi id validation'
+      end
+    end
+
+    context 'when creating an MHV account' do
+      let(:user) { create(:user, idme_uuid:) }
+      let!(:user_verification) { create(:idme_user_verification, idme_uuid:) }
+      let(:idme_uuid) { 'some-idme-uuid' }
+
+      before do
+        allow(user).to receive(:create_mhv_account_async)
+      end
+
+      context 'when the client_id is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+        it 'calls create_mhv_account_async' do
+          described_class.new(user, client_id).perform
+          expect(user).to have_received(:create_mhv_account_async)
+        end
+      end
+
+      context 'when the client_id is in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+        let(:client_id) { 'mhv' }
+
+        it 'does not call create_mhv_account_async' do
+          described_class.new(user, client_id).perform
+          expect(user).not_to have_received(:create_mhv_account_async)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- Skip ssoe after_login MHV account creation for specific clients
- Add skip_mhv_creation_api parameter to ToU redirect for specific clients that  frontend will pass back when accepting ToU

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-740
- https://github.com/department-of-veterans-affairs/vets-website/pull/33008

## Testing done
checkout vi-740 on vets website
- Test logging in with SSOe 
   - Change `SKIP_MHV_ACCOUNT_CREATION_CLIENTS` to `[vaweb]`
   - Sign In
   - It should not have enqueued MHV::AccountCreatorJob http://localhost3000/sidekiq/queues/default 
- Test accepting ToU
  - with `SKIP_MHV_ACCOUNT_CREATION_CLIENTS` set to `[vaweb]`
    - it should not enqueue a job

## What areas of the site does it impact?
ToU, MHV Account Creation, 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

