### PR TITLE
EDM-346/enable gids flight school mocks

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -942,6 +942,13 @@
   :base_uri: <%= "#{URI(Settings.gids.url).host}:#{URI(Settings.gids.url).port}" %>
   :endpoints:
     - :method: :get
+      :path: "/gids/v0/institution_programs"
+      :file_path: "gids/programs"
+      # Mock only enabled when filtering by flight programs, see: lib/gi/search_client.rb
+      :cache_multiple_responses:
+        :uid_location: query
+        :uid_locator: type
+    - :method: :get
       :path: "/gids/v1/lce"
       :file_path: "gids/lce"
       :cache_multiple_responses:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -489,7 +489,8 @@ gids:
   url: https://dev.va.gov/gids
   open_timeout: 1
   read_timeout: 1
-  use_mocks: false
+  search:
+    use_mocks: false
   lce:
     use_mocks: false
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -489,6 +489,7 @@ gids:
   url: https://dev.va.gov/gids
   open_timeout: 1
   read_timeout: 1
+  use_mocks: false
   lce:
     use_mocks: false
 

--- a/lib/gi/search_client.rb
+++ b/lib/gi/search_client.rb
@@ -8,8 +8,6 @@ module GI
   class SearchClient < GI::Client
     configuration GI::SearchConfiguration
 
-    FLIGHT_PROGRAM_TYPE = 'FLGT'
-
     def get_institution_search_results_v0(params = {})
       response = perform(:get, 'v0/institutions', params)
       gids_response(response)
@@ -18,9 +16,7 @@ module GI
     def get_institution_program_search_results_v0(params = {})
       # Mock response if querying for flight school programs
       # TO-DO: Remove after flight school program data becomes accessible
-      if params[:type] == FLIGHT_PROGRAM_TYPE
-        config.instance_variable_set(:@program_type_flight, true)
-      end
+      config.instance_variable_set(:@program_type_flight, true) if params[:type] == 'FLGT'
 
       response = perform(:get, 'v0/institution_programs', params)
       gids_response(response)

--- a/lib/gi/search_client.rb
+++ b/lib/gi/search_client.rb
@@ -8,12 +8,20 @@ module GI
   class SearchClient < GI::Client
     configuration GI::SearchConfiguration
 
+    FLIGHT_PROGRAM_TYPE = 'FLGT'
+
     def get_institution_search_results_v0(params = {})
       response = perform(:get, 'v0/institutions', params)
       gids_response(response)
     end
 
     def get_institution_program_search_results_v0(params = {})
+      # Mock response if querying for flight school programs
+      # TO-DO: Remove after flight school program data becomes accessible
+      if params[:type] == FLIGHT_PROGRAM_TYPE
+        config.instance_variable_set(:@program_type_flight, true)
+      end
+
       response = perform(:get, 'v0/institution_programs', params)
       gids_response(response)
     end

--- a/lib/gi/search_configuration.rb
+++ b/lib/gi/search_configuration.rb
@@ -8,7 +8,7 @@ module GI
     # Mock response if querying for flight school programs
     # TO-DO: Remove after flight school program data becomes accessible
     def use_mocks?
-      (@program_type_flight && Settings.gids.use_mocks) || false
+      (@program_type_flight && Settings.gids.search.use_mocks) || false
     end
   end
 end

--- a/lib/gi/search_configuration.rb
+++ b/lib/gi/search_configuration.rb
@@ -4,5 +4,11 @@ module GI
   class SearchConfiguration < GI::Configuration
     self.read_timeout = Settings.gids.search&.read_timeout || 4
     self.open_timeout = Settings.gids.search&.open_timeout || 4
+
+    # Mock response if querying for flight school programs
+    # TO-DO: Remove after flight school program data becomes accessible
+    def use_mocks?
+      (@program_type_flight && Settings.gids.use_mocks) || false
+    end
   end
 end

--- a/lib/gi/search_configuration.rb
+++ b/lib/gi/search_configuration.rb
@@ -8,7 +8,10 @@ module GI
     # Mock response if querying for flight school programs
     # TO-DO: Remove after flight school program data becomes accessible
     def use_mocks?
-      (@program_type_flight && Settings.gids.search.use_mocks) || false
+      return false unless instance_variable_defined?(:@program_type_flight)
+
+      querying_by_flight = remove_instance_variable(:@program_type_flight)
+      querying_by_flight && Settings.gids.search.use_mocks || false
     end
   end
 end

--- a/lib/gi/search_configuration.rb
+++ b/lib/gi/search_configuration.rb
@@ -11,7 +11,7 @@ module GI
       return false unless instance_variable_defined?(:@program_type_flight)
 
       querying_by_flight = remove_instance_variable(:@program_type_flight)
-      querying_by_flight && Settings.gids.search.use_mocks || false
+      (querying_by_flight && Settings.gids.search.use_mocks) || false
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)*: App and betamocks settings updated to enable mock data for `GI::SearchClient` endpoints for comparison tool. `GI::SearchClient` and `GI::SearchConfiguration` updated to only use mocks on a request to `institution_programs` search endpoint when a query parameter of `type == 'FLGT'` is present
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)* Temporarily solution to test new GI Comparison Tool feature until flight program data is made available via WEAMS, which is being worked in parallel. There didn't appear to be a way in betamocks settings to only mock responses if a specific query parameter is passed in, while letting all other requests go through. So some additional logic was added to search client and search configuration's `use_mocks?`
- *(Which team do you work for, does your team own the maintenance of this component?)* Education Data Migration (EDM), yes
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/563
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3291
- https://jira.devops.va.gov/browse/EDM-346

## What areas of the site does it impact?

GI Bill Comparison Tool

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
