### PR TITLE
[10-10CG] Update Form1010cg::SubmissionJob spec to stub all Flipper calls

### DIFF
--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Form1010cg::SubmissionJob do
   let(:statsd_key_prefix) { described_class::STATSD_KEY_PREFIX }
   let(:zsf_tags) { described_class::DD_ZSF_TAGS }
 
+  before do
+    allow(Flipper).to receive(:enabled?).and_call_original
+  end
+
   it 'has a retry count of 16' do
     expect(described_class.get_sidekiq_options['retry']).to eq(16)
   end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Added `allow(Flipper).to receive(:enabled?).and_call_original`  in a before for the `Form1010cg::SubmissionJob` to ensure any Flipper toggles are stubbed. `SavedClaim::CaregiversAssistanceClaim` was expecting a different flipper toggle to be stubbed and it wasn't, so it was using the stub from the spec that was for a different feature. 
- 10-10 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95897

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
None

## What areas of the site does it impact?
10-10CG Submission Job Spec

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
