### PR TITLE
Remove PCIUAddress from Betamocks setup

### DIFF
--- a/docs/setup/betamocks.md
+++ b/docs/setup/betamocks.md
@@ -58,16 +58,6 @@ Each service description has a `base_uri` (pulled from Settings)
 - `method:` a symbol of the http verb `:get`, `:post`, `:put`...
 - `path:` the path that combined with the base_uri makes a full URI
 - `file_path:` where to save the file (relative to betamocks' cache dir)
-```yaml
-:services:
-
-# EVSS::PCIUAddress
-- :base_uri: <%= URI(Settings.evss.url).host %>
-  :endpoints:
-  - :method: :get
-    :path: "/wss-pciu-services-web/rest/pciuServices/v1/states"
-    :file_path: "evss/pciu_address"
-```
 
 3. In config/settings.yml set betamocks recording to true:
 ```yaml

--- a/docs/setup/betamocks.md
+++ b/docs/setup/betamocks.md
@@ -52,12 +52,25 @@ def connection
 end
 ```
 
-2. Add endpoints to be mocked to the services config file.
+2. Add endpoints to be mocked to the [services config file](../../config/betamocks/services_config.yml).
 Each service description has a `base_uri` (pulled from Settings)
 `endpoints` is an array of hashes with:
 - `method:` a symbol of the http verb `:get`, `:post`, `:put`...
 - `path:` the path that combined with the base_uri makes a full URI
 - `file_path:` where to save the file (relative to betamocks' cache dir)
+```yaml
+:services:
+
+# VA Profile / Vet360
+  :base_uri: <%= "#{URI(Settings.vet360.url).host}:#{URI(Settings.vet360.url).port}" %>
+  :endpoints:
+    - :method: :get
+      :path: "/demographics/demographics/v1/*/*"
+      :file_path: "vet360/demographics/default"
+    - :method: :post
+      :path: "/profile-service/profile/v3/*/*"
+      :file_path: "vet360/profile-service/default"
+```
 
 3. In config/settings.yml set betamocks recording to true:
 ```yaml

--- a/docs/setup/betamocks.md
+++ b/docs/setup/betamocks.md
@@ -64,12 +64,9 @@ Each service description has a `base_uri` (pulled from Settings)
 # VA Profile / Vet360
   :base_uri: <%= "#{URI(Settings.vet360.url).host}:#{URI(Settings.vet360.url).port}" %>
   :endpoints:
-    - :method: :get
-      :path: "/demographics/demographics/v1/*/*"
-      :file_path: "vet360/demographics/default"
-    - :method: :post
-      :path: "/profile-service/profile/v3/*/*"
-      :file_path: "vet360/profile-service/default"
+  - :method: :post
+    :path: "/profile-service/profile/v3/*/*"
+    :file_path: "vet360/profile-service/default"
 ```
 
 3. In config/settings.yml set betamocks recording to true:


### PR DESCRIPTION
## Summary

Removes EVSS::PCIUAddress from Betamocks setup as part of EVSS PCIU migration epic.

## Related issue(s)

[Github Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79044)

## Testing done

- Passes all specs. 

## What areas of the site does it impact?
Betamocks setup cleanup.
