### PR TITLE
Move Hardcoded Settings to vets-api - Part 1

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -9,16 +9,10 @@ check_in:
   chip_api_v2:
     mock: false
     timeout: 30
-  chip_api:
-    mock: false
-    timeout: 30
   lorota_v2:
     mock: false
   travel_reimbursement_api:
     redis_token_expiry: 3540
-claims_api:
-  s3:
-    enabled: true
 clamav:
   mock: false
 coverband:

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,50 @@
+betamocks:
+  recording: false
+central_mail:
+  upload:
+    enabled: true
+check_in:
+  authentication:
+    retry_attempt_expiry: 604800
+  chip_api_v2:
+    mock: false
+    timeout: 30
+  chip_api:
+    mock: false
+    timeout: 30
+  lorota_v2:
+    mock: false
+  travel_reimbursement_api:
+    redis_token_expiry: 3540
+claims_api:
+  s3:
+    enabled: true
+clamav:
+  mock: false
+coverband:
+  github_organization: department-of-veterans-affairs
+decision_review:
+  mock: false
+  pdf_validation:
+    enabled: true
+dogstatsd:
+  enabled: true
+evss:
+  s3:
+    uploads_enabled: true
+expiry_scanner:
+  slack:
+    channel_id: C24RH0W11
+flipper:
+  github_organization: department-of-veterans-affairs
+  mute_logs: false
+form_10_10cg:
+  poa:
+    s3:
+      enabled: true
+form526_backup:
+  submission_method: single
+google_analytics_cvu:
+  type: service_account
 hca:
   ca: []


### PR DESCRIPTION
## Summary

- Some settings values in environment helm charts are hardcoded and the same in each environment
- Those values can be moved to `config/settings/production.yml` in vets-api
- production refers to the RAILS_ENV which is "production" in preview environments, dev, staging, sandbox, and production
- This is part 1 of 2

**Note**: these values will still be overridden by settings.local.yml from the environment helm charts until they are removed.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97711
- Part 2: https://github.com/department-of-veterans-affairs/vets-api/pull/19605
- Original List: https://docs.google.com/spreadsheets/d/1-7PLskyY67b4J1fsk-FADYxnSN1UrmVziFfFIt_1saU/edit?gid=697038896#gid=697038896

Manifest PRs:
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3284
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3285

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  Settings in named environments (ie not local) can access these values