### PR TITLE
Fix Rails 7.2 Deprecation warnings

### DIFF
--- a/lib/config_helper.rb
+++ b/lib/config_helper.rb
@@ -6,7 +6,7 @@ module ConfigHelper
   module_function
 
   def setup_action_mailer(config)
-    config.action_mailer.preview_path = Rails.root.join('spec', 'mailers', 'previews')
+    config.action_mailer.preview_paths = [Rails.root.join('spec', 'mailers', 'previews')]
     config.action_mailer.show_previews = Rails.env.development? || FeatureFlipper.staging_email?
 
     if FeatureFlipper.send_email?


### PR DESCRIPTION
## Summary

- Fix Deprecation warnings blocking Rails 7.2+ upgrade

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98145

## Testing done

- Specs Passing and local server booting after making changes