### PR TITLE
feat(vets-api): Configure ExternalSecrets to Read Secrets from External AWS Account

### DIFF
--- a/chart/templates/environment-secrets.yaml
+++ b/chart/templates/environment-secrets.yaml
@@ -44,3 +44,39 @@ spec:
         - regexp:
             source: "[^a-zA-Z0-9 -]"
             target: "_"
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vets-api-checkin-SecretsManager-secretstore
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-4"
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-gov-west-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: vets-api
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: checkin-secretsmanager-vars
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  secretStoreRef:
+    name: vets-api-checkin-SecretsManager-secretstore
+    kind: SecretStore
+  dataFrom:
+    - extract:
+        key: arn:aws-us-gov:secretsmanager:us-gov-west-1:432896750513:secret:shared/dsva/${$root.Values.target_env}/combined_secrets
+    - extract:
+        key: arn:aws-us-gov:secretsmanager:us-gov-west-1:239516274380:secret:shared/dsva/${$root.Values.target_env}/combined_secrets

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -123,6 +123,8 @@ spec:
           envFrom:
             - secretRef:
                 name: common-environment-ssm-vars
+            - secretRef:
+                name: checkin-secretsmanager-vars
         {{- if $root.Values.clamav.enabled  }}
         - name: clamav
           image: "{{ $root.Values.clamav.image.value }}:{{ $root.Values.clamav.image.tag }}"


### PR DESCRIPTION
## Summary
https://github.com/department-of-veterans-affairs/checkin-devops/issues/477

I linked to the parent issue in our [Checkin-DevOps repository](https://github.com/department-of-veterans-affairs/checkin-devops). In summary, we're trying to get Vets-API (specifically Check-in Apps) to get Ruby configs from our AWS Accounts instead for the DSVAgovCloud AWS Account.  This will give us an extra degree of control as our infrastructure is being migrated from one `vaec-cms` AWS account to another account `vaec-cie`.

In our AWS Accounts we've already applied resource polices to the secrets we want to share. This allows the DSVAgovCloud AWS Root principal to read secrets from our AWS Accounts just as if it was reading from its own. The only extra piece is full ARNs must be used instead of paths in `templates/secrets.yaml`.  [Pull Request 14848](https://github.com/department-of-veterans-affairs/devops/pull/14848) is the other part of this. It grants permissions to the External Secrets controller IAM Role to retrieve just the secrets we define. The only standing question I have with the DevOps PR is whether `dsva-vagov-[env]-cluster-ext-secrets-controller` or `dsva-vagov-[env]-cluster-vets-api` is the IAM role I need to update permissions? Both?

## Related issue(s)
https://github.com/department-of-veterans-affairs/checkin-devops/issues/712

## Related Pull Requests(s)
https://github.com/department-of-veterans-affairs/devops/pull/14848

## Testing done

Initial implementation of concept to retrieve values across AWS Accounts per official documentation and best practices.

## What areas of the site does it impact?


## Acceptance criteria

- [ ]  Secrets Manager secrets from `vaec-cie` and `vaec-cms` AWS Accounts are loaded up into DSVAgovCloud's EKS Cluster for use by Vets-API in `DEV`

## Requested Feedback
