### PR TITLE
98402: Add indexes to SavedClaim for Decision Review sidekiq job queries

### DIFF
--- a/db/migrate/20241204221534_add_indexes_to_saved_claims.rb
+++ b/db/migrate/20241204221534_add_indexes_to_saved_claims.rb
@@ -1,0 +1,8 @@
+class AddIndexesToSavedClaims < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :saved_claims, [:metadata, :type], where: "(metadata LIKE '%error%')", algorithm: :concurrently
+    add_index :saved_claims, :delete_date, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241204221534_add_indexes_to_saved_claims.rb
+++ b/db/migrate/20241204221534_add_indexes_to_saved_claims.rb
@@ -2,7 +2,7 @@ class AddIndexesToSavedClaims < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :saved_claims, [:metadata, :type], where: "(metadata LIKE '%error%')", algorithm: :concurrently
+    add_index :saved_claims, [:metadata, :type], where: "(metadata LIKE '%error%')", name: "idx_saved_claims_partial_metadata_like_error_and_type", algorithm: :concurrently
     add_index :saved_claims, :delete_date, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1096,7 +1096,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_04_222335) do
     t.index ["delete_date"], name: "index_saved_claims_on_delete_date"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
-    t.index ["metadata", "type"], name: "index_saved_claims_on_metadata_and_type", where: "(metadata ~~ '%error%'::text)"
+    t.index ["metadata", "type"], name: "idx_saved_claims_partial_metadata_like_error_and_type", where: "(metadata ~~ '%error%'::text)"
   end
 
   create_table "schema_contract_validations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1093,8 +1093,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_04_222335) do
     t.text "metadata"
     t.datetime "metadata_updated_at"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
+    t.index ["delete_date"], name: "index_saved_claims_on_delete_date"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
+    t.index ["metadata", "type"], name: "index_saved_claims_on_metadata_and_type", where: "(metadata ~~ '%error%'::text)"
   end
 
   create_table "schema_contract_validations", force: :cascade do |t|


### PR DESCRIPTION
## Summary
This adds indexes to SavedClaim to help address slow queries and query timeouts for the Decision Review sidekiq jobs.

This is owned by the Benefits Decision Review team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/98402

## Testing done
Tested locally

## What areas of the site does it impact?
This adds new indexes to the `saved_claims` table.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
