### PR TITLE
Add logging for recent clinic details

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
@@ -58,6 +58,7 @@ module VAOS
             location_id = appt.location_id
             clinic_ids = appt.clinic
             clinic = mobile_facility_service.get_clinic_with_cache(station_id: location_id, clinic_id: clinic_ids)
+            log_recent_clinic_details(location_id, clinic_ids, clinic)
 
             # if clinic details are not returned, log 'not found' message
             clinic.nil? ? log_no_clinic_details_found(location_id, clinic_ids) : sorted_clinics.push(clinic)
@@ -92,6 +93,11 @@ module VAOS
       def log_no_clinic_details_found(station_id, clinic_id)
         Rails.logger.info 'VAOS last_visited_clinic', "No clinic details found for station: #{station_id} " \
                                                       "and clinic: #{clinic_id}"
+      end
+
+      def log_recent_clinic_details(station_id, clinic_id, clinic)
+        Rails.logger.info("VAOS recent_clinics details for station: #{station_id} and clinic: #{clinic_id} " \
+                          "- #{clinic.to_json}")
       end
 
       def unable_to_lookup_clinic?(appt)


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We're adding some logging to better track the responses provided by the new recent clinic endpoint
- Appointments (VAOS) Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98519

## Testing done

- [x] *New code is covered by unit tests*
- Ensured existing unit tests pass

## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

