### PR TITLE
96605 Add new monitoring for form submits and Pega updates - IVC CHAMPVA Forms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -173,6 +173,9 @@ features:
   champva_failure_email_job_enabled:
     actor_type: user
     description: Enables sending failure notification emails for IVC CHAMPVA form submissions that lack a Pega status
+  champva_enhanced_monitor_logging:
+    actor_type: user
+    description: Enables using the new IVC CHAMPVA Monitoring logging class for enhanced Stats D info.
   check_in_experience_enabled:
     actor_type: user
     description: Enables the health care check-in experiences

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -23,7 +23,6 @@ module IvcChampva
               { json: { error_message: 'Invalid JSON keys' }, status: :bad_request }
             end
 
-          monitor.track_update_status(data['form_uuid'], data['status'])
           render json: response[:json], status: response[:status]
         rescue JSON::ParserError => e
           render json: { error_message: "JSON parsing error: #{e.message}" }, status: :internal_server_error
@@ -46,6 +45,7 @@ module IvcChampva
           # We only need the first form, outside of the file_names field, the data is the same.
           form = ivc_forms.first
           send_email(form_uuid, ivc_forms.first) if form.email.present?
+          monitor.track_update_status(form_uuid, status)
 
           { json: {}, status: :ok }
         else
@@ -94,15 +94,15 @@ module IvcChampva
       def fetch_forms_by_uuid(form_uuid)
         @fetch_forms_by_uuid ||= IvcChampvaForm.where(form_uuid:)
       end
-    end
 
-    ##
-    # retreive a monitor for tracking
-    #
-    # @return [IvcChampva::Monitor]
-    #
-    def monitor
-      @monitor ||= IvcChampva::Monitor.new
+      ##
+      # retreive a monitor for tracking
+      #
+      # @return [IvcChampva::Monitor]
+      #
+      def monitor
+        @monitor ||= IvcChampva::Monitor.new
+      end
     end
   end
 end

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -45,7 +45,10 @@ module IvcChampva
           # We only need the first form, outside of the file_names field, the data is the same.
           form = ivc_forms.first
           send_email(form_uuid, ivc_forms.first) if form.email.present?
-          monitor.track_update_status(form_uuid, status)
+
+          if Flipper.enabled?(:champva_enhanced_monitor_logging, @current_user)
+            monitor.track_update_status(form_uuid, status)
+          end
 
           { json: {}, status: :ok }
         else

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ivc_champva/monitor'
+
 module IvcChampva
   module V1
     class PegaController < SignIn::ServiceAccountApplicationController
@@ -21,6 +23,7 @@ module IvcChampva
               { json: { error_message: 'Invalid JSON keys' }, status: :bad_request }
             end
 
+          monitor.track_update_status(data['form_uuid'], data['status'])
           render json: response[:json], status: response[:status]
         rescue JSON::ParserError => e
           render json: { error_message: "JSON parsing error: #{e.message}" }, status: :internal_server_error
@@ -91,6 +94,15 @@ module IvcChampva
       def fetch_forms_by_uuid(form_uuid)
         @fetch_forms_by_uuid ||= IvcChampvaForm.where(form_uuid:)
       end
+    end
+
+    ##
+    # retreive a monitor for tracking
+    #
+    # @return [IvcChampva::Monitor]
+    #
+    def monitor
+      @monitor ||= IvcChampva::Monitor.new
     end
   end
 end

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ivc_champva/monitor'
+
 module IvcChampva
   class FileUploader
     def initialize(form_id, metadata, file_paths, insert_db_row = false) # rubocop:disable Style/OptionalBooleanParameter
@@ -48,6 +50,8 @@ module IvcChampva
         s3_status: response_status,
         pega_status:
       )
+
+      monitor.track_insert_form(@metadata['uuid'], @form_id)
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error("Database Insertion Error for #{@metadata['uuid']}: #{e.message}")
     end
@@ -88,6 +92,15 @@ module IvcChampva
       return nil unless email.present? && email.match?(/\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i)
 
       email
+    end
+
+    ##
+    # retreive a monitor for tracking
+    #
+    # @return [IvcChampva::Monitor]
+    #
+    def monitor
+      @monitor ||= IvcChampva::Monitor.new
     end
   end
 end

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -51,7 +51,9 @@ module IvcChampva
         pega_status:
       )
 
-      monitor.track_insert_form(@metadata['uuid'], @form_id)
+      if Flipper.enabled?(:champva_enhanced_monitor_logging, @current_user)
+        monitor.track_insert_form(@metadata['uuid'], @form_id)
+      end
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error("Database Insertion Error for #{@metadata['uuid']}: #{e.message}")
     end

--- a/modules/ivc_champva/lib/ivc_champva/monitor.rb
+++ b/modules/ivc_champva/lib/ivc_champva/monitor.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'zero_silent_failures/monitor'
+
+module IvcChampva
+  class Monitor < ::ZeroSilentFailures::Monitor
+    STATS_KEY = 'api.ivc_champva_form'
+
+    def initialize
+      super('ivc-champva-forms')
+    end
+
+    # form_uuid: string of the uuid included in a form's metadata
+    # form_id: string of the form's government ID (e.g., 10-10d)
+    def track_insert_form(form_uuid, form_id)
+      additional_context = {
+        form_uuid:,
+        form_id:
+      }
+      track_request('info', "IVC ChampVA Forms - #{form_id} inserted into database", "#{STATS_KEY}.insert_form",
+                    call_location: caller_locations.first, **additional_context)
+    end
+
+    # form_uuid: string of the uuid included in a form's metadata
+    # status: string of new Pega status being applied to form
+    def track_update_status(form_uuid, status)
+      additional_context = {
+        form_uuid:,
+        status:
+      }
+      track_request('info', "IVC ChampVA Forms - #{form_uuid} status updated to #{status}", "#{STATS_KEY}.update_status",
+                    call_location: caller_locations.first, **additional_context)
+    end
+  end
+end

--- a/modules/ivc_champva/lib/ivc_champva/monitor.rb
+++ b/modules/ivc_champva/lib/ivc_champva/monitor.rb
@@ -7,7 +7,7 @@ module IvcChampva
     STATS_KEY = 'api.ivc_champva_form'
 
     def initialize
-      super('ivc-champva-forms')
+      super('veteran-ivc-champva-forms')
     end
 
     # form_uuid: string of the uuid included in a form's metadata
@@ -28,7 +28,8 @@ module IvcChampva
         form_uuid:,
         status:
       }
-      track_request('info', "IVC ChampVA Forms - #{form_uuid} status updated to #{status}", "#{STATS_KEY}.update_status",
+      track_request('info', "IVC ChampVA Forms - #{form_uuid} status updated to #{status}",
+                    "#{STATS_KEY}.update_status",
                     call_location: caller_locations.first, **additional_context)
     end
   end

--- a/modules/ivc_champva/spec/services/monitor_spec.rb
+++ b/modules/ivc_champva/spec/services/monitor_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../lib/ivc_champva/monitor'
+
+RSpec.describe IvcChampva::Monitor do
+  let(:monitor) { described_class.new }
+
+  context 'with params supplied' do
+    describe '#track_update_status' do
+      it 'logs sidekiq success' do
+        payload = {
+          form_uuid: '12345678-1234-5678-1234-567812345678',
+          status: 'Processed'
+        }
+
+        expect(monitor).to receive(:track_update_status).with(
+          payload[:form_uuid], payload[:status]
+        )
+        monitor.track_update_status(payload[:form_uuid], payload[:status])
+      end
+    end
+
+    describe '#track_insert_form' do
+      it 'logs sidekiq success' do
+        payload = {
+          form_uuid: '12345678-1234-5678-1234-567812345678',
+          form_id: 'vha_10_10d'
+        }
+
+        expect(monitor).to receive(:track_insert_form).with(
+          payload[:form_uuid], payload[:form_id]
+        )
+        monitor.track_insert_form(payload[:form_uuid], payload[:form_id])
+      end
+    end
+  end
+end

--- a/modules/ivc_champva/spec/services/monitor_spec.rb
+++ b/modules/ivc_champva/spec/services/monitor_spec.rb
@@ -6,6 +6,12 @@ require_relative '../../lib/ivc_champva/monitor'
 RSpec.describe IvcChampva::Monitor do
   let(:monitor) { described_class.new }
 
+  before do
+    allow(Flipper).to receive(:enabled?)
+      .with(:champva_enhanced_monitor_logging, @current_user)
+      .and_return(true)
+  end
+
   context 'with params supplied' do
     describe '#track_update_status' do
       it 'logs sidekiq success' do


### PR DESCRIPTION
## Summary

- Adds new logging class based on `ZeroSilentFailures::Monitor`
- Adds logging in two locations

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96605

## Testing done

- [X] *New code is covered by unit tests*

## Screenshots

Example of the submission log:

![sub_l](https://github.com/user-attachments/assets/d8f8c696-6d55-49ce-9db4-c391e3df376a)

## What areas of the site does it impact?

IVC CHAMPVA forms

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

NA