### PR TITLE
Uses new callback_metadata field in VANotify::Notification

### DIFF
--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -109,7 +109,7 @@ module VaNotify
         notification_id: response.id,
         source_location: find_caller_locations,
         callback: callback_options[:callback],
-        metadata: callback_options[:metadata]
+        callback_metadata: callback_options[:callback_metadata]
       )
 
       if notification.save

--- a/modules/va_notify/spec/lib/service_spec.rb
+++ b/modules/va_notify/spec/lib/service_spec.rb
@@ -146,7 +146,7 @@ describe VaNotify::Service do
 
         it 'with callback data' do
           VCR.use_cassette('va_notify/success_email') do
-            subject = described_class.new(test_api_key, { callback: 'TestCallback', metadata: 'optional_metadata' })
+            subject = described_class.new(test_api_key, { callback: 'TestCallback', callback_metadata: 'optional_metadata' })
             allow(Flipper).to receive(:enabled?).with(:va_notify_notification_creation).and_return(true)
 
             subject.send_email(send_email_parameters)
@@ -154,7 +154,7 @@ describe VaNotify::Service do
             notification = VANotify::Notification.first
             expect(notification.source_location).to include('modules/va_notify/spec/lib/service_spec.rb')
             expect(notification.callback).to eq('TestCallback')
-            expect(notification.metadata).to eq('optional_metadata')
+            expect(notification.callback_metadata).to eq('optional_metadata')
           end
         end
       end

--- a/modules/va_notify/spec/lib/service_spec.rb
+++ b/modules/va_notify/spec/lib/service_spec.rb
@@ -146,7 +146,8 @@ describe VaNotify::Service do
 
         it 'with callback data' do
           VCR.use_cassette('va_notify/success_email') do
-            subject = described_class.new(test_api_key, { callback: 'TestCallback', callback_metadata: 'optional_metadata' })
+            subject = described_class.new(test_api_key,
+                                          { callback: 'TestCallback', callback_metadata: 'optional_metadata' })
             allow(Flipper).to receive(:enabled?).with(:va_notify_notification_creation).and_return(true)
 
             subject.send_email(send_email_parameters)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*

> yes

- *(Summarize the changes that have been made to the platform)*

> Before this PR: 
> 
> When creating a VANotify::Notification, if the callback_options Hash included a String value on the key of `metadata`, it would be written to the metadata attribute
>
> example: 
> ```rb
>   # metadata is currently a String datatype
>
>   callback_options = { callback: "String", metadata: "String" }
> ```
>
> After this PR: 
> 
> Since this work is behind a flipper and not in prod yet, we're going to use the new field of
> `callback_metadata` (recently added to the vanotify::notifications table) the intention is to receive a Hash within the callback_options hash (instead of a String) 
> 
> example: 
> ```rb
>   # metadata is currently a String datatype
>
>   callback_options = { callback: "String", callback_metadata: JSONB }
> ```
>
> NOTE: Yes the key has changed from metadata -> callback_metadata. Our documentation (not yet published) will be updated to reflect this nuance

- *(If bug, how to reproduce)*

> N/A

- *(What is the solution, why is this the solution?)*

> this is the solution because JSONB is more idiomatic in regards to the overall schema of the vets-api; Also, this is the next step of the work after adding the `callback_metadata` field to the `vanotify::notifications` table

- *(Which team do you work for, does your team own the maintenance of this component?)*

> VA Notify

- *(If introducing a flipper, what is the success criteria being targeted?)*

> N/A

## Related issue(s)

1. [https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247150&issue=department-of-veterans-affairs%7Cvanotify-team%7C1411](https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247150&issue=department-of-veterans-affairs%7Cvanotify-team%7C1411)
2. [https://github.com/department-of-veterans-affairs/vets-api/pull/19472](https://github.com/department-of-veterans-affairs/vets-api/pull/19472)
3. [https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247327&issue=department-of-veterans-affairs%7Cvanotify-team%7C1410](https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247327&issue=department-of-veterans-affairs%7Cvanotify-team%7C1410)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*

```bash
bundle exec rspec  modules/va_notify/spec/lib/service_spec.rb
```

- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
