### PR TITLE
Fix typo in else

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -405,7 +405,7 @@ module Form526ClaimFastTrackingConcern
   end
 
   def log_flashes
-    if flashes.includes?('Amyotrophic Lateral Sclerosis')
+    if flashes.include?('Amyotrophic Lateral Sclerosis')
       Rails.logger.info('Flash Prototype Added', { submitted_claim_id:, flash: 'Amyotrophic Lateral Sclerosis' })
     end
   rescue => e


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Fixes conditional on log statement. Current bug is already rescued.
- On submission of 526 form, we attempt to check flashes to see if it includes a particular flash on the claim.
- I'm on the Employee Experience team; we work with the Disability Experience team which maintains Form 526.

## Related issue(s)

- [Ticket](https://github.com/department-of-veterans-affairs/abd-vro/issues/3710)
- bug introduced in this [PR](https://github.com/department-of-veterans-affairs/vets-api/pull/19485)

## Testing done
- Old behavior incorrectly uses `includes?` on array instead of `include?`

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
* no user functionality is affected

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
