### PR TITLE
remove my_va_form_submission_statuses feature flag

### DIFF
--- a/app/controllers/v0/my_va/submission_statuses_controller.rb
+++ b/app/controllers/v0/my_va/submission_statuses_controller.rb
@@ -6,7 +6,6 @@ module V0
   module MyVA
     class SubmissionStatusesController < ApplicationController
       service_tag 'form-submission-statuses'
-      before_action :controller_enabled?
 
       def show
         report = Forms::SubmissionStatuses::Report.new(
@@ -20,12 +19,6 @@ module V0
       end
 
       private
-
-      def controller_enabled?
-        unless Flipper.enabled?(:my_va_form_submission_statuses, @current_user)
-          raise Common::Exceptions::Forbidden, detail: 'Submission statuses are disabled.'
-        end
-      end
 
       def allowed_forms
         %w[20-10206 20-10207 21-0845 21-0972 21-10210 21-4142 21-4142a 21P-0847]

--- a/config/features.yml
+++ b/config/features.yml
@@ -1155,9 +1155,6 @@ features:
   my_va_lighthouse_uploads_report:
     actor_type: user
     description: Use lighthouse /uploads/report endpoint for Form status
-  my_va_form_submission_statuses:
-    actor_type: user
-    description: Enables users to view the status of submitted forms.
   my_va_form_submission_pdf_link:
     actor_type: user
     description: Enables users to view PDF link within submitted forms cards

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -3748,7 +3748,6 @@ RSpec.describe 'the v0 API documentation', type: %i[apivore request], order: :de
       let(:headers) { { '_headers' => { 'Cookie' => sign_in(user, nil, true) } } }
 
       before do
-        Flipper.enable(:my_va_form_submission_statuses)
         create(:form_submission, :with_form214142, user_account_id: user.user_account_uuid)
         create(:form_submission, :with_form210845, user_account_id: user.user_account_uuid)
         create(:form_submission, :with_form_blocked, user_account_id: user.user_account_uuid)

--- a/spec/requests/v0/my_va/submission_statuses_spec.rb
+++ b/spec/requests/v0/my_va/submission_statuses_spec.rb
@@ -11,170 +11,149 @@ RSpec.describe 'V0::MyVA::SubmissionStatuses', feature: :form_submission,
     sign_in_as(user)
   end
 
-  context 'when feature flag disabled' do
-    before { Flipper.disable(:my_va_form_submission_statuses) }
+  context 'when user has submissions' do
+    before do
+      create(:form_submission, :with_form214142, user_account_id: user.user_account_uuid)
+      create(:form_submission, :with_form210845, user_account_id: user.user_account_uuid)
+      create(:form_submission, :with_form_blocked, user_account_id: user.user_account_uuid)
+    end
 
-    it 'returns a forbidden message' do
+    it 'returns submission statuses' do
       VCR.use_cassette('forms/submission_statuses/200_valid') do
         get '/v0/my_va/submission_statuses'
       end
 
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to have_http_status(:ok)
 
-      error = JSON.parse(response.body)['errors'].first
-      expect(error['detail']).to eq('Submission statuses are disabled.')
+      results = JSON.parse(response.body)['data']
+      expect(results.size).to eq(2)
+    end
+
+    it 'returns all fields' do
+      VCR.use_cassette('forms/submission_statuses/200_valid') do
+        get '/v0/my_va/submission_statuses'
+      end
+
+      expect(response).to have_http_status(:ok)
+
+      results = JSON.parse(response.body)['data']
+      keys = %w[id detail form_type message status created_at updated_at]
+      expect(results.first['attributes'].keys.sort).to eq(keys.sort)
+    end
+
+    context 'when intake status response has an error' do
+      it 'responds with an errors collection' do
+        VCR.use_cassette('forms/submission_statuses/401_invalid') do
+          get '/v0/my_va/submission_statuses'
+        end
+
+        expect(response).to have_http_status(296)
+        keys = %w[status source title detail]
+
+        error = JSON.parse(response.body)['errors'].first
+        expect(error.keys.sort).to eq(keys.sort)
+
+        expect(error['source']).to eq('Lighthouse - Benefits Intake API')
+      end
+    end
+
+    context 'when intake status request is unauthorized' do
+      it 'responds with an unauthorized error message' do
+        VCR.use_cassette('forms/submission_statuses/401_invalid') do
+          get '/v0/my_va/submission_statuses'
+        end
+
+        expect(response).to have_http_status(296)
+
+        error = JSON.parse(response.body)['errors'].first
+        expect(error['status']).to eq(401)
+        expect(error['title']).to eq('Form Submission Status: Unauthorized')
+      end
+    end
+
+    context 'when the intake status request payload is too large' do
+      it 'responds with a request entity too large message' do
+        VCR.use_cassette('forms/submission_statuses/413_invalid') do
+          get '/v0/my_va/submission_statuses'
+        end
+
+        expect(response).to have_http_status(296)
+
+        error = JSON.parse(response.body)['errors'].first
+        expect(error['status']).to eq(413)
+        expect(error['title']).to eq('Form Submission Status: Request Entity Too Large')
+      end
+    end
+
+    context 'when the intake service is unable to process entity' do
+      it 'responds with an unprocessable content message' do
+        VCR.use_cassette('forms/submission_statuses/422_invalid') do
+          get '/v0/my_va/submission_statuses'
+        end
+
+        expect(response).to have_http_status(296)
+
+        error = JSON.parse(response.body)['errors'].first
+        expect(error['status']).to eq(422)
+        expect(error['title']).to eq('Form Submission Status: Unprocessable Content')
+      end
+
+      context 'when too many requests are sent to the intake service' do
+        it 'responds with a rate limit exceeded message' do
+          VCR.use_cassette('forms/submission_statuses/429_invalid') do
+            get '/v0/my_va/submission_statuses'
+          end
+
+          expect(response).to have_http_status(296)
+
+          error = JSON.parse(response.body)['errors'].first
+          expect(error['status']).to eq(429)
+          expect(error['title']).to eq('Form Submission Status: Too Many Requests')
+        end
+      end
+    end
+
+    context 'when an unexpected intake service server error occurs' do
+      it 'returns an internal server error' do
+        VCR.use_cassette('forms/submission_statuses/500_invalid') do
+          get '/v0/my_va/submission_statuses'
+        end
+
+        expect(response).to have_http_status(296)
+
+        error = JSON.parse(response.body)['errors'].first
+        expect(error['status']).to eq(500)
+        expect(error['title']).to eq('Form Submission Status: Internal Server Error')
+      end
+    end
+
+    context 'when the request to the intake service takes too long' do
+      it 'returns a getway timeout message' do
+        VCR.use_cassette('forms/submission_statuses/504_invalid') do
+          get '/v0/my_va/submission_statuses'
+        end
+
+        expect(response).to have_http_status(296)
+
+        error = JSON.parse(response.body)['errors'].first
+        expect(error['status']).to eq(504)
+        expect(error['title']).to eq('Form Submission Status: Gateway Timeout')
+      end
     end
   end
 
-  context 'when feature flag enabled' do
+  context 'when user has no submissions' do
     before do
-      Flipper.enable(:my_va_form_submission_statuses)
+      allow_any_instance_of(Forms::SubmissionStatuses::Gateway).to receive(:submissions).and_return([])
     end
 
-    context 'when user has submissions' do
-      before do
-        create(:form_submission, :with_form214142, user_account_id: user.user_account_uuid)
-        create(:form_submission, :with_form210845, user_account_id: user.user_account_uuid)
-        create(:form_submission, :with_form_blocked, user_account_id: user.user_account_uuid)
-      end
+    it 'returns an empty array' do
+      get '/v0/my_va/submission_statuses'
 
-      it 'returns submission statuses' do
-        VCR.use_cassette('forms/submission_statuses/200_valid') do
-          get '/v0/my_va/submission_statuses'
-        end
+      expect(response).to have_http_status(:ok)
 
-        expect(response).to have_http_status(:ok)
-
-        results = JSON.parse(response.body)['data']
-        expect(results.size).to eq(2)
-      end
-
-      it 'returns all fields' do
-        VCR.use_cassette('forms/submission_statuses/200_valid') do
-          get '/v0/my_va/submission_statuses'
-        end
-
-        expect(response).to have_http_status(:ok)
-
-        results = JSON.parse(response.body)['data']
-        keys = %w[id detail form_type message status created_at updated_at]
-        expect(results.first['attributes'].keys.sort).to eq(keys.sort)
-      end
-
-      context 'when intake status response has an error' do
-        it 'responds with an errors collection' do
-          VCR.use_cassette('forms/submission_statuses/401_invalid') do
-            get '/v0/my_va/submission_statuses'
-          end
-
-          expect(response).to have_http_status(296)
-          keys = %w[status source title detail]
-
-          error = JSON.parse(response.body)['errors'].first
-          expect(error.keys.sort).to eq(keys.sort)
-
-          expect(error['source']).to eq('Lighthouse - Benefits Intake API')
-        end
-      end
-
-      context 'when intake status request is unauthorized' do
-        it 'responds with an unauthorized error message' do
-          VCR.use_cassette('forms/submission_statuses/401_invalid') do
-            get '/v0/my_va/submission_statuses'
-          end
-
-          expect(response).to have_http_status(296)
-
-          error = JSON.parse(response.body)['errors'].first
-          expect(error['status']).to eq(401)
-          expect(error['title']).to eq('Form Submission Status: Unauthorized')
-        end
-      end
-
-      context 'when the intake status request payload is too large' do
-        it 'responds with a request entity too large message' do
-          VCR.use_cassette('forms/submission_statuses/413_invalid') do
-            get '/v0/my_va/submission_statuses'
-          end
-
-          expect(response).to have_http_status(296)
-
-          error = JSON.parse(response.body)['errors'].first
-          expect(error['status']).to eq(413)
-          expect(error['title']).to eq('Form Submission Status: Request Entity Too Large')
-        end
-      end
-
-      context 'when the intake service is unable to process entity' do
-        it 'responds with an unprocessable content message' do
-          VCR.use_cassette('forms/submission_statuses/422_invalid') do
-            get '/v0/my_va/submission_statuses'
-          end
-
-          expect(response).to have_http_status(296)
-
-          error = JSON.parse(response.body)['errors'].first
-          expect(error['status']).to eq(422)
-          expect(error['title']).to eq('Form Submission Status: Unprocessable Content')
-        end
-
-        context 'when too many requests are sent to the intake service' do
-          it 'responds with a rate limit exceeded message' do
-            VCR.use_cassette('forms/submission_statuses/429_invalid') do
-              get '/v0/my_va/submission_statuses'
-            end
-
-            expect(response).to have_http_status(296)
-
-            error = JSON.parse(response.body)['errors'].first
-            expect(error['status']).to eq(429)
-            expect(error['title']).to eq('Form Submission Status: Too Many Requests')
-          end
-        end
-      end
-
-      context 'when an unexpected intake service server error occurs' do
-        it 'returns an internal server error' do
-          VCR.use_cassette('forms/submission_statuses/500_invalid') do
-            get '/v0/my_va/submission_statuses'
-          end
-
-          expect(response).to have_http_status(296)
-
-          error = JSON.parse(response.body)['errors'].first
-          expect(error['status']).to eq(500)
-          expect(error['title']).to eq('Form Submission Status: Internal Server Error')
-        end
-      end
-
-      context 'when the request to the intake service takes too long' do
-        it 'returns a getway timeout message' do
-          VCR.use_cassette('forms/submission_statuses/504_invalid') do
-            get '/v0/my_va/submission_statuses'
-          end
-
-          expect(response).to have_http_status(296)
-
-          error = JSON.parse(response.body)['errors'].first
-          expect(error['status']).to eq(504)
-          expect(error['title']).to eq('Form Submission Status: Gateway Timeout')
-        end
-      end
-    end
-
-    context 'when user has no submissions' do
-      before do
-        allow_any_instance_of(Forms::SubmissionStatuses::Gateway).to receive(:submissions).and_return([])
-      end
-
-      it 'returns an empty array' do
-        get '/v0/my_va/submission_statuses'
-
-        expect(response).to have_http_status(:ok)
-
-        results = JSON.parse(response.body)['data']
-        expect(results).to be_empty
-      end
+      results = JSON.parse(response.body)['data']
+      expect(results).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR removes the `my_va_form_submission_statuses` feature toggle from config list

## Related issue(s)

- ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/94831
- cleanup PR on `vets-website`: https://github.com/department-of-veterans-affairs/vets-website/pull/33081

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
