### PR TITLE
[API-42062] Update /power-of-attorney-requests/decide docs

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -358,6 +358,16 @@
                             "type": "string",
                             "description": "The reason for declining the request.",
                             "nullable": true
+                          },
+                          "participantId": {
+                            "type": "string",
+                            "description": "The unique identifier of the requestʼs participant. Required if the decision is DECLINED.",
+                            "nullable": true
+                          },
+                          "representativeId": {
+                            "type": "string",
+                            "description": "The unique identifier of the requestʼs representative. Required if the decision is DECLINED.",
+                            "nullable": true
                           }
                         }
                       }

--- a/modules/claims_api/config/schemas/v2/power_of_attorney_requests/param/decision/post.json
+++ b/modules/claims_api/config/schemas/v2/power_of_attorney_requests/param/decision/post.json
@@ -40,6 +40,16 @@
               ],
               "description": "The reason for declining the request.",
               "nullable": true
+            },
+            "participantId": {
+              "type": "string",
+              "description": "The unique identifier of the requestʼs participant. Required if the decision is DECLINED.",
+              "nullable": true
+            },
+            "representativeId": {
+              "type": "string",
+              "description": "The unique identifier of the requestʼs representative. Required if the decision is DECLINED.",
+              "nullable": true
             }
           }
         }


### PR DESCRIPTION
## Summary

Add participantId and representativeId to the /decide request body in v2 staging docs. See https://github.com/department-of-veterans-affairs/vets-api/pull/19362 for more.

## Related issue(s)

[API-42062](https://jira.devops.va.gov/browse/API-42062)

## Testing done

Visual inspection.

## Screenshots

<img width="1190" alt="new-decide-docs" src="https://github.com/user-attachments/assets/463d5e32-d29d-4f3a-8472-3ebfdaf3803a">

## What areas of the site does it impact?

v2 staging docs.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

N/A
