### PR TITLE
[API-37025] Parallelize BGS calls in /power-of-attorney-request creation (POC)

### DIFF
--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
@@ -99,23 +99,21 @@ module ClaimsApi
       end
 
       def create_vnp_ptcpnt(participant_id)
-        ClaimsApi::VnpPtcpntService
-          .new(external_uid: @veteran_participant_id, external_key: @veteran_participant_id)
-          .vnp_ptcpnt_create(
-            {
-              vnp_proc_id: @vnp_proc_id,
-              vnp_ptcpnt_id: nil,
-              fraud_ind: nil,
-              legacy_poa_cd: nil,
-              misc_vendor_ind: nil,
-              ptcpnt_short_nm: nil,
-              ptcpnt_type_nm: PTCPNT_TYPE,
-              tax_idfctn_nbr: nil,
-              tin_waiver_reason_type_cd: nil,
-              ptcpnt_fk_ptcpnt_id: nil,
-              corp_ptcpnt_id: participant_id
-            }.merge(bgs_jrn_fields)
-          )
+        vnp_ptcpnt_service.vnp_ptcpnt_create(
+          {
+            vnp_proc_id: @vnp_proc_id,
+            vnp_ptcpnt_id: nil,
+            fraud_ind: nil,
+            legacy_poa_cd: nil,
+            misc_vendor_ind: nil,
+            ptcpnt_short_nm: nil,
+            ptcpnt_type_nm: PTCPNT_TYPE,
+            tax_idfctn_nbr: nil,
+            tin_waiver_reason_type_cd: nil,
+            ptcpnt_fk_ptcpnt_id: nil,
+            corp_ptcpnt_id: participant_id
+          }.merge(bgs_jrn_fields)
+        )
       end
 
       def create_vnp_person(person, vnp_ptcpnt_id)
@@ -279,6 +277,11 @@ module ClaimsApi
       end
       # rubocop: enable Metrics/MethodLength
       # rubocop: enable Naming/VariableNumber
+
+      def vnp_ptcpnt_service
+        @vnp_ptcpnt_service ||= ClaimsApi::VnpPtcpntService
+                                .new(external_uid: @veteran_participant_id, external_key: @veteran_participant_id)
+      end
 
       def vnp_ptcpnt_addrs_service
         @vnp_ptcpnt_addrs_service ||= ClaimsApi::VnpPtcpntAddrsService

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
@@ -136,8 +136,7 @@ module ClaimsApi
 
       # rubocop: disable Metrics/MethodLength
       def create_vnp_mailing_address(address, vnp_ptcpnt_id)
-        ClaimsApi::VnpPtcpntAddrsService
-          .new(external_uid: @veteran_participant_id, external_key: @veteran_participant_id)
+        vnp_ptcpnt_addrs_service
           .vnp_ptcpnt_addrs_create(
             {
               vnp_ptcpnt_addrs_id: nil,
@@ -182,8 +181,7 @@ module ClaimsApi
 
       # rubocop: disable Metrics/MethodLength
       def create_vnp_email_address(email, vnp_ptcpnt_id)
-        ClaimsApi::VnpPtcpntAddrsService
-          .new(external_uid: @veteran_participant_id, external_key: @veteran_participant_id)
+        vnp_ptcpnt_addrs_service
           .vnp_ptcpnt_addrs_create(
             {
               vnp_ptcpnt_addrs_id: nil,
@@ -281,6 +279,11 @@ module ClaimsApi
       end
       # rubocop: enable Metrics/MethodLength
       # rubocop: enable Naming/VariableNumber
+
+      def vnp_ptcpnt_addrs_service
+        @vnp_ptcpnt_addrs_service ||= ClaimsApi::VnpPtcpntAddrsService
+                                      .new(external_uid: @veteran_participant_id, external_key: @veteran_participant_id)
+      end
 
       def bgs_jrn_fields
         {

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/terminate_existing_requests.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/terminate_existing_requests.rb
@@ -38,9 +38,14 @@ module ClaimsApi
       end
 
       def set_to_obsolete(request)
-        ClaimsApi::ManageRepresentativeService
-          .new(external_uid: @veteran_participant_id, external_key: @veteran_participant_id)
-          .update_poa_request(representative: request[:representative], proc_id: request[:proc_id])
+        manage_representative_service.update_poa_request(representative: request[:representative],
+                                                         proc_id: request[:proc_id])
+      end
+
+      def manage_representative_service
+        @manage_representative_service ||= ClaimsApi::ManageRepresentativeService
+                                           .new(external_uid: @veteran_participant_id,
+                                                external_key: @veteran_participant_id)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Parallelize BGS calls (proof of concept)
- Memoize BGS services

```mermaid
sequenceDiagram
    CreateRequest->>VnpProcServiceV2: vnp_proc_create
    VnpProcServiceV2->>CreateRequest: vnp_proc_id
    par
        CreateRequest->>VnpProcFormService: vnp_proc_form_create(vnp_proc_id)
        VnpProcFormService-->VnpProcFormService: create
    and
        CreateRequest->>VnpPtcpntService: vnp_ptcpnt_create(vnp_proc_id)
        VnpPtcpntService->>CreateRequest: Veteran vnp_ptcpnt_id
    end
    par create_vonapp_data
        CreateRequest->>VnpPersonService: vnp_person_create(vnp_proc_id, vnp_ptcpnt_id)
        VnpPersonService-->VnpPersonService: create
    and
        CreateRequest->>VnpPtcpntAddrsService: vnp_ptcpnt_addrs_create(vnp_proc_id, vnp_ptcpnt_id, 'Mailing')
        VnpPtcpntAddrsService-->VnpPtcpntAddrsService: create
    and
        CreateRequest->>VnpPtcpntAddrsService: vnp_ptcpnt_addrs_create(vnp_proc_id, vnp_ptcpnt_id, 'Email')
        VnpPtcpntAddrsService-->VnpPtcpntAddrsService: create
    and
        CreateRequest->>VnpPtcpntPhoneService: vnp_ptcpnt_phone_create(vnp_proc_id, vnp_ptcpnt_id)
        VnpPtcpntPhoneService-->VnpPtcpntPhoneService: create
    end
    opt if has_claimant
        CreateRequest->>VnpPtcpntService: vnp_ptcpnt_create(vnp_proc_id)
        VnpPtcpntService->>CreateRequest: Claimant vnp_ptcpnt_id
        Note over CreateRequest,VnpPtcpntPhoneService: Repeat parallelized create_vonapp_data with Claimant vnp_ptcpnt_id
    end
    CreateRequest->>VeteranRepresentativeService: create_veteran_representative(vnp_proc_id, Veteran or Claimant vnp_ptcpnt_id)
    VeteranRepresentativeService->>CreateRequest: Veteran representative
```

## Related issue(s)

[API-37025](https://jira.devops.va.gov/browse/API-37025)

## Testing done

- Same testing process as https://github.com/department-of-veterans-affairs/vets-api/pull/19210.
- Observed a 5.46 second response time in the parallel request vs 7.91 seconds in the serial request (~30% improvement).

## Screenshots

N/A

## What areas of the site does it impact?

ClaimsApi::PowerOfAttorneyRequestService::CreateRequest

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

We break up the vonapp_data creation by veteran and claimant (i.e., we parallelize 4 calls to BGS, check if there is a claimant, and if so, send another 4 parallelized calls to BGS). We _could_ make all 8 of these calls in parallel by creating the claimantʼs `vnp_ptcpnt_id` earlier in the process, but that would make the code harder to follow (checking for claimant many times, building the promises outside of `create_vonapp_data`, etc.).

How often do we expect a claimant to be present? If frequently, the added complexity might be worth the performance gain.
