### PR TITLE
Fixing flaky spec for sign in controller around duration log

### DIFF
--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -1137,6 +1137,11 @@ RSpec.describe V0::SignInController, type: :controller do
 
               before do
                 allow(SecureRandom).to receive(:uuid).and_return(client_code)
+                Timecop.freeze
+              end
+
+              after do
+                Timecop.return
               end
 
               shared_context 'dslogon successful callback' do


### PR DESCRIPTION
## Summary

- This PR fixes a flaky spec in the Sign in Controller that was occurring when the spec took a bit longer than expected and the duration field for a log was different than the expected value