### PR TITLE
#95986 rescue db connection error

### DIFF
--- a/app/sidekiq/decision_review/saved_claim_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_status_updater_job.rb
@@ -24,7 +24,7 @@ module DecisionReview
     SECONDARY_FORM_ATTRIBUTES_TO_STORE = %w[status detail updated_at].freeze
 
     def perform
-      return unless enabled? && records_to_update.present?
+      return unless should_perform?
 
       StatsD.increment("#{statsd_prefix}.processing_records", records_to_update.size)
 
@@ -89,6 +89,13 @@ module DecisionReview
 
     def enabled?
       raise Common::Exceptions::NotImplemented
+    end
+
+    def should_perform?
+      enabled? && records_to_update.present?
+    rescue => e
+      StatsD.increment("#{statsd_prefix}.error")
+      Rails.logger.error("#{log_prefix} error", { message: e.message })
     end
 
     def decision_review_service

--- a/spec/sidekiq/decision_review/hlr_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/hlr_status_updater_job_spec.rb
@@ -131,6 +131,22 @@ RSpec.describe DecisionReview::HlrStatusUpdaterJob, type: :job do
             .exactly(1).time
         end
       end
+
+      context 'Retrieving SavedClaim records fails' do
+        before do
+          allow(SavedClaim::HigherLevelReview).to receive(:where).and_raise(ActiveRecord::ConnectionTimeoutError)
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'rescues the error and logs' do
+          subject.new.perform
+
+          expect(Rails.logger).to have_received(:error)
+            .with('DecisionReview::SavedClaimHlrStatusUpdaterJob error', anything)
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_hlr_status_updater.error').once
+        end
+      end
     end
 
     context 'with flag disabled' do

--- a/spec/sidekiq/decision_review/nod_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/nod_status_updater_job_spec.rb
@@ -296,6 +296,22 @@ RSpec.describe DecisionReview::NodStatusUpdaterJob, type: :job do
         end
       end
 
+      context 'Retrieving SavedClaim records fails' do
+        before do
+          allow(SavedClaim::NoticeOfDisagreement).to receive(:where).and_raise(ActiveRecord::ConnectionTimeoutError)
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'rescues the error and logs' do
+          subject.new.perform
+
+          expect(Rails.logger).to have_received(:error)
+            .with('DecisionReview::SavedClaimNodStatusUpdaterJob error', anything)
+          expect(StatsD).to have_received(:increment)
+            .with('worker.decision_review.saved_claim_nod_status_updater.error').once
+        end
+      end
+
       context 'an error occurs while processing' do
         before do
           SavedClaim::NoticeOfDisagreement.create(guid: SecureRandom.uuid, form: '{}')


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Add rescue to status polling job for fetching initial set of records
- Decision Review, yes

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95986

## Testing done

- [x] *New code is covered by unit tests*
- If fetching the saved claims failed, the entire job would fail and not retry. Now it rescues, logs, and the job will run again in 1 hour

## What areas of the site does it impact?
Better error handling for background jobs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
