### PR TITLE
Handle 20-10206 error message scrubbing

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -29,6 +29,10 @@ module SimpleFormsApi
       @data.dig('address', 'country') == 'USA'
     end
 
+    def words_to_remove
+      citizen_ssn + address + date_of_birth + home_phone
+    end
+
     def desired_stamps
       []
     end
@@ -54,6 +58,36 @@ module SimpleFormsApi
       identity = data['preparer_type']
       StatsD.increment("#{STATS_KEY}.#{identity}")
       Rails.logger.info('Simple forms api - 20-10206 submission user identity', identity:, confirmation_number:)
+    end
+
+    private
+
+    def citizen_ssn
+      [
+        data.dig('citizen_id', 'ssn')&.[](0..2),
+        data.dig('citizen_id', 'ssn')&.[](3..4),
+        data.dig('citizen_id', 'ssn')&.[](5..8)
+      ]
+    end
+
+    def address
+      [data.dig('address', 'postal_code')&.[](0..4), data.dig('address', 'postal_code')&.[](5..8)]
+    end
+
+    def date_of_birth
+      [
+        data['date_of_birth']&.[](0..3),
+        data['date_of_birth']&.[](5..6),
+        data['date_of_birth']&.[](8..9)
+      ]
+    end
+
+    def home_phone
+      [
+        data['home_phone']&.gsub('-', '')&.[](0..2),
+        data['home_phone']&.gsub('-', '')&.[](3..5),
+        data['home_phone']&.gsub('-', '')&.[](6..9)
+      ]
     end
   end
 end

--- a/modules/simple_forms_api/lib/simple_forms_api.rb
+++ b/modules/simple_forms_api/lib/simple_forms_api.rb
@@ -39,6 +39,8 @@ module SimpleFormsApi
           words_to_remove += SimpleFormsApi::VBA210966.new(params).words_to_remove
         when '20-10207'
           words_to_remove += SimpleFormsApi::VBA2010207.new(params).words_to_remove
+        when '20-10206'
+          words_to_remove += SimpleFormsApi::VBA2010206.new(params).words_to_remove
         when '40-10007'
           words_to_remove += SimpleFormsApi::VBA4010007.new(params).words_to_remove
         else


### PR DESCRIPTION
## Summary
This PR handles scrubbing error messages for 20-10206 so that we can still glean _something_ from the message without it revealing PII.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=88138715&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1874
