### PR TITLE
Remove obsolete feature toggles

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1386,10 +1386,6 @@ features:
     actor_type: user
     description: Toggle for new vaos service va appointments.
     enable_in_development: true
-  va_online_scheduling_facilities_service_v2:
-    actor_type: user
-    description: Toggle for new mobile facility service v2 endpoints
-    enable_in_development: true
   va_online_scheduling_vaos_v2_next:
     actor_type: user
     enable_in_development: true
@@ -1414,14 +1410,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for proof of concept to help Veteran contact a facility when the type of care is not available
-  va_online_scheduling_after_visit_summary:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for After visit summary feature.
-  va_online_scheduling_start_scheduling_link:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for Start Scheduling action link.
   va_dependents_v2:
     actor_type: user
     description: Allows us to toggle bewteen V1 and V2 of the 686c-674 forms.

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -15,7 +15,6 @@ module VAOS
       AVS_ERROR_MESSAGE = 'Error retrieving AVS link'
       MANILA_PHILIPPINES_FACILITY_ID = '358'
 
-      AVS_FLIPPER = :va_online_scheduling_after_visit_summary
       ORACLE_HEALTH_CANCELLATIONS = :va_online_scheduling_enable_OH_cancellations
       APPOINTMENTS_USE_VPG = :va_online_scheduling_use_vpg
       APPOINTMENTS_ENABLE_OH_REQUESTS = :va_online_scheduling_enable_OH_requests
@@ -326,9 +325,7 @@ module VAOS
 
         extract_appointment_fields(appointment)
 
-        if avs_applicable?(appointment, include[:avs]) && Flipper.enabled?(AVS_FLIPPER, user)
-          fetch_avs_and_update_appt_body(appointment)
-        end
+        fetch_avs_and_update_appt_body(appointment) if avs_applicable?(appointment, include[:avs])
 
         if cc?(appointment) && %w[proposed cancelled].include?(appointment[:status])
           find_and_merge_provider_name(appointment)

--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -331,7 +331,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
         context 'using VAOS' do
           before do
             Flipper.disable(:va_online_scheduling_use_vpg)
-            Flipper.enable(:va_online_scheduling_after_visit_summary)
           end
 
           it 'fetches appointment list and includes avs on past booked appointments' do
@@ -658,7 +657,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
       context 'when the VAOS service returns a single appointment' do
         before do
           Flipper.disable(:va_online_scheduling_use_vpg)
-          Flipper.enable(:va_online_scheduling_after_visit_summary)
         end
 
         let(:avs_path) do


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This PR removes three feature toggles:
  - va_online_scheduling_after_visit_summary
  - va_online_scheduling_facilities_service_v2
  - va_online_scheduling_start_scheduling_link
- Appointments (VAOS) Team
- After code is removed, I'll proceed with removing the toggles from the ArgoCD environments

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95921
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95924
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95925

## Testing done

- Updated and ensured all existing tests pass

## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
