### PR TITLE
Art/power of attorney request status updates.models

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_19_134025) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -267,6 +267,27 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_19_134025) do
     t.string "veteran_icn"
     t.jsonb "metadata", default: {}
     t.index ["veteran_icn"], name: "index_appeals_api_supplemental_claims_on_veteran_icn"
+  end
+
+  create_table "ar_power_of_attorney_request_decisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "type", null: false
+    t.text "declination_reason"
+  end
+
+  create_table "ar_power_of_attorney_request_expirations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  end
+
+  create_table "ar_power_of_attorney_request_replacements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  end
+
+  create_table "ar_power_of_attorney_request_status_updates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "status_updating_type", null: false
+    t.uuid "status_updating_id", null: false
+    t.datetime "created_at", null: false
+  end
+
+  create_table "ar_power_of_attorney_request_withdrawals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "reason"
   end
 
   create_table "async_transactions", id: :serial, force: :cascade do |t|

--- a/modules/accredited_representative_portal/accredited_representative_portal.gemspec
+++ b/modules/accredited_representative_portal/accredited_representative_portal.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
   spec.test_files = Dir['spec/**/*']
+
+  spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'rspec-rails'
 end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_decision.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_decision.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestDecision < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+
+    self.inheritance_column = nil
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_expiration.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_expiration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestExpiration < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_replacement.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_replacement.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestReplacement < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_status_update.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_status_update.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestStatusUpdate < ApplicationRecord
+    delegated_type :status_updating, types: %w[
+      PowerOfAttorneyRequestReplacements
+      PowerOfAttorneyRequestExpirations
+      PowerOfAttorneyRequestWithdrawals
+      PowerOfAttorneyRequestDecisions
+    ]
+
+    module StatusUpdating
+      extend ActiveSupport::Concern
+
+      included do
+        has_one(
+          :power_of_attorney_request_status_update,
+          as: :status_updating,
+          touch: true
+        )
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_withdrawal.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_withdrawal.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestWithdrawal < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+  end
+end

--- a/modules/accredited_representative_portal/bin/rails
+++ b/modules/accredited_representative_portal/bin/rails
@@ -1,11 +1,14 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ENGINE_ROOT = File.expand_path('../..', __dir__)
-ENGINE_PATH = File.expand_path('../../lib/accredited_representative_portal/engine', __dir__)
+require 'pathname'
+
+ENGINE_ROOT = Pathname(__dir__).parent
+ENGINE_PATH = ENGINE_ROOT / 'lib/accredited_representative_portal/engine'
+BUNDLE_GEMFILE = ENGINE_ROOT / 'Gemfile'
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+ENV['BUNDLE_GEMFILE'] ||= BUNDLE_GEMFILE.to_path
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 require 'rails/all'

--- a/modules/accredited_representative_portal/db/migrate/20241125061506_create_ar_power_of_attorney_request_status_updates.rb
+++ b/modules/accredited_representative_portal/db/migrate/20241125061506_create_ar_power_of_attorney_request_status_updates.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateArPowerOfAttorneyRequestStatusUpdates < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ar_power_of_attorney_request_status_updates, id: :uuid do |t|
+      t.string 'status_updating_type', null: false
+      t.uuid 'status_updating_id', null: false
+      t.datetime 'created_at', null: false
+    end
+
+    create_table :ar_power_of_attorney_request_replacements, id: :uuid
+
+    create_table :ar_power_of_attorney_request_expirations, id: :uuid
+
+    create_table :ar_power_of_attorney_request_withdrawals, id: :uuid do |t|
+      t.text 'reason'
+    end
+
+    create_table :ar_power_of_attorney_request_decisions, id: :uuid do |t|
+      t.string 'type', null: false
+      t.text 'declination_reason'
+    end
+  end
+end

--- a/modules/accredited_representative_portal/lib/accredited_representative_portal/engine.rb
+++ b/modules/accredited_representative_portal/lib/accredited_representative_portal/engine.rb
@@ -3,7 +3,27 @@
 module AccreditedRepresentativePortal
   class Engine < ::Rails::Engine
     isolate_namespace AccreditedRepresentativePortal
+
+    # `isolate_namespace` redefines `table_name_prefix` on load of
+    # `active_record`, so we append our own callback to redefine it again how we
+    # want.
+    ActiveSupport.on_load(:active_record) do
+      AccreditedRepresentativePortal.redefine_singleton_method(:table_name_prefix) do
+        'ar_'
+      end
+    end
+
     config.generators.api_only = true
+
+    # So that the app-wide migration command notices our engine's migrations.
+    initializer :append_migrations do |app|
+      unless app.root.to_s.match? root.to_s
+        config.paths['db/migrate'].expanded.each do |expanded_path|
+          app.config.paths['db/migrate'] << expanded_path
+          ActiveRecord::Migrator.migrations_paths << expanded_path
+        end
+      end
+    end
 
     initializer 'model_core.factories', after: 'factory_bot.set_factory_paths' do
       FactoryBot.definition_file_paths << File.expand_path('../../spec/factories', __dir__) if defined?(FactoryBot)

--- a/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_request_status_update_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_request_status_update_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative '../../rails_helper'
+
+mod = AccreditedRepresentativePortal
+RSpec.describe mod::PowerOfAttorneyRequestStatusUpdate, type: :model do
+  it 'conveniently returns heterogeneous lists' do
+    travel_to '2024-11-25T09:46:24Z'
+
+    ids = []
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestDecision.new(
+          type: 'acceptance'
+        )
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestDecision.new(
+          type: 'declination',
+          declination_reason: 'Some declination reason.'
+        )
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestReplacement.new
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestExpiration.new
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestWithdrawal.new(
+          reason: 'Some withdrawal reason.'
+        )
+      ).id
+
+    status_updates = described_class.includes(:status_updating).find(ids)
+
+    actual =
+      status_updates.map do |status_update|
+        serialized =
+          case status_update.status_updating
+          when mod::PowerOfAttorneyRequestDecision
+            {
+              type: 'decision',
+              decision_type: status_update.status_updating.type,
+              declination_reason: status_update.status_updating.declination_reason
+            }
+          when mod::PowerOfAttorneyRequestWithdrawal
+            {
+              type: 'withdrawal',
+              reason: status_update.status_updating.reason
+            }
+          when mod::PowerOfAttorneyRequestExpiration
+            {
+              type: 'expiration'
+            }
+          when mod::PowerOfAttorneyRequestReplacement
+            {
+              type: 'replacement'
+            }
+          end
+
+        serialized.merge!(
+          created_at: status_update.created_at.iso8601
+        )
+      end
+
+    expect(actual).to eq(
+      [
+        {
+          type: 'decision',
+          decision_type: 'acceptance',
+          declination_reason: nil,
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'decision',
+          decision_type: 'declination',
+          declination_reason: 'Some declination reason.',
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'replacement',
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'expiration',
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'withdrawal',
+          reason: 'Some withdrawal reason.',
+          created_at: '2024-11-25T09:46:24Z'
+        }
+      ]
+    )
+  end
+end


### PR DESCRIPTION
Spikes modeling of POA request status updates with `ActiveRecord`'s newer [delegated types feature](https://guides.rubyonrails.org/association_basics.html#delegated-types) as a good fit for querying one-to-many of subtypes. E.g.:
```ruby
poa_request = PowerOfAttorneyRequest.first
poa_request.status_updates.includes(:status_updating).order(created_at: :desc).limit(50)
```

### Notes
- We could also namespace e.g. `PowerOfAttorneyRequest::Withdrawal` if we want