### PR TITLE
Add error messaging to Veteran Verification /status endpoint

### DIFF
--- a/lib/lighthouse/veteran_verification/constants.rb
+++ b/lib/lighthouse/veteran_verification/constants.rb
@@ -1,0 +1,16 @@
+module VeteranVerification
+  module Constants
+    NOT_FOUND_MESSAGE = [
+      'We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status ' \
+        'card for you right now.',
+      'To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711).' \
+        ' They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.'
+    ]
+    NOT_ELIGIBLE_MESSAGE = [
+      'Our records show that you’re not eligible for a Veteran status card. To get a Veteran status card, you ' \
+        'must have received an honorable discharge for at least one period of service.',
+      'If you think your discharge status is incorrect, call the Defense Manpower Data Center at 800-538-9552 ' \
+        '(TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.'
+    ]
+  end
+end

--- a/lib/lighthouse/veteran_verification/constants.rb
+++ b/lib/lighthouse/veteran_verification/constants.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 module VeteranVerification
   module Constants
     NOT_FOUND_MESSAGE = [
       'We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status ' \
-        'card for you right now.',
+      'card for you right now.',
       'To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711).' \
-        ' They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.'
-    ]
+      ' They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.'
+    ].freeze
     NOT_ELIGIBLE_MESSAGE = [
       'Our records show that you’re not eligible for a Veteran status card. To get a Veteran status card, you ' \
-        'must have received an honorable discharge for at least one period of service.',
+      'must have received an honorable discharge for at least one period of service.',
       'If you think your discharge status is incorrect, call the Defense Manpower Data Center at 800-538-9552 ' \
-        '(TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.'
-    ]
+      '(TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.'
+    ].freeze
   end
 end

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -60,14 +60,14 @@ module VeteranVerification
 
     def transform_response(response)
       attributes = response['data']['attributes']
-      return response if attributes['veteran_status'] != 'not confirmed' || !attributes.include?('not_confirmed_reason')
+      return response if attributes['veteran_status'] != 'not confirmed' || attributes.exclude?('not_confirmed_reason')
 
-      if attributes['not_confirmed_reason'] == 'NOT_TITLE_38'
-        response['data']['message'] = VeteranVerification::Constants::NOT_ELIGIBLE_MESSAGE
-      else
-        response['data']['message'] = VeteranVerification::Constants::NOT_FOUND_MESSAGE
-      end
-
+      response['data']['message'] =
+        if attributes['not_confirmed_reason'] == 'NOT_TITLE_38'
+          VeteranVerification::Constants::NOT_ELIGIBLE_MESSAGE
+        else
+          VeteranVerification::Constants::NOT_FOUND_MESSAGE
+        end
       response
     end
   end

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -2,6 +2,7 @@
 
 require 'common/client/base'
 require 'lighthouse/veteran_verification/configuration'
+require 'lighthouse/veteran_verification/constants'
 require 'lighthouse/service_exception'
 
 module VeteranVerification
@@ -36,12 +37,14 @@ module VeteranVerification
     #   see https://developer.va.gov/explore/api/veteran-service-history-and-eligibility/docs
     def get_vet_verification_status(icn, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
       endpoint = 'status'
-      config.get(
+      response = config.get(
         "#{endpoint}/#{icn}",
         lighthouse_client_id,
         lighthouse_rsa_key_path,
         options
       ).body
+
+      transform_response(response)
     rescue => e
       handle_error(e, lighthouse_client_id, endpoint)
     end
@@ -53,6 +56,19 @@ module VeteranVerification
         lighthouse_client_id,
         "#{config.base_api_path}/#{endpoint}"
       )
+    end
+
+    def transform_response(response)
+      attributes = response['data']['attributes']
+      return response if attributes['veteran_status'] != 'not confirmed' || !attributes.include?('not_confirmed_reason')
+
+      if attributes['not_confirmed_reason'] == 'NOT_TITLE_38'
+        response['data']['message'] = VeteranVerification::Constants::NOT_ELIGIBLE_MESSAGE
+      else
+        response['data']['message'] = VeteranVerification::Constants::NOT_FOUND_MESSAGE
+      end
+
+      response
     end
   end
 end

--- a/spec/controllers/v0/profile/vet_verification_statuses_controller_spec.rb
+++ b/spec/controllers/v0/profile/vet_verification_statuses_controller_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe V0::Profile::VetVerificationStatusesController, type: :controller
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['data']['attributes']['veteran_status']).to eq('not confirmed')
         expect(parsed_body['data']['attributes']['not_confirmed_reason']).to eq('PERSON_NOT_FOUND')
+        expect(parsed_body['data']['message']).to eq(VeteranVerification::Constants::NOT_FOUND_MESSAGE)
       end
     end
   end

--- a/spec/lib/lighthouse/veteran_verification/service_spec.rb
+++ b/spec/lib/lighthouse/veteran_verification/service_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'lighthouse/veteran_verification/constants'
 require 'lighthouse/veteran_verification/service'
 require 'lighthouse/service_exception'
 
@@ -65,9 +66,22 @@ RSpec.describe VeteranVerification::Service do
         it 'retrieves veteran not confirmed status from the Lighthouse API' do
           VCR.use_cassette('lighthouse/veteran_verification/status/200_not_confirmed_response') do
             response = @service.get_vet_verification_status('1012666182V203559', '', '')
+
             expect(response['data']['id']).to eq('1012666182V203559')
             expect(response['data']['attributes']['veteran_status']).to eq('not confirmed')
             expect(response['data']['attributes']).to have_key('not_confirmed_reason')
+            expect(response['data']['message']).to eq(VeteranVerification::Constants::NOT_ELIGIBLE_MESSAGE)
+          end
+        end
+
+        it 'retrieves veteran not found status from the Lighthouse API' do
+          VCR.use_cassette('lighthouse/veteran_verification/status/200_person_not_found_response') do
+            response = @service.get_vet_verification_status('1012667145V762141', '', '')
+
+            expect(response['data']['id']).to eq(nil)
+            expect(response['data']['attributes']['veteran_status']).to eq('not confirmed')
+            expect(response['data']['attributes']).to have_key('not_confirmed_reason')
+            expect(response['data']['message']).to eq(VeteranVerification::Constants::NOT_FOUND_MESSAGE)
           end
         end
 


### PR DESCRIPTION
## Summary
- This work is not behind a feature toggle.
- This change adds error message logic to a new route for getting confirmation of a veteran's Title 38 status. This endpoint returns data from the Lighthouse Veteran Service History and Eligibility API `/status` endpoint, which will be used to determine if a veteran is eligible to view their Proof of Status card. If the veteran is found to be ineligible, this change provides more detailed information to display to the user to help them understand why and who to contact to correct it, if they choose.
- Documentation and further logging will be added in a forthcoming PR.
- I work on the IIR Product team and we currently own this feature.

## Related issue(s)

- [1210](https://github.com/department-of-veterans-affairs/va-iir/issues/1210)

## Testing done

- [x] *New code is covered by unit tests*
- There is no old behavior, as this is a completely new implementation. 

## Screenshots


## What areas of the site does it impact?
This change does not impact any areas outside of the newly added files.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

