### PR TITLE
Change date that is written to the PDF

### DIFF
--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -88,7 +88,6 @@ module Lighthouse
         form['vaFileNumber'] || form['veteranSocialSecurityNumber'],
         address['postalCode'],
         "#{@claim.class} va.gov",
-        @claim.form_id,
         @claim.business_line
       )
     end

--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -45,13 +45,9 @@ module Lighthouse
     def perform(saved_claim_id)
       init(saved_claim_id)
 
+      # Create document stamps
       @pdf_path = process_record(@claim)
 
-      # if @claim.form_id == '21P-530V2'
-      #               process_record(@claim, @claim.created_at, @claim.form_id)
-      #             else
-      #               process_record(@claim)
-      #             end
       @attachment_paths = @claim.persistent_attachments.map { |record| process_record(record) }
 
       create_form_submission_attempt

--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -88,6 +88,7 @@ module Lighthouse
         form['vaFileNumber'] || form['veteranSocialSecurityNumber'],
         address['postalCode'],
         "#{@claim.class} va.gov",
+        @claim.form_id,
         @claim.business_line
       )
     end

--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -42,14 +42,16 @@ module Lighthouse
       end
     end
 
-    def perform(saved_claim_id) # rubocop:disable Metrics/MethodLength
+    def perform(saved_claim_id)
       init(saved_claim_id)
 
-      @pdf_path = if @claim.form_id == '21P-530V2'
-                    process_record(@claim, @claim.created_at, @claim.form_id)
-                  else
-                    process_record(@claim)
-                  end
+      @pdf_path = process_record(@claim)
+
+      # if @claim.form_id == '21P-530V2'
+      #               process_record(@claim, @claim.created_at, @claim.form_id)
+      #             else
+      #               process_record(@claim)
+      #             end
       @attachment_paths = @claim.persistent_attachments.map { |record| process_record(record) }
 
       create_form_submission_attempt
@@ -95,21 +97,27 @@ module Lighthouse
       )
     end
 
-    def process_record(record, timestamp = nil, form_id = nil)
+    def process_record(record)
       pdf_path = record.to_pdf
-      stamped_path1 = PDFUtilities::DatestampPdf.new(pdf_path).run(text: 'VA.GOV', x: 5, y: 5, timestamp:)
+      # coordinates 0, 0 is bottom left of the PDF
+      # This is the bottom left of the form, right under the form date, e.g. "AUG 2022"
+      stamped_path1 = PDFUtilities::DatestampPdf.new(pdf_path).run(text: 'VA.GOV', x: 5, y: 5,
+                                                                   timestamp: record.created_at)
+      # This is the top right of the PDF, above "OMB approved line"
       stamped_path2 = PDFUtilities::DatestampPdf.new(stamped_path1).run(
         text: 'FDC Reviewed - va.gov Submission',
         x: 400,
         y: 770,
         text_only: true
       )
-      document = if form_id.present? && ['21P-530V2'].include?(form_id)
-                   stamped_pdf_with_form(form_id, stamped_path2,
-                                         timestamp)
-                 else
-                   stamped_path2
-                 end
+
+      document = stamped_path2
+
+      if ['21P-530V2'].include?(record.form_id)
+        # If you are doing a burial form, add the extra box that is filled out
+        document = stamped_pdf_with_form(record.form_id, stamped_path2,
+                                         record.created_at)
+      end
 
       @lighthouse_service.valid_document?(document:)
     rescue => e
@@ -132,6 +140,8 @@ module Lighthouse
       }
     end
 
+    # This seems to be specific to burials
+    # This is stamping the (Do not write in this space portion of the PDF)
     def stamped_pdf_with_form(form_id, path, timestamp)
       PDFUtilities::DatestampPdf.new(path).run(
         text: 'Application Submitted on va.gov',

--- a/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
       ).and_return(path)
       allow(service).to receive(:valid_document?).and_return(path)
 
-      expect(job.process_record(record, timestamp, form_id)).to eq(path)
+      expect(job.process_record(record)).to eq(path)
     end
 
     it 'handles an invalid record' do
@@ -190,7 +190,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
       expect(StatsD).to receive(:increment).with('worker.lighthouse.submit_benefits_intake_claim.document_upload_error')
 
       expect do
-        job.process_record(record, timestamp, form_id)
+        job.process_record(record)
       end.to raise_error(BenefitsIntakeService::Service::InvalidDocumentError)
     end
   end

--- a/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
@@ -162,7 +162,6 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
       datestamp_double2 = double
       datestamp_double3 = double
       timestamp = claim.created_at
-      form_id = '21P-530V2'
 
       expect(record).to receive(:to_pdf).and_return('path1')
       expect(PDFUtilities::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)

--- a/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
 
     it 'processes a record and add stamps' do
       record = double
-      allow(record).to receive(:created_at).and_return(claim.created_at)
+      allow(record).to receive_messages({ created_at: nil, form_id: '21P-530' })
       datestamp_double1 = double
       datestamp_double2 = double
 
@@ -103,6 +103,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
 
     it 'processes a 21P-530V2 record and add stamps' do
       record = double
+      allow(record).to receive_messages({ created_at: claim.created_at, form_id: '21P-530V2' })
       datestamp_double1 = double
       datestamp_double2 = double
       datestamp_double3 = double
@@ -138,6 +139,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
 
     it 'handles an invalid record' do
       record = double
+      allow(record).to receive_messages({ created_at: nil, form_id: '21P-530' })
       datestamp_double1 = double
       datestamp_double2 = double
 
@@ -159,6 +161,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
 
     it 'handles an invalid 21P-530V2 record' do
       record = double
+      allow(record).to receive_messages({ created_at: claim.created_at, form_id: '21P-530V2' })
       datestamp_double1 = double
       datestamp_double2 = double
       datestamp_double3 = double

--- a/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
 
     it 'processes a record and add stamps' do
       record = double
+      allow(record).to receive(:created_at).and_return(claim.created_at)
       datestamp_double1 = double
       datestamp_double2 = double
 
@@ -109,7 +110,8 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
 
       expect(record).to receive(:to_pdf).and_return('path1')
       expect(PDFUtilities::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)
-      expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5, timestamp:).and_return('path2')
+      expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5,
+                                                      timestamp: timestamp).and_return('path2')
       expect(PDFUtilities::DatestampPdf).to receive(:new).with('path2').and_return(datestamp_double2)
       expect(datestamp_double2).to receive(:run).with(
         text: 'FDC Reviewed - va.gov Submission',

--- a/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
       datestamp_double2 = double
       datestamp_double3 = double
       timestamp = claim.created_at
-      form_id = '21P-530V2'
 
       expect(record).to receive(:to_pdf).and_return('path1')
       expect(PDFUtilities::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)


### PR DESCRIPTION
## Summary
This is a change to which date is written to the PDF.  I think we should be writing the created_at date, not now().
I've also cleaned up some code and added comments.

This is **not** behind a flipper.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97183


