### PR TITLE
Vebt 674 - VYE update cert_through logic to not include future dates

### DIFF
--- a/modules/vye/app/controllers/vye/v1/verifications_controller.rb
+++ b/modules/vye/app/controllers/vye/v1/verifications_controller.rb
@@ -28,10 +28,23 @@ module Vye
       private
 
       def cert_through_date
-        # act_end is defined as timestamp without time zone
-        found = Time.new(1970, 1, 1, 0, 0, 0, 0) # '1970-01-01 00:00:00'
+        found = Time.new(1970, 1, 1, 0, 0, 0, 0)
+        current_date = Time.zone.today
 
-        pending_verifications.each { |pv| found = pv.act_end if pv.act_end > found }
+        # Get final award end date
+        final_award_end = pending_verifications.map { |pv| pv.act_end.to_date }.max
+
+        if current_date >= final_award_end # If we're on or past the final award, return that final date
+          return pending_verifications.find { |pv| pv.act_end.to_date == final_award_end }&.act_end
+        else
+          # Otherwise, return the end of the previous month
+          month_end = current_date.prev_month.end_of_month
+
+          # Find verification that includes this month end
+          pending_verifications.each do |pv|
+            found = month_end.to_time if pv.act_end.to_date >= month_end
+          end
+        end
 
         return nil if found.eql?(Time.new(1970, 1, 1, 0, 0, 0, 0))
 

--- a/modules/vye/spec/controllers/vye/v1/verifications_controller_spec.rb
+++ b/modules/vye/spec/controllers/vye/v1/verifications_controller_spec.rb
@@ -50,5 +50,32 @@ RSpec.describe Vye::V1::VerificationsController, type: :controller do
         expect(verification.transact_date).to eq(highest_act_end)
       end
     end
+
+    it 'sets the cert_through date based on current date relative to award end dates' do
+      # rubocop:disable RSpec/ConstantDefinitionInBlock
+      VerificationTest = Struct.new(:act_end)
+      # rubocop:enable RSpec/ConstantDefinitionInBlock
+      award_dates = [
+        Time.zone.parse('2024-08-10'),
+        Time.zone.parse('2024-10-15'),
+        Time.zone.parse('2024-12-15')
+      ]
+
+      test_verifications = award_dates.map { |date| VerificationTest.new(date) }
+
+      # rubocop:disable RSpec/SubjectStub
+      allow(subject).to receive(:pending_verifications).and_return(test_verifications)
+      # rubocop:enable RSpec/SubjectStub
+
+      Timecop.freeze(Time.zone.parse('2024-11-15')) do
+        expect(subject.send(:cert_through_date).to_date).to eq(Date.new(2024, 10, 31))
+      end
+
+      # show last award day rather than last day of previous month when award has ended
+      Timecop.freeze(Time.zone.parse('2024-12-15')) do
+        expect(subject.send(:cert_through_date).to_date).to eq(Date.new(2024, 12, 15))
+        expect(subject.send(:cert_through_date).to_date).not_to eq(Date.new(2024, 11, 30))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
-  update vye cert_through logic to not include future dates per this logic:

Award August 01 2024 – Dec 15 2024
 
If the current date is Aug 31 or before Sept 30:
the user should have a cert through date of Aug 31

If the current date is Sept 30 or before Oct 31:
The user should have a cert through date of Sept 30

If the current date is Oct 31 or before Nov 30:
The user should have a cert through date of Oct 31

If the current date is Nov 30 or before Dec 15:
The user should have a cert through date of Nov 30

If the current date is Dec 15 or later
The user should have a cert through date of Dec 15.

The cert through date will always be either the end of a month or during the month, but never in the future. The entire purpose of this application is to verify that the user was in school last month during the time that is on record.

- not a bug
- update cert_through logic to meet above requirements
- VEBT

## Related issue(s)

- [vebt-674](https://jira.devops.va.gov/browse/VEBT-674)

## Testing done

- [x] *New code is covered by unit tests*
- cert_through used latest award end date for cert_through date
- cert_through date in nightly bdn batch job do not contain future dates

## What areas of the site does it impact?
VYE

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

