### PR TITLE
[API-43040] POA v1 - Conditionally require zip for US

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -8927,8 +8927,23 @@
                                 "required": [
                                   "numberAndStreet",
                                   "city",
-                                  "country",
-                                  "zipFirstFive"
+                                  "country"
+                                ],
+                                "allOf": [
+                                  {
+                                    "if": {
+                                      "properties": {
+                                        "country": {
+                                          "const": "US"
+                                        }
+                                      }
+                                    },
+                                    "then": {
+                                      "required": [
+                                        "zipFirstFive"
+                                      ]
+                                    }
+                                  }
                                 ],
                                 "properties": {
                                   "numberAndStreet": {
@@ -8963,13 +8978,13 @@
                                     "example": "US"
                                   },
                                   "zipFirstFive": {
-                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
                                     "type": "string",
                                     "pattern": "^\\d{5}?$",
                                     "example": "12345"
                                   },
                                   "zipLastFour": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "description": "Zip code (Last 4 digits) of the address.",
                                     "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789"
@@ -9067,8 +9082,23 @@
                                 "required": [
                                   "numberAndStreet",
                                   "city",
-                                  "country",
-                                  "zipFirstFive"
+                                  "country"
+                                ],
+                                "allOf": [
+                                  {
+                                    "if": {
+                                      "properties": {
+                                        "country": {
+                                          "const": "US"
+                                        }
+                                      }
+                                    },
+                                    "then": {
+                                      "required": [
+                                        "zipFirstFive"
+                                      ]
+                                    }
+                                  }
                                 ],
                                 "properties": {
                                   "numberAndStreet": {
@@ -9103,13 +9133,13 @@
                                     "example": "US"
                                   },
                                   "zipFirstFive": {
-                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
                                     "type": "string",
                                     "pattern": "^\\d{5}?$",
                                     "example": "12345"
                                   },
                                   "zipLastFour": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "description": "Zip code (Last 4 digits) of the address.",
                                     "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789"
@@ -9203,8 +9233,23 @@
                                 "required": [
                                   "numberAndStreet",
                                   "city",
-                                  "country",
-                                  "zipFirstFive"
+                                  "country"
+                                ],
+                                "allOf": [
+                                  {
+                                    "if": {
+                                      "properties": {
+                                        "country": {
+                                          "const": "US"
+                                        }
+                                      }
+                                    },
+                                    "then": {
+                                      "required": [
+                                        "zipFirstFive"
+                                      ]
+                                    }
+                                  }
                                 ],
                                 "properties": {
                                   "numberAndStreet": {
@@ -9239,13 +9284,13 @@
                                     "example": "US"
                                   },
                                   "zipFirstFive": {
-                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
                                     "type": "string",
                                     "pattern": "^\\d{5}?$",
                                     "example": "12345"
                                   },
                                   "zipLastFour": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "description": "Zip code (Last 4 digits) of the address.",
                                     "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789"
@@ -10795,8 +10840,23 @@
                                 "required": [
                                   "numberAndStreet",
                                   "city",
-                                  "country",
-                                  "zipFirstFive"
+                                  "country"
+                                ],
+                                "allOf": [
+                                  {
+                                    "if": {
+                                      "properties": {
+                                        "country": {
+                                          "const": "US"
+                                        }
+                                      }
+                                    },
+                                    "then": {
+                                      "required": [
+                                        "zipFirstFive"
+                                      ]
+                                    }
+                                  }
                                 ],
                                 "properties": {
                                   "numberAndStreet": {
@@ -10831,13 +10891,13 @@
                                     "example": "US"
                                   },
                                   "zipFirstFive": {
-                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
                                     "type": "string",
                                     "pattern": "^\\d{5}?$",
                                     "example": "12345"
                                   },
                                   "zipLastFour": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "description": "Zip code (Last 4 digits) of the address.",
                                     "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789"
@@ -10935,8 +10995,23 @@
                                 "required": [
                                   "numberAndStreet",
                                   "city",
-                                  "country",
-                                  "zipFirstFive"
+                                  "country"
+                                ],
+                                "allOf": [
+                                  {
+                                    "if": {
+                                      "properties": {
+                                        "country": {
+                                          "const": "US"
+                                        }
+                                      }
+                                    },
+                                    "then": {
+                                      "required": [
+                                        "zipFirstFive"
+                                      ]
+                                    }
+                                  }
                                 ],
                                 "properties": {
                                   "numberAndStreet": {
@@ -10971,13 +11046,13 @@
                                     "example": "US"
                                   },
                                   "zipFirstFive": {
-                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
                                     "type": "string",
                                     "pattern": "^\\d{5}?$",
                                     "example": "12345"
                                   },
                                   "zipLastFour": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "description": "Zip code (Last 4 digits) of the address.",
                                     "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789"
@@ -11071,8 +11146,23 @@
                                 "required": [
                                   "numberAndStreet",
                                   "city",
-                                  "country",
-                                  "zipFirstFive"
+                                  "country"
+                                ],
+                                "allOf": [
+                                  {
+                                    "if": {
+                                      "properties": {
+                                        "country": {
+                                          "const": "US"
+                                        }
+                                      }
+                                    },
+                                    "then": {
+                                      "required": [
+                                        "zipFirstFive"
+                                      ]
+                                    }
+                                  }
                                 ],
                                 "properties": {
                                   "numberAndStreet": {
@@ -11107,13 +11197,13 @@
                                     "example": "US"
                                   },
                                   "zipFirstFive": {
-                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
                                     "type": "string",
                                     "pattern": "^\\d{5}?$",
                                     "example": "12345"
                                   },
                                   "zipLastFour": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "description": "Zip code (Last 4 digits) of the address.",
                                     "type": "string",
                                     "pattern": "^\\d{4}?$",
                                     "example": "6789"

--- a/modules/claims_api/config/schemas/v1/2122.json
+++ b/modules/claims_api/config/schemas/v1/2122.json
@@ -63,13 +63,13 @@
               "example": "US"
             },
             "zipFirstFive": {
-              "description": "Zipcode (First 5 digits) of the address. Required if country is 'US'.",
+              "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
               "type": "string",
               "pattern": "^\\d{5}?$",
               "example": "12345"
             },
             "zipLastFour": {
-              "description": "Zipcode (Last 4 digits) of the address.",
+              "description": "Zip code (Last 4 digits) of the address.",
               "type": "string",
               "pattern": "^\\d{4}?$",
               "example": "6789"
@@ -202,13 +202,13 @@
               "example": "US"
             },
             "zipFirstFive": {
-              "description": "Zipcode (First 5 digits) of the address. Required if country is 'US'.",
+              "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
               "type": "string",
               "pattern": "^\\d{5}?$",
               "example": "12345"
             },
             "zipLastFour": {
-              "description": "Zipcode (Last 4 digits) of the address.",
+              "description": "Zip code (Last 4 digits) of the address.",
               "type": "string",
               "pattern": "^\\d{4}?$",
               "example": "6789"
@@ -335,13 +335,13 @@
               "example": "US"
             },
             "zipFirstFive": {
-              "description": "Zipcode (First 5 digits) of the address. Required if country is 'US'.",
+              "description": "Zip code (First 5 digits) of the address. Required if country is 'US'.",
               "type": "string",
               "pattern": "^\\d{5}?$",
               "example": "12345"
             },
             "zipLastFour": {
-              "description": "Zipcode (Last 4 digits) of the address.",
+              "description": "Zip code (Last 4 digits) of the address.",
               "type": "string",
               "pattern": "^\\d{4}?$",
               "example": "6789"

--- a/modules/claims_api/config/schemas/v1/2122.json
+++ b/modules/claims_api/config/schemas/v1/2122.json
@@ -20,8 +20,19 @@
           "required": [
             "numberAndStreet",
             "city",
-            "country",
-            "zipFirstFive"
+            "country"
+          ],
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "country": { "const": "US" }
+                }
+              },
+              "then": {
+                "required": ["zipFirstFive"]
+              }
+            }
           ],
           "properties" : {
             "numberAndStreet": {
@@ -52,7 +63,7 @@
               "example": "US"
             },
             "zipFirstFive": {
-              "description": "Zipcode (First 5 digits) of the address.",
+              "description": "Zipcode (First 5 digits) of the address. Required if country is 'US'.",
               "type": "string",
               "pattern": "^\\d{5}?$",
               "example": "12345"
@@ -148,8 +159,19 @@
           "required": [
             "numberAndStreet",
             "city",
-            "country",
-            "zipFirstFive"
+            "country"
+          ],
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "country": { "const": "US" }
+                }
+              },
+              "then": {
+                "required": ["zipFirstFive"]
+              }
+            }
           ],
           "properties" : {
             "numberAndStreet": {
@@ -180,7 +202,7 @@
               "example": "US"
             },
             "zipFirstFive": {
-              "description": "Zipcode (First 5 digits) of the address.",
+              "description": "Zipcode (First 5 digits) of the address. Required if country is 'US'.",
               "type": "string",
               "pattern": "^\\d{5}?$",
               "example": "12345"
@@ -270,8 +292,19 @@
           "required": [
             "numberAndStreet",
             "city",
-            "country",
-            "zipFirstFive"
+            "country"
+          ],
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "country": { "const": "US" }
+                }
+              },
+              "then": {
+                "required": ["zipFirstFive"]
+              }
+            }
           ],
           "properties" : {
             "numberAndStreet": {
@@ -302,7 +335,7 @@
               "example": "US"
             },
             "zipFirstFive": {
-              "description": "Zipcode (First 5 digits) of the address.",
+              "description": "Zipcode (First 5 digits) of the address. Required if country is 'US'.",
               "type": "string",
               "pattern": "^\\d{5}?$",
               "example": "12345"


### PR DESCRIPTION
## Summary

- Update v1 2122 schema to require `zipFirstFive` if and only if `country` is `'US'`. Apply to addresses on:
  - `veteran`
  - `claimant`
  - `serviceOrganization`
- Change 'Zipcode' to 'Zip code' for the above descriptions (including `zipLastFour`).
- Update v1 docs

## Related issue(s)

[API-43040](https://jira.devops.va.gov/browse/API-43040)

## Testing done

- [x] *New code is covered by unit tests*
- Manual submissions to /v1/forms/2122 with all combinations of `country` and `zipFirstFive`.

## Screenshots
<img width="1358" alt="zip-first-five" src="https://github.com/user-attachments/assets/d717a135-7c7d-4cef-87cc-3313f81bcd44">



## What areas of the site does it impact?

v1 2122 schema and docs

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

N/A
