### PR TITLE
[API-42992][API-43008] Add recipients and consumer to email report

### DIFF
--- a/modules/claims_api/app/mailers/claims_api/submission_report_mailer.rb
+++ b/modules/claims_api/app/mailers/claims_api/submission_report_mailer.rb
@@ -10,6 +10,8 @@ module ClaimsApi
       matthew.christianson@adhocteam.us
       rockwell.rice@oddball.io
       tyler.coleman@oddball.io
+      Janet.Coutinho@va.gov
+      Michael.Harlow@va.gov
     ].freeze
 
     def build(date_from, date_to, data)

--- a/modules/claims_api/lib/claims_api/cid_mapper.rb
+++ b/modules/claims_api/lib/claims_api/cid_mapper.rb
@@ -11,7 +11,8 @@ module ClaimsApi
       '0oadnavva9u5F6vRz297' => 'Vet Claim Pro',
       '0oagdm49ygCSJTp8X297' => 'VA.gov',
       '0oaqzbqj9wGOCJBG8297' => 'Panoramic Software',
-      '0oao7p92peuKEvQ73297' => 'VetraSpec'
+      '0oao7p92peuKEvQ73297' => 'VetraSpec',
+      '0oaucamufx5L2o4Ey297' => 'VBA (OBI)'
     }.freeze
 
     def initialize(cid:)

--- a/modules/claims_api/spec/mailers/report_monthly_submissions_spec.rb
+++ b/modules/claims_api/spec/mailers/report_monthly_submissions_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe ClaimsApi::SubmissionReportMailer, type: [:mailer] do
           matthew.christianson@adhocteam.us
           rockwell.rice@oddball.io
           tyler.coleman@oddball.io
+          Janet.Coutinho@va.gov
+          Michael.Harlow@va.gov
         ]
       )
     end


### PR DESCRIPTION
## Summary

- Add recipients to monthly email report
- Add consumer to CID-consumer mapping

## Related issue(s)

- [API-42992](https://jira.devops.va.gov/browse/API-42992)
- [API-43008](https://jira.devops.va.gov/browse/API-43008)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

- Monthly claims API email report recipients
- CID mapper

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
