### PR TITLE
[VI-762] Properly managing UserVerification creating during SSOe auth flow

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,7 +65,7 @@ class User < Common::RedisStore
   end
 
   def user_verification
-    @user_verification ||= get_user_verification
+    @user_verification ||= UserVerification.find_by(id: user_verification_id)
   end
 
   def user_account
@@ -73,7 +73,7 @@ class User < Common::RedisStore
   end
 
   def user_verification_id
-    @user_verification_id ||= user_verification&.id
+    @user_verification_id ||= get_user_verification&.id
   end
 
   def user_account_uuid


### PR DESCRIPTION
## Summary

- This PR creates a `UserVerification` object before the `User` object has been persisted on SSOe authentications
- This prevents an issue where a `User` object potentially stored a related (but technically incorrect) `UserVerification` for that authenticated session'

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-762

## Testing done

- [ ] Logged in with verified DSLogon user, checked `user.user_verification` and noted the returned object
- [ ] Logged in with a new LOA1 id.me user that had the same email as the DSLogon user, checked `user.user_verification` and confirmed the new `UserVerification` was associated with the id.me credential, not the DSLogon credential

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Before PR changes, authenticate with a DSLogon user, in a rails console, check `user.user_verification`
- [ ] Create an ID.me loa1 account that has the same email as the DSLogon account, so that the ID.me uuids are the same for both accoutns
- [ ] Authenticate with the new ID.me loa1 account, confirm that `user.user_verification` is associated with the DSLogon account, NOT the ID.me account
- [ ] Follow the above steps with PR changes, confirm that the `user.user_verification` of the ID.me loa1 user is the proper ID.me account


