### PR TITLE
vi-838: Add Operation param, update tests

### DIFF
--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .with(force_authn: true)
               expect { call_endpoint }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                             tags: ["type:#{type}", 'version:v1', 'client_id:vaweb'],
+                                             tags: ["type:#{type}", 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'],
                                              **once)
                 .and trigger_statsd_increment(described_class::STATSD_SSO_SAMLREQUEST_KEY,
                                               tags: ["type:#{type}",
@@ -148,7 +148,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'logs the USiP client application' do
                 expect { call_endpoint }
                   .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                               tags: ["type:#{type}", 'version:v1', 'client_id:vamobile'], **once)
+                                               tags: ["type:#{type}", 'version:v1', 'client_id:vamobile', 'operation:non_interstitial'], **once)
               end
             end
           end
@@ -165,7 +165,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
               expect { call_endpoint }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                             tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                             tags: ['type:custom', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
                 .and trigger_statsd_increment(described_class::STATSD_SSO_SAMLREQUEST_KEY,
                                               tags: ['type:custom',
                                                      "context:#{IAL::LOGIN_GOV_IAL2}",
@@ -192,7 +192,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -212,7 +212,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception when ial parameter is not 1 or 2' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -237,7 +237,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
               expect { call_endpoint }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                             tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                             tags: ['type:custom', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
 
               expect(response).to have_http_status(:ok)
               expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
@@ -259,7 +259,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -279,7 +279,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               it 'raises exception' do
                 expect { call_endpoint }
                   .not_to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb'], **once)
+                                                   tags: ['type:custom', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
                 expect(response).to have_http_status(:bad_request)
                 expect(JSON.parse(response.body))
                   .to eq({
@@ -301,7 +301,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /sessions/idme_signup/new to SessionsController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['type:idme_signup', 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ['type:idme_signup', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
             expect(response).to have_http_status(:ok)
             expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
                                   'originating_request_id' => nil, 'type' => 'signup')
@@ -316,7 +316,8 @@ RSpec.describe V1::SessionsController, type: :controller do
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                            tags: ['type:idme_signup_verified',
                                                   'version:v1',
-                                                  'client_id:vaweb'], **once)
+                                                  'client_id:vaweb',
+                                                  'operation:non_interstitial'], **once)
             expect(response).to have_http_status(:ok)
             expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
                                   'originating_request_id' => nil, 'type' => 'signup')
@@ -329,7 +330,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /sessions/logingov_signup/new to SessionsController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['type:logingov_signup', 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ['type:logingov_signup', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
             expect(response).to have_http_status(:ok)
             expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
                                   'originating_request_id' => nil, 'type' => 'signup')
@@ -344,7 +345,8 @@ RSpec.describe V1::SessionsController, type: :controller do
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                            tags: ['type:logingov_signup_verified',
                                                   'version:v1',
-                                                  'client_id:vaweb'], **once)
+                                                  'client_id:vaweb',
+                                                  'operation:non_interstitial'], **once)
             expect(response).to have_http_status(:ok)
             expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
                                   'originating_request_id' => nil, 'type' => 'signup')
@@ -363,7 +365,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'routes /v1/sessions/slo/new to SessionController#new' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ['type:slo', 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ['type:slo', 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
             expect(response).to have_http_status(:found)
           end
 
@@ -416,7 +418,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           it 'does not delete cookies' do
             expect { call_endpoint }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                           tags: ["type:#{type}", 'version:v1', 'client_id:vaweb'], **once)
+                                           tags: ["type:#{type}", 'version:v1', 'client_id:vaweb', 'operation:non_interstitial'], **once)
             expect(response).to have_http_status(:ok)
             expect(cookies['vagov_saml_request_localhost']).not_to be_nil
           end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *This work is behind a feature toggle (flipper): NO*
- This PR adds "Operation" as a param to Sessions Controller for interstitial options.
- *(Which team do you work for, does your team own the maintenance of this component?)* Identity-Platform

## Related issue(s)

- [vi-838](https://jira.devops.va.gov/browse/VI-838)

## Testing done

- [ ] For testing I put this logger `  Rails.logger.info("Operation: #{operation} | Type: #{type} | Client ID: #{client_id}")` in the `new` action in the sessions controller. Then I ran the following to check the params through the log. 

```
params = { type: 'idme_verified', operation: 'interstitial_verify', client_id: 'vaweb' }
controller = V1::SessionsController.new
controller.params = params
controller.new
```
This should output something like this:
`=> "Rails -- Operation: interstitial_verify | Type: idme_verified | Client ID: vaweb"`

```
params = { type: 'idme_verified', client_id: 'vaweb' }
controller.params = params
controller.new
```
This should output something like this:
`=> "Rails -- Operation: non_interstitial | Type: idme_verified | Client ID: vaweb"`

## What areas of the site does it impact?
- verified idme new sessions

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

