### PR TITLE
Move Hardcoded Settings to vets-api - Part 2

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,54 @@
 hca:
   ca: []
+lighthouse:
+  benefits_intake:
+    path: /services/vba_documents
+    use_mocks: false
+    version: v1
+  veteran_verification:
+    form526:
+      use_mocks: false
+maintenance:
+  services:
+    bgs: P5Q2OCZ
+modules_appeals_api:
+  higher_level_review_pii_expunge_enabled: false
+  legacy_appeals_enabled: true
+  notice_of_disagreement_pii_expunge_enabled: false
+  schema_dir: config/schemas
+  supplemental_claim_updater_enabled: false
+  supplemental_claims_enabled: true
+mvi:
+  pii_logging: false
+session_cookie:
+  secure: true
+sidekiq_admin_panel: false
+sidekiq:
+  github_organization: department-of-veterans-affairs
+va_profile:
+  contact_information:
+    cache_enabled: true
+    enabled: true
+    mock: false
+    timeout: 30
+  demographics:
+    cache_enabled: false
+    enabled: true
+    mock: false
+    timeout: 30
+  military_personnel:
+    cache_enabled: false
+    enabled: true
+    mock: false
+    timeout: 30
+  veteran_status:
+    mock: false
+vba_documents:
+  enable_validate_document_endpoint: true
+  s3:
+    enabled: true
+  slack:
+    daily_notification_hour: 7
+    in_flight_notification_hung_time_in_days: 14
+    renotification_in_minutes: 1440
+    update_stalled_notification_in_minutes: 180

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -14,7 +14,6 @@ maintenance:
 modules_appeals_api:
   legacy_appeals_enabled: true
   schema_dir: config/schemas
-  supplemental_claims_enabled: true
 mvi:
   pii_logging: false
 session_cookie:

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -12,11 +12,8 @@ maintenance:
   services:
     bgs: P5Q2OCZ
 modules_appeals_api:
-  higher_level_review_pii_expunge_enabled: false
   legacy_appeals_enabled: true
-  notice_of_disagreement_pii_expunge_enabled: false
   schema_dir: config/schemas
-  supplemental_claim_updater_enabled: false
   supplemental_claims_enabled: true
 mvi:
   pii_logging: false


### PR DESCRIPTION
## Summary

- Some settings values in environment helm charts are hardcoded and the same in each environment
- Those values can be moved to `config/settings/production.yml` in vets-api
- production refers to the RAILS_ENV which is "production" in preview environments, dev, staging, sandbox, and production
- This is part 2 of 2

**Note**: these values will still be overridden by settings.local.yml from the environment helm charts until they are removed. PRs for the environment helm charts have not yet been created

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97711
- Part 1: https://github.com/department-of-veterans-affairs/vets-api/pull/19604
- Original List: https://docs.google.com/spreadsheets/d/1-7PLskyY67b4J1fsk-FADYxnSN1UrmVziFfFIt_1saU/edit?gid=697038896#gid=697038896

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  Settings in named environments (ie not local) can access these values