### PR TITLE
add debug development & test gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,6 +206,7 @@ group :development, :test do
   gem 'byebug', platforms: :ruby # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'danger'
   gem 'database_cleaner'
+  gem 'debug'
   gem 'factory_bot_rails'
   gem 'faker'
   # CAUTION: faraday_curl may not provide all headers used in the actual faraday request. Be cautious if using this to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,9 @@ GEM
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     declarative (0.0.20)
     deep_merge (1.2.2)
     descendants_tracker (0.0.4)
@@ -1175,6 +1178,7 @@ DEPENDENCIES
   date_validator
   ddtrace
   debts_api!
+  debug
   decision_reviews!
   dhp_connected_devices!
   dogstatsd-ruby (= 5.6.3)


### PR DESCRIPTION
[Ruby's official debugging library](https://github.com/ruby/debug) [added in 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/) is excellent. I'd like to use it during the course of development e.g. `binding.b` AKA `binding.break`