### PR TITLE
dbex/97956-separation-location-string: separation location code to string

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -182,7 +182,8 @@ module V0
     # while SavedClaim (vets-json-schema) is expecting a string
     def temp_separation_location_fix
       if form_content.is_a?(Hash) && form_content['form526'].is_a?(Hash)
-        separation_location_code = form_content.dig('form526', 'serviceInformation', 'separationLocation')
+        separation_location_code = form_content.dig('form526', 'serviceInformation', 'separationLocation',
+                                                    'separationLocationCode')
         unless separation_location_code.nil?
           form_content['form526']['serviceInformation']['separationLocation']['separationLocationCode'] =
             separation_location_code.to_s


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- add missing `separationLocationCode` path

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97956

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

