### PR TITLE
Modifies fields of va_notify_notifications table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_14_213556) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_18_234337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1378,11 +1378,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_14_213556) do
     t.text "status_reason"
     t.text "provider"
     t.text "source_location"
-    t.text "callback"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "metadata"
     t.jsonb "callback_metadata"
+    t.text "callback_klass"
+    t.uuid "template_id"
   end
 
   create_table "vba_documents_monthly_stats", force: :cascade do |t|

--- a/modules/va_notify/app/services/va_notify/status_update.rb
+++ b/modules/va_notify/app/services/va_notify/status_update.rb
@@ -9,7 +9,7 @@ module VANotify
 
       return if callback_info_missing?
 
-      klass = constantized_class(notification.callback)
+      klass = constantized_class(notification.callback_klass)
       if klass.respond_to?(:call)
         begin
           klass.call(notification)
@@ -35,7 +35,7 @@ module VANotify
     end
 
     def callback_info_missing?
-      if notification.callback.blank?
+      if notification.callback_klass.blank?
         Rails.logger.info(message: "VANotify - no callback provided for notification: #{notification.id}")
         true
       else

--- a/modules/va_notify/db/migrate/20241118234337_applies_modifications_to_va_notify_notifications.rb
+++ b/modules/va_notify/db/migrate/20241118234337_applies_modifications_to_va_notify_notifications.rb
@@ -1,0 +1,11 @@
+class AppliesModificationsToVANotifyNotifications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :va_notify_notifications, :callback_klass, :text
+    add_column :va_notify_notifications, :template_id, :uuid
+
+    safety_assured do
+      remove_column :va_notify_notifications, :metadata
+      remove_column :va_notify_notifications, :callback
+    end
+  end
+end

--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -108,7 +108,7 @@ module VaNotify
       notification = VANotify::Notification.new(
         notification_id: response.id,
         source_location: find_caller_locations,
-        callback: callback_options[:callback],
+        callback_klass: callback_options[:callback],
         callback_metadata: callback_options[:callback_metadata]
       )
 

--- a/modules/va_notify/spec/lib/service_spec.rb
+++ b/modules/va_notify/spec/lib/service_spec.rb
@@ -124,8 +124,8 @@ describe VaNotify::Service do
             expect(VANotify::Notification.count).to eq(1)
             notification = VANotify::Notification.first
             expect(notification.source_location).to include('modules/va_notify/spec/lib/service_spec.rb')
-            expect(notification.callback).to eq(nil)
-            expect(notification.metadata).to eq(nil)
+            expect(notification.callback_klass).to eq(nil)
+            expect(notification.callback_metadata).to eq(nil)
           end
         end
 
@@ -139,8 +139,8 @@ describe VaNotify::Service do
             expect(VANotify::Notification.count).to eq(1)
             notification = VANotify::Notification.first
             expect(notification.source_location).to include('modules/va_notify/spec/lib/service_spec.rb')
-            expect(notification.callback).to eq(nil)
-            expect(notification.metadata).to eq(nil)
+            expect(notification.callback_klass).to eq(nil)
+            expect(notification.callback_metadata).to eq(nil)
           end
         end
 
@@ -154,7 +154,7 @@ describe VaNotify::Service do
             expect(VANotify::Notification.count).to eq(1)
             notification = VANotify::Notification.first
             expect(notification.source_location).to include('modules/va_notify/spec/lib/service_spec.rb')
-            expect(notification.callback).to eq('TestCallback')
+            expect(notification.callback_klass).to eq('TestCallback')
             expect(notification.callback_metadata).to eq('optional_metadata')
           end
         end

--- a/modules/va_notify/spec/services/status_update_spec.rb
+++ b/modules/va_notify/spec/services/status_update_spec.rb
@@ -30,7 +30,7 @@ describe VANotify::StatusUpdate do
         }
 
         allow(notification.callback_klass.constantize).to receive(:call).with(notification).and_raise(StandardError,
-                                                                                                'Something went wrong')
+                                                                                                      'Something went wrong')
 
         expect(Rails.logger).to receive(:info).with('Something went wrong')
 

--- a/modules/va_notify/spec/services/status_update_spec.rb
+++ b/modules/va_notify/spec/services/status_update_spec.rb
@@ -10,7 +10,7 @@ describe VANotify::StatusUpdate do
     context 'notification with callback' do
       it 'invokes callback class #call' do
         notification_id = SecureRandom.uuid
-        create(:notification, notification_id:, callback: 'VANotify::OtherTeam::OtherForm')
+        create(:notification, notification_id:, callback_klass: 'VANotify::OtherTeam::OtherForm')
         allow(VANotify::OtherTeam::OtherForm).to receive(:call)
 
         provider_callback = {
@@ -24,12 +24,12 @@ describe VANotify::StatusUpdate do
 
       it 'logs error message if #call fails' do
         notification_id = SecureRandom.uuid
-        notification = create(:notification, notification_id:, callback: 'VANotify::OtherTeam::OtherForm')
+        notification = create(:notification, notification_id:, callback_klass: 'VANotify::OtherTeam::OtherForm')
         provider_callback = {
           id: notification_id
         }
 
-        allow(notification.callback.constantize).to receive(:call).with(notification).and_raise(StandardError,
+        allow(notification.callback_klass.constantize).to receive(:call).with(notification).and_raise(StandardError,
                                                                                                 'Something went wrong')
 
         expect(Rails.logger).to receive(:info).with('Something went wrong')
@@ -40,7 +40,7 @@ describe VANotify::StatusUpdate do
       it 'logs a message and source location if callback klass does not implement #call' do
         notification_id = SecureRandom.uuid
         notification = create(:notification, notification_id:,
-                                             callback: 'VANotify::NonCompliantModule::NonCompliantClass')
+                                             callback_klass: 'VANotify::NonCompliantModule::NonCompliantClass')
         provider_callback = {
           id: notification_id
         }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*

> Yes

- *(Summarize the changes that have been made to the platform)*

> before this PR: 
> the va_notify_notifications table had a field of `metadata`. The same table also has a `callback` field. The same table is also without the `template_id` field.
> 
> After this PR:
> * the `metadata` field has been removed, since it's been replaced by `callback_metadata`.  
> * the `callback` field has been replaced by `callback_klass` (same datatype). 
> * the `template_id` field has been added (datatype: :uuid)

- *(If bug, how to reproduce)*

> N/A

- *(What is the solution, why is this the solution?)*

> This is the solution because the `metadata` field has been replaced by `callback_metadata` which is a `jsonb` field. Also, the `callback_klass` matches the convention here. Finally, the `template_id` field has been requested to be added, as it will be broadcast downstream.

- *(Which team do you work for, does your team own the maintenance of this component?)*

> VA Notify

- *(If introducing a flipper, what is the success criteria being targeted?)*

> N/A

## Related issue(s)

1. [https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247150&issue=department-of-veterans-affairs%7Cvanotify-team%7C1411](https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247150&issue=department-of-veterans-affairs%7Cvanotify-team%7C1411)
2. [https://github.com/department-of-veterans-affairs/vets-api/pull/19472](https://github.com/department-of-veterans-affairs/vets-api/pull/19472)
3. [https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247327&issue=department-of-veterans-affairs%7Cvanotify-team%7C1410](https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=85247327&issue=department-of-veterans-affairs%7Cvanotify-team%7C1410)
4. [https://github.com/department-of-veterans-affairs/vets-api/pull/19494](https://github.com/department-of-veterans-affairs/vets-api/pull/19494)


## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
