### PR TITLE
[VACMS-19943]Add tests to cover the UpdateAll Banners job

### DIFF
--- a/modules/banners/spec/sidekiq/banners_update_all_job_spec.rb
+++ b/modules/banners/spec/sidekiq/banners_update_all_job_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Banners::UpdateAllJob, type: :job do
+  let(:job) { described_class.new }
+
+  before do
+    allow(Flipper).to receive(:enabled?).with(:banner_update_alternative_banners).and_return(true)
+    allow(Banners).to receive(:update_all)
+    allow(StatsD).to receive(:increment)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  describe '#perform' do
+    context 'when enabled' do
+      it 'calls Banners.update_all' do
+        job.perform
+        expect(Banners).to have_received(:update_all)
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:banner_update_alternative_banners).and_return(false)
+      end
+
+      it 'does not call Banners.update_all' do
+        job.perform
+        expect(Banners).not_to have_received(:update_all)
+      end
+    end
+
+    context 'when Banners::Updater::BannerDataFetchError is raised' do
+      before do
+        allow(Banners).to receive(:update_all).and_raise(Banners::Updater::BannerDataFetchError.new('Fetch error'))
+      end
+
+      it 'increments the banner_data_fetch_error metric' do
+        expect { job.perform }.to raise_error(Banners::Updater::BannerDataFetchError)
+        expect(StatsD).to have_received(:increment).with('banners.sidekiq.update_all_banners.banner_data_fetch_error')
+      end
+
+      it 'logs the error' do
+        expect { job.perform }.to raise_error(Banners::Updater::BannerDataFetchError)
+        expect(Rails.logger).to have_received(:error).with(
+          'Banner data fetch failed',
+          { error_message: 'Fetch error', error_class: 'Banners::Updater::BannerDataFetchError' }
+        )
+      end
+    end
+  end
+
+  describe 'sidekiq_retries_exhausted' do
+    let(:msg) do
+      {
+        'jid' => '123',
+        'class' => 'Banners::UpdateAllJob',
+        'error_class' => 'SomeError',
+        'error_message' => 'Something went wrong'
+      }
+    end
+
+    it 'increments the exhausted metric' do
+      described_class.sidekiq_retries_exhausted_block.call(msg, nil)
+      expect(StatsD).to have_received(:increment).with('banners.sidekiq.update_all_banners.exhausted')
+    end
+
+    it 'logs the retries exhausted message' do
+      described_class.sidekiq_retries_exhausted_block.call(msg, nil)
+      expect(Rails.logger).to have_received(:error).with(
+        'Banners::UpdateAllJob retries exhausted',
+        { job_id: '123', error_class: 'SomeError', error_message: 'Something went wrong' }
+      )
+    end
+
+    context 'when an error occurs in the retries exhausted block' do
+      before do
+        allow(Rails.logger).to receive(:error).and_raise(StandardError.new('Logging error'))
+      end
+
+      it 'logs the failure and raises the error' do
+        expect {
+          described_class.sidekiq_retries_exhausted_block.call(msg, nil)
+        }.to raise_error(StandardError, 'Logging error')
+
+        expect(Rails.logger).to have_received(:error).with(
+          'Failure in Banners::UpdateAllJob#sidekiq_retries_exhausted',
+          {
+            messaged_content: 'Logging error',
+            job_id: '123',
+            pre_exhaustion_failure: {
+              error_class: 'SomeError',
+              error_message: 'Something went wrong'
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/modules/banners/spec/sidekiq/banners_update_all_job_spec.rb
+++ b/modules/banners/spec/sidekiq/banners_update_all_job_spec.rb
@@ -81,9 +81,7 @@ RSpec.describe Banners::UpdateAllJob, type: :job do
       end
 
       it 'logs the failure and raises the error' do
-        expect {
-          described_class.sidekiq_retries_exhausted_block.call(msg, nil)
-        }.to raise_error(StandardError, 'Logging error')
+        expect { described_class.sidekiq_retries_exhausted_block.call(msg, nil) }.to raise_error(StandardError, 'Logging error')
 
         expect(Rails.logger).to have_received(:error).with(
           'Failure in Banners::UpdateAllJob#sidekiq_retries_exhausted',

--- a/modules/banners/spec/sidekiq/banners_update_all_job_spec.rb
+++ b/modules/banners/spec/sidekiq/banners_update_all_job_spec.rb
@@ -81,7 +81,9 @@ RSpec.describe Banners::UpdateAllJob, type: :job do
       end
 
       it 'logs the failure and raises the error' do
-        expect { described_class.sidekiq_retries_exhausted_block.call(msg, nil) }.to raise_error(StandardError, 'Logging error')
+        expect do
+          described_class.sidekiq_retries_exhausted_block.call(msg, nil)
+        end.to raise_error(StandardError, 'Logging error')
 
         expect(Rails.logger).to have_received(:error).with(
           'Failure in Banners::UpdateAllJob#sidekiq_retries_exhausted',


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):* YES, the banner api and it's related jobs are, this PR contains only tests 
- This adds unit tests to cover the `Banners::UpdateAllJob`
- Sitewide team

## Related issue(s)

- Addition of job: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19452
- Issue that prompted this work: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19943

## Testing done

- [x] *New code is covered by unit tests*
- This new spec covers the `Banners::UpdateAllJob`

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Banners related CI testing

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


