### PR TITLE
dbex/97956-separation-location-string: temporary - turn separation loccation code into string for saved claim

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -52,6 +52,8 @@ module V0
     end
 
     def submit_all_claim
+      temp_separation_location_fix
+
       saved_claim = SavedClaim::DisabilityCompensation::Form526AllClaim.from_hash(form_content)
       saved_claim.save ? log_success(saved_claim) : log_failure(saved_claim)
       submission = create_submission(saved_claim)
@@ -172,5 +174,17 @@ module V0
       end
       false
     end
+
+    # TEMPORARY
+    # Turn separation location into string
+    # 11/18/2024 BRD EVSS -> Lighthouse migration caused separation location to turn into an integer,
+    # while SavedClaim (vets-json-schema) is expecting a string
+    def temp_separation_location_fix
+      separation_location_code =
+        form_content['form526']['serviceInformation']['separationLocation']['separationLocationCode'].to_s
+      form_content['form526']['serviceInformation']['separationLocation']['separationLocationCode'] =
+        separation_location_code
+    end
+    # END TEMPORARY
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- in #submit_all_claim, force separation location to be a string

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] turn on BRD separation location migration http://localhost:3000/flipper/features/disability_compensation_lighthouse_brd
- [ ] start BDD claim
- [ ] choose separation location 
- [ ] submit for
- [ ] before: #submit_all_claim would return an error
- [ ] after: #submit_all_claim should create a sidekiq job!

## Screenshots
n/a

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
