### PR TITLE
Decision Reviews: Add Engine Sidekiq Jobs to Schedule

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -229,11 +229,22 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   mgr.register('30 * * * *', 'DecisionReview::NodStatusUpdaterJob')
   mgr.register('50 * * * *', 'DecisionReview::ScStatusUpdaterJob')
 
+  # Engine version: Hourly jobs that update DR SavedClaims with delete_date
+  mgr.register('10 * * * *', 'DecisionReviews::HlrStatusUpdaterJob')
+  mgr.register('15 * * * *', 'DecisionReviews::NodStatusUpdaterJob')
+  mgr.register('40 * * * *', 'DecisionReviews::ScStatusUpdaterJob')
+
   # Clean SavedClaim records that are past delete date
   mgr.register('0 7 * * *', 'DecisionReview::DeleteSavedClaimRecordsJob')
 
+  # Engine version: Clean SavedClaim records that are past delete date
+  mgr.register('0 5 * * *', 'DecisionReviews::DeleteSavedClaimRecordsJob')
+
   # Send Decision Review emails to Veteran for failed form/evidence submissions
   mgr.register('5 1 * * *', 'DecisionReview::FailureNotificationEmailJob')
+
+  # Engine version: Send Decision Review emails to Veteran for failed form/evidence submissions
+  mgr.register('5 0 * * *', 'DecisionReviews::FailureNotificationEmailJob')
 
   # Daily 0000 hrs job for Vye: performs ingress of state from BDN & TIMS.
   mgr.register('15 00 * * 1-5', 'Vye::MidnightRun::IngressBdn')


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Engine migration: start running both the engine version and original version of scheduled jobs. They should behave identically, with no duplication of behavior.
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews, yes

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/98352

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Only the original version of jobs ran. If this works without errors, the old versions will be removed and only the engine version will run.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
See that SavedClaim records are updated with correct status, deleted when past max age, and notification emails go out. See that this is happening at the time the engine job runs, with no errors. In case there is an error, original jobs will run after so no behavior is lost.

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Background jobs for managing DR SavedClaim records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature