### PR TITLE
Fix form dig, and add metrics for flashes.

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -12,7 +12,9 @@ module Form526ClaimFastTrackingConcern
   RRD_STATSD_KEY_PREFIX = 'worker.rapid_ready_for_decision'
   MAX_CFI_STATSD_KEY_PREFIX = 'api.max_cfi'
   EP_MERGE_STATSD_KEY_PREFIX = 'worker.ep_merge'
+  FLASHES_STATSD_KEY = 'worker.flashes'
 
+  FLASH_PROTOTYPES = ['Amyotrophic Lateral Sclerosis'].freeze
   EP_MERGE_BASE_CODES = %w[010 110 020].freeze
   EP_MERGE_SPECIAL_ISSUE = 'EMP'
   OPEN_STATUSES = [
@@ -99,7 +101,7 @@ module Form526ClaimFastTrackingConcern
   end
 
   def flashes
-    form.dig('form526', 'form526', 'flashes') || []
+    form['flashes'] || []
   end
 
   def disabilities
@@ -405,8 +407,10 @@ module Form526ClaimFastTrackingConcern
   end
 
   def log_flashes
-    if flashes.include?('Amyotrophic Lateral Sclerosis')
-      Rails.logger.info('Flash Prototype Added', { submitted_claim_id:, flash: 'Amyotrophic Lateral Sclerosis' })
+    flash_prototypes = FLASH_PROTOTYPES & flashes
+    Rails.logger.info('Flash Prototype Added', { submitted_claim_id:, flashes: }) if flash_prototypes.any?
+    flashes.each do |flash|
+      StatsD.increment(FLASHES_STATSD_KEY, tags: ["flash:#{flash}", "prototype:#{flash_prototypes.include?(flash)}"])
     end
   rescue => e
     Rails.logger.error("Failed to log Flash Prototypes #{e.message}.", backtrace: e.backtrace)

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -81,12 +81,24 @@ FactoryBot.define do
     end
   end
 
+  trait :als_claim_for_increase do
+    user { FactoryBot.create(:disabilities_compensation_user, icn: '2000163') }
+    form_json do
+      File.read("#{submissions_path}/only_526_als.json")
+    end
+  end
+
+  trait :als_claim_for_increase_terminally_ill do
+    user { FactoryBot.create(:disabilities_compensation_user, icn: '2000163') }
+    form_json do
+      File.read("#{submissions_path}/only_526_als_terminally_ill.json")
+    end
+  end
+
   trait :asthma_claim_for_increase do
     user { FactoryBot.create(:disabilities_compensation_user, icn: '2000163') }
     form_json do
-      File.read(::Rails.root.join(
-        *'/spec/support/disability_compensation_form/submissions/only_526_asthma.json'.split('/')
-      ).to_s)
+      File.read("#{submissions_path}/only_526_asthma.json")
     end
   end
 

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -80,6 +80,109 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       described_class.drain
     end
 
+    context 'Submission inspection for flashes' do
+      before do
+        allow(Rails.logger).to receive(:info)
+        allow(StatsD).to receive(:increment)
+      end
+
+      def submit_it
+        subject.perform_async(submission.id)
+        VCR.use_cassette('virtual_regional_office/contention_classification_null_response') do
+          described_class.drain
+        end
+        submission.reload
+        expect(Form526JobStatus.last.status).to eq 'success'
+      end
+
+      context 'without any flashes' do
+        let(:submission) do
+          create(:form526_submission,
+                 :asthma_claim_for_increase,
+                 user_uuid: user.uuid,
+                 auth_headers_json: auth_headers.to_json,
+                 saved_claim_id: saved_claim.id)
+        end
+
+        it 'does not log or push metrics' do
+          submit_it
+
+          expect(Rails.logger).not_to have_received(:info).with('Flash Prototype Added', anything)
+          expect(StatsD).not_to have_received(:increment).with('worker.flashes', anything)
+        end
+      end
+
+      context 'with flash but without prototype' do
+        let(:submission) do
+          create(:form526_submission,
+                 :without_diagnostic_code,
+                 user_uuid: user.uuid,
+                 auth_headers_json: auth_headers.to_json,
+                 saved_claim_id: saved_claim.id)
+        end
+
+        it 'does not log prototype statement but pushes metrics' do
+          submit_it
+
+          expect(Rails.logger).not_to have_received(:info).with('Flash Prototype Added', anything)
+          expect(StatsD).to have_received(:increment).with(
+            'worker.flashes',
+            tags: ['flash:Priority Processing - Veteran over age 85', 'prototype:false']
+          ).once
+        end
+      end
+
+      context 'with ALS flash' do
+        let(:submission) do
+          create(:form526_submission,
+                 :als_claim_for_increase,
+                 user_uuid: user.uuid,
+                 auth_headers_json: auth_headers.to_json,
+                 saved_claim_id: saved_claim.id)
+        end
+
+        it 'logs prototype statement and pushes metrics' do
+          submit_it
+
+          expect(Rails.logger).to have_received(:info).with(
+            'Flash Prototype Added',
+            { submitted_claim_id:, flashes: ['Amyotrophic Lateral Sclerosis'] }
+          ).once
+          expect(StatsD).to have_received(:increment).with(
+            'worker.flashes',
+            tags: ['flash:Amyotrophic Lateral Sclerosis', 'prototype:true']
+          ).once
+        end
+      end
+
+      context 'with multiple flashes' do
+        let(:submission) do
+          create(:form526_submission,
+                 :als_claim_for_increase_terminally_ill,
+                 user_uuid: user.uuid,
+                 auth_headers_json: auth_headers.to_json,
+                 saved_claim_id: saved_claim.id)
+        end
+
+        it 'logs prototype statement and pushes metrics' do
+          submit_it
+
+          expect(Rails.logger).to have_received(:info).with(
+            'Flash Prototype Added',
+            { submitted_claim_id:, flashes: ['Amyotrophic Lateral Sclerosis', 'Terminally Ill'] }
+          ).once
+          expect(StatsD).to have_received(:increment).with(
+            'worker.flashes',
+            tags: ['flash:Amyotrophic Lateral Sclerosis', 'prototype:true']
+          ).once
+          expect(StatsD).to have_received(:increment).with(
+            'worker.flashes',
+            tags: ['flash:Terminally Ill', 'prototype:false']
+          ).once
+        end
+      end
+    end
+
     context 'with contention classification enabled' do
       context 'when diagnostic code is not set' do
         let(:submission) do

--- a/spec/support/disability_compensation_form/submissions/only_526_als.json
+++ b/spec/support/disability_compensation_form/submissions/only_526_als.json
@@ -1,0 +1,131 @@
+{
+  "form526": {
+    "form526": {
+      "veteran": {
+        "emailAddress": "test@email.com",
+        "alternateEmailAddress": "test2@email.com",
+        "mailingAddress": {
+          "country": "USA",
+          "addressLine1": "1234 Classy Street",
+          "addressLine2": "Apartment 567",
+          "type": "DOMESTIC",
+          "city": "Quaint Town",
+          "state": "OR",
+          "zipFirstFive": "85918",
+          "zipLastFour": "1212"
+        },
+        "forwardingAddress": {
+          "effectiveDate": "2018-03-29",
+          "country": "USA",
+          "addressLine1": "1234 de Buen Tono Calle",
+          "addressLine2": "Apartamento 567",
+          "type": "MILITARY",
+          "militaryPostOfficeTypeCode": "APO",
+          "militaryStateCode": "AA",
+          "zipFirstFive": "12345",
+          "zipLastFour": "6789"
+        },
+        "primaryPhone": {
+          "areaCode": "202",
+          "phoneNumber": "4561111"
+        },
+        "homelessness": {
+          "hasPointOfContact": true,
+          "pointOfContact": {
+            "pointOfContactName": "Ted",
+            "primaryPhone": {
+              "areaCode": "123",
+              "phoneNumber": "4567890"
+            }
+          }
+        },
+        "serviceNumber": "string"
+      },
+      "militaryPayments": {
+        "payments": [],
+        "receiveCompensationInLieuOfRetired": false
+      },
+      "serviceInformation": {
+        "servicePeriods": [
+          {
+            "serviceBranch": "National Oceanic & Atmospheric Administration",
+            "activeDutyBeginDate": "2018-03-29",
+            "activeDutyEndDate": "2018-03-29"
+          }
+        ],
+        "reservesNationalGuardService": {
+          "title10Activation": {
+            "title10ActivationDate": "2018-03-29",
+            "anticipatedSeparationDate": "2018-03-29"
+          },
+          "obligationTermOfServiceFromDate": "2018-03-29",
+          "obligationTermOfServiceToDate": "2018-03-29",
+          "unitName": "string",
+          "inactiveDutyTrainingPay": {
+            "waiveVABenefitsToRetainTrainingPay": false
+          }
+        },
+        "alternateNames": [
+          {
+            "firstName": "string",
+            "middleName": "string",
+            "lastName": "string"
+          }
+        ],
+        "confinements": [
+          {
+            "confinementBeginDate": "2018-03-29",
+            "confinementEndDate": "2018-03-29",
+            "verifiedIndicator": false
+          }
+        ]
+      },
+      "disabilities": [
+        {
+          "name": "ALS (amyotrophic lateral sclerosis)",
+          "classificationCode": "9007",
+          "disabilityActionType": "INCREASE",
+          "ratedDisabilityId": "1",
+          "diagnosticCode": 7101,
+          "secondaryDisabilities": []
+        }
+      ],
+      "treatments": [
+        {
+          "center": {
+            "name": "string",
+            "type": "DOD_MTF",
+            "country": "USA",
+            "city": "string",
+            "state": "OR"
+          },
+          "startDate": "2018-03-29",
+          "endDate": "2018-03-29"
+        }
+      ],
+      "specialCircumstances": [
+        {
+          "name": "string",
+          "code": "string",
+          "needed": false
+        }
+      ],
+      "standardClaim": false,
+      "claimantCertification": true,
+      "autoCestPDFGenerationDisabled": false,
+      "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+      "directDeposit": {
+        "accountType": "CHECKING",
+        "accountNumber": "9876543211234",
+        "routingNumber": "042102115",
+        "bankName": "Comerica"
+      }
+    }
+  },
+  "form526_uploads": [],
+  "form4142": null,
+  "form0781": null,
+  "form8940": null,
+  "flashes": ["Amyotrophic Lateral Sclerosis"]
+}
+

--- a/spec/support/disability_compensation_form/submissions/only_526_als_terminally_ill.json
+++ b/spec/support/disability_compensation_form/submissions/only_526_als_terminally_ill.json
@@ -1,0 +1,131 @@
+{
+  "form526": {
+    "form526": {
+      "veteran": {
+        "emailAddress": "test@email.com",
+        "alternateEmailAddress": "test2@email.com",
+        "mailingAddress": {
+          "country": "USA",
+          "addressLine1": "1234 Classy Street",
+          "addressLine2": "Apartment 567",
+          "type": "DOMESTIC",
+          "city": "Quaint Town",
+          "state": "OR",
+          "zipFirstFive": "85918",
+          "zipLastFour": "1212"
+        },
+        "forwardingAddress": {
+          "effectiveDate": "2018-03-29",
+          "country": "USA",
+          "addressLine1": "1234 de Buen Tono Calle",
+          "addressLine2": "Apartamento 567",
+          "type": "MILITARY",
+          "militaryPostOfficeTypeCode": "APO",
+          "militaryStateCode": "AA",
+          "zipFirstFive": "12345",
+          "zipLastFour": "6789"
+        },
+        "primaryPhone": {
+          "areaCode": "202",
+          "phoneNumber": "4561111"
+        },
+        "homelessness": {
+          "hasPointOfContact": true,
+          "pointOfContact": {
+            "pointOfContactName": "Ted",
+            "primaryPhone": {
+              "areaCode": "123",
+              "phoneNumber": "4567890"
+            }
+          }
+        },
+        "serviceNumber": "string"
+      },
+      "militaryPayments": {
+        "payments": [],
+        "receiveCompensationInLieuOfRetired": false
+      },
+      "serviceInformation": {
+        "servicePeriods": [
+          {
+            "serviceBranch": "National Oceanic & Atmospheric Administration",
+            "activeDutyBeginDate": "2018-03-29",
+            "activeDutyEndDate": "2018-03-29"
+          }
+        ],
+        "reservesNationalGuardService": {
+          "title10Activation": {
+            "title10ActivationDate": "2018-03-29",
+            "anticipatedSeparationDate": "2018-03-29"
+          },
+          "obligationTermOfServiceFromDate": "2018-03-29",
+          "obligationTermOfServiceToDate": "2018-03-29",
+          "unitName": "string",
+          "inactiveDutyTrainingPay": {
+            "waiveVABenefitsToRetainTrainingPay": false
+          }
+        },
+        "alternateNames": [
+          {
+            "firstName": "string",
+            "middleName": "string",
+            "lastName": "string"
+          }
+        ],
+        "confinements": [
+          {
+            "confinementBeginDate": "2018-03-29",
+            "confinementEndDate": "2018-03-29",
+            "verifiedIndicator": false
+          }
+        ]
+      },
+      "disabilities": [
+        {
+          "name": "ALS (amyotrophic lateral sclerosis)",
+          "classificationCode": "9007",
+          "disabilityActionType": "INCREASE",
+          "ratedDisabilityId": "1",
+          "diagnosticCode": 7101,
+          "secondaryDisabilities": []
+        }
+      ],
+      "treatments": [
+        {
+          "center": {
+            "name": "string",
+            "type": "DOD_MTF",
+            "country": "USA",
+            "city": "string",
+            "state": "OR"
+          },
+          "startDate": "2018-03-29",
+          "endDate": "2018-03-29"
+        }
+      ],
+      "specialCircumstances": [
+        {
+          "name": "string",
+          "code": "string",
+          "needed": false
+        }
+      ],
+      "standardClaim": false,
+      "claimantCertification": true,
+      "autoCestPDFGenerationDisabled": false,
+      "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+      "directDeposit": {
+        "accountType": "CHECKING",
+        "accountNumber": "9876543211234",
+        "routingNumber": "042102115",
+        "bankName": "Comerica"
+      }
+    }
+  },
+  "form526_uploads": [],
+  "form4142": null,
+  "form0781": null,
+  "form8940": null,
+  "flashes": ["Amyotrophic Lateral Sclerosis", "Terminally Ill"]
+}
+


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Fixes a form 526 dig to get flashes and adds metrics for flashes added to claims
- On submission of 526 form, we attempt to check flashes to see if it includes a particular flash on the claim. 
- I'm on the Employee Experience team; we work with the Disability Experience team which maintains Form 526.

## Related issue(s)
- Follow on to initially adding ALS flash capability for:
   - https://github.com/department-of-veterans-affairs/abd-vro/issues/3667

## Testing done

- [x] *New code is covered by unit tests*
- Old behavior:
  - Incorrect dig to get flashes resulting in always having empty array of flashes and never logging statement
- New behavior:
  - correct form dig
  - logs list of flashes along with submitted claim id if a flash prototype is in the list of flashes. Only current prototype is `Amyotrophic Lateral Sclerosis` flash and is behind the feature flag `disability_526_ee_process_als_flash` and is not enabled in production
  - pushes an increment to datadog for each flash, prototype or not
  - this will allow gathering metrics for flashes applied via va.gov form 526 submission

## What areas of the site does it impact?
* no user functionality is affected
* metrics in datadog will be available on this [dashboard](https://vagov.ddog-gov.com/dashboard/2zx-k9i-rzw/flashes-employee-experience)

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution

