### PR TITLE
remove on pull_request in be_review_prs.yml

### DIFF
--- a/.github/workflows/be_review_prs.yml
+++ b/.github/workflows/be_review_prs.yml
@@ -3,7 +3,6 @@ on:
   pull_request_review:
     types: [submitted]
 
-
 jobs:
   check-approval-requirements:
     permissions: write-all

--- a/.github/workflows/be_review_prs.yml
+++ b/.github/workflows/be_review_prs.yml
@@ -3,6 +3,7 @@ on:
   pull_request_review:
     types: [submitted]
 
+
 jobs:
   check-approval-requirements:
     permissions: write-all

--- a/.github/workflows/be_review_prs.yml
+++ b/.github/workflows/be_review_prs.yml
@@ -1,7 +1,5 @@
 name: Require backend-review-group approval
 on:
-  pull_request:
-    types: [opened, reopened, review_requested, synchronize, ready_for_review]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary
Sometimes this check runs twice and will be ❌ until you manually re-run it, which is time-consuming and error-prone (sometimes you forget to re-run).

## Testing done
- [x] have someone non backend-review-group approve PR and see if the check runs but doesn't succeed
- [x] push more changes to PR dismisses reviews and check doesn't run.
- [x] Have a backend-review-group person approve. Check should run and succeed. 