### PR TITLE
1284 1095 b job errors

### DIFF
--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -5,6 +5,7 @@ require 'sentry_logging'
 module Form1095
   class New1095BsJob
     include Sidekiq::Job
+    include SentryLogging
 
     sidekiq_options(unique_for: 4.hours)
 

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sentry_logging'
+
 module Form1095
   class New1095BsJob
     include Sidekiq::Job
@@ -74,7 +76,7 @@ module Form1095
     def produce_1095_hash(form_fields, unique_id, coverage_arr)
       {
         unique_id:,
-        veteran_icn: form_fields[:A15].gsub(/\A0{6}|0{6}\z/, ''),
+        veteran_icn: form_fields[:A15]&.gsub(/\A0{6}|0{6}\z/, ''),
         form_data: {
           last_name: form_fields[:A01] || '',
           first_name: form_fields[:A02] || '',


### PR DESCRIPTION
## Summary

The 1095-B background job, which imports 1095-B records from files added by the enrollment system to S3, has been failing for a very long time. The underlying issues are a nil method error and failure to require a method that is required

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1284

## Testing done

I tested this by modifying the test data and ensuring that this edge case passes. I did not write new tests for this because these are integration tests and it didn't feel appropriate to test every variation of the data model. There is already a test case 'does not save invalid forms from S3 file'. This is effectively covered by that case. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

It only impacts this cron job that runs in the background once per day. There is no broader impact

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback


