### PR TITLE
restrict running `check-approval-requirements` to PRs on master

### DIFF
--- a/.github/workflows/be_review_prs.yml
+++ b/.github/workflows/be_review_prs.yml
@@ -2,6 +2,8 @@ name: Require backend-review-group approval
 on:
   pull_request_review:
     types: [submitted]
+    branches:
+      - master
 
 jobs:
   check-approval-requirements:


### PR DESCRIPTION
## Summary
We only need to run this action on PRs going into the `master` branch. It's possible a team is working from a feature branch. Example: https://github.com/department-of-veterans-affairs/vets-api/pull/19552

I thought we might need it on the `parent-helm-charts` branch, but ALL of those files are owned by backend-review-group ([parent-helm-charts CODEOWNERS](https://github.com/department-of-veterans-affairs/vets-api/blob/parent-helm-charts/.github/CODEOWNERS)) so this extra check isn't necessary.

## Related issue(s)
https://dsva.slack.com/archives/C0460N83Y9G/p1732580536226669

## Testing done/Screenshots
In this PR when base is `master`:
![image](https://github.com/user-attachments/assets/d49325b6-5874-426a-a9ba-0878555d4c7a)

In this PR when I changed the base to a different branch:
![image](https://github.com/user-attachments/assets/a6ca8e14-d665-4101-88d6-9d84862a422d)

## What areas of the site does it impact?
`check-approval-requirements` workflow
