### PR TITLE
[VACMS-19842]Fix the ability to find banners via subpage inheritance

### DIFF
--- a/modules/banners/app/models/banner.rb
+++ b/modules/banners/app/models/banner.rb
@@ -35,24 +35,23 @@ class Banner < ApplicationRecord
                                                 { path: path } } } } }
                                       ].to_json))
 
-    # Subpage inheritance check: Matches on any `entityUrl` or `fieldOffice` entity path where `limit_subpage_inheritance` is false.
+    # Subpage inheritance check: Matches on any `entityUrl` where `limit_subpage_inheritance` is false.
     subpage_pattern = "/#{normalized_path.split('/').first}"
     subpage_condition = where('banners.context @> ?',
+                              [
+                                { entity:
+                                  { entityUrl:
+                                  { path: subpage_pattern } } }
+                              ].to_json)
+                        .or(where('banners.context @> ?',
                                   [
                                     { entity:
-                                     { entityUrl:
-                                      { path: subpage_pattern } } }
-                                  ].to_json)
-                            .or(where('banners.context @> ?',
-                                      [
+                                      { fieldOffice:
                                         { entity:
-                                          { fieldOffice:
-                                            { entity:
-                                              { entityUrl:
-                                                { path: subpage_pattern } } } } }
-                                      ].to_json))
-                          .where(limit_subpage_inheritance: false)
-
+                                          { entityUrl:
+                                            { path: subpage_pattern } } } } }
+                                  ].to_json))
+                        .where(limit_subpage_inheritance: false)
 
     # Look for both exact paths and subpage matches
     exact_path_conditions.or(subpage_condition)

--- a/modules/banners/lib/banners/profile/vamc.rb
+++ b/modules/banners/lib/banners/profile/vamc.rb
@@ -16,7 +16,7 @@ module Banners
           operating_status_cta: graphql_banner_response['fieldAlertOperatingStatusCta'],
           email_updates_button: graphql_banner_response['fieldAlertEmailUpdatesButton'],
           find_facilities_cta: graphql_banner_response['fieldAlertFindFacilitiesCta'],
-          limit_subpage_inheritance: graphql_banner_response['fieldAlertLimitSubpageInheritance'] || false
+          limit_subpage_inheritance: graphql_banner_response['fieldAlertInheritanceSubpages'] || false
         }
       end
     end

--- a/modules/banners/spec/models/banner_spec.rb
+++ b/modules/banners/spec/models/banner_spec.rb
@@ -31,77 +31,73 @@ Rspec.describe Banner, type: :model do
 
     let!(:matching_banner1) do
       create(:banner,
-        entity_bundle: banner_type,
-        limit_subpage_inheritance: false,
-        context: [
-          {
-            entity: {
-              entityUrl: { path: path },
-              fieldOffice: {
-                entity: {
-                  entityUrl: { path: '/some-other-path' }
-                }
-              }
-            }
-          }
-        ]
-      )
+             entity_bundle: banner_type,
+             limit_subpage_inheritance: false,
+             context: [
+               {
+                 entity: {
+                   entityUrl: { path: path },
+                   fieldOffice: {
+                     entity: {
+                       entityUrl: { path: '/some-other-path' }
+                     }
+                   }
+                 }
+               }
+             ])
     end
 
     let!(:matching_banner2) do
       create(:banner,
-        entity_bundle: banner_type,
-        limit_subpage_inheritance: false,
-        context: [
-          {
-            entity: {
-              entityUrl: { path: '/some-other-path' },
-              fieldOffice: {
-                entity: {
-                  entityUrl: { path: path }
-                }
-              }
-            }
-          }
-        ]
-      )
+             entity_bundle: banner_type,
+             limit_subpage_inheritance: false,
+             context: [
+               {
+                 entity: {
+                   entityUrl: { path: '/some-other-path' },
+                   fieldOffice: {
+                     entity: {
+                       entityUrl: { path: path }
+                     }
+                   }
+                 }
+               }
+             ])
     end
 
     let!(:matching_non_inheriting_banner) do
       create(:banner,
-        entity_bundle: banner_type,
-        limit_subpage_inheritance: true,
-        context: [
-          {
-            entity: {
-                entityUrl: { path: path },
-                fieldOffice: {
-                  entity: {
-                    entityUrl: { path: '/some-other-path' }
-                  }
-                }
-              }
-          }
-        ]
-      )
+             entity_bundle: banner_type,
+             limit_subpage_inheritance: true,
+             context: [
+               {
+                 entity: {
+                   entityUrl: { path: path },
+                   fieldOffice: {
+                     entity: {
+                       entityUrl: { path: '/some-other-path' }
+                     }
+                   }
+                 }
+               }
+             ])
     end
 
     let!(:non_matching_banner) do
       create(:banner,
-        entity_bundle: 'different_type',
-        context: [
-          {
-            entity: {
-              entityUrl: { path: '/some-other-path' },
-              fieldOffice: {
-                entity: {
-                  entityUrl: { path: '/another-path' }
-                }
-              }
-            }
-          }
-        ]
-      )
+             entity_bundle: 'different_type',
+             context: [
+               {
+                 entity: {
+                   entityUrl: { path: '/some-other-path' },
+                   fieldOffice: {
+                     entity: {
+                       entityUrl: { path: '/another-path' }
+                     }
+                   }
+                 }
+               }
+             ])
     end
 
     it 'returns banners that match the path type for both direct entityUrls and fieldOffice.entity.entityUrls' do
@@ -111,7 +107,7 @@ Rspec.describe Banner, type: :model do
     end
 
     it 'returns banners that match the path type for subpages, but not if limit_subpage_inheritance?' do
-      result = Banner.by_path(path + '/locations/specific-va-facility')
+      result = Banner.by_path("#{path}/locations/specific-va-facility")
 
       expect(result).to contain_exactly(matching_banner1, matching_banner2)
       expect(result).not_to include(matching_non_inheriting_banner)

--- a/modules/banners/spec/models/banner_spec.rb
+++ b/modules/banners/spec/models/banner_spec.rb
@@ -30,63 +30,78 @@ Rspec.describe Banner, type: :model do
     let(:banner_type) { 'full_width_banner_alert' }
 
     let!(:matching_banner1) do
-      create(:banner, entity_bundle: banner_type, limit_subpage_inheritance: false, context: [
-               {
-                 entity: {
-                   entityUrl: { path: path },
-                   fieldOffice: {
-                     entity: {
-                       entityUrl: { path: '/some-other-path' }
-                     }
-                   }
-                 }
-               }
-             ])
+      create(:banner,
+        entity_bundle: banner_type,
+        limit_subpage_inheritance: false,
+        context: [
+          {
+            entity: {
+              entityUrl: { path: path },
+              fieldOffice: {
+                entity: {
+                  entityUrl: { path: '/some-other-path' }
+                }
+              }
+            }
+          }
+        ]
+      )
     end
 
     let!(:matching_banner2) do
-      create(:banner, entity_bundle: banner_type, limit_subpage_inheritance: false, context: [
-               {
-                 entity: {
-                   entityUrl: { path: '/some-other-path' },
-                   fieldOffice: {
-                     entity: {
-                       entityUrl: { path: path }
-                     }
-                   }
-                 }
-               }
-             ])
+      create(:banner,
+        entity_bundle: banner_type,
+        limit_subpage_inheritance: false,
+        context: [
+          {
+            entity: {
+              entityUrl: { path: '/some-other-path' },
+              fieldOffice: {
+                entity: {
+                  entityUrl: { path: path }
+                }
+              }
+            }
+          }
+        ]
+      )
     end
 
     let!(:matching_non_inheriting_banner) do
-      create(:banner, entity_bundle: banner_type, limit_subpage_inheritance: true, context: [
-        {
-                 entity: {
-                   entityUrl: { path: path },
-                   fieldOffice: {
-                     entity: {
-                       entityUrl: { path: '/some-other-path' }
-                     }
-                   }
-                 }
-               }
-             ])
+      create(:banner,
+        entity_bundle: banner_type,
+        limit_subpage_inheritance: true,
+        context: [
+          {
+            entity: {
+                entityUrl: { path: path },
+                fieldOffice: {
+                  entity: {
+                    entityUrl: { path: '/some-other-path' }
+                  }
+                }
+              }
+          }
+        ]
+      )
     end
 
     let!(:non_matching_banner) do
-      create(:banner, entity_bundle: 'different_type', context: [
-               {
-                 entity: {
-                   entityUrl: { path: '/some-other-path' },
-                   fieldOffice: {
-                     entity: {
-                       entityUrl: { path: '/another-path' }
-                     }
-                   }
-                 }
-               }
-             ])
+      create(:banner,
+        entity_bundle: 'different_type',
+        context: [
+          {
+            entity: {
+              entityUrl: { path: '/some-other-path' },
+              fieldOffice: {
+                entity: {
+                  entityUrl: { path: '/another-path' }
+                }
+              }
+            }
+          }
+        ]
+      )
     end
 
     it 'returns banners that match the path type for both direct entityUrls and fieldOffice.entity.entityUrls' do

--- a/modules/banners/spec/models/banner_spec.rb
+++ b/modules/banners/spec/models/banner_spec.rb
@@ -30,7 +30,7 @@ Rspec.describe Banner, type: :model do
     let(:banner_type) { 'full_width_banner_alert' }
 
     let!(:matching_banner1) do
-      create(:banner, entity_bundle: banner_type, context: [
+      create(:banner, entity_bundle: banner_type, limit_subpage_inheritance: false, context: [
                {
                  entity: {
                    entityUrl: { path: path },
@@ -45,13 +45,28 @@ Rspec.describe Banner, type: :model do
     end
 
     let!(:matching_banner2) do
-      create(:banner, entity_bundle: banner_type, context: [
+      create(:banner, entity_bundle: banner_type, limit_subpage_inheritance: false, context: [
                {
                  entity: {
                    entityUrl: { path: '/some-other-path' },
                    fieldOffice: {
                      entity: {
                        entityUrl: { path: path }
+                     }
+                   }
+                 }
+               }
+             ])
+    end
+
+    let!(:matching_non_inheriting_banner) do
+      create(:banner, entity_bundle: banner_type, limit_subpage_inheritance: true, context: [
+        {
+                 entity: {
+                   entityUrl: { path: path },
+                   fieldOffice: {
+                     entity: {
+                       entityUrl: { path: '/some-other-path' }
                      }
                    }
                  }
@@ -77,7 +92,14 @@ Rspec.describe Banner, type: :model do
     it 'returns banners that match the path type for both direct entityUrls and fieldOffice.entity.entityUrls' do
       result = Banner.by_path(path)
 
+      expect(result).to contain_exactly(matching_banner1, matching_banner2, matching_non_inheriting_banner)
+    end
+
+    it 'returns banners that match the path type for subpages, but not if limit_subpage_inheritance?' do
+      result = Banner.by_path(path + '/locations/specific-va-facility')
+
       expect(result).to contain_exactly(matching_banner1, matching_banner2)
+      expect(result).not_to include(matching_non_inheriting_banner)
     end
 
     it 'does not return banners that do not match the path' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This adjusts the `Banner.by_path` scope to be able to find subpages of a banner with more complex path's
- Try to fetch a clinic's banner from the API, you will find with exact path matches things work well, but not when getting into specific paths
- This makes the matching a bit more flexible by working off the root piece of the path to indicate the location being observed by a user
- Also includes an update to the profile mapping to correct typo for subpage inheritance
- Sitewide team (Facilities)

## Related issue(s)

- Issue that lead to finding this work: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19842
- Original ticket introducing `Banner.by_path`: https://github.com/department-of-veterans-affairs/vets-api/pull/19088

## Testing done

- [x] *New code is covered by unit tests*
- Prior to changes this would not return a matching path for specific locations like `/va-facility/locations/va-clinic`, now it will but only when subpage inheritance is allowed.

## Screenshots
Test coverage remains strong
<img width="1381" alt="Screenshot 2024-12-06 at 9 10 56 AM" src="https://github.com/user-attachments/assets/4fe699d4-3197-4c92-9cc8-f49fe3326ece">


## What areas of the site does it impact?
None that are live today, mainly effects the Banners API

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

