### PR TITLE
Add Vet Verification Status logging and monitoring capabilities

### DIFF
--- a/lib/lighthouse/veteran_verification/constants.rb
+++ b/lib/lighthouse/veteran_verification/constants.rb
@@ -2,6 +2,9 @@
 
 module VeteranVerification
   module Constants
+    STATSD_VET_VERIFICATION_TOTAL_KEY = 'api.lighthouse.vet_verification_status.total'
+    STATSD_VET_VERIFICATION_FAIL_KEY = 'api.lighthouse.vet_verification_status.fail'
+
     ERROR_MESSAGE = [
       'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again ' \
       'later.'

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -47,7 +47,10 @@ module VeteranVerification
 
       transform_response(response)
     rescue => e
+      StatsD.increment(VeteranVerification::Constants::STATSD_VET_VERIFICATION_FAIL_KEY)
       handle_error(e, lighthouse_client_id, endpoint)
+    ensure
+      StatsD.increment(VeteranVerification::Constants::STATSD_VET_VERIFICATION_TOTAL_KEY)
     end
 
     def handle_error(error, lighthouse_client_id, endpoint, options = {})
@@ -73,7 +76,13 @@ module VeteranVerification
         else
           VeteranVerification::Constants::NOT_FOUND_MESSAGE
         end
+
+      log_reason(reason)
       response
+    end
+
+    def log_reason(reason)
+      ::Rails.logger.info('Vet Verification Status Success', { not_confirmed_reason: reason})
     end
   end
 end

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -82,7 +82,7 @@ module VeteranVerification
     end
 
     def log_reason(reason)
-      ::Rails.logger.info('Vet Verification Status Success', { not_confirmed_reason: reason})
+      ::Rails.logger.info('Vet Verification Status Success', { not_confirmed_reason: reason })
     end
   end
 end

--- a/spec/lib/lighthouse/veteran_verification/service_spec.rb
+++ b/spec/lib/lighthouse/veteran_verification/service_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe VeteranVerification::Service do
 
         it 'retrieves veteran confirmation status from the Lighthouse API' do
           VCR.use_cassette('lighthouse/veteran_verification/status/200_response') do
+            expect(StatsD).to receive(:increment).with(
+              VeteranVerification::Constants::STATSD_VET_VERIFICATION_TOTAL_KEY
+            )
+
             response = @service.get_vet_verification_status(icn, '', '')
 
             expect(response['data']['id']).to eq('1012667145V762142')
@@ -66,6 +70,10 @@ RSpec.describe VeteranVerification::Service do
 
         it 'retrieves error status from the Lighthouse API' do
           VCR.use_cassette('lighthouse/veteran_verification/status/200_error_response') do
+            expect(StatsD).to receive(:increment).with(
+              VeteranVerification::Constants::STATSD_VET_VERIFICATION_TOTAL_KEY
+            )
+
             response = @service.get_vet_verification_status('1012666182V20', '', '')
 
             expect(response['data']['id']).to eq('1012666182V20')
@@ -110,6 +118,12 @@ RSpec.describe VeteranVerification::Service do
 
         Lighthouse::ServiceException::ERROR_MAP.except(404, 422, 499, 501).each do |status, error_class|
           it "throws a #{status} error if Lighthouse sends it back" do
+            expect(StatsD).to receive(:increment).with(
+              VeteranVerification::Constants::STATSD_VET_VERIFICATION_TOTAL_KEY
+            )
+            expect(StatsD).to receive(:increment).with(
+              VeteranVerification::Constants::STATSD_VET_VERIFICATION_FAIL_KEY
+            )
             expect do
               test_error(
                 "lighthouse/veteran_verification/status/#{status}_response"


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change adds statsd monitoring and some logging to a brand new endpoint that is not hooked up to any frontend.
- I am on the IIR Product team and we own the Veteran Status Card feature.

## Related issue(s)

- [1254](https://github.com/department-of-veterans-affairs/va-iir/issues/1254)

## Testing done

- [x] *New code is covered by unit tests*
- No old behavior as this is a new endpoint.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
