### PR TITLE
98326 Update ZSF logging - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/lib/ivc_champva/monitor.rb
+++ b/modules/ivc_champva/lib/ivc_champva/monitor.rb
@@ -32,5 +32,15 @@ module IvcChampva
                     "#{STATS_KEY}.update_status",
                     call_location: caller_locations.first, **additional_context)
     end
+
+    # form_id: string of the form's government ID (e.g., 10-10d)
+    def track_missing_status_email_sent(form_id)
+      additional_context = {
+        form_id:
+      }
+      track_request('info', "IVC ChampVA Forms - #{form_id} missing status failure email sent",
+                    "#{STATS_KEY}.form_missing_status_email_sent",
+                    call_location: caller_locations.first, **additional_context)
+    end
   end
 end

--- a/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
@@ -18,35 +18,11 @@ RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
     expect(StatsD).to have_received(:gauge).with('ivc_champva.forms_missing_status.count', forms.count)
   end
 
-  it 'sends each form UUID to DataDog' do
-    IvcChampva::MissingFormStatusJob.new.perform
-
-    forms.each do |form|
-      expect(StatsD).to have_received(:increment).with('ivc_champva.form_missing_status', tags: ["id:#{form.id}"])
-    end
-  end
-
   it 'logs an error if an exception occurs' do
     allow(IvcChampvaForm).to receive(:where).and_raise(StandardError.new('Something went wrong'))
 
     expect(Rails.logger).to receive(:error).twice
 
     IvcChampva::MissingFormStatusJob.new.perform
-  end
-
-  context 'Feature champva_failure_email_job_enabled=true' do
-    before do
-      allow(Flipper).to receive(:enabled?)
-        .with(:champva_failure_email_job_enabled, @current_user)
-        .and_return(true)
-    end
-
-    it 'sends count of forms missing Pega status for >= 7 days to DataDog' do
-      IvcChampva::MissingFormStatusJob.new.perform
-      forms.each do |form|
-        expect(StatsD).to have_received(:increment)
-          .with('ivc_champva.form_missing_status_email_sent', tags: ["id:#{form.id}"])
-      end
-    end
   end
 end

--- a/modules/ivc_champva/spec/services/monitor_spec.rb
+++ b/modules/ivc_champva/spec/services/monitor_spec.rb
@@ -40,5 +40,18 @@ RSpec.describe IvcChampva::Monitor do
         monitor.track_insert_form(payload[:form_uuid], payload[:form_id])
       end
     end
+
+    describe '#track_missing_status_email_sent' do
+      it 'logs sidekiq success' do
+        payload = {
+          form_id: 'vha_10_10d'
+        }
+
+        expect(monitor).to receive(:track_missing_status_email_sent).with(
+          payload[:form_id]
+        )
+        monitor.track_missing_status_email_sent(payload[:form_id])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR updates the logging surrounding Pega status failure notification emails to use the new ZSF monitor class. Logs are also now configured to send to the watchtower [ZSF dashboard](https://vagov.ddog-gov.com/dashboard/n6c-twn-swr/silent-failure-tracker?fromUser=false&refresh_mode=sliding&from_ts=1725290886762&to_ts=1733243286762&live=true).

- Updates logging calls to use the new ZSF monitor class

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98326
## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

This screenshot shows that our logs reach the ZSF watchtower dashboard (staging is pictured):
![zsf_dash](https://github.com/user-attachments/assets/004cbe7d-2f4e-44c8-bd6f-7681ebeb02dd)

## What areas of the site does it impact?

IVC CHAMPVA forms

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
