### PR TITLE
Add note to Simple Forms API README about native setup

### DIFF
--- a/modules/simple_forms_api/README.rdoc
+++ b/modules/simple_forms_api/README.rdoc
@@ -1,13 +1,13 @@
 = SimpleFormsApi
-This module allows you to generate form_mappings based on a PDF file. 
-With this in place, you can submit a form payload from the vets-website 
-and have this module map that payload to the associated PDF and submit it 
+This module allows you to generate form_mappings based on a PDF file.
+With this in place, you can submit a form payload from the vets-website
+and have this module map that payload to the associated PDF and submit it
 to the Benefits Intake API in Lighthouse.
 
 Note: The following command can currently only be run locally after following the [Native setup](https://github.com/department-of-veterans-affairs/vets-api/blob/master/docs/setup/native.md) instructions.
 
 To generate files:
-  rails simple_forms_api:generate\['path to PDF file'\]
+  rails simple_forms_api:generate['modules/simple_forms_api/templates/YOUR_PDF_FILE.pdf']
 
 Submission endpoint:
 /simple_forms_api/v1/simple_forms

--- a/modules/simple_forms_api/README.rdoc
+++ b/modules/simple_forms_api/README.rdoc
@@ -4,8 +4,10 @@ With this in place, you can submit a form payload from the vets-website
 and have this module map that payload to the associated PDF and submit it 
 to the Benefits Intake API in Lighthouse.
 
+Note: The following command can currently only be run locally after following the [Native setup](https://github.com/department-of-veterans-affairs/vets-api/blob/master/docs/setup/native.md) instructions.
+
 To generate files:
-rails simple_forms_api:generate\['path to PDF file'\]
+  rails simple_forms_api:generate\['path to PDF file'\]
 
 Submission endpoint:
 /simple_forms_api/v1/simple_forms


### PR DESCRIPTION
## Summary

- Adds some clarification to the `README` for the `simple_forms_api` module about the setup needed to run the `rails` command locally as well was the path needed by the command to find the appropriate PDF file.

## Testing done

- Ran the `rails` command referenced in the `README` successfully using the new instructions.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

It would be nice to be able to run this command using the Docker setup, but that would be a more involved fix.