### PR TITLE
Add healthcheck endpoints to v2/decision_reviews

### DIFF
--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -28,6 +28,9 @@ AppealsApi::Engine.routes.draw do
 
   namespace :v2, defaults: { format: 'json' } do
     namespace :decision_reviews do
+      get :healthcheck, to: '/appeals_api/metadata#healthcheck'
+      get :upstream_healthcheck, to: '/appeals_api/metadata#decision_reviews_upstream_healthcheck'
+
       get 'contestable_issues/:decision_review_type', to: 'contestable_issues#index'
 
       namespace :higher_level_reviews do


### PR DESCRIPTION
## Summary
[By request of Cassowary](https://lighthouseva.slack.com/archives/C02SHTY8VNW/p1733339803494519?thread_ts=1732055966.272019&cid=C02SHTY8VNW), this adds healthcheck & upstream_healthcheck into our `v2/decision_reviews/` endpoints.

## Related issue(s)
N/A

## Testing done

`rails routes` & `curl` verification

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature