### PR TITLE
95907 Add missing class method to failure email logic - IVC CHAMPVA

### DIFF
--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -40,6 +40,10 @@ module IvcChampva
       Rails.logger.error e.backtrace.join("\n")
     end
 
+    def fetch_forms_by_uuid(form_uuid)
+      @fetch_forms_by_uuid ||= IvcChampvaForm.where(form_uuid:)
+    end
+
     def send_failure_email(form, template_id)
       form_data =
         {


### PR DESCRIPTION
## Summary

This PR adds a class method to fetch a form object from the DB by UUID. It was previously referenced, but not actually implemented in this class. 

- This work is behind a feature toggle (flipper): **YES**
- Added a class method to get a form from the DB by UUID
- Team: **IVC CHAMPVA**
  
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95907

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
NA

## What areas of the site does it impact?

IVC CHAMPVA forms only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
