### PR TITLE
add better error logging

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/pdf_stamper.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/pdf_stamper.rb
@@ -9,15 +9,14 @@ module IvcChampva
     SUBMISSION_DATE_TITLE = 'Application Submitted:'
 
     def self.stamp_pdf(stamped_template_path, form, current_loa)
-      if File.exist? stamped_template_path
-        stamp_signature(stamped_template_path, form)
+      return unless File.exist?(stamped_template_path)
 
-        stamp_auth_text(stamped_template_path, current_loa)
-
-        stamp_submission_date(stamped_template_path, form.submission_date_stamps)
-      else
-        raise "stamped template file does not exist: #{stamped_template_path}"
-      end
+      stamp_signature(stamped_template_path, form)
+      stamp_auth_text(stamped_template_path, current_loa)
+      stamp_submission_date(stamped_template_path, form.submission_date_stamps)
+    rescue => e
+      Rails.logger.error "Error stamping PDF: #{e.message}"
+      raise "Error stamping PDF: #{stamped_template_path}"
     end
 
     def self.stamp_signature(stamped_template_path, form)

--- a/modules/ivc_champva/app/services/ivc_champva/pdf_stamper.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/pdf_stamper.rb
@@ -62,7 +62,7 @@ module IvcChampva
 
       perform_multistamp(stamped_template_path, stamp_path)
     rescue => e
-      Rails.logger.error 'Simple forms api - Failed to generate stamped file', message: e.message
+      Rails.logger.error 'IVC CHAMPVA forms api - Failed to generate stamped file', message: e.message
       raise
     ensure
       Common::FileHelpers.delete_file_if_exists(stamp_path) if defined?(stamp_path)
@@ -117,10 +117,12 @@ module IvcChampva
       raise StandardError, "An error occurred while verifying stamp: #{e}"
     end
 
-    def self.verified_multistamp(stamped_template_path, stamp_text, page_configuration, *)
+    def self.verified_multistamp(stamped_template_path, stamp_text, page_configuration, *args)
       raise StandardError, 'The provided stamp content was empty.' if stamp_text.blank?
 
-      verify(stamped_template_path) { multistamp(stamped_template_path, stamp_text, page_configuration, *) }
+      verify(stamped_template_path) { multistamp(stamped_template_path, stamp_text, page_configuration, *args) }
+    rescue => e
+      raise StandardError, "An error occurred while verifying multistamp stamp: #{e.message}"
     end
 
     def self.get_page_configuration(page, position)

--- a/modules/ivc_champva/spec/services/pdf_stamper_spec.rb
+++ b/modules/ivc_champva/spec/services/pdf_stamper_spec.rb
@@ -98,7 +98,9 @@ describe IvcChampva::PdfStamper do
       let(:config) { nil }
 
       it 'raises an error' do
-        expect { verified_multistamp }.to raise_error('The provided stamp content was empty.')
+        expect do
+          verified_multistamp
+        end.to raise_error('An error occurred while verifying multistamp stamp: The provided stamp content was empty.')
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO

There are several improvements to the  stamp_pdf method, enhancing both its efficiency and error handling:

1. Early Return for File Existence Check:
Instead of using an if/else block to check if the file exists, it will now use an early return (return unless File.exist?(stamped_template_path)) This simplifies the code and reduces nesting, making it more readable.

2. Added Robust Error Handling:
This PR will introduce a rescue block to gracefully handle potential errors during the PDF stamping process. This ensures the  application doesn't crash if something goes wrong.

3. Improved Error Logging:
Inside the rescue block, there is now log the error message (Rails.logger.error "Error stamping PDF: #{e.message}"), providing more context for debugging by including the specific exception message.

4.More Informative Error Raising:
When re-raising the error, it will provide a more general message (raise "Error stamping PDF: #{stamped_template_path}") that focuses on the action (stamping the PDF) rather than just the file existence. This gives a clearer indication of where the problem occurred.


## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1533/views/1?sliceBy%5Bvalue%5D=Sprint+5&filterQuery=parent-issue%3A%22department-of-veterans-affairs%2Fva.gov-team%2395910%22&pane=issue&itemId=87423266&issue=department-of-veterans-affairs%7Cva.gov-team%7C97231

## Testing done

- [x ] *New code is covered by unit tests*
- Ran 7959f2 and 1010d with supporting doc.


_Note: Optional_

## What areas of the site does it impact?
IVC CHAMPVA forms


