### PR TITLE
Change RES Date/time to UTC

### DIFF
--- a/lib/res/ch31_form.rb
+++ b/lib/res/ch31_form.rb
@@ -55,8 +55,7 @@ module RES
         internationalNumber: form_data['internationalNumber'],
         email: form_data['email'],
         documentId: form_data['documentId'],
-        # RES asked specifically for UTC as MM/dd/yyyy hh:mm AM/PM EST
-        receivedDate: @claim.created_at.to_date.strftime('%m/%d/%Y %I:%M %p EST'),
+        receivedDate: @claim.created_at.iso8601, # e.g. "2024-12-02T17:36:52Z"
         veteranAddress: mapped_address_hash(form_data['veteranAddress'])
       }
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change was requested by RES.

## Testing done

```
time = Time.now              # Current local time
est_time = time.in_time_zone('Eastern Time (US & Canada)')
formatted_time = est_time.strftime("%m/%d/%Y %I:%M %p EST")
puts formatted_time
```
