### PR TITLE
Rename argument in get_supplemental_claim_upload

### DIFF
--- a/app/sidekiq/decision_review/sc_status_updater_job.rb
+++ b/app/sidekiq/decision_review/sc_status_updater_job.rb
@@ -26,8 +26,8 @@ module DecisionReview
       decision_review_service.get_supplemental_claim(guid).body
     end
 
-    def get_evidence_status(uuid)
-      decision_review_service.get_supplemental_claim_upload(uuid:).body
+    def get_evidence_status(guid)
+      decision_review_service.get_supplemental_claim_upload(guid:).body
     end
 
     def evidence?

--- a/lib/decision_review_v1/appeals/supplemental_claim_services.rb
+++ b/lib/decision_review_v1/appeals/supplemental_claim_services.rb
@@ -230,12 +230,12 @@ module DecisionReviewV1
       ##
       # Returns all of the data associated with a specific Supplemental Claim Evidence Submission.
       #
-      # @param uuid [uuid] supplemental Claim UUID Evidence Submission
+      # @param guid [guid] supplemental Claim UUID Evidence Submission
       # @return [Faraday::Response]
       #
-      def get_supplemental_claim_upload(uuid:)
+      def get_supplemental_claim_upload(guid:)
         with_monitoring_and_error_handling do
-          perform :get, "supplemental_claims/evidence_submissions/#{uuid}", nil
+          perform :get, "supplemental_claims/evidence_submissions/#{guid}", nil
         end
       end
 

--- a/spec/lib/decision_review_v1/service_spec.rb
+++ b/spec/lib/decision_review_v1/service_spec.rb
@@ -684,10 +684,10 @@ describe DecisionReviewV1::Service do
 
   describe '#get_supplemental_claim_upload' do
     subject do
-      described_class.new.get_supplemental_claim_upload(uuid:)
+      described_class.new.get_supplemental_claim_upload(guid:)
     end
 
-    let(:uuid) { '59cdb98f-f94b-4aaa-8952-4d1e59b6e40a' }
+    let(:guid) { '59cdb98f-f94b-4aaa-8952-4d1e59b6e40a' }
 
     context '200 response' do
       it 'returns a properly formatted 200 response' do

--- a/spec/sidekiq/decision_review/sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/sc_status_updater_job_spec.rb
@@ -125,13 +125,13 @@ RSpec.describe DecisionReview::ScStatusUpdaterJob, type: :job do
         end
 
         it 'only sets delete_date for SavedClaim::SupplementalClaim with all attachments in vbms status' do
-          expect(service).to receive(:get_supplemental_claim_upload).with(uuid: upload_id)
+          expect(service).to receive(:get_supplemental_claim_upload).with(guid: upload_id)
                                                                     .and_return(upload_response_vbms)
-          expect(service).to receive(:get_supplemental_claim_upload).with(uuid: upload_id2)
+          expect(service).to receive(:get_supplemental_claim_upload).with(guid: upload_id2)
                                                                     .and_return(upload_response_processing)
-          expect(service).to receive(:get_supplemental_claim_upload).with(uuid: upload_id3)
+          expect(service).to receive(:get_supplemental_claim_upload).with(guid: upload_id3)
                                                                     .and_return(upload_response_vbms)
-          expect(service).to receive(:get_supplemental_claim_upload).with(uuid: upload_id4)
+          expect(service).to receive(:get_supplemental_claim_upload).with(guid: upload_id4)
                                                                     .and_return(upload_response_processing)
 
           expect(service).to receive(:get_supplemental_claim).with(guid1).and_return(response_complete)
@@ -439,10 +439,10 @@ RSpec.describe DecisionReview::ScStatusUpdaterJob, type: :job do
           expect(service).to receive(:get_supplemental_claim).with(guid1).and_return(response_pending)
           expect(service).to receive(:get_supplemental_claim).with(guid2).and_return(response_error)
 
-          expect(service).not_to receive(:get_supplemental_claim_upload).with(uuid: upload_id)
-          expect(service).to receive(:get_supplemental_claim_upload).with(uuid: upload_id2)
+          expect(service).not_to receive(:get_supplemental_claim_upload).with(guid: upload_id)
+          expect(service).to receive(:get_supplemental_claim_upload).with(guid: upload_id2)
                                                                     .and_return(upload_response_error)
-          expect(service).to receive(:get_supplemental_claim_upload).with(uuid: upload_id3)
+          expect(service).to receive(:get_supplemental_claim_upload).with(guid: upload_id3)
                                                                     .and_return(upload_response_processing)
 
           subject.new.perform


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- was :uuid, now :guid
- to match get_notice_of_disagreement_upload for easier code sharing and shared testing
- Decision Reviews, yes

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/96645

## Testing done

- [x] *New code is covered by unit tests*
- Changed one named argument from :uuid to :guid

## What areas of the site does it impact?
DecisionReviewV1::Appeals::SupplementalClaimServices

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature