### PR TITLE
Offramp 21-0966 to PDF route when Intent API is down

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -95,9 +95,9 @@ module SimpleFormsApi
         end
 
         json_for210966(confirmation_number, expiration_date, existing_intents)
-      rescue Common::Exceptions::UnprocessableEntity, Net::ReadTimeout => e
+      rescue Common::Exceptions::UnprocessableEntity, Exceptions::BenefitsClaimsApiDownError => e
         # Common::Exceptions::UnprocessableEntity: There is an authentication issue with the Intent to File API
-        # Faraday::TimeoutError: The Intent to File API is down or timed out
+        # Exceptions::BenefitsClaimsApiDownError: The Intent to File API is down or timed out
         # In either case, we revert to sending a PDF to Central Mail through the Benefits Intake API
         prepare_params_for_benefits_intake_and_log_error(e)
         submit_form_to_benefits_intake

--- a/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/intent_to_file.rb
@@ -26,9 +26,7 @@ module SimpleFormsApi
         type = benefit_type.downcase
         next if existing_intents[type]
 
-        response = benefits_claims_lighthouse_service.create_intent_to_file(type, ssn)
-        confirmation_number = response.dig('data', 'id')
-        expiration_date = response.dig('data', 'attributes', 'expirationDate')
+        confirmation_number, expiration_date = create_intent_to_file(type, ssn)
       end
 
       user_account_uuid = user.user_account_uuid
@@ -59,6 +57,21 @@ module SimpleFormsApi
 
     def benefits_claims_lighthouse_service
       @benefits_claims_lighthouse_service ||= BenefitsClaims::Service.new(icn)
+    end
+
+    def create_intent_to_file(type, ssn)
+      response = benefits_claims_lighthouse_service.create_intent_to_file(type, ssn)
+      [response.dig('data', 'id'), response.dig('data', 'attributes', 'expirationDate')]
+    rescue Common::Exceptions::ResourceNotFound => e
+      Rails.logger.error(
+        'Simple forms api - Benefits Claims API, intent to file endpoint is down',
+        {
+          intent_type: type,
+          form_number: params[:form_number],
+          error: e
+        }
+      )
+      raise Exceptions::BenefitsClaimsApiDownError
     end
 
     def existing_compensation_intent

--- a/modules/simple_forms_api/lib/simple_forms_api.rb
+++ b/modules/simple_forms_api/lib/simple_forms_api.rb
@@ -75,5 +75,7 @@ module SimpleFormsApi
         words.uniq.sort_by(&:length).reverse
       end
     end
+
+    class BenefitsClaimsApiDownError < RuntimeError; end
   end
 end

--- a/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
+++ b/modules/simple_forms_api/spec/services/intent_to_file_spec.rb
@@ -4,22 +4,55 @@ require 'rails_helper'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe SimpleFormsApi::IntentToFile do
-  describe 'an Intent To File has previously been submitted' do
-    let(:params) do
+  let(:ssn) { 'fake-ssn' }
+  let(:icn) { '123498767V234859' }
+  let(:params) do
+    {
+      'benefit_selection' => {
+        'COMPENSATION' => true
+      },
+      'preparer_identification' => 'VETERAN',
+      'veteran_id' => {
+        'ssn' => ssn
+      }
+    }
+  end
+
+  describe '#submit' do
+    let(:expiration_date) { 'fake-expiration-date' }
+    let(:id) { 'fake-id' }
+    let(:compensation_intent) do
       {
-        'benefit_selection' => {
-          'COMPENSATION' => true
-        },
-        'preparer_identification' => 'VETERAN',
-        'preparer_id' => {
-          'ssn' => 'fake-ssn'
+        'data' => {
+          'id' => id,
+          'attributes' => {
+            'expirationDate' => expiration_date
+          }
         }
       }
     end
 
+    context 'lighthouse service is down' do
+      it 'raises Exceptions::BenefitsClaimsApiDownError' do
+        intent_to_file_service = SimpleFormsApi::IntentToFile.new(build(:user), params)
+        allow_any_instance_of(BenefitsClaims::Service).to receive(:get_intent_to_file).with('compensation')
+                                                                                      .and_return(nil)
+        allow_any_instance_of(BenefitsClaims::Service).to receive(:get_intent_to_file).with('pension').and_return(nil)
+        allow_any_instance_of(BenefitsClaims::Service).to receive(:get_intent_to_file).with('survivor').and_return(nil)
+        allow_any_instance_of(BenefitsClaims::Service).to receive(:create_intent_to_file).with(
+          'compensation',
+          ssn
+        ).and_raise(Common::Exceptions::ResourceNotFound)
+
+        expect { intent_to_file_service.submit }.to raise_error(SimpleFormsApi::Exceptions::BenefitsClaimsApiDownError)
+      end
+    end
+  end
+
+  describe 'an Intent To File has previously been submitted' do
     it 'returns no confirmation number and no expiration date if no new ITF is filed' do
       user = build(:user)
-      allow(user).to receive_messages(icn: '123498767V234859', participant_id: 'fake-participant-id')
+      allow(user).to receive_messages(icn:, participant_id: 'fake-participant-id')
       intent_to_file_service = SimpleFormsApi::IntentToFile.new(user, params)
       expiration_date = 'fake-expiration-date'
       compensation_intent = {
@@ -41,22 +74,8 @@ describe SimpleFormsApi::IntentToFile do
   end
 
   describe 'no Intent to File has previously been submitted' do
-    let(:ssn) { 'fake-ssn' }
-    let(:params) do
-      {
-        'benefit_selection' => {
-          'COMPENSATION' => true
-        },
-        'preparer_identification' => 'VETERAN',
-        'veteran_id' => {
-          'ssn' => ssn
-        }
-      }
-    end
-
     it 'return the expiration date of a newly-created Intent To File' do
-      user = build(:user)
-      intent_to_file_service = SimpleFormsApi::IntentToFile.new(user, params)
+      intent_to_file_service = SimpleFormsApi::IntentToFile.new(build(:user), params)
       expiration_date = 'fake-expiration-date'
       id = 'fake-id'
       compensation_intent = {


### PR DESCRIPTION
## Summary
This PR fixes something which we believed already works (but doesn't). This PR explicitly raises a new exception, `SimpleFormsApi::Exceptions::BenefitsClaimsApiDownError`, when we fail to create an intent to file with the Intent API. Tests are updated a little refactored.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=88585252&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1883
