### PR TITLE
Handle separate emails for different 21-0966 paths

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1303,6 +1303,8 @@ vanotify:
         form21_674_action_needed_email: form21_674_action_needed_email_template_id
         form21_0966_confirmation_email: form21_0966_confirmation_email_template_id
         form21_0966_error_email: form21_0966_error_email_template_id
+        form21_0966_received_email: form21_0966_received_email_template_id
+        form21_0966_itf_api_received_email: form21_0966_itf_api_received_email_template_id
         form21_0972_confirmation_email: form21_0972_confirmation_email_template_id
         form21_0972_error_email: form21_0972_error_email_template_id
         form21_0972_received_email: form21_0972_received_email_template_id

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -91,7 +91,7 @@ module SimpleFormsApi
         form.track_user_identity(confirmation_number)
 
         if confirmation_number && Flipper.enabled?(:simple_forms_email_confirmations)
-          send_confirmation_email(parsed_form_data, get_form_id, confirmation_number)
+          send_intent_received_email(parsed_form_data, confirmation_number, expiration_date)
         end
 
         json_for210966(confirmation_number, expiration_date, existing_intents)
@@ -288,6 +288,22 @@ module SimpleFormsApi
         notification_email = SimpleFormsApi::NotificationEmail.new(
           config,
           notification_type: :confirmation,
+          user: @current_user
+        )
+        notification_email.send
+      end
+
+      def send_intent_received_email(parsed_form_data, confirmation_number, expiration_date)
+        config = {
+          form_data: parsed_form_data,
+          form_number: 'vba_21_0966_intent_api',
+          confirmation_number:,
+          date_submitted: Time.zone.today.strftime('%B %d, %Y'),
+          expiration_date:
+        }
+        notification_email = SimpleFormsApi::NotificationEmail.new(
+          config,
+          notification_type: :received,
           user: @current_user
         )
         notification_email.send

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -2,8 +2,8 @@
 
 module SimpleFormsApi
   class NotificationEmail
-    attr_reader :form_number, :confirmation_number, :date_submitted, :lighthouse_updated_at, :notification_type, :user,
-                :user_account, :form_data
+    attr_reader :form_number, :confirmation_number, :date_submitted, :expiration_date, :lighthouse_updated_at,
+                :notification_type, :user, :user_account, :form_data
 
     TEMPLATE_IDS = {
       'vba_21_0845' => {
@@ -19,7 +19,10 @@ module SimpleFormsApi
       'vba_21_0966' => {
         confirmation: Settings.vanotify.services.va_gov.template_id.form21_0966_confirmation_email,
         error: Settings.vanotify.services.va_gov.template_id.form21_0966_error_email,
-        received: nil
+        received: Settings.vanotify.services.va_gov.template_id.form21_0966_received_email
+      },
+      'vba_21_0966_intent_api' => {
+        received: Settings.vanotify.services.va_gov.template_id.form21_0966_itf_api_received_email
       },
       'vba_21_0972' => {
         confirmation: Settings.vanotify.services.va_gov.template_id.form21_0972_confirmation_email,
@@ -66,6 +69,7 @@ module SimpleFormsApi
       @form_number = config[:form_number]
       @confirmation_number = config[:confirmation_number]
       @date_submitted = config[:date_submitted]
+      @expiration_date = config[:expiration_date]
       @lighthouse_updated_at = config[:lighthouse_updated_at]
       @notification_type = notification_type
       @user = user
@@ -90,11 +94,16 @@ module SimpleFormsApi
 
     def check_missing_keys(config)
       missing_keys = %i[form_data form_number confirmation_number date_submitted].select { |key| config[key].nil? }
+      if config[:form_number] == 'vba_21_0966_intent_api' && config[:expiration_date].nil?
+        missing_keys << :expiration_date
+      end
       raise ArgumentError, "Missing keys: #{missing_keys.join(', ')}" if missing_keys.any?
     end
 
     def flipper?
-      Flipper.enabled?(:"form#{form_number.gsub('vba_', '')}_confirmation_email")
+      number = form_number
+      number = 'vba_21_0966' if form_number.start_with? 'vba_21_0966'
+      Flipper.enabled?(:"form#{number.gsub('vba_', '')}_confirmation_email")
     end
 
     def enqueue_email(at, template_id)
@@ -153,7 +162,7 @@ module SimpleFormsApi
         form21_0845_contact_info[0]
       when 'vba_21p_0847', 'vba_21_0972'
         form_data['preparer_email']
-      when 'vba_21_0966'
+      when 'vba_21_0966', 'vba_21_0966_intent_api'
         form21_0966_email_address
       when 'vba_21_4142'
         form_data.dig('veteran', 'email')
@@ -177,7 +186,7 @@ module SimpleFormsApi
         form21_0845_contact_info[1]
       when 'vba_21p_0847'
         form_data.dig('preparer_name', 'first')
-      when 'vba_21_0966'
+      when 'vba_21_0966', 'vba_21_0966_intent_api'
         form21_0966_first_name
       when 'vba_21_0972'
         form_data.dig('preparer_full_name', 'first')
@@ -218,7 +227,7 @@ module SimpleFormsApi
     end
 
     def get_personalization(first_name)
-      if @form_number == 'vba_21_0966'
+      if @form_number.start_with? 'vba_21_0966'
         default_personalization(first_name).merge(form21_0966_personalization)
       else
         default_personalization(first_name)
@@ -329,18 +338,31 @@ module SimpleFormsApi
     end
 
     def form21_0966_personalization
+      intent_to_file_benefits, intent_to_file_benefits_links = get_intent_to_file_benefits_variables
+      {
+        'intent_to_file_benefits' => intent_to_file_benefits,
+        'intent_to_file_benefits_links' => intent_to_file_benefits_links,
+        'itf_api_expiration_date' => expiration_date
+      }
+    end
+
+    def get_intent_to_file_benefits_variables
       benefits = @form_data['benefit_selection']
-      intent_to_file_benefits = if benefits['compensation'] && benefits['pension']
-                                  'Disability Compensation (VA Form 21-526EZ) and Pension (VA Form 21P-527EZ)'
-                                elsif benefits['compensation']
-                                  'Disability Compensation (VA Form 21-526EZ)'
-                                elsif benefits['pension']
-                                  'Pension (VA Form 21P-527EZ)'
-                                elsif benefits['survivor']
-                                  'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
-                                    ' (VA Form 21P-534 or VA Form 21P-534EZ)'
-                                end
-      { 'intent_to_file_benefits' => intent_to_file_benefits }
+      if benefits['compensation'] && benefits['pension']
+        ['Disability Compensation (VA Form 21-526EZ) and Pension (VA Form 21P-527EZ)',
+         '[Complete your Disability compensation claim (VA Form 21-526EZ)](https://www.va.gov/disability/' \
+         'file-disability-claim-form-21-526ez/introduction) and [Complete your Pension claim (VA Form 21P-527EZ)](https://www.va.gov/find-forms/about-form-21p-527ez/)']
+      elsif benefits['compensation']
+        ['Disability Compensation (VA Form 21-526EZ)',
+         '[Complete your Disability compensation claim (VA Form 21-526EZ)](https://www.va.gov/disability/file-disability-claim-form-21-526ez/introduction)']
+      elsif benefits['pension']
+        ['Pension (VA Form 21P-527EZ)',
+         '[Pension claim (VA Form 21P-527EZ)](https://www.va.gov/find-forms/about-form-21p-527ez/)']
+      elsif benefits['survivor']
+        ['Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
+         ' (VA Form 21P-534 or VA Form 21P-534EZ)',
+         '[Pension claim for survivors (21P-534EZ)](https://www.va.gov/find-forms/about-form-21p-534ez/)']
+      end
     end
 
     def form40_10007_first_name

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -852,7 +852,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         end
 
         context 'veteran preparer' do
-          it 'successful submission' do
+          it 'sends the received email' do
             allow_any_instance_of(SimpleFormsApi::IntentToFile)
               .to receive(:submit).and_return([confirmation_number, Time.zone.now])
             allow_any_instance_of(SimpleFormsApi::IntentToFile)
@@ -867,7 +867,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
 
             expect(VANotify::EmailJob).to have_received(:perform_async).with(
               'abraham.lincoln@vets.gov',
-              'form21_0966_confirmation_email_template_id',
+              'form21_0966_received_email_template_id',
               {
                 'first_name' => 'Veteran',
                 'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -729,7 +729,35 @@ describe SimpleFormsApi::NotificationEmail do
       end
       let(:user) { create(:user, :loa3) }
 
-      context 'template_id is provided', unless: notification_type == :received do
+      it 'sends the email' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+
+        subject = described_class.new(config, notification_type:, user:)
+
+        subject.send
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          user.va_profile_email,
+          "form21_0966_#{notification_type}_email_template_id",
+          {
+            'first_name' => 'Veteran',
+            'date_submitted' => date_submitted,
+            'confirmation_number' => 'confirmation_number',
+            'lighthouse_updated_at' => nil,
+            'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
+                                         ' (VA Form 21P-534 or VA Form 21P-534EZ)',
+            'intent_to_file_benefits_links' => '[Pension claim for survivors (21P-534EZ)](https://www.va.gov/find-forms/about-form-21p-534ez/)',
+            'itf_api_expiration_date' => nil
+          }
+        )
+      end
+
+      context 'preparer is surviving dependent' do
+        before do
+          data['preparer_identification'] = 'SURVIVING_DEPENDENT'
+          config[:form_data] = data
+        end
+
         it 'sends the email' do
           allow(VANotify::EmailJob).to receive(:perform_async)
 
@@ -738,23 +766,39 @@ describe SimpleFormsApi::NotificationEmail do
           subject.send
 
           expect(VANotify::EmailJob).to have_received(:perform_async).with(
-            user.va_profile_email,
+            'survivor@dependent.com',
             "form21_0966_#{notification_type}_email_template_id",
             {
-              'first_name' => 'Veteran',
+              'first_name' => 'I',
               'date_submitted' => date_submitted,
               'confirmation_number' => 'confirmation_number',
               'lighthouse_updated_at' => nil,
               'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
-                                           ' (VA Form 21P-534 or VA Form 21P-534EZ)'
+                                           ' (VA Form 21P-534 or VA Form 21P-534EZ)',
+              'intent_to_file_benefits_links' => '[Pension claim for survivors (21P-534EZ)](https://www.va.gov/find-forms/about-form-21p-534ez/)',
+              'itf_api_expiration_date' => nil
             }
           )
         end
+      end
+    end
 
-        context 'preparer is surviving dependent' do
-          before do
-            data['preparer_identification'] = 'SURVIVING_DEPENDENT'
-            config[:form_data] = data
+    describe '21_0966 through Intent to File API', if: notification_type == :received do
+      let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
+      let(:expiration_date) { 1.year.from_now.strftime('%B %d, %Y') }
+      let(:data) do
+        fixture_path = Rails.root.join(
+          'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'
+        )
+        JSON.parse(fixture_path.read)
+      end
+      let(:user) { create(:user, :loa3) }
+
+      context 'template_id is provided' do
+        context 'expiration_date is provided' do
+          let(:config) do
+            { form_data: data, form_number: 'vba_21_0966_intent_api',
+              confirmation_number: 'confirmation_number', date_submitted:, expiration_date: }
           end
 
           it 'sends the email' do
@@ -765,22 +809,70 @@ describe SimpleFormsApi::NotificationEmail do
             subject.send
 
             expect(VANotify::EmailJob).to have_received(:perform_async).with(
-              'survivor@dependent.com',
-              "form21_0966_#{notification_type}_email_template_id",
+              user.va_profile_email,
+              'form21_0966_itf_api_received_email_template_id',
               {
-                'first_name' => 'I',
+                'first_name' => 'Veteran',
                 'date_submitted' => date_submitted,
                 'confirmation_number' => 'confirmation_number',
                 'lighthouse_updated_at' => nil,
                 'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
-                                             ' (VA Form 21P-534 or VA Form 21P-534EZ)'
+                                             ' (VA Form 21P-534 or VA Form 21P-534EZ)',
+                'intent_to_file_benefits_links' => '[Pension claim for survivors (21P-534EZ)](https://www.va.gov/find-forms/about-form-21p-534ez/)',
+                'itf_api_expiration_date' => expiration_date
               }
             )
+          end
+
+          context 'preparer is surviving dependent' do
+            before do
+              data['preparer_identification'] = 'SURVIVING_DEPENDENT'
+              config[:form_data] = data
+            end
+
+            it 'sends the email' do
+              allow(VANotify::EmailJob).to receive(:perform_async)
+
+              subject = described_class.new(config, notification_type:, user:)
+
+              subject.send
+
+              expect(VANotify::EmailJob).to have_received(:perform_async).with(
+                'survivor@dependent.com',
+                'form21_0966_itf_api_received_email_template_id',
+                {
+                  'first_name' => 'I',
+                  'date_submitted' => date_submitted,
+                  'confirmation_number' => 'confirmation_number',
+                  'lighthouse_updated_at' => nil,
+                  'intent_to_file_benefits' => 'Survivors Pension and/or Dependency and Indemnity Compensation (DIC)' \
+                                               ' (VA Form 21P-534 or VA Form 21P-534EZ)',
+                  'intent_to_file_benefits_links' => '[Pension claim for survivors (21P-534EZ)](https://www.va.gov/find-forms/about-form-21p-534ez/)',
+                  'itf_api_expiration_date' => expiration_date
+                }
+              )
+            end
+          end
+        end
+
+        context 'expiration_date is missing' do
+          let(:config) do
+            { form_data: data, form_number: 'vba_21_0966_intent_api',
+              confirmation_number: 'confirmation_number', date_submitted: }
+          end
+
+          it 'raises ArgumentError' do
+            expect { described_class.new(config, notification_type:, user:) }.to raise_error(ArgumentError)
           end
         end
       end
 
-      context 'template_id is missing', if: notification_type == :received do
+      context 'template_id is missing', unless: notification_type == :received do
+        let(:config) do
+          { form_data: data, form_number: 'vba_21_0966_intent_api',
+            confirmation_number: 'confirmation_number', date_submitted:, expiration_date: }
+        end
+
         let(:data) do
           fixture_path = Rails.root.join(
             'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_0966.json'


### PR DESCRIPTION
## Summary
This PR differentiates between 21-0966s that are submitted async vs sync so that we send a different email in each case, upon submission.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=86250028&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1841
