### PR TITLE
add team and feature Rspec tags to personal info related files

### DIFF
--- a/spec/lib/va_profile/demographics/service_spec.rb
+++ b/spec/lib/va_profile/demographics/service_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'va_profile/demographics/service'
 
-describe VAProfile::Demographics::Service, :skip_vet360 do
+describe VAProfile::Demographics::Service,  feature: :personal_info,
+                                            team_owner: :vfs_authenticated_experience_backend,
+                                            type: :service do
   subject { described_class.new(user) }
 
   let(:user) { build(:user, :loa3) }

--- a/spec/lib/va_profile/models/gender_identity_spec.rb
+++ b/spec/lib/va_profile/models/gender_identity_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'va_profile/models/gender_identity'
 
-describe VAProfile::Models::GenderIdentity do
+describe VAProfile::Models::GenderIdentity, feature: :personal_info,
+                                            team_owner: :vfs_authenticated_experience_backend,
+                                            type: :model do
   let(:model) { VAProfile::Models::GenderIdentity.new(code: 'F', name: 'Woman') }
 
   context 'is valid' do

--- a/spec/lib/va_profile/models/preferred_name_spec.rb
+++ b/spec/lib/va_profile/models/preferred_name_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'va_profile/models/preferred_name'
 
-describe VAProfile::Models::PreferredName do
+describe VAProfile::Models::PreferredName,  feature: :personal_info,
+                                            team_owner: :vfs_authenticated_experience_backend,
+                                            type: :model do
   let(:model) { VAProfile::Models::PreferredName.new }
 
   # must only contain alpha, -, acute, grave, diaresis, cirumflex, tilde (case insensitive)

--- a/spec/requests/v0/profile/gender_identities_spec.rb
+++ b/spec/requests/v0/profile/gender_identities_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'va_profile/models/gender_identity'
 
-RSpec.describe 'V0::Profile::GenderIdentities', type: :request do
+RSpec.describe 'V0::Profile::GenderIdentities', feature: :personal_info,
+                                                team_owner: :vfs_authenticated_experience_backend,
+                                                type: :request do
   include SchemaMatchers
 
   let(:user) { build(:user, :loa3) }

--- a/spec/requests/v0/profile/personal_information_spec.rb
+++ b/spec/requests/v0/profile/personal_information_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'support/error_details'
 
-RSpec.describe 'V0::Profile::PersonalInformation', type: :request do
+RSpec.describe 'V0::Profile::PersonalInformation',  feature: :personal_info,
+                                                    team_owner: :vfs_authenticated_experience_backend,
+                                                    type: :request do
   include SchemaMatchers
   include ErrorDetails
 

--- a/spec/requests/v0/profile/preferred_names_spec.rb
+++ b/spec/requests/v0/profile/preferred_names_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 require 'va_profile/models/preferred_name'
 
-RSpec.describe 'V0::Profile::PreferredNames' do
+RSpec.describe 'V0::Profile::PreferredNames', feature: :personal_info,
+                                              team_owner: :vfs_authenticated_experience_backend,
+                                              type: :request do
   include SchemaMatchers
 
   let(:user) { build(:user, :loa3) }


### PR DESCRIPTION
## Summary
Added `team_owner` and `feature` RSpec tags to the spec files for `personal info`, `preferred name`, `gender identities`, and `service`.

Refer to the [RSpec Tagging Guide](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/tutorials/testing/rspec_tags.md) for more details.

---

## Related Issue(s)
- [#96569](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96569)

---

## Testing Done
Ran the following command to verify the tags:

```bash
bundle exec rspec spec --tag feature:personal_info
```

## Results:
Finished in 1.28 seconds
37 examples, 0 failures

