### PR TITLE
DBEX/98283: update retryable error handler for lighthouse requests

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -182,15 +182,8 @@ module EVSS
         handle_errors(submission, e)
       end
 
-      def handle_errors(submission, error) # rubocop:disable Metrics/MethodLength
-        if error.instance_of?(Common::Exceptions::UnprocessableEntity)
-          error_clone = error.deep_dup
-          upstream_error = error_clone.errors.first.stringify_keys
-          unless (upstream_error['source'].present? && upstream_error['source']['pointer'].present?) ||
-                 upstream_error['detail'].downcase.include?('retries will fail')
-            error = Common::Exceptions::UpstreamUnprocessableEntity.new(errors: error.errors)
-          end
-        end
+      def handle_errors(submission, error)
+        error = retries_will_fail_error(error)
         raise error
       rescue Common::Exceptions::BackendServiceException,
              Common::Exceptions::Unauthorized, # 401 (UnauthorizedError?)
@@ -201,8 +194,8 @@ module EVSS
              Common::Exceptions::ExternalServerInternalServerError, # 500
              Common::Exceptions::NotImplemented, # 501
              Common::Exceptions::BadGateway, # 502
-             Common::Exceptions::ServiceUnavailable, # 503 (ServiceUnavailableException?)
-             Common::Exceptions::GatewayTimeout, # 504 (already here)
+             Common::Exceptions::ServiceUnavailable, # 503 (ServiceUnavailableException)
+             Common::Exceptions::GatewayTimeout, # 504
              Breakers::OutageException => e
         retryable_error_handler(submission, e)
       rescue EVSS::DisabilityCompensationForm::ServiceException => e
@@ -210,6 +203,19 @@ module EVSS
         retry_form526_error_handler!(submission, e)
       rescue => e
         non_retryable_error_handler(submission, e)
+      end
+
+      # check if this error from the provider will fail retires
+      def retries_will_fail_error(error)
+        if error.instance_of?(Common::Exceptions::UnprocessableEntity)
+          error_clone = error.deep_dup
+          upstream_error = error_clone.errors.first.stringify_keys
+          unless (upstream_error['source'].present? && upstream_error['source']['pointer'].present?) ||
+                 upstream_error['detail'].downcase.include?('retries will fail')
+            error = Common::Exceptions::UpstreamUnprocessableEntity.new(errors: error.errors)
+          end
+        end
+        error
       end
 
       def retryable_error_handler(_submission, error)

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -706,9 +706,9 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             allow_any_instance_of(Form526ClaimFastTrackingConcern).to receive(:prepare_for_ep_merge!).and_return(nil)
             allow_any_instance_of(Form526ClaimFastTrackingConcern).to receive(:pending_eps?).and_return(false)
             allow_any_instance_of(Form526ClaimFastTrackingConcern).to receive(:classify_vagov_contentions)
-                                                                        .and_return(nil)
+              .and_return(nil)
             allow_any_instance_of(VeteranVerification::Service).to receive(:get_rated_disabilities)
-                                                                .and_raise(error_class.new(status:))
+              .and_raise(error_class.new(status:))
             expect_retryable_error(error_class)
           end
         end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -694,6 +694,23 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
               .and_raise(error_class.new(status:))
             expect_retryable_error(error_class)
           end
+
+          it "throws a #{status} error if Lighthouse sends it back for rated disabilities" do
+            allow_any_instance_of(Flipper)
+              .to(receive(:enabled?))
+              .with('disability_compensation_lighthouse_rated_disabilities_provider_background', anything)
+              .and_return(true)
+            allow_any_instance_of(EVSS::DisabilityCompensationForm::SubmitForm526)
+              .to(receive(:fail_submission_feature_enabled?))
+              .and_return(false)
+            allow_any_instance_of(Form526ClaimFastTrackingConcern).to receive(:prepare_for_ep_merge!).and_return(nil)
+            allow_any_instance_of(Form526ClaimFastTrackingConcern).to receive(:pending_eps?).and_return(false)
+            allow_any_instance_of(Form526ClaimFastTrackingConcern).to receive(:classify_vagov_contentions)
+                                                                        .and_return(nil)
+            allow_any_instance_of(VeteranVerification::Service).to receive(:get_rated_disabilities)
+                                                                .and_raise(error_class.new(status:))
+            expect_retryable_error(error_class)
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES and NO*
- switching out the legacy error handler with the new lighthouse statuses that we retry on in preparation for 100% lighthouse

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98283

## Testing done

- [x] *New code is covered by unit tests*
- errors are categorized by "non-retryable", such as a validation error (422) versus a retryable, such as bad gateway (502)
- now we are handling more retryable situations, such as a service being down, for all service calls during the primary form 526 submission path

## Screenshots
n/a

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

