### PR TITLE
dbex/received-email-first-name: use `submission.get_first_name` method

### DIFF
--- a/app/sidekiq/lighthouse/poll_form526_pdf.rb
+++ b/app/sidekiq/lighthouse/poll_form526_pdf.rb
@@ -141,10 +141,10 @@ module Lighthouse
 
     def send_confirmation_email(submission)
       user_uuid = submission.user_uuid
-      user = User.find(user_uuid)
-      first_name = user&.first_name&.upcase.presence || auth_headers&.dig('va_eauth_firstName')&.upcase
       Rails.logger.info("Form526ConfirmationEmailJob called for user #{user_uuid},
                                                         submission: #{submission_id} from poll_form526_pdf")
+
+      first_name = submission.get_first_name
       params = submission.personalization_parameters(first_name)
       Form526ConfirmationEmailJob.perform_async(params)
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- uses `get_first_name` method on the submission in the polling job to ensure first name is found

## Related issue(s)

- [#97221](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97221)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
n/a

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

