### PR TITLE
Add new not_confirmed_reason logic to error messaging generation

### DIFF
--- a/lib/lighthouse/veteran_verification/constants.rb
+++ b/lib/lighthouse/veteran_verification/constants.rb
@@ -2,6 +2,10 @@
 
 module VeteranVerification
   module Constants
+    ERROR_MESSAGE = [
+      'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again ' \
+      'later.'
+    ].freeze
     NOT_FOUND_MESSAGE = [
       'We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status ' \
       'card for you right now.',

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -62,8 +62,11 @@ module VeteranVerification
       attributes = response['data']['attributes']
       return response if attributes['veteran_status'] != 'not confirmed' || attributes.exclude?('not_confirmed_reason')
 
+      reason = attributes['not_confirmed_reason']
       response['data']['message'] =
-        if attributes['not_confirmed_reason'] == 'NOT_TITLE_38'
+        if reason == 'ERROR'
+          VeteranVerification::Constants::ERROR_MESSAGE
+        elsif reason == 'NOT_TITLE_38'
           VeteranVerification::Constants::NOT_ELIGIBLE_MESSAGE
         else
           VeteranVerification::Constants::NOT_FOUND_MESSAGE

--- a/spec/lib/lighthouse/veteran_verification/service_spec.rb
+++ b/spec/lib/lighthouse/veteran_verification/service_spec.rb
@@ -57,9 +57,21 @@ RSpec.describe VeteranVerification::Service do
         it 'retrieves veteran confirmation status from the Lighthouse API' do
           VCR.use_cassette('lighthouse/veteran_verification/status/200_response') do
             response = @service.get_vet_verification_status(icn, '', '')
+
             expect(response['data']['id']).to eq('1012667145V762142')
             expect(response['data']['type']).to eq('veteran_status_confirmations')
             expect(response['data']['attributes']['veteran_status']).to eq('confirmed')
+          end
+        end
+
+        it 'retrieves error status from the Lighthouse API' do
+          VCR.use_cassette('lighthouse/veteran_verification/status/200_error_response') do
+            response = @service.get_vet_verification_status('1012666182V20', '', '')
+
+            expect(response['data']['id']).to eq('1012666182V20')
+            expect(response['data']['attributes']['veteran_status']).to eq('not confirmed')
+            expect(response['data']['attributes']).to have_key('not_confirmed_reason')
+            expect(response['data']['message']).to eq(VeteranVerification::Constants::ERROR_MESSAGE)
           end
         end
 
@@ -79,6 +91,17 @@ RSpec.describe VeteranVerification::Service do
             response = @service.get_vet_verification_status('1012667145V762141', '', '')
 
             expect(response['data']['id']).to eq(nil)
+            expect(response['data']['attributes']['veteran_status']).to eq('not confirmed')
+            expect(response['data']['attributes']).to have_key('not_confirmed_reason')
+            expect(response['data']['message']).to eq(VeteranVerification::Constants::NOT_FOUND_MESSAGE)
+          end
+        end
+
+        it 'retrieves more research required status from the Lighthouse API' do
+          VCR.use_cassette('lighthouse/veteran_verification/status/200_more_research_required_response') do
+            response = @service.get_vet_verification_status('1012667145V762149', '', '')
+
+            expect(response['data']['id']).to eq('1012667145V762149')
             expect(response['data']['attributes']['veteran_status']).to eq('not confirmed')
             expect(response['data']['attributes']).to have_key('not_confirmed_reason')
             expect(response['data']['message']).to eq(VeteranVerification::Constants::NOT_FOUND_MESSAGE)

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_error_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_error_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<LIGHTHOUSE_DIRECT_DEPOSIT_HOST>/services/veteran_verification/v2/status/1012666182V20"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 19:06:24 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '38'
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Limit:
+      - '120'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"1012666182V20","type":"veteran_status_confirmations","attributes":{"veteran_status":"not
+        confirmed","not_confirmed_reason":"ERROR"}}}'
+  recorded_at: Thu, 31 Oct 2024 19:06:24 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_more_research_required_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/status/200_more_research_required_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<LIGHTHOUSE_DIRECT_DEPOSIT_HOST>/services/veteran_verification/v2/status/1012667145V762149"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 31 Oct 2024 19:06:24 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Ratelimit-Reset:
+      - '38'
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      Ratelimit-Limit:
+      - '120'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"1012667145V762149","type":"veteran_status_confirmations","attributes":{"veteran_status":"not
+        confirmed","not_confirmed_reason":"MORE_RESEARCH_REQUIRED"}}}'
+  recorded_at: Thu, 31 Oct 2024 19:06:24 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change adds new not_confirmed_reason logic in the error messaging generation for the Veteran Verification service. There were new not_confirmed_reasons shared with our team by the Lighthouse API team, so we needed to make sure that we supplied useful messaging to the user when those reasons are returned from the LH API. This work is not behind a feature toggle as the endpoint is brand new and not currently being used by any frontend.
- I am on the IIR Product team and we own the Veteran Status Card feature.

## Related issue(s)

- [1248](https://github.com/department-of-veterans-affairs/va-iir/issues/1248)

## Testing done

- [x] *New code is covered by unit tests*
- There is no old behavior as this is a brand new endpoint and new logic for the error messaging.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
