### PR TITLE
VACMS-11590 Remove facilities_ppms_suppress_community_care flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -550,9 +550,6 @@ features:
   facilities_ppms_suppress_all:
     actor_type: user
     description: Hide all ppms search options
-  facilities_ppms_suppress_community_care:
-    actor_type: user
-    description: Hide ppms community care searches
   facilities_ppms_suppress_pharmacies:
     actor_type: user
     description: Front End Flag to suppress the ability to search for pharmacies


### PR DESCRIPTION
## Summary
Removal of `facilities_ppms_suppress_community_care` flipper.

Flipper is currently OFF in production:

<img width="848" alt="388290861-88e6d704-7b14-4bb7-840a-2a98c2303482" src="https://github.com/user-attachments/assets/c5490689-21e9-4968-9bb5-687d5149c116">

Flipper is currently OFF in staging:
<img width="852" alt="388290854-b91fc76e-cbe6-4d48-89a6-5b03762b31fe" src="https://github.com/user-attachments/assets/38b25fb0-ecb6-4202-a433-a3c0024fcbe1">

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11590

vets-website PR for removing all usage of this flipper: https://github.com/department-of-veterans-affairs/vets-website/pull/33147