### PR TITLE
Api 41369 replace bgsext in vbms upload

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -241,6 +241,10 @@ features:
     actor_type: user
     description: When enabled, sends 526 forms to BD via the refactored logic
     enable_in_development: true
+  claims_api_poa_vbms_updater_uses_local_bgs:
+    actor_type: user
+    description: Enables poa vbms updater to use local_bgs
+    enable_in_development: true
   confirmation_page_new:
     actor_type: user
     description: Enables the 2024 version of the confirmation page view in simple forms

--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -79,6 +79,17 @@ module ClaimsApi
       end
 
       ##
+      # CorporateUpdateServiceBean
+      #
+      module CorporateUpdateWebService
+        DEFINITION =
+          Service.new(
+            bean: CorporateUpdateServiceBean::DEFINITION,
+            path: 'ClaimantWebService'
+          )
+      end
+
+      ##
       # EBenefitsBnftClaimStatusWebServiceBean
       #
       module EBenefitsBenefitClaimStatusWebServiceBean

--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -83,9 +83,12 @@ module ClaimsApi
       #
       module CorporateUpdateWebService
         DEFINITION =
-          Service.new(
-            bean: CorporateUpdateServiceBean::DEFINITION,
-            path: 'ClaimantWebService'
+          Bean.new(
+            path: 'CorporateUpdateWebService',
+            namespaces: Namespaces.new(
+              target: 'http://services.share.benefits.vba.va.gov/',
+              data: nil
+            )
           )
       end
 

--- a/modules/claims_api/lib/bgs_service/corporate_update_web_service.rb
+++ b/modules/claims_api/lib/bgs_service/corporate_update_web_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  class CorporateUpdateWebService < ClaimsApi::LocalBGS
+    def bean_name
+      'CorporateUpdateServiceBean'
+    end
+
+    def corporate_update
+      self
+    end
+
+    # update a POA relationship
+    def update_poa_access(participant_id:, poa_code:, allow_poa_access: 'y', allow_poa_c_add: 'y')
+      body = Nokogiri::XML::DocumentFragment.parse <<~EOXML
+        <ptcpntId>#{participant_id}</ptcpntId>
+        <poa>#{poa_code}</poa>
+        <allowPoaAccess>#{allow_poa_access}</allowPoaAccess>
+        <allowPoaCadd>#{allow_poa_c_add}</allowPoaCadd>
+      EOXML
+
+      response = make_request(endpoint: bean_name, action: 'updatePoaAccess', body:)
+      response[:return]
+    end
+  end
+end

--- a/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
@@ -1,87 +1,100 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'bgs_service/corporate_update_web_service'
 
 RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
   subject { described_class }
 
-  before do
-    Sidekiq::Job.clear_all
-  end
+  [true, false].each do |flipped|
+    before do
+      Sidekiq::Job.clear_all
 
-  let(:user) { FactoryBot.create(:user, :loa3) }
-  let(:auth_headers) do
-    headers = EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
-    headers['va_eauth_pnid'] = '796104437'
-    headers
-  end
-
-  context 'when address change is present and allowed' do
-    let(:allow_poa_c_add) { 'Y' }
-    let(:consent_address_change) { true }
-
-    it 'updates a the BIRLS record for a qualifying POA submittal' do
-      poa = create_poa
-      create_mock_lighthouse_service
-      subject.new.perform(poa.id)
+      if flipped
+        Flipper.enable(:claims_api_poa_vbms_updater_uses_local_bgs)
+        @clazz = ClaimsApi::CorporateUpdateWebService
+        # @clazz_new =
+      else
+        Flipper.disable(:claims_api_poa_vbms_updater_uses_local_bgs)
+        @clazz = BGS::Services
+        # @clazz.new =
+      end
     end
-  end
 
-  context 'when address change is present and not allowed' do
-    let(:allow_poa_c_add) { 'N' }
-    let(:consent_address_change) { false }
-
-    it 'updates a the BIRLS record for a qualifying POA submittal' do
-      poa = create_poa
-      create_mock_lighthouse_service
-      subject.new.perform(poa.id)
+    let(:user) { FactoryBot.create(:user, :loa3) }
+    let(:auth_headers) do
+      headers = EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
+      headers['va_eauth_pnid'] = '796104437'
+      headers
     end
-  end
 
-  context 'when address change is not present' do
-    let(:allow_poa_c_add) { 'N' }
-    let(:consent_address_change) { nil }
+    context 'when address change is present and allowed' do
+      let(:allow_poa_c_add) { 'Y' }
+      let(:consent_address_change) { true }
 
-    it 'updates a the BIRLS record for a qualifying POA submittal' do
-      poa = create_poa
-      create_mock_lighthouse_service
-      subject.new.perform(poa.id)
+      it 'updates a the BIRLS record for a qualifying POA submittal' do
+        poa = create_poa
+        create_mock_lighthouse_service
+        subject.new.perform(poa.id)
+      end
     end
-  end
 
-  context 'when BGS fails the error is handled' do
-    let(:allow_poa_c_add) { 'Y' }
-    let(:consent_address_change) { true }
+    context 'when address change is present and not allowed' do
+      let(:allow_poa_c_add) { 'N' }
+      let(:consent_address_change) { false }
 
-    it 'marks the form as errored' do
-      poa = create_poa
-      create_mock_lighthouse_service_bgs_failure # API-31645 real life example
-      subject.new.perform(poa.id)
-
-      poa.reload
-      expect(poa.status).to eq('errored')
-      expect(poa.vbms_error_message).to eq('updatePoaAccess: No POA found on system of record')
+      it 'updates a the BIRLS record for a qualifying POA submittal' do
+        poa = create_poa
+        create_mock_lighthouse_service
+        subject.new.perform(poa.id)
+      end
     end
-  end
 
-  context 'when an errored job has exhausted its retries' do
-    let(:allow_poa_c_add) { 'Y' }
-    let(:consent_address_change) { true }
+    context 'when address change is not present' do
+      let(:allow_poa_c_add) { 'N' }
+      let(:consent_address_change) { nil }
 
-    it 'logs to the ClaimsApi Logger' do
-      poa = create_poa
-      error_msg = 'An error occurred for the POA VBMS Updater Job'
-      msg = { 'args' => [poa.id],
-              'class' => subject,
-              'error_message' => error_msg }
+      it 'updates a the BIRLS record for a qualifying POA submittal' do
+        poa = create_poa
+        create_mock_lighthouse_service
+        subject.new.perform(poa.id)
+      end
+    end
 
-      described_class.within_sidekiq_retries_exhausted_block(msg) do
-        expect(ClaimsApi::Logger).to receive(:log).with(
-          'claims_api_retries_exhausted',
-          record_id: poa.id,
-          detail: "Job retries exhausted for #{subject}",
-          error: error_msg
-        )
+    context 'when BGS fails the error is handled' do
+      let(:allow_poa_c_add) { 'Y' }
+      let(:consent_address_change) { true }
+
+      it 'marks the form as errored' do
+        poa = create_poa
+        create_mock_lighthouse_service_bgs_failure # API-31645 real life example
+        subject.new.perform(poa.id)
+
+        poa.reload
+        expect(poa.status).to eq('errored')
+        expect(poa.vbms_error_message).to eq('updatePoaAccess: No POA found on system of record')
+      end
+    end
+
+    context 'when an errored job has exhausted its retries' do
+      let(:allow_poa_c_add) { 'Y' }
+      let(:consent_address_change) { true }
+
+      it 'logs to the ClaimsApi Logger' do
+        poa = create_poa
+        error_msg = 'An error occurred for the POA VBMS Updater Job'
+        msg = { 'args' => [poa.id],
+                'class' => subject,
+                'error_message' => error_msg }
+
+        described_class.within_sidekiq_retries_exhausted_block(msg) do
+          expect(ClaimsApi::Logger).to receive(:log).with(
+            'claims_api_retries_exhausted',
+            record_id: poa.id,
+            detail: "Job retries exhausted for #{subject}",
+            error: error_msg
+          )
+        end
       end
     end
   end
@@ -99,7 +112,7 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
   end
 
   def create_mock_lighthouse_service
-    corporate_update_stub = BGS::Services.new(external_uid: 'uid', external_key: 'key').corporate_update
+    corporate_update_stub = @clazz.new(external_uid: 'uid', external_key: 'key').corporate_update
     expect(corporate_update_stub).to receive(:update_poa_access).with(
       participant_id: user.participant_id,
       poa_code: '074',
@@ -112,7 +125,7 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
   end
 
   def create_mock_lighthouse_service_bgs_failure
-    allow_any_instance_of(BGS::Services).to receive(:corporate_update) do |_instance|
+    allow_any_instance_of(@clazz).to receive(:corporate_update) do |_instance|
       corporate_update_stub = instance_double('BGS::CorporateUpdate')
       allow(corporate_update_stub).to receive(:update_poa_access)
         .with(
@@ -124,7 +137,7 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
       corporate_update_stub
     end
 
-    allow(BGS::Services).to receive(:new) do
+    allow(@clazz).to receive(:new) do
       services_double = instance_double('BGS::Services')
       allow(services_double).to receive(:corporate_update)
         .and_raise(BGS::ShareError.new('updatePoaAccess: No POA found on system of record'))


### PR DESCRIPTION
## Summary
* _The test file makes it appears as if a bunch of tests changed, they did not.  All I did was update it to under with and without the feature flag enabled and switch between the classes that need to be called, probably easier to look at in your editor to see that._
* Adds `corporate_update_web_service`
* Adds to definition file
* Adds feature flag
* Updates `poa_vbms_updater` to use` local_bgs` when feature flag enabled
* Updates `poa_vbms_updater_spec` to have tests with feature flag enabled and disabled
* 
## Related issue(s)
[API-41369](https://jira.devops.va.gov/browse/API-41369)

## Testing done

#### Testing Notes
* This one can be tested doing a v2 POA submit as the Veteran (not dependent)
* Easiest way to verify is check the response code when it runs with the feature flag enabled.
* Then of course you can also:
```
@ssl_verify_mode =
if Settings.bgs.ssl_verify_mode == 'none'
OpenSSL::SSL::VERIFY_NONE
else
OpenSSL::SSL::VERIFY_PEER
end

ClaimsApi::LocalBGS.new(external_uid:'a', external_key:'b').fetch_namespace(Faraday::Connection.new(ssl: { verify_mode: @ssl_verify_mode }), "CorporateUpdateServiceBean/CorporateUpdateServiceBean/CorporateUpdateWebService")
```
* Should get `=> "http://services.share.benefits.vba.va.gov/"`

## Screenshots

## What areas of the site does it impact?
	modified:   modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
	new file:   modules/claims_api/lib/bgs_service/corporate_update_web_service.rb
	modified:   modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
