### PR TITLE
98315 Fix off-by-one error in supporting file counts - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -73,7 +73,9 @@ module IvcChampva
 
         applicants_count = parsed_form_data[applicant_key]&.count.to_i
         total_applicants_count = applicants_count.to_f / additional_pdf_count
-        applicant_rounded_number = total_applicants_count.ceil
+        # Must always be at least 1, so that `attachment_ids` still contains the
+        # `form_id` even on forms that don't have an `applicants` array (e.g. FMP2)
+        applicant_rounded_number = total_applicants_count.ceil.zero? ? 1 : total_applicants_count.ceil
 
         form = form_class.new(parsed_form_data)
         # DataDog Tracking


### PR DESCRIPTION
## Summary

This PR fixes a bug that was producing an off-by-one count of attached supporting documents in certain IVC forms.

Previously, the logic that checked if an overflow PDF was needed would give incorrect results due to the expectation that every form that contains additional attachments also contains an `applicants` array.

**Fix**

The fix is to make sure that `applicant_rounded_number` is always at least 1 (since we always have one applicant, whether the `applicants` array is present or not).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98315

## Testing done

- [ ] *New code is covered by unit tests*
- Manual testing
- Previously, forms that included attachments but did not have an `applicants` array would skip adding the first attachment to the database. After this fix, all files are accounted for in the DB.
- To verify
  - run vets-api and vets-website locally
  - go to localhost:3001/health-care/foreign-medical-program/file-claim-form-10-7959f-2/introduction 
  - Submit the form with a single supporting attachment
  - In the local rails console, run the following: `IvcChampvaForm.where('file_name lIKE ?', '%7959f_2_support%')`. There should be one result (previously there would be 0). 

## Screenshots

| |before|after|
|-|------|-----|
|Files in DB|No supporting doc present: ![Screenshot 2024-12-06 at 08 58 19](https://github.com/user-attachments/assets/265531e4-03d0-48d4-bc6c-e92e0df3d969)|Supporting doc present: ![Screenshot 2024-12-06 at 08 53 31](https://github.com/user-attachments/assets/899abc0b-e2d5-4b60-bf64-63ba984162ed)|

## What areas of the site does it impact?

IVC CHAMPVA forms only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA