### PR TITLE
EDM/Fix mismatched amendment keys for Post-911 SOB

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1212,7 +1212,7 @@ spec/factories/form_attachments.rb @department-of-veterans-affairs/Disability-Ex
 spec/factories/form_submission_attempts.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/form_submissions.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/gi_bill_feedback.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/factories/gi_bill_status_response.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/factories/gi_bill_status_response.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/gids_response.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/hca_attachment.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/health_care_application.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/lib/lighthouse/benefits_education/amendment.rb
+++ b/lib/lighthouse/benefits_education/amendment.rb
@@ -26,7 +26,7 @@ module BenefitsEducation
     attribute :type, String
     attribute :status, String
     attribute :change_effective_date, String
-      
+
     def initialize(attributes)
       # Amendment objects previously weren't being serialized because of mismatched keys
       key_mapping = { 'residence_hours' => 'on_campus_hours',

--- a/lib/lighthouse/benefits_education/amendment.rb
+++ b/lib/lighthouse/benefits_education/amendment.rb
@@ -26,5 +26,16 @@ module BenefitsEducation
     attribute :type, String
     attribute :status, String
     attribute :change_effective_date, String
+      
+    def initialize(attributes)
+      # Amendment objects previously weren't being serialized because of mismatched keys
+      key_mapping = { 'residence_hours' => 'on_campus_hours',
+                      'distance_hours' => 'online_hours',
+                      'amendment_type' => 'type',
+                      'amendment_status' => 'status',
+                      'amendment_effective_date' => 'change_effective_date' }
+      attributes.transform_keys! { |key| key_mapping[key] || key }
+      super(attributes)
+    end
   end
 end

--- a/spec/factories/gi_bill_status_response.rb
+++ b/spec/factories/gi_bill_status_response.rb
@@ -33,7 +33,14 @@ FactoryBot.define do
         online_hours: 0.0,
         yellow_ribbon_amount: 0.0,
         status: 'Approved',
-        amendments: []
+        amendments: [{
+          on_campus_hours: 7,
+          online_hours: 4,
+          yellow_ribbon_amount: 8,
+          type: 'CourseDrop',
+          status: 'Approved',
+          change_effective_date: '2015-11-11T07:25:00Z'
+        }]
       }]
     }
     initialize_with { new(status: 200, response: {}) }

--- a/spec/serializers/post911_gi_bill_status_serializer_spec.rb
+++ b/spec/serializers/post911_gi_bill_status_serializer_spec.rb
@@ -78,6 +78,19 @@ describe Post911GIBillStatusSerializer, type: :serializer do
     expect(attributes['enrollments'].first.keys).to eq expected_attributes
   end
 
+  context 'enrollment' do
+    let(:enrollment) { attributes['enrollments'].first }
+
+    it 'includes :amendments' do
+      expect(enrollment['amendments'].size).to eq gi_bill_status.enrollments.first.amendments.size
+    end
+
+    it 'includes :amendments with attributes' do
+      expected_attributes = gi_bill_status.enrollments.first.amendments.first.attributes.keys.map(&:to_s)
+      expect(enrollment['amendments'].first.keys).to eq expected_attributes
+    end
+  end
+
   private
 
   def expect_entitlement(serialized_entitlement, entitlement)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)*: `v1/post911_gi_bill_status` has been incorrectly serializing nested amendment objects. Key mapping added to transform keys in line with similar key mapping for parent [enrollment object](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/lighthouse/benefits_education/enrollment.rb)
- *(If bug, how to reproduce)* Enrollment history has been removed from SOB frontend. But you can test by logging into staging as vets.gov.user+0@gmail.com, and then in separate window hitting [staging-api](https://staging-api.va.gov/v1/post911_gi_bill_status). Nested amendment object will contain null values except for yellow_ribbon_amount, which has correct key
- *(What is the solution, why is this the solution?)* Add key mapping to correct mismatched keys. Different solution could have been to update the returned key values themselves for the endpoint, swagger file, etc... but that would also require any dependent service to make updates. I don't believe the amendment object is currently being displayed anywhere on VA.gov but just for posterity implementing this fix while we make other updates to the endpoint
- *(Which team do you work for, does your team own the maintenance of this component?)* Education Data Migration (EDM), yes
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://jira.devops.va.gov/browse/EDM-393

## Testing done

Updated spec tests to ensure mock responses included and tested for presence of amendment data

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

Post-911 Statement of Benefits

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
