### PR TITLE
98062: Remove silent_failure increment from SavedClaim updater jobs

### DIFF
--- a/app/sidekiq/decision_review/failure_notification_email_job.rb
+++ b/app/sidekiq/decision_review/failure_notification_email_job.rb
@@ -157,6 +157,10 @@ module DecisionReview
       params = { submitted_appeal_uuid: submission.submitted_appeal_uuid, appeal_type:, message: e.message }
       Rails.logger.error('DecisionReview::FailureNotificationEmailJob form error', params)
       StatsD.increment("#{STATSD_KEY_PREFIX}.form.error", tags: ["appeal_type:#{appeal_type}"])
+
+      tags = ["service:#{DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}",
+              'function: form submission to Lighthouse']
+      StatsD.increment('silent_failure', tags:)
     end
 
     def record_secondary_form_email_send_successful(secondary_form, notification_id)
@@ -183,6 +187,10 @@ module DecisionReview
                  message: e.message }
       Rails.logger.error('DecisionReview::FailureNotificationEmailJob secondary form error', params)
       StatsD.increment("#{STATSD_KEY_PREFIX}.secondary_form.error", tags: ["appeal_type:#{appeal_type}"])
+
+      tags = ["service:#{DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}",
+              'function: secondary form submission to Lighthouse']
+      StatsD.increment('silent_failure', tags:)
     end
 
     def record_evidence_email_send_successful(upload, notification_id)
@@ -213,6 +221,10 @@ module DecisionReview
       }
       Rails.logger.error('DecisionReview::FailureNotificationEmailJob evidence error', params)
       StatsD.increment("#{STATSD_KEY_PREFIX}.evidence.error", tags: ["appeal_type:#{appeal_type}"])
+
+      tags = ["service:#{DecisionReviewV1::APPEAL_TYPE_TO_SERVICE_MAP[appeal_type]}",
+              'function: evidence submission to Lighthouse']
+      StatsD.increment('silent_failure', tags:)
     end
 
     def enabled?

--- a/app/sidekiq/decision_review/saved_claim_status_updater_job.rb
+++ b/app/sidekiq/decision_review/saved_claim_status_updater_job.rb
@@ -178,11 +178,7 @@ module DecisionReview
       # Skip logging and statsd metrics when there is no status change
       return if JSON.parse(record.metadata || '{}')['status'] == status
 
-      if status == ERROR_STATUS
-        Rails.logger.info("#{log_prefix} form status error", guid: record.guid)
-        tags = [service_tag, 'function: form submission to Lighthouse']
-        StatsD.increment('silent_failure', tags:)
-      end
+      Rails.logger.info("#{log_prefix} form status error", guid: record.guid) if status == ERROR_STATUS
 
       StatsD.increment("#{statsd_prefix}.status", tags: ["status:#{status}"])
     end
@@ -191,11 +187,7 @@ module DecisionReview
       # Skip logging and statsd metrics when there is no status change
       return if JSON.parse(form.status || '{}')['status'] == status
 
-      if status == ERROR_STATUS
-        Rails.logger.info("#{log_prefix} secondary form status error", guid: form.guid)
-        tags = ['service:supplemental-claims-4142', 'function: PDF submission to Lighthouse']
-        StatsD.increment('silent_failure', tags:)
-      end
+      Rails.logger.info("#{log_prefix} secondary form status error", guid: form.guid) if status == ERROR_STATUS
 
       StatsD.increment("#{statsd_prefix}_secondary_form.status", tags: ["status:#{status}"])
     end
@@ -228,8 +220,6 @@ module DecisionReview
           error_type = get_error_type(upload['detail'])
           params = { guid: record.guid, lighthouse_upload_id: upload_id, detail: upload['detail'], error_type: }
           Rails.logger.info("#{log_prefix} evidence status error", params)
-          tags = [service_tag, 'function: evidence submission to Lighthouse']
-          StatsD.increment('silent_failure', tags:)
         end
 
         StatsD.increment("#{statsd_prefix}_upload.status", tags: ["status:#{status}"])

--- a/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
@@ -486,6 +486,8 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
           expect(Rails.logger).to have_received(:error).with(*logger_params)
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.failure_notification_email.form.error', tags: ['appeal_type:SC'])
+          expect(StatsD).to have_received(:increment)
+            .with('silent_failure', tags: ['service:supplemental-claims', 'function: form submission to Lighthouse'])
         end
       end
 
@@ -535,6 +537,9 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
           expect(Rails.logger).to have_received(:error).with(*logger_params)
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.failure_notification_email.evidence.error', tags: ['appeal_type:SC'])
+          expect(StatsD).to have_received(:increment)
+            .with('silent_failure',
+                  tags: ['service:supplemental-claims', 'function: evidence submission to Lighthouse'])
         end
       end
 
@@ -570,6 +575,9 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
           expect(Rails.logger).to have_received(:error).with(*logger_params)
           expect(StatsD).to have_received(:increment)
             .with('worker.decision_review.failure_notification_email.secondary_form.error', tags: ['appeal_type:SC'])
+          expect(StatsD).to have_received(:increment)
+            .with('silent_failure',
+                  tags: ['service:supplemental-claims', 'function: secondary form submission to Lighthouse'])
         end
       end
 

--- a/spec/sidekiq/decision_review/shared_examples_for_status_updater_jobs.rb
+++ b/spec/sidekiq/decision_review/shared_examples_for_status_updater_jobs.rb
@@ -151,9 +151,6 @@ RSpec.shared_examples 'status updater job with base forms' do |subclass|
         .with("#{log_prefix} form status error", guid: guid1)
       expect(Rails.logger).to have_received(:info)
         .with("#{log_prefix} form status error", guid: guid2)
-      expect(StatsD).to have_received(:increment)
-        .with('silent_failure', tags: [service_tag, 'function: form submission to Lighthouse'])
-        .exactly(1).time
     end
   end
 
@@ -382,10 +379,6 @@ RSpec.shared_examples 'status updater job when forms include evidence' do |subcl
               guid: guid2, lighthouse_upload_id: upload_id2,
               detail: 'Upstream status: Errors: ERR-EMMS-FAILED, Corrupted File detected. EMMS-GCIO-0, ...',
               error_type: 'corrupted-file')
-      expect(StatsD).to have_received(:increment)
-        .with('silent_failure', tags: [service_tag,
-                                       'function: evidence submission to Lighthouse'])
-        .exactly(1).time
     end
   end
 end


### PR DESCRIPTION
## Summary
This removes an incremented `silent_failure` metric from the SavedClaim updater jobs.

This is owned by the Benefits Decision Review team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/98062

## Testing done
Manually testing and spec tests
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
This impacts the SavedClaim status updater jobs and StatsD metrics.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
