### PR TITLE
[VI-694] Recache MPI when MHV User Account API runs

### DIFF
--- a/app/services/mhv/user_account/creator.rb
+++ b/app/services/mhv/user_account/creator.rb
@@ -32,7 +32,7 @@ module MHV
       def create_mhv_user_account!
         account = MHVUserAccount.new(mhv_account_creation_response)
         account.validate!
-
+        MPIData.find(icn)&.destroy
         account
       end
 


### PR DESCRIPTION
## Summary

- This PR resets the MPI cache when the MHV User Account API is completed

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-694

## Testing done

- [ ] 

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ]  Authenticate with user who has at least one treatment facility ID in MPI
- [ ]  Confirm MHV User Account API was requested
- [ ]  Confirm MPI cache was broken by confirming an extra MPI call was made
