### PR TITLE
[VI-740] Skipping MHV Account Creation API for custom authentication when user must accept terms of use

### DIFF
--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -26,7 +26,7 @@ module SAML
     MOBILE_CLIENT_ID = 'mobile'
     UNIFIED_SIGN_IN_CLIENTS = %w[vaweb mhv myvahealth ebenefits vamobile vaoccmobile].freeze
     TERMS_OF_USE_DECLINED_PATH = '/terms-of-use/declined'
-    SKIP_MHV_ACCOUNT_CREATION_CLIENTS = %w[mhv].freeze
+    SKIP_MHV_ACCOUNT_CREATION_CLIENTS = %w[mhv custom].freeze
 
     attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :tracker
 


### PR DESCRIPTION
## Summary

- This PR adds 'custom' to the list of terms of use redirected clients that will not trigger the MHV Account creation API

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-740

## What areas of the site does it impact?
Authentication

