### PR TITLE
Create feature toggle for frontend LH implementation

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1525,6 +1525,10 @@ features:
     actor_type: user
     description: Enables the use of LH API instead of Profile API for the Veteran Status Card display
     enable_in_development: false
+  veteran_status_card_use_lighthouse_frontend:
+    actor_type: user
+    description: Enables the use of LH API instead of Profile API for the Veteran Status Card display, story 1145
+    enable_in_development: false
   vre_trigger_action_needed_email:
     actor_type: user
     description: Set whether to enable VANotify email to Veteran for VRE failure exhaustion


### PR DESCRIPTION
## Summary

- This PR adds a feature toggle for the Veteran Status card feature to use the Lighthouse API instead of the Profile API. This will help our team implement on the frontend and test out this new API integration.
- I work on the IIR Product team and we currently own this feature.
- The success criteria targeted is to make sure that we receive the same access rate or better for known test users when trying to view their Vet Status card.
- The companion vets-website PR is [here](https://github.com/department-of-veterans-affairs/vets-website/pull/33392).

## Related issue(s)

- [1264](https://github.com/department-of-veterans-affairs/va-iir/issues/1264)

## Testing done

- This change only includes adding a new feature toggle.

## What areas of the site does it impact?
This change only includes adding a new feature toggle.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
