### PR TITLE
[SIMPLE-FORMS] fix: updates to S3 presigned URL and directory naming logic

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/file_utilities.rb
@@ -78,12 +78,12 @@ module SimpleFormsApi
         File.write(File.join(dir_path, file_name), content)
       end
 
-      def unique_file_name(form_number, id)
-        "#{Time.zone.today.strftime('%-m.%d.%y')}_form_#{form_number}_vagov_#{id}"
+      def unique_file_name(form_number, id, date = Time.zone.today)
+        "#{date.strftime('%-m.%d.%y')}_form_#{form_number}_vagov_#{id}"
       end
 
-      def dated_directory_name(form_number)
-        "#{Time.zone.today.strftime('%-m.%d.%y')}-Form#{form_number}"
+      def dated_directory_name(form_number, date = Time.zone.today)
+        "#{date.strftime('%-m.%d.%y')}-Form#{form_number}"
       end
 
       def write_manifest(row, path)

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -41,6 +41,12 @@ module SimpleFormsApi
         config.handle_error("Failed #{upload_type} upload: #{id}", e)
       end
 
+      def retrieve_presigned_url
+        archive = config.submission_archive_class.new(config:, id:, type: upload_type)
+        @archive_path, @manifest_row = archive.retrieval_data
+        generate_presigned_url(type: upload_type)
+      end
+
       private
 
       attr_reader :archive_path, :config, :id, :manifest_row, :parent_dir, :temp_directory_path, :upload_type
@@ -115,12 +121,6 @@ module SimpleFormsApi
 
       def generate_presigned_url(type: upload_type)
         s3_uploader.get_s3_link(s3_upload_file_path(type))
-      end
-
-      def retrieve_presigned_url
-        archive = config.submission_archive_class.new(config:, id:, type: upload_type)
-        @archive_path, @manifest_row = archive.retrieval_data
-        generate_presigned_url(type: upload_type)
       end
 
       def s3_upload_file_path(type)

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/s3_client.rb
@@ -10,8 +10,8 @@ module SimpleFormsApi
       include FileUtilities
 
       class << self
-        def fetch_presigned_url(id, type: :submission)
-          new(id:).generate_presigned_url(type:)
+        def fetch_presigned_url(id, config:, type: :submission)
+          new(id:, config:, type:).retrieve_presigned_url
         end
       end
 
@@ -115,6 +115,12 @@ module SimpleFormsApi
 
       def generate_presigned_url(type: upload_type)
         s3_uploader.get_s3_link(s3_upload_file_path(type))
+      end
+
+      def retrieve_presigned_url
+        archive = config.submission_archive_class.new(config:, id:, type: upload_type)
+        @archive_path, @manifest_row = archive.retrieval_data
+        generate_presigned_url(type: upload_type)
       end
 
       def s3_upload_file_path(type)

--- a/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_remediation/submission_archive.rb
@@ -37,6 +37,12 @@ module SimpleFormsApi
         config.handle_error("Failed building submission: #{id}", e)
       end
 
+      def retrieval_data
+        extension = archive_type == :submission ? 'pdf' : 'zip'
+        final_path = "#{temp_directory_path}#{submission_file_name}.#{extension}"
+        [final_path, manifest_entry]
+      end
+
       private
 
       attr_reader :archive_type, :attachments, :config, :file_path, :id, :metadata, :pdf_already_exists, :submission,

--- a/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/s3_client_spec.rb
@@ -71,7 +71,10 @@ RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
     allow(CarrierWave::SanitizedFile).to receive(:new).with(file_double).and_return(carrier_wave_file)
     allow(CSV).to receive(:open).and_return(true)
     allow(SimpleFormsApi::FormRemediation::SubmissionArchive).to(receive(:new).and_return(submission_archive_double))
-    allow(submission_archive_double).to receive(:build!).and_return([local_archive_path, manifest_entry])
+    allow(submission_archive_double).to receive_messages(
+      build!: [local_archive_path, manifest_entry],
+      retrieval_data: [local_archive_path, manifest_entry]
+    )
     allow(SimpleFormsApi::FormRemediation::Uploader).to receive_messages(new: uploader)
     allow(uploader).to receive(:get_s3_link).with(s3_archive_path).and_return('/s3_url/stuff.pdf')
     allow(uploader).to receive_messages(get_s3_file: s3_file, store!: carrier_wave_file)
@@ -84,6 +87,11 @@ RSpec.describe SimpleFormsApi::FormRemediation::S3Client do
       let(:type) { archive_type }
 
       describe '.fetch_presigned_url' do
+        subject(:fetch_presigned_url) { described_class.fetch_presigned_url(benefits_intake_uuid, config:, type:) }
+
+        it 'returns the s3 link' do
+          expect(fetch_presigned_url).to eq('/s3_url/stuff.pdf')
+        end
       end
 
       describe '#initialize' do

--- a/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_remediation/submission_archive_spec.rb
@@ -192,6 +192,27 @@ RSpec.describe SimpleFormsApi::FormRemediation::SubmissionArchive do
           include_examples 'successfully built submission archive'
         end
       end
+
+      describe '#retrieval_data' do
+        subject(:retrieval_data) { archive_instance.retrieval_data }
+
+        let(:archive_instance) { described_class.new(**hydrated_submission_args) }
+        let(:file_name) { "#{temp_file_path}/#{submission_file_path}.#{type == :remediation ? 'zip' : 'pdf'}" }
+
+        it 'returns the correct archive path and manifest row' do
+          expect(retrieval_data.first).to include(file_name)
+          expect(retrieval_data.second).to eq(
+            [
+              submission.created_at,
+              form_type,
+              benefits_intake_uuid,
+              metadata['fileNumber'],
+              metadata['veteranFirstName'],
+              metadata['veteranLastName']
+            ]
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- This pull request updates the S3 client to generate presigned URLs without creating new files or directories, streamlining the file handling and S3 upload logic within the `simple_forms_api` service. It also modifies the date-based file and directory naming conventions to improve efficiency.
- To reproduce the previous behavior, attempt to generate presigned URLs using the existing S3 client, which would create temporary files and directories.
- The solution involves refactoring the S3 client to implement a new method, `retrieve_presigned_url`, which accesses existing archive data directly. This eliminates the need for temporary file generation and consolidates directory naming logic. This approach is chosen for its efficiency and clarity in handling S3 paths.
- I work for the Veteran Facing Forms team, which owns the maintenance of this component.
- The success criteria for the feature toggle include ensuring that the S3 client retrieves presigned URLs correctly without generating files, and that the new naming logic functions as intended.

## Related issue(s)

- [Updates to S3 Presigned URL and Directory Naming Logic](https://github.com/va.gov-team/va.gov-team/issues/1865)

## Testing done

- [x] New code is covered by unit tests
- Prior to this change, generating a presigned URL would create temporary files and directories, which was inefficient.
- To verify the changes:
  1. Test the S3 client to ensure it retrieves presigned URLs without generating any files.
  2. Check that the date-based naming logic works correctly by providing different submission creation dates.
  3. Run the RSpec tests in `s3_client_spec.rb` and `submission_archive_spec.rb` to confirm that all new and modified methods function as expected.

## What areas of the site does it impact?

- This update impacts the S3 file handling and upload logic within the `simple_forms_api` service, specifically in how presigned URLs are generated and how files and directories are named.

## Acceptance criteria

- [x] I fixed unit tests and integration tests for each feature.
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [x] Documentation has been updated.
- [x] No sensitive information is captured in logging, hardcoded, or specs.
- [x] Feature has a monitor built into Datadog.
- [x] I logged into a local build and verified all authenticated routes work as expected.

## Requested Feedback

I would appreciate feedback on the new naming conventions and whether the changes to the S3 client meet the expected efficiency improvements.