### PR TITLE
Api 41366 replace bgs ext poa vbms updater

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -214,6 +214,10 @@ features:
     actor_type: user
     description: Diverts codepath to LocalBGSRefactored
     enable_in_development: true
+  claims_api_poa_vbms_updater_uses_local_bgs:
+    actor_type: user
+    description: Enables poa vbms updater to use local_bgs
+    enable_in_development: true
   claims_api_bd_refactor:
     actor_type: user
     description: Diverts codepath to use refactored BD methods

--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -79,6 +79,37 @@ module ClaimsApi
       end
 
       ##
+      # CorporateUpdateServiceBean
+      #
+      module CorporateUpdateServiceBean
+        DEFINITION =
+          Bean.new(
+            path: 'CorporateUpdateServiceBean',
+            namespaces: Namespaces.new(
+              target: 'http://services.share.benefits.vba.va.gov/',
+              data: nil
+            )
+          )
+      end
+
+      module CorporateUpdateWebService
+        DEFINITION =
+          Service.new(
+            bean: CorporateUpdateServiceBean::DEFINITION,
+            path: 'CorporateUpdateWebService'
+          )
+
+        module UpdatePoaAccess
+          DEFINITION =
+            Action.new(
+              service: CorporateUpdateWebService::DEFINITION,
+              name: 'updatePoaAccess',
+              key: 'return'
+            )
+        end
+      end
+
+      ##
       # EBenefitsBnftClaimStatusWebServiceBean
       #
       module EBenefitsBenefitClaimStatusWebServiceBean

--- a/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bgs'
+require 'bgs_service/corporate_update_service'
 
 module ClaimsApi
   class PoaVBMSUpdater < ClaimsApi::ServiceBase
@@ -17,7 +18,7 @@ module ClaimsApi
         poa_code:
       )
 
-      response = update_poa_access(participant_id: poa_form.auth_headers['va_eauth_pid'],
+      response = update_poa_access(poa_form:, participant_id: poa_form.auth_headers['va_eauth_pid'],
                                    poa_code:, allow_poa_access: 'y')
 
       if response[:return_code] == 'GUIE50000'
@@ -46,7 +47,7 @@ module ClaimsApi
       poa_form.form_data['consentAddressChange']
     end
 
-    def update_poa_access(participant_id:, poa_code:, allow_poa_access:)
+    def update_poa_access(poa_form:, participant_id:, poa_code:, allow_poa_access:)
       # allow_poa_c_add reports 'No Data' if sent lowercase
       if Flipper.enabled? :claims_api_poa_vbms_updater_uses_local_bgs
         service = corporate_update_service

--- a/modules/claims_api/lib/bgs_service/corporate_update_service.rb
+++ b/modules/claims_api/lib/bgs_service/corporate_update_service.rb
@@ -1,0 +1,19 @@
+module ClaimsApi
+  class CorporateUpdateService < ClaimsApi::LocalBGS
+    def bean_name
+      'CorporateUpdateServiceBean/CorporateUpdateWebService'
+    end
+
+    def update_poa_access(participant_id:, poa_code:, allow_poa_access: 'y', allow_poa_c_add: 'y')
+      body = Nokogiri::XML::DocumentFragment.parse <<~EOXML
+        <ptcpntId>#{participant_id}</ptcpntId>
+        <poa>#{poa_code}</poa>
+        <allowPoaAccess>#{allow_poa_access}</allowPoaAccess>
+        <allowPoaCadd>#{allow_poa_c_add}</allowPoaCadd>
+      EOXML
+
+      response = make_request(endpoint: bean_name, action: 'update_poa_access', body:, key: 'return')
+      response&.dig(:body, :update_poa_access_response) || response
+    end
+  end
+end

--- a/modules/claims_api/lib/bgs_service/corporate_update_service.rb
+++ b/modules/claims_api/lib/bgs_service/corporate_update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClaimsApi
   class CorporateUpdateService < ClaimsApi::LocalBGS
     def bean_name

--- a/modules/claims_api/spec/lib/claims_api/find_definition_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/find_definition_spec.rb
@@ -31,6 +31,21 @@ describe ClaimsApi::LocalBGSRefactored::FindDefinition do
         end
       end
 
+      context 'CorporateUpdateServiceBean' do
+        let(:endpoint) { 'CorporateUpdateServiceBean/CorporateUpdateWebService' }
+        let(:action) { 'updatePoaAccess' }
+        let(:key) { 'return' }
+
+        it 'response with the correct attributes for CorporateUpdateServiceBean' do
+          result = subject.for_action(endpoint, action)
+          parsed_result = JSON.parse(result.to_json)
+
+          expect(parsed_result['service']['bean']['path']).to eq 'CorporateUpdateServiceBean'
+          expect(parsed_result['service']['path']).to eq 'CorporateUpdateWebService'
+          expect(parsed_result['service']['bean']['namespaces']['target']).to eq 'http://services.share.benefits.vba.va.gov/'
+        end
+      end
+
       context 'EBenefitsBnftClaimStatusWebServiceBean' do
         let(:endpoint) { 'EBenefitsBnftClaimStatusWebServiceBean/EBenefitsBnftClaimStatusWebService' }
         let(:action) { 'findBenefitClaimsStatusByPtcpntId' }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Adds flipper feature in config
- Adds logic to PoaVBMSUpdater for flipper
- Adds CorporateUpdateWebService & definitions
- Updates tests

## Related issue(s)

[API-41366](https://jira.devops.va.gov/browse/API-41366)

## Testing done

- [x] *New code is covered by unit tests*
- Local Postman tests for v1 submit_form_2122 & v2 submit_power_of_attorney


## What areas of the site does it impact?
POA VBMS Updater logic

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

