### PR TITLE
Add confirmation page toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1766,6 +1766,10 @@ features:
     actor_type: user
     description: Enable Burial form v2 re-design
     enable_in_development: true
+  burial_confirmation_page:
+    actor_type: user
+    description: Toggle showing the updated confirmation page
+    enable_in_development: true
   burial_error_email_notification:
     actor_type: cookie_id
     description: Toggle sending of the Action Needed email notification


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Adds a new feature toggle for the front-end confirmation page updates

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95585

## What areas of the site does it impact?
Burials

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

