### PR TITLE
96358 Fix for out of order attachment ids - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -90,7 +90,7 @@ module IvcChampva
 
       def supporting_document_ids(parsed_form_data)
         cached_uploads = []
-        parsed_form_data['supporting_docs'].each do |d|
+        parsed_form_data['supporting_docs']&.each do |d|
           # Get the database record that corresponds to this file upload:
           record = PersistentAttachments::MilitaryRecords.find_by(guid: d['confirmation_code'])
           # Push to our array with some extra information so we can sort by date uploaded:

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -132,7 +132,6 @@ module IvcChampva
                       end
           metadata = IvcChampva::MetadataValidator.validate(form.metadata)
           file_paths = form.handle_attachments(file_path)
-          byebug
 
           [file_paths, metadata.merge({ 'attachment_ids' => attachment_ids })]
         end

--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -26,6 +26,7 @@ module IvcChampva
         File.rename(file_path, file_path_uuid)
         attachments = get_attachments
         file_paths = [file_path_uuid]
+        byebug
 
         if attachments.count.positive?
           supporting_doc_index = 0

--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -26,7 +26,6 @@ module IvcChampva
         File.rename(file_path, file_path_uuid)
         attachments = get_attachments
         file_paths = [file_path_uuid]
-        byebug
 
         if attachments.count.positive?
           supporting_doc_index = 0

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe 'IvcChampva::V1::Forms::Uploads', type: :request do
 
       it 'uploads a PDF file to S3' do
         mock_form = double(first_name: 'Veteran', last_name: 'Surname', form_uuid: 'some_uuid')
+        allow(PersistentAttachments::MilitaryRecords).to receive(:find_by)
+          .and_return(double('Record1', created_at: 1.day.ago, id: 'some_uuid', file: double(id: 'file0')))
         allow(IvcChampvaForm).to receive(:first).and_return(mock_form)
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(true)
 


### PR DESCRIPTION
## Summary

This PR fixes an issue with how attachment metadata is prepared before being sent to Pega for ingestion. Previously, the document types (`attachment_id`, e.g.: 'Birth certificate') were rolled into a list based solely on the order of the front end configuration.

These values were then matched up with the list of attachments in the cache on the backend. However, if a user uploaded files in any order other than the order in which they encounter them, the alignment between attachment_id and the file itself would be thrown off. This caused files to be mis-categorized.

By reorganizing the `attachment_id` array to match with the order files were uploaded, metadata gets matched correctly regardless of how the user uploaded their files.

- Matches supporting docs up to database records and sorts by date created

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96358

## Testing done

- [X] *New code is covered by unit tests*

## Screenshots
NA

## What areas of the site does it impact?
IVC CHAMPVA forms

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
