### PR TITLE
Decrease timeouts in code checks

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Database
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_minutes: 20
+          timeout_minutes: 10
           retry_wait_seconds: 3 # Seconds
           max_attempts: 3
           command: |
@@ -134,7 +134,7 @@ jobs:
               -c "CI=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_test -n 24  -e 'bin/rails db:reset'"
 
       - name: Run Specs
-        timeout-minutes: 20
+        timeout-minutes: 15
         run: |
           docker compose -f docker-compose.test.yml run web bash \
           -c "CI=true DISABLE_BOOTSNAP=true bundle exec parallel_rspec spec/ modules/ -n 24 -o '--color --tty'"


### PR DESCRIPTION
## Summary
When tests run successfully (whether they pass or fail), they finish in 6-8 minutes. But for the past couple months, we've seen tests hit the timeout–not because tests are still running–things just stall out. Ticket to address the root cause is linked below. 

I've never seen the database take much time at all (< a few min). We could decrease the tests more if we want 🤷 

## Related issue(s)

- To actually resolve the issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/97560


## What areas of the site does it impact?
code checks in CI