### PR TITLE
Renames feature flag to match current naming conventions

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1451,7 +1451,7 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to enable request workflow for Oracle Health appointments.
-  vaos_online_scheduling_remove_podiatry:
+  va_online_scheduling_remove_podiatry:
     actor_type: user
     enable_in_development: true
     description: Toggle to remove Podiatry from the type of care list when scheduling an online appointment.


### PR DESCRIPTION
## Summary

This renames a feature flag used by the VAOS application in order to keep with existing naming conventions in use.

The old name is: `vaos_online_scheduling_remove_podiatry`
All of our current flags use the `va_online_scheduling...` convention.

Our FE code expects `va_online_scheduling_remove_podiatry` -- no changes are required there.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/95332#issuecomment-2477076156

## Testing done

- Local testing

## Acceptance criteria
- [ ] The feature flag is correctly named

