### PR TITLE
add aedp_VADX feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -23,6 +23,10 @@ features:
     actor_type: user
     description: Enables the endpoints of the accredited representative portal
     enable_in_development: true
+  aedp_VADX:
+    actor_type: user
+    description: Enables the VADX experimental features in the AEDP application
+    enable_in_development: true
   all_claims_add_disabilities_enhancement:
     actor_type: user
     description: Enables enhancement to the 21-526EZ "Add Disabilities" page being implemented by the Conditions Team.

--- a/config/features.yml
+++ b/config/features.yml
@@ -23,7 +23,7 @@ features:
     actor_type: user
     description: Enables the endpoints of the accredited representative portal
     enable_in_development: true
-  aedp_VADX:
+  aedp_vadx:
     actor_type: user
     description: Enables the VADX experimental features in the AEDP application
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Adds a single toggle to enable experimental work for the Authenticated Experience Design Patterns team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/196

## Testing done

- tested locally. Just adding a single flag

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
No impact to current site. Adding flag, to this and FE for work that will only live on staging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
