### PR TITLE
97918: Update email retrieval for DR email notifications

### DIFF
--- a/app/models/appeal_submission.rb
+++ b/app/models/appeal_submission.rb
@@ -79,11 +79,10 @@ class AppealSubmission < ApplicationRecord
   end
 
   def current_email_address
-    va_profile = ::VAProfile::ContactInformation::Service.get_person(get_mpi_profile.vet360_id.to_s)&.person
-    raise 'Failed to fetch VA profile' if va_profile.nil?
+    sc = SavedClaim.find_by(guid: submitted_appeal_uuid)
+    form = JSON.parse(sc.form)
 
-    current_emails = va_profile.emails.select { |email| email.effective_end_date.nil? }
-    email = current_emails.first&.email_address
+    email = form.dig('data', 'attributes', 'veteran', 'email')
     raise 'Failed to retrieve email address' if email.nil?
 
     email

--- a/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/decision_review/failure_notification_email_job_spec.rb
@@ -45,26 +45,34 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
   end
 
   let(:email_address) { 'testuser@test.com' }
-  let(:emails) { build(:email, email_address:) }
-  let(:person) { build(:person, emails:) }
-  let(:person_response) { instance_double(VAProfile::ContactInformation::PersonResponse, person:) }
+  let(:form) do
+    {
+      data: {
+        attributes: {
+          veteran: {
+            email: email_address
+          }
+        }
+      }
+    }.to_json
+  end
 
   let(:email_address2) { 'testuser2@test.com' }
-  let(:emails2) { build(:email, email_address: email_address2) }
-  let(:person2) { build(:person, emails: emails2) }
-  let(:person_response2) { instance_double(VAProfile::ContactInformation::PersonResponse, person: person2) }
+  let(:form2) do
+    {
+      data: {
+        attributes: {
+          veteran: {
+            email: email_address2
+          }
+        }
+      }
+    }.to_json
+  end
 
   before do
     allow(VaNotify::Service).to receive(:new).and_return(vanotify_service)
     allow(MPI::Service).to receive(:new).and_return(mpi_service)
-
-    allow(VAProfile::ContactInformation::Service).to receive(:get_person)
-    allow(VAProfile::ContactInformation::Service).to receive(:get_person)
-      .with(mpi_profile&.vet360_id)
-      .and_return(person_response)
-    allow(VAProfile::ContactInformation::Service).to receive(:get_person)
-      .with(mpi_profile2.vet360_id)
-      .and_return(person_response2)
   end
 
   describe 'perform' do
@@ -89,10 +97,9 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
         let(:reference) { "SC-form-#{guid1}" }
 
         before do
-          SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}', metadata: '{"status":"error"}')
-          SavedClaim::SupplementalClaim.create(guid: guid2, form: '{}',
-                                               metadata: '{"status":"error"}')
-          SavedClaim::SupplementalClaim.create(guid: guid3, form: '{}', metadata: '{"status":"pending"}')
+          SavedClaim::SupplementalClaim.create(guid: guid1, form:, metadata: '{"status":"error"}')
+          SavedClaim::SupplementalClaim.create(guid: guid2, form:, metadata: '{"status":"error"}')
+          SavedClaim::SupplementalClaim.create(guid: guid3, form: form2, metadata: '{"status":"pending"}')
 
           create(:appeal_submission, user_uuid:, type_of_appeal: 'SC', submitted_appeal_uuid: guid1, created_at:)
           create(:appeal_submission, user_uuid:, type_of_appeal: 'SC', submitted_appeal_uuid: guid2,
@@ -243,9 +250,9 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
         let(:reference2) { "NOD-evidence-#{upload_guid5}" }
 
         before do
-          SavedClaim::NoticeOfDisagreement.create(guid: guid1, form: '{}', metadata: metadata1.to_json)
+          SavedClaim::NoticeOfDisagreement.create(guid: guid1, form:, metadata: metadata1.to_json)
           SavedClaim::NoticeOfDisagreement.create(guid: guid2, form: '{}', metadata: metadata2.to_json)
-          SavedClaim::NoticeOfDisagreement.create(guid: guid3, form: '{}', metadata: metadata3.to_json)
+          SavedClaim::NoticeOfDisagreement.create(guid: guid3, form: form2, metadata: metadata3.to_json)
           SavedClaim::NoticeOfDisagreement.create(guid: guid4, form: '{}', metadata: nil)
 
           # 1 error no email, 1 vbms, 1 error already emailed
@@ -380,8 +387,8 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
         let(:reference) { "SC-secondary_form-#{secondary_form1.guid}" }
 
         before do
-          SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}')
-          SavedClaim::SupplementalClaim.create(guid: guid2, form: '{}')
+          SavedClaim::SupplementalClaim.create(guid: guid1, form:)
+          SavedClaim::SupplementalClaim.create(guid: guid2, form:)
         end
 
         context 'with flag enabled' do
@@ -514,7 +521,7 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
         let(:message) { 'Failed to fetch MPI profile' }
 
         before do
-          SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}', metadata: metadata.to_json)
+          SavedClaim::SupplementalClaim.create(guid: guid1, form:, metadata: metadata.to_json)
           appeal_submission = create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid1)
 
           upload = create(:appeal_submission_upload, lighthouse_upload_id:, appeal_submission:)
@@ -553,7 +560,7 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
         end
 
         before do
-          SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}')
+          SavedClaim::SupplementalClaim.create(guid: guid1, form:)
           appeal_submission = create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid1)
 
           create(:secondary_appeal_form4142, guid: lighthouse_upload_id, status: secondary_form_status_error,
@@ -575,7 +582,7 @@ RSpec.describe DecisionReview::FailureNotificationEmailJob, type: :job do
 
       context 'when there are no errors to email' do
         before do
-          SavedClaim::SupplementalClaim.create(guid: guid1, form: '{}')
+          SavedClaim::SupplementalClaim.create(guid: guid1, form:)
         end
 
         it 'does not send emails' do

--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -32,11 +32,6 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
     service
   end
 
-  let(:email_address) { 'testuser@test.com' }
-  let(:emails) { build(:email, email_address:) }
-  let(:person) { build(:person, emails:) }
-  let(:person_response) { instance_double(VAProfile::ContactInformation::PersonResponse, person:) }
-
   before do
     allow(VaNotify::Service).to receive(:new).and_return(vanotify_service)
     allow(MPI::Service).to receive(:new).and_return(mpi_service)
@@ -89,6 +84,22 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
           }
         end
         let(:tags) { ['service:supplemental-claims', 'function: secondary form submission to Lighthouse'] }
+        let(:email_address) { 'testuser@test.com' }
+        let(:form) do
+          {
+            data: {
+              attributes: {
+                veteran: {
+                  email: email_address
+                }
+              }
+            }
+          }.to_json
+        end
+
+        before do
+          SavedClaim::NoticeOfDisagreement.create(guid: submitted_appeal_uuid, form:)
+        end
 
         it 'increments statsd correctly when email is sent' do
           expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }

--- a/spec/sidekiq/decision_review/submit_upload_spec.rb
+++ b/spec/sidekiq/decision_review/submit_upload_spec.rb
@@ -30,11 +30,6 @@ RSpec.describe DecisionReview::SubmitUpload, type: :job do
     service
   end
 
-  let(:email_address) { 'testuser@test.com' }
-  let(:emails) { build(:email, email_address:) }
-  let(:person) { build(:person, emails:) }
-  let(:person_response) { instance_double(VAProfile::ContactInformation::PersonResponse, person:) }
-
   before do
     allow(VaNotify::Service).to receive(:new).and_return(vanotify_service)
     allow(MPI::Service).to receive(:new).and_return(mpi_service)
@@ -281,6 +276,22 @@ RSpec.describe DecisionReview::SubmitUpload, type: :job do
         end
 
         let(:tags) { ['service:board-appeal', 'function: evidence submission to Lighthouse'] }
+        let(:email_address) { 'testuser@test.com' }
+        let(:form) do
+          {
+            data: {
+              attributes: {
+                veteran: {
+                  email: email_address
+                }
+              }
+            }
+          }.to_json
+        end
+
+        before do
+          SavedClaim::SupplementalClaim.create(guid: appeal_submission.submitted_appeal_uuid, form:)
+        end
 
         it 'increments statsd correctly when email is sent' do
           expect { described_class.new.sidekiq_retries_exhausted_block.call(msg) }


### PR DESCRIPTION
## Summary
This PR removes the usage of `VAProfile::ContactInformation::Service.get_person` to obtain the Veteran's email when sending out failure notification emails as emails are provided as part of the form submission.

This is owned by the Benefits Decision Review team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/97918

## Testing done
Tested locally and spec tests
- [x] *New code is covered by unit tests*
Email address is saved in the DR SavedClaim models so that can be used instead of calling `VAProfile::ContactInformation::Service.get_person`.

## What areas of the site does it impact?
The impacted parts of the site are sidekiq jobs: FailureNotificationEmailJob, Form4142Submit job, and SubmitUpload job

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
