### PR TITLE
Remove max_auth_retry_limit from production.yml

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,7 +7,6 @@ central_mail:
 
 check_in:
   authentication:
-    max_auth_retry_limit: 3
     retry_attempt_expiry: 604800 # 7 Days
   chip_api_v2:
     mock: false


### PR DESCRIPTION
## Summary

- Unintentionally added `check_in/authentication/max_auth_retry_limit`

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  max_auth_retry_limit is removed