### PR TITLE
ART 96891 Initial POA Request and Form Migrations and Models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'aws-sdk-s3', '~> 1'
 gem 'aws-sdk-sns', '~> 1'
 gem 'betamocks', git: 'https://github.com/department-of-veterans-affairs/betamocks', branch: 'master'
 gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'bgs', ref: '350e45ae69'
+gem 'blind_index'
 gem 'blueprinter'
 gem 'bootsnap', require: false
 gem 'breakers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,7 @@ GEM
       base64
       gyoku (>= 0.4.0)
       nokogiri
+    argon2-kdf (0.2.0)
     ast (2.4.2)
     attr_extras (7.1.0)
     awesome_print (1.9.2)
@@ -273,6 +274,9 @@ GEM
     bigdecimal (3.1.8)
     bigdecimal (3.1.8-java)
     bindex (0.8.1)
+    blind_index (2.6.1)
+      activesupport (>= 7)
+      argon2-kdf (>= 0.2)
     blueprinter (1.1.2)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -1136,6 +1140,7 @@ DEPENDENCIES
   banners!
   betamocks!
   bgs_ext!
+  blind_index
   blueprinter
   bootsnap
   brakeman

--- a/db/migrate/20241206225126_add_indexes_to_ar_power_of_attorney_forms.rb
+++ b/db/migrate/20241206225126_add_indexes_to_ar_power_of_attorney_forms.rb
@@ -1,0 +1,9 @@
+class AddIndexesToArPowerOfAttorneyForms < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ar_power_of_attorney_forms, :city_bidx, algorithm: :concurrently
+    add_index :ar_power_of_attorney_forms, :state_bidx, algorithm: :concurrently
+    add_index :ar_power_of_attorney_forms, :zipcode_bidx, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_06_225126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -269,6 +269,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
     t.index ["veteran_icn"], name: "index_appeals_api_supplemental_claims_on_veteran_icn"
   end
 
+  create_table "ar_power_of_attorney_forms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "ar_power_of_attorney_request_id"
+    t.text "data_ciphertext"
+    t.string "city_bidx"
+    t.string "state_bidx"
+    t.string "zipcode_bidx"
+    t.index ["ar_power_of_attorney_request_id"], name: "index_ar_poa_forms_on_ar_poa_request_id"
+    t.index ["city_bidx"], name: "index_ar_power_of_attorney_forms_on_city_bidx"
+    t.index ["state_bidx"], name: "index_ar_power_of_attorney_forms_on_state_bidx"
+    t.index ["zipcode_bidx"], name: "index_ar_power_of_attorney_forms_on_zipcode_bidx"
+  end
+
   create_table "ar_power_of_attorney_request_decisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type", null: false
     t.text "declination_reason"
@@ -288,6 +300,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
 
   create_table "ar_power_of_attorney_request_withdrawals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "reason"
+  end
+
+  create_table "ar_power_of_attorney_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "claimant_id"
+    t.uuid "latest_status_update_id"
+    t.datetime "created_at"
+    t.index ["claimant_id"], name: "index_ar_power_of_attorney_requests_on_claimant_id"
+    t.index ["latest_status_update_id"], name: "index_ar_power_of_attorney_requests_on_latest_status_update_id"
   end
 
   create_table "async_transactions", id: :serial, force: :cascade do |t|
@@ -1077,6 +1097,32 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
+  create_table "power_of_attorney_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_account_id", null: false
+    t.uuid "requested_individual_id"
+    t.uuid "requested_organization_id"
+    t.string "city_bidx"
+    t.string "state_bidx"
+    t.string "zip_code_bidx"
+    t.text "consent_limitation_data_ciphertext"
+    t.string "first_name_ciphertext"
+    t.string "last_name_ciphertext"
+    t.boolean "change_of_address_authorization", default: false, null: false
+    t.boolean "has_consent_limitations", default: false, null: false
+    t.string "status", null: false
+    t.datetime "expires_at"
+    t.text "encrypted_kms_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["city_bidx"], name: "index_power_of_attorney_requests_on_city_bidx"
+    t.index ["requested_individual_id"], name: "index_power_of_attorney_requests_on_requested_individual_id"
+    t.index ["requested_organization_id"], name: "index_power_of_attorney_requests_on_requested_organization_id"
+    t.index ["state_bidx"], name: "index_power_of_attorney_requests_on_state_bidx"
+    t.index ["status"], name: "index_power_of_attorney_requests_on_status"
+    t.index ["user_account_id"], name: "index_power_of_attorney_requests_on_user_account_id"
+    t.index ["zip_code_bidx"], name: "index_power_of_attorney_requests_on_zip_code_bidx"
+  end
+
   create_table "preneed_submissions", id: :serial, force: :cascade do |t|
     t.string "tracking_number", null: false
     t.string "application_uuid"
@@ -1720,6 +1766,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "appeal_submissions", "user_accounts"
+  add_foreign_key "ar_power_of_attorney_forms", "ar_power_of_attorney_requests"
+  add_foreign_key "ar_power_of_attorney_requests", "ar_power_of_attorney_request_status_updates", column: "latest_status_update_id"
   add_foreign_key "async_transactions", "user_accounts"
   add_foreign_key "claim_va_notifications", "saved_claims"
   add_foreign_key "claims_api_claim_submissions", "claims_api_auto_established_claims", column: "claim_id"
@@ -1740,6 +1788,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
   add_foreign_key "mhv_opt_in_flags", "user_accounts"
   add_foreign_key "oauth_sessions", "user_accounts"
   add_foreign_key "oauth_sessions", "user_verifications"
+  add_foreign_key "power_of_attorney_requests", "accredited_individuals", column: "requested_individual_id"
+  add_foreign_key "power_of_attorney_requests", "accredited_organizations", column: "requested_organization_id"
+  add_foreign_key "power_of_attorney_requests", "user_accounts"
   add_foreign_key "terms_of_use_agreements", "user_accounts"
   add_foreign_key "user_acceptable_verified_credentials", "user_accounts"
   add_foreign_key "user_credential_emails", "user_verifications"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_19_134025) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_25_061506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -267,6 +267,27 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_19_134025) do
     t.string "veteran_icn"
     t.jsonb "metadata", default: {}
     t.index ["veteran_icn"], name: "index_appeals_api_supplemental_claims_on_veteran_icn"
+  end
+
+  create_table "ar_power_of_attorney_request_decisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "type", null: false
+    t.text "declination_reason"
+  end
+
+  create_table "ar_power_of_attorney_request_expirations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  end
+
+  create_table "ar_power_of_attorney_request_replacements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  end
+
+  create_table "ar_power_of_attorney_request_status_updates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "status_updating_type", null: false
+    t.uuid "status_updating_id", null: false
+    t.datetime "created_at", null: false
+  end
+
+  create_table "ar_power_of_attorney_request_withdrawals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "reason"
   end
 
   create_table "async_transactions", id: :serial, force: :cascade do |t|

--- a/modules/accredited_representative_portal/accredited_representative_portal.gemspec
+++ b/modules/accredited_representative_portal/accredited_representative_portal.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
   spec.test_files = Dir['spec/**/*']
+
+  spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'rspec-rails'
 end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyForm < ApplicationRecord
+    belongs_to :power_of_attorney_request,
+               class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest',
+               foreign_key: :ar_power_of_attorney_request_id, # explicit foreign key
+               inverse_of: :form
+
+    has_kms_key
+    has_encrypted :data_ciphertext, key: :kms_key, **lockbox_options
+
+    blind_index :city
+    blind_index :state
+    blind_index :zipcode
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequest < ApplicationRecord
+    belongs_to :latest_status_update,
+               class_name: 'PowerOfAttorneyRequestStatusUpdate',
+               optional: true
+
+    has_one :form,
+            class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyForm',
+            foreign_key: :ar_power_of_attorney_request_id, # explicit foreign key
+            inverse_of: :power_of_attorney_request,
+            dependent: :destroy
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_decision.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_decision.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestDecision < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+
+    self.inheritance_column = nil
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_expiration.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_expiration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestExpiration < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_replacement.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_replacement.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestReplacement < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_status_update.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_status_update.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestStatusUpdate < ApplicationRecord
+    delegated_type :status_updating, types: %w[
+      PowerOfAttorneyRequestReplacements
+      PowerOfAttorneyRequestExpirations
+      PowerOfAttorneyRequestWithdrawals
+      PowerOfAttorneyRequestDecisions
+    ]
+
+    module StatusUpdating
+      extend ActiveSupport::Concern
+
+      included do
+        has_one(
+          :power_of_attorney_request_status_update,
+          as: :status_updating,
+          touch: true
+        )
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_withdrawal.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_withdrawal.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestWithdrawal < ApplicationRecord
+    include PowerOfAttorneyRequestStatusUpdate::StatusUpdating
+  end
+end

--- a/modules/accredited_representative_portal/bin/rails
+++ b/modules/accredited_representative_portal/bin/rails
@@ -1,11 +1,14 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ENGINE_ROOT = File.expand_path('../..', __dir__)
-ENGINE_PATH = File.expand_path('../../lib/accredited_representative_portal/engine', __dir__)
+require 'pathname'
+
+ENGINE_ROOT = Pathname(__dir__).parent
+ENGINE_PATH = ENGINE_ROOT / 'lib/accredited_representative_portal/engine'
+BUNDLE_GEMFILE = ENGINE_ROOT / 'Gemfile'
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+ENV['BUNDLE_GEMFILE'] ||= BUNDLE_GEMFILE.to_path
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 require 'rails/all'

--- a/modules/accredited_representative_portal/db/migrate/20241125061506_create_ar_power_of_attorney_request_status_updates.rb
+++ b/modules/accredited_representative_portal/db/migrate/20241125061506_create_ar_power_of_attorney_request_status_updates.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateArPowerOfAttorneyRequestStatusUpdates < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ar_power_of_attorney_request_status_updates, id: :uuid do |t|
+      t.string 'status_updating_type', null: false
+      t.uuid 'status_updating_id', null: false
+      t.datetime 'created_at', null: false
+    end
+
+    create_table :ar_power_of_attorney_request_replacements, id: :uuid
+
+    create_table :ar_power_of_attorney_request_expirations, id: :uuid
+
+    create_table :ar_power_of_attorney_request_withdrawals, id: :uuid do |t|
+      t.text 'reason'
+    end
+
+    create_table :ar_power_of_attorney_request_decisions, id: :uuid do |t|
+      t.string 'type', null: false
+      t.text 'declination_reason'
+    end
+  end
+end

--- a/modules/accredited_representative_portal/db/migrate/20241206215009_create_ar_power_of_attorney_requests.rb
+++ b/modules/accredited_representative_portal/db/migrate/20241206215009_create_ar_power_of_attorney_requests.rb
@@ -1,0 +1,9 @@
+class CreateArPowerOfAttorneyRequests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ar_power_of_attorney_requests, id: :uuid do |t|
+      t.references :claimant, type: :uuid
+      t.references :latest_status_update, type: :uuid, foreign_key: { to_table: :ar_power_of_attorney_request_status_updates }
+      t.datetime :created_at
+    end
+  end
+end

--- a/modules/accredited_representative_portal/db/migrate/20241206215049_create_ar_power_of_attorney_forms.rb
+++ b/modules/accredited_representative_portal/db/migrate/20241206215049_create_ar_power_of_attorney_forms.rb
@@ -1,0 +1,14 @@
+class CreateArPowerOfAttorneyForms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ar_power_of_attorney_forms, id: :uuid do |t|
+      t.references :ar_power_of_attorney_request,
+        type: :uuid,
+        foreign_key: true,
+        index: { name: 'index_ar_poa_forms_on_ar_poa_request_id' }  # shortened name
+      t.text :data_ciphertext
+      t.string :city_bidx
+      t.string :state_bidx
+      t.string :zipcode_bidx
+    end
+  end
+end

--- a/modules/accredited_representative_portal/lib/accredited_representative_portal/engine.rb
+++ b/modules/accredited_representative_portal/lib/accredited_representative_portal/engine.rb
@@ -3,7 +3,27 @@
 module AccreditedRepresentativePortal
   class Engine < ::Rails::Engine
     isolate_namespace AccreditedRepresentativePortal
+
+    # `isolate_namespace` redefines `table_name_prefix` on load of
+    # `active_record`, so we append our own callback to redefine it again how we
+    # want.
+    ActiveSupport.on_load(:active_record) do
+      AccreditedRepresentativePortal.redefine_singleton_method(:table_name_prefix) do
+        'ar_'
+      end
+    end
+
     config.generators.api_only = true
+
+    # So that the app-wide migration command notices our engine's migrations.
+    initializer :append_migrations do |app|
+      unless app.root.to_s.match? root.to_s
+        config.paths['db/migrate'].expanded.each do |expanded_path|
+          app.config.paths['db/migrate'] << expanded_path
+          ActiveRecord::Migrator.migrations_paths << expanded_path
+        end
+      end
+    end
 
     initializer 'model_core.factories', after: 'factory_bot.set_factory_paths' do
       FactoryBot.definition_file_paths << File.expand_path('../../spec/factories', __dir__) if defined?(FactoryBot)

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_forms.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_forms.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ar_power_of_attorney_form, class: 'AccreditedRepresentativePortal::PowerOfAttorneyForm' do
+    association :power_of_attorney_request, factory: :ar_power_of_attorney_request
+
+    data_ciphertext { 'sensitive_data' }
+    city_bidx { 'city_index' }
+    state_bidx { 'state_index' }
+    zipcode_bidx { 'zipcode_index' }
+  end
+end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_requests.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_requests.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ar_power_of_attorney_request, class: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest' do
+    trait :with_form do
+      after(:create) do |request|
+        create(:ar_power_of_attorney_form, power_of_attorney_request: request)
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_form_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_form_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AccreditedRepresentativePortal
+  RSpec.describe PowerOfAttorneyForm, type: :model do
+    describe 'table name' do
+      it 'uses custom table name' do
+        expect(described_class.table_name).to eq 'ar_power_of_attorney_forms'
+      end
+    end
+
+    describe 'associations' do
+      it 'belongs to power of attorney request' do
+        expect(described_class.new).to belong_to(:power_of_attorney_request)
+          .with_foreign_key('ar_power_of_attorney_request_id')
+      end
+    end
+
+    describe 'encryption' do
+      it 'has kms key' do
+        expect(described_class).to respond_to(:has_kms_key)
+      end
+
+      it 'encrypts data' do
+        expect(described_class).to respond_to(:has_encrypted)
+      end
+    end
+
+    describe 'blind indexes' do
+      it 'has blind indexes for location fields' do
+        expect(described_class.blind_indexes).to include(:city, :state, :zipcode)
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_request_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_request_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AccreditedRepresentativePortal
+  RSpec.describe PowerOfAttorneyRequest, type: :model do
+    describe 'table name' do
+      it 'uses custom table name' do
+        expect(described_class.table_name).to eq 'ar_power_of_attorney_requests'
+      end
+    end
+
+    describe 'associations' do
+      it 'belongs to latest status update' do
+        expect(described_class.new).to belong_to(:latest_status_update)
+          .class_name('PowerOfAttorneyRequestStatusUpdate')
+          .optional
+      end
+
+      it 'has one form' do
+        expect(described_class.new).to have_one(:form)
+          .class_name('AccreditedRepresentativePortal::PowerOfAttorneyForm')
+          .with_foreign_key(:ar_power_of_attorney_request_id)
+          .inverse_of(:power_of_attorney_request)
+          .dependent(:destroy)
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_request_status_update_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representatiive_portal/power_of_attorney_request_status_update_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative '../../rails_helper'
+
+mod = AccreditedRepresentativePortal
+RSpec.describe mod::PowerOfAttorneyRequestStatusUpdate, type: :model do
+  it 'conveniently returns heterogeneous lists' do
+    travel_to '2024-11-25T09:46:24Z'
+
+    ids = []
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestDecision.new(
+          type: 'acceptance'
+        )
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestDecision.new(
+          type: 'declination',
+          declination_reason: 'Some declination reason.'
+        )
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestReplacement.new
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestExpiration.new
+      ).id
+
+    ids <<
+      described_class.create!(
+        status_updating: mod::PowerOfAttorneyRequestWithdrawal.new(
+          reason: 'Some withdrawal reason.'
+        )
+      ).id
+
+    status_updates = described_class.includes(:status_updating).find(ids)
+
+    actual =
+      status_updates.map do |status_update|
+        serialized =
+          case status_update.status_updating
+          when mod::PowerOfAttorneyRequestDecision
+            {
+              type: 'decision',
+              decision_type: status_update.status_updating.type,
+              declination_reason: status_update.status_updating.declination_reason
+            }
+          when mod::PowerOfAttorneyRequestWithdrawal
+            {
+              type: 'withdrawal',
+              reason: status_update.status_updating.reason
+            }
+          when mod::PowerOfAttorneyRequestExpiration
+            {
+              type: 'expiration'
+            }
+          when mod::PowerOfAttorneyRequestReplacement
+            {
+              type: 'replacement'
+            }
+          end
+
+        serialized.merge!(
+          created_at: status_update.created_at.iso8601
+        )
+      end
+
+    expect(actual).to eq(
+      [
+        {
+          type: 'decision',
+          decision_type: 'acceptance',
+          declination_reason: nil,
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'decision',
+          decision_type: 'declination',
+          declination_reason: 'Some declination reason.',
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'replacement',
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'expiration',
+          created_at: '2024-11-25T09:46:24Z'
+        },
+        {
+          type: 'withdrawal',
+          reason: 'Some withdrawal reason.',
+          created_at: '2024-11-25T09:46:24Z'
+        }
+      ]
+    )
+  end
+end


### PR DESCRIPTION
This PR introduces the `PowerOfAttorneyForm` and `PowerOfAttorneyRequest` models along with the associated migrations, factories, and tests. These models are essential for supporting power of attorney features in the Accredited Representative Portal module.

depends on: https://github.com/department-of-veterans-affairs/vets-api/pull/19600