### PR TITLE
[VI-771] Adding preferred name to user serializer, sourced from MPI

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,6 +131,10 @@ class User < Common::RedisStore
     }
   end
 
+  def preferred_name
+    preferred_name_mpi
+  end
+
   def gender
     identity.gender.presence || gender_mpi
   end
@@ -234,6 +238,10 @@ class User < Common::RedisStore
 
   def first_name_mpi
     given_names&.first
+  end
+
+  def preferred_name_mpi
+    mpi_profile&.preferred_names&.first
   end
 
   def middle_name_mpi

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -71,6 +71,7 @@ module Users
         first_name: user.first_name,
         middle_name: user.middle_name,
         last_name: user.last_name,
+        preferred_name: user.preferred_name,
         birth_date: user.birth_date,
         gender: user.gender,
         zip: user.postal_code,

--- a/app/swagger/swagger/schemas/user_internal_services.rb
+++ b/app/swagger/swagger/schemas/user_internal_services.rb
@@ -36,6 +36,7 @@ module Swagger
               property :first_name, type: :string, example: 'Abigail'
               property :middle_name, type: :string, example: 'Jane'
               property :last_name, type: :string, example: 'Brown'
+              property :preferred_name, type: %i[string null], example: 'Abby'
               property :birth_date, type: :string, example: '1900-01-01'
               property :gender, type: :string, example: 'F'
               property :zip,

--- a/lib/mpi/models/mvi_profile_identity.rb
+++ b/lib/mpi/models/mvi_profile_identity.rb
@@ -10,6 +10,7 @@ module MPI
 
       attribute :given_names, Array[String]
       attribute :family_name, String
+      attribute :preferred_names, Array[String]
       attribute :suffix, String
       attribute :gender, String
       attribute :birth_date, Common::DateTimeString

--- a/lib/mpi/responses/profile_parser.rb
+++ b/lib/mpi/responses/profile_parser.rb
@@ -144,10 +144,12 @@ module MPI
         person_component = locate_element(person, PATIENT_PERSON_PREFIX)
         person_types = parse_person_type(person)
         name = parse_name(locate_elements(person_component, NAME_XPATH))
+        preferred_names = parse_name(locate_elements(person_component, NAME_XPATH), indicator: NAME_PREFERRED_INDICATOR)
         {
           given_names: name[:given],
           family_name: name[:family],
           suffix: name[:suffix],
+          preferred_names: preferred_names[:given],
           gender: locate_element(person_component, GENDER_XPATH),
           birth_date: locate_element(person_component, DOB_XPATH),
           deceased_date: locate_element(person_component, DECEASED_XPATH),
@@ -248,15 +250,15 @@ module MPI
         { given:, family: }
       end
 
-      def parse_name(name)
-        name_element = parse_name_node(name, indicator: NAME_LEGAL_INDICATOR)
+      def parse_name(name, indicator: NAME_LEGAL_INDICATOR)
+        name_element = parse_name_node(name, indicator:)
 
         given = [*name_element.locate('given')].map { |el| el.nodes.first.capitalize }
-        family = name_element.locate('family').first.nodes.first.capitalize
+        family = name_element.locate('family')&.first&.nodes&.first&.capitalize
         suffix = name_element.locate('suffix')&.first&.nodes&.first&.capitalize
         { given:, family:, suffix: }
       rescue
-        Rails.logger.warn 'MPI::Response.parse_name failed'
+        Rails.logger.warn 'MPI::Response.parse_name failed' if indicator == NAME_LEGAL_INDICATOR
         { given: nil, family: nil }
       end
 

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -38,6 +38,7 @@ end
 FactoryBot.define do
   factory :mpi_profile, class: 'MPI::Models::MviProfile' do
     given_names { Array.new(1) { Faker::Name.first_name } }
+    preferred_names { Array.new(1) { Faker::Name.first_name } }
     family_name { Faker::Name.last_name }
     suffix { Faker::Name.suffix }
     gender { %w[M F].sample }
@@ -82,6 +83,7 @@ FactoryBot.define do
 
     factory :mpi_profile_response do
       given_names { %w[John William] }
+      preferred_names { [] }
       family_name { 'Smith' }
       suffix { 'Sr' }
       gender { 'M' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
       middle_name { nil }
       last_name { 'lincoln' }
       gender { 'M' }
+      preferred_name { 'abe' }
       birth_date { '1809-02-12' }
       ssn { '796111863' }
       idme_uuid { 'b2fab2b5-6af0-45e1-a9e2-394347af91ef' }
@@ -94,6 +95,7 @@ FactoryBot.define do
       mpi_profile do
         given_names = [first_name]
         given_names << middle_name if middle_name.present?
+        preferred_names = [preferred_name]
 
         mpi_attributes = { active_mhv_ids:,
                            address:,
@@ -105,6 +107,7 @@ FactoryBot.define do
                            family_name: last_name,
                            gender:,
                            given_names:,
+                           preferred_names:,
                            home_phone:,
                            icn:,
                            mhv_ids:,

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -126,6 +126,7 @@ describe MPI::Responses::ProfileParser do
             :address_austin,
             family_name: 'Smith',
             given_names: %w[John William],
+            preferred_names: %w[General],
             suffix: 'Sr',
             birls_id: nil,
             birls_ids: [],

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -368,6 +368,10 @@ RSpec.describe User, type: :model do
               country: 'USA' }
           end
 
+          it 'fetches preferred name from MPI' do
+            expect(user.preferred_name).to eq(user.preferred_name_mpi)
+          end
+
           context 'user has an address' do
             it 'returns mpi_profile\'s address as hash' do
               expect(user.address).to eq(expected_address)

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -190,6 +190,10 @@ RSpec.describe Users::Profile do
         expect(profile[:last_name]).to eq(user.last_name)
       end
 
+      it 'includes preferred_name' do
+        expect(profile[:preferred_name]).to eq(user.preferred_name)
+      end
+
       it 'includes birth_date' do
         expect(profile[:birth_date]).to eq(user.birth_date)
       end

--- a/spec/support/rakelib/users_serialized.json
+++ b/spec/support/rakelib/users_serialized.json
@@ -14,6 +14,7 @@
       ":first_name": "Abraham",
       ":middle_name": null,
       ":last_name": "Lincoln",
+      ":preferred_name": "abe",
       ":gender": "M",
       ":birth_date": "1809-02-12",
       ":zip": null,
@@ -35,10 +36,13 @@
       ":response": {
         "^o": "MPI::Responses::FindProfileResponse",
         "status": "OK",
-        "profile": {
+      "profile": {
           "^o": "MPI::Models::MviProfile",
           "given_names": [
             "Abraham"
+          ],
+          "preferred_names": [
+            "abe"
           ],
           "family_name": "Lincoln",
           "suffix": "Jr",
@@ -118,6 +122,9 @@
             "Jebediah"
           ],
           "family_name": "Simpson",
+          "preferred_names": [
+            "abe"
+          ],
           "suffix": null,
           "gender": "M",
           "birth_date": "19690406",

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -97,6 +97,7 @@
                 "first_name",
                 "middle_name",
                 "last_name",
+                "preferred_name",
                 "birth_date",
                 "gender",
                 "zip",
@@ -132,6 +133,12 @@
                   ]
                 },
                 "last_name": {
+                  "type": [
+                    "string",
+                    null
+                  ]
+                },
+                "preferred_name": {
                   "type": [
                     "string",
                     null

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -101,6 +101,7 @@
                 "first_name",
                 "middle_name",
                 "last_name",
+                "preferred_name",
                 "birth_date",
                 "gender",
                 "zip",
@@ -134,6 +135,12 @@
                 },
                 "last_name": {
                   "type": "string"
+                },
+                "preferred_name": {
+                  "type": [
+                    "string",
+                    null
+                  ]
                 },
                 "birth_date": {
                   "type": "string"

--- a/spec/support/schemas_camelized/user_loa1.json
+++ b/spec/support/schemas_camelized/user_loa1.json
@@ -97,6 +97,7 @@
                 "firstName",
                 "middleName",
                 "lastName",
+                "preferredName",
                 "birthDate",
                 "gender",
                 "zip",
@@ -132,6 +133,12 @@
                   ]
                 },
                 "lastName": {
+                  "type": [
+                    "string",
+                    null
+                  ]
+                },
+                "preferredName": {
                   "type": [
                     "string",
                     null

--- a/spec/support/schemas_camelized/user_loa3.json
+++ b/spec/support/schemas_camelized/user_loa3.json
@@ -101,6 +101,7 @@
                 "firstName",
                 "middleName",
                 "lastName",
+                "preferredName",
                 "birthDate",
                 "gender",
                 "zip",
@@ -134,6 +135,12 @@
                 },
                 "lastName": {
                   "type": "string"
+                },
+                "preferredName": {
+                  "type": [
+                    "string",
+                    null
+                  ]
                 },
                 "birthDate": {
                   "type": "string"


### PR DESCRIPTION
## Summary

- This PR adds the `preferred_name` field to the `/user` serialized response
- This field is sourced from the MPI 'preferred_name' stanza

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-771

## Testing done

- [ ] Authenticated with a user who has preferred name set (in MPI this is designated with `ASGN`)
- [ ] Confirmed `/v0/user` response included `preferred_name` field

## What areas of the site does it impact?
Serialized User response

## Acceptance criteria

- [ ]  Find an MPI record in mock data with a name that has label `ASGN`
- [ ] Authenticate with that user
- [ ] Confirm that `/v0/user` response includes `preferred_name` field