### PR TITLE
Bugfix to overflow box 8E on the 0781a form generated by the 526 flow

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
@@ -149,7 +149,7 @@ module EVSS
           if parsed_forms[form_type_key].present?
             file_type_and_file_objs << {
               type: actual_form_types,
-              file: process_0781(uuid, FORM_ID_0781, parsed_forms[form_type_key],
+              file: process_0781(uuid, actual_form_types, parsed_forms[form_type_key],
                                  upload: false)
             }
           end

--- a/lib/pdf_fill/forms/va210781a.rb
+++ b/lib/pdf_fill/forms/va210781a.rb
@@ -157,7 +157,8 @@ module PdfFill
             }
           },
           'incidentDescription' => {
-            key: "incidentDescription[#{ITERATOR}]"
+            key: "incidentDescription[#{ITERATOR}]",
+            limit: 536
           },
           'combinedName0' => {
             limit: 80,


### PR DESCRIPTION
Previously (or currently I guess) box 8E on 0781a's generated from the 526 flow, does not have overflow set. 

This results in all the characters, no matter how many, being put in the box. While all data is technically there, after a number of chars, it exceeds the space in the box and becomes overlapped by the rest of the form, and not visible to adjudicators. 

Box 8E in the 0781 is set to `268 chars` , depending on the chars, I have been able to fit up to 275 in the box, so 268 is probably max, minus a safe buffer.

Box 8E on the 0781a, is bigger. And can fit roughly double the amount of chars. I am prosing setting box 8E on the 0781a to exactly double what the 0781 smaller box is set to, so `536 chars`