### PR TITLE
Don't break on empty data

### DIFF
--- a/modules/representation_management/lib/representation_management/v0/pdf_constructor/form_2122a.rb
+++ b/modules/representation_management/lib/representation_management/v0/pdf_constructor/form_2122a.rb
@@ -205,7 +205,7 @@ module RepresentationManagement
             # 19b Consent Outside Access
             "#{PAGE2_KEY}.Checkbox_I_Authorize_VA_To_Disclose_All_My_Records_Other_Than_As_Provided_In_Items_20_And_21[1]": data.consent_outside_access == true ? 1 : 0,
             # 19b text box
-            "#{PAGE2_KEY}.Provide_The_Names_Of_The_Individuals_Here[0]": data.consent_team_members.to_sentence
+            "#{PAGE2_KEY}.Provide_The_Names_Of_The_Individuals_Here[0]": data.consent_team_members&.to_sentence
           }
         end
         # rubocop:enable Metrics/LineLength

--- a/modules/representation_management/spec/requests/representation_management/v0/pdf_generator_2122a_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/pdf_generator_2122a_spec.rb
@@ -115,6 +115,21 @@ RSpec.describe 'RepresentationManagement::V0::PdfGenerator2122a', type: :request
       end
     end
 
+    context 'When submitting without consent_team_members' do
+      before do
+        params[:pdf_generator2122a].delete(:consent_team_members)
+        post(base_path, params:)
+      end
+
+      it 'responds with a ok status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'responds with a PDF' do
+        expect(response.content_type).to eq('application/pdf')
+      end
+    end
+
     context 'when triggering validation errors' do
       context 'when submitting without the representative first name for a single validation error' do
         before do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform):* A line that was expecting data was breaking because that data wasn't being sent along yet.  That code now tolerates empty data.
- *(If bug, how to reproduce):* Go through the 2122a appoint a rep flow on staging.
- *(What is the solution, why is this the solution?):* This will allow the 2122a to generate a PDF successfully.
- *(Which team do you work for, does your team own the maintenance of this component?):* FAR/ARM, yes.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97553
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change:* 500 error
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing:* Use the staging frontend to create a request body and submit it to the 2122a endpoint.  It should return a PDF.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas):* Just the `representation_management` module.

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
