### PR TITLE
97726: Add DR HLR V2 API endpoint

### DIFF
--- a/app/controllers/v2/higher_level_reviews_controller.rb
+++ b/app/controllers/v2/higher_level_reviews_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'decision_review/utilities/saved_claim/service'
+
+module V2
+  class HigherLevelReviewsController < AppealsBaseControllerV1
+    include DecisionReview::SavedClaim::Service
+    service_tag 'higher-level-review'
+
+    def show
+      render json: decision_review_service.get_higher_level_review(params[:id]).body
+    rescue => e
+      log_exception_to_personal_information_log(
+        e, error_class: error_class(method: 'show', exception_class: e.class), id: params[:id]
+      )
+      raise
+    end
+
+    def create
+      hlr_response_body = decision_review_service
+                          .create_higher_level_review(request_body: request_body_hash, user: @current_user,
+                                                      version: 'V2')
+                          .body
+      submitted_appeal_uuid = hlr_response_body.dig('data', 'id')
+      ActiveRecord::Base.transaction do
+        AppealSubmission.create!(user_uuid: @current_user.uuid, user_account: @current_user.user_account,
+                                 type_of_appeal: 'HLR', submitted_appeal_uuid:)
+
+        store_saved_claim(claim_class: SavedClaim::HigherLevelReview, form: request_body_hash.to_json,
+                          guid: submitted_appeal_uuid)
+
+        # Clear in-progress form since submit was successful
+        InProgressForm.form_for_user('20-0996', current_user)&.destroy!
+      end
+      render json: hlr_response_body
+    rescue => e
+      ::Rails.logger.error(
+        message: "Exception occurred while submitting Higher Level Review: #{e.message}",
+        backtrace: e.backtrace
+      )
+
+      handle_personal_info_error(e)
+    end
+
+    private
+
+    def error_class(method:, exception_class:)
+      "#{self.class.name}##{method} exception #{exception_class} (HLR_V2)"
+    end
+
+    def handle_personal_info_error(e)
+      request = begin
+        { body: request_body_hash }
+      rescue
+        request_body_debug_data
+      end
+
+      log_exception_to_personal_information_log(
+        e, error_class: error_class(method: 'create', exception_class: e.class), request:
+      )
+      raise
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,6 +446,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :v2, defaults: { format: 'json' } do
+    resources :higher_level_reviews, only: %i[create show]
+  end
+
   root 'v0/example#index', module: 'v0'
 
   scope '/services' do

--- a/lib/decision_review_v1/service.rb
+++ b/lib/decision_review_v1/service.rb
@@ -34,11 +34,11 @@ module DecisionReviewV1
     # @param user [User] Veteran who the form is in regard to
     # @return [Faraday::Response]
     #
-    def create_higher_level_review(request_body:, user:)
+    def create_higher_level_review(request_body:, user:, version: 'V1')
       with_monitoring_and_error_handling do
         headers = create_higher_level_review_headers(user)
         common_log_params = { key: :overall_claim_submission, form_id: '996', user_uuid: user.uuid,
-                              downstream_system: 'Lighthouse' }
+                              downstream_system: 'Lighthouse', params: { version: } }
         begin
           response = perform :post, 'higher_level_reviews', request_body, headers
           log_formatted(**common_log_params.merge(is_success: true, status_code: response.status, body: '[Redacted]'))
@@ -48,7 +48,7 @@ module DecisionReviewV1
         end
         raise_schema_error_unless_200_status response.status
         validate_against_schema json: response.body, schema: HLR_CREATE_RESPONSE_SCHEMA,
-                                append_to_error_class: ' (HLR_V1)'
+                                append_to_error_class: " (HLR_#{version}})"
         response
       end
     end

--- a/spec/requests/v2/higher_level_reviews_spec.rb
+++ b/spec/requests/v2/higher_level_reviews_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'support/controller_spec_helper'
 
-RSpec.describe 'V1::HigherLevelReviews', type: :request do
+RSpec.describe 'V2::HigherLevelReviews', type: :request do
   let(:user) { build(:user, :loa3) }
   let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
   let(:success_log_args) do
@@ -19,7 +19,7 @@ RSpec.describe 'V1::HigherLevelReviews', type: :request do
         status_code: 200,
         body: '[Redacted]'
       },
-      version: 'V1'
+      version: 'V2'
     }
   end
   let(:error_log_args) do
@@ -35,7 +35,7 @@ RSpec.describe 'V1::HigherLevelReviews', type: :request do
         status_code: 422,
         body: response_error_body
       },
-      version: 'V1'
+      version: 'V2'
     }
   end
 
@@ -59,11 +59,11 @@ RSpec.describe 'V1::HigherLevelReviews', type: :request do
 
   describe '#create' do
     def personal_information_logs
-      PersonalInformationLog.where 'error_class like ?', 'V1::HigherLevelReviewsController#create exception % (HLR_V1)'
+      PersonalInformationLog.where 'error_class like ?', 'V2::HigherLevelReviewsController#create exception % (HLR_V2)'
     end
 
     subject do
-      post '/v1/higher_level_reviews',
+      post '/v2/higher_level_reviews',
            params: VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY_V1').to_json,
            headers:
     end


### PR DESCRIPTION
## Summary
This adds a separate `/v2/higher-level-reviews` endpoint to distinguish between different versions of the submitted HLR form.

This is owned by the Decision Reviews team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/97726

## Testing done
Tested locally and spec tests

- [x] *New code is covered by unit tests*
New endpoint /v2/ was added. The logic is the same for both endpoints, with an additional param being logged to identify the form version being used.

## What areas of the site does it impact?
New route `/v2/higher-level-reviews`

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
