### PR TITLE
Log job start as info

### DIFF
--- a/lib/burials/monitor.rb
+++ b/lib/burials/monitor.rb
@@ -73,7 +73,7 @@ module Burials
         user_account_uuid: current_user&.user_account_uuid,
         tags:
       }
-      track_request('error', '21P-530EZ submission to Sidekiq begun', "#{CLAIM_STATS_KEY}.attempt",
+      track_request('info', '21P-530EZ submission to Sidekiq begun', "#{CLAIM_STATS_KEY}.attempt",
                     call_location: caller_locations.first, **additional_context)
     end
 

--- a/spec/lib/burials/monitor_spec.rb
+++ b/spec/lib/burials/monitor_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Burials::Monitor do
         }
 
         expect(monitor).to receive(:track_request).with(
-          'error',
+          'info',
           log,
           "#{claim_stats_key}.attempt",
           call_location: anything,


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- When the Sidekiq job begins, it should log as 'info', not as an error. 

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Burials

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature