### PR TITLE
DBEX/97336: `Lighthouse::ServiceException` handler send invoker payload to Rails Logger

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -16,15 +16,16 @@ module V0
     before_action :validate_name_part, only: [:suggested_conditions]
 
     def rated_disabilities
+      invoker = 'V0::DisabilityCompensationFormsController#rated_disabilities'
       api_provider = ApiProviderFactory.call(
         type: ApiProviderFactory::FACTORIES[:rated_disabilities],
         provider: nil,
-        options: { icn: @current_user.icn.to_s, auth_headers: },
+        options: { icn: @current_user.icn.to_s, auth_headers:, invoker: },
         current_user: @current_user,
         feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_RATED_DISABILITIES_FOREGROUND
       )
 
-      response = api_provider.get_rated_disabilities
+      response = api_provider.get_rated_disabilities(nil, nil, { invoker: })
 
       render json: RatedDisabilitiesSerializer.new(response)
     end

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -20,7 +20,7 @@ module V0
       api_provider = ApiProviderFactory.call(
         type: ApiProviderFactory::FACTORIES[:rated_disabilities],
         provider: nil,
-        options: { icn: @current_user.icn.to_s, auth_headers:, invoker: },
+        options: { icn: @current_user.icn.to_s, auth_headers: },
         current_user: @current_user,
         feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_RATED_DISABILITIES_FOREGROUND
       )

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -350,7 +350,8 @@ module Form526ClaimFastTrackingConcern
   # fetch, memoize, and return all of the veteran's rated disabilities from EVSS
   def all_rated_disabilities
     settings = Settings.lighthouse.veteran_verification.form526
-    icn = UserAccount.where(id: user_account_id).first&.icn
+    icn = account&.icn
+    invoker = 'Form526ClaimFastTrackingConcern#all_rated_disabilities'
     api_provider = ApiProviderFactory.call(
       type: ApiProviderFactory::FACTORIES[:rated_disabilities],
       provider: nil,
@@ -361,7 +362,11 @@ module Form526ClaimFastTrackingConcern
     )
 
     @all_rated_disabilities ||= begin
-      response = api_provider.get_rated_disabilities(settings.access_token.client_id, settings.access_token.rsa_key)
+      response = api_provider.get_rated_disabilities(
+        settings.access_token.client_id,
+        settings.access_token.rsa_key,
+        { invoker: }
+      )
       response.rated_disabilities
     end
   end

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -133,8 +133,8 @@ class FormProfiles::VA526ez < FormProfile
       current_user: user,
       feature_toggle: ApiProviderFactory::FEATURE_TOGGLE_RATED_DISABILITIES_FOREGROUND
     )
-
-    response = api_provider.get_rated_disabilities
+    invoker = 'FormProfiles::VA526ez#initialize_rated_disabilities_information'
+    response = api_provider.get_rated_disabilities(nil, nil, { invoker: })
     ClaimFastTracking::MaxRatingAnnotator.annotate_disabilities(response)
 
     # Remap response object to schema fields

--- a/lib/disability_compensation/providers/rated_disabilities/evss_rated_disabilities_provider.rb
+++ b/lib/disability_compensation/providers/rated_disabilities/evss_rated_disabilities_provider.rb
@@ -12,7 +12,7 @@ class EvssRatedDisabilitiesProvider
 
   # @param [string] _client_id: (unused) the lighthouse_client_id requested from Lighthouse
   # @param [string] _rsa_key_path: (unused) path to the private RSA key used to create the lighthouse_client_id
-  def get_rated_disabilities(_client_id = nil, _rsa_key_path = nil)
+  def get_rated_disabilities(_client_id = nil, _rsa_key_path = nil, _options = {})
     data = @service.get_rated_disabilities
     transform(data)
   end

--- a/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider.rb
+++ b/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider.rb
@@ -7,6 +7,7 @@ require 'lighthouse/veteran_verification/service'
 class LighthouseRatedDisabilitiesProvider
   include RatedDisabilitiesProvider
 
+  # @param [string] :icn icn of the user
   def initialize(icn)
     @service = VeteranVerification::Service.new
     @icn = icn
@@ -23,15 +24,17 @@ class LighthouseRatedDisabilitiesProvider
   # @param [string] lighthouse_client_id: the lighthouse_client_id requested from Lighthouse
   # @param [string] lighthouse_rsa_key_path: path to the private RSA key used to create the lighthouse_client_id
   # @return [DisabilityCompensation::ApiProvider::RatedDisabilitiesResponse] a list of individual disability ratings
-  def get_rated_disabilities(lighthouse_client_id = nil, lighthouse_rsa_key_path = nil)
-    data = get_data(lighthouse_client_id, lighthouse_rsa_key_path)
+  # @option options [string] :invoker where this method was called from
+  def get_rated_disabilities(lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
+    data = get_data(lighthouse_client_id, lighthouse_rsa_key_path, options)
     transform(data['data']['attributes']['individual_ratings'])
   end
 
   # @param [string] lighthouse_client_id: the lighthouse_client_id requested from Lighthouse
   # @param [string] lighthouse_rsa_key_path: path to the private RSA key used to create the lighthouse_client_id
-  def get_data(lighthouse_client_id = nil, lighthouse_rsa_key_path = nil)
-    @service.get_rated_disabilities(@icn, lighthouse_client_id, lighthouse_rsa_key_path)
+  # @option options [string] :invoker where this method was called from
+  def get_data(lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
+    @service.get_rated_disabilities(@icn, lighthouse_client_id, lighthouse_rsa_key_path, options)
   end
 
   def transform(data)

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -18,6 +18,7 @@ module VeteranVerification
     # @option options [string] :aud_claim_url option to override the aud_claim_url for LH Veteran Verification APIs
     # @option options [hash] :auth_params a hash to send in auth params to create the access token
     # @option options [string] :host a base host for the Lighthouse API call
+    # @option options [string] :invoker where this method was called from
     def get_rated_disabilities(icn, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
       endpoint = 'disability_rating'
       config
@@ -29,7 +30,7 @@ module VeteranVerification
         )
         .body
     rescue => e
-      handle_error(e, lighthouse_client_id, endpoint)
+      handle_error(e, lighthouse_client_id, endpoint, options)
     end
 
     ##
@@ -49,12 +50,13 @@ module VeteranVerification
       handle_error(e, lighthouse_client_id, endpoint)
     end
 
-    def handle_error(error, lighthouse_client_id, endpoint)
+    def handle_error(error, lighthouse_client_id, endpoint, options = {})
       Lighthouse::ServiceException.send_error(
         error,
         self.class.to_s.underscore,
         lighthouse_client_id,
-        "#{config.base_api_path}/#{endpoint}"
+        "#{config.base_api_path}/#{endpoint}",
+        options
       )
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- this adds a way to be able to see where the Lighthouse rated disabilities provider is failing: 526 versus some other invoker. 
- datadog query: `@payload.invoker:*` (or a targeted value)
- can be used by other apps that use the `Lighthouse::ServiceException` class if wanted :)

## Related issue(s)

- [#97336](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97336)

## Testing done

- testing in datadog for the invoker payload

## Screenshots
n/a

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

