### PR TITLE
Revert "98402: Add indexes to SavedClaim for Decision Review sidekiq job queries"

### DIFF
--- a/db/migrate/20241204221534_add_indexes_to_saved_claims.rb
+++ b/db/migrate/20241204221534_add_indexes_to_saved_claims.rb
@@ -1,8 +1,0 @@
-class AddIndexesToSavedClaims < ActiveRecord::Migration[7.1]
-  disable_ddl_transaction!
-
-  def change
-    add_index :saved_claims, [:metadata, :type], where: "(metadata LIKE '%error%')", name: "idx_saved_claims_partial_metadata_like_error_and_type", algorithm: :concurrently
-    add_index :saved_claims, :delete_date, algorithm: :concurrently
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1093,10 +1093,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_04_222335) do
     t.text "metadata"
     t.datetime "metadata_updated_at"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
-    t.index ["delete_date"], name: "index_saved_claims_on_delete_date"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
-    t.index ["metadata", "type"], name: "idx_saved_claims_partial_metadata_like_error_and_type", where: "(metadata ~~ '%error%'::text)"
   end
 
   create_table "schema_contract_validations", force: :cascade do |t|


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#19758

```
{"host":"db-migrate-x2gnk","application":"vets-api-server","environment":"production","timestamp":"2024-12-09T18:01:16.816662Z","level":"info","level_index":2,"pid":1,"thread":"12280","named_tags":{"dd":{"env":"eks-prod","service":"vets-api","version":"77c9d4e2940998547f03a1b86d3e0c2aeccc31b6","trace_id":"0","span_id":"0"},"ddsource":"ruby"},"name":"ActiveRecord::Base","message":"Migrating to AddIndexesToSavedClaims (20241204221534)"}
== 20241204221534 AddIndexesToSavedClaims: migrating ==========================
-- add_index(:saved_claims, [:metadata, :type], {:where=>"(metadata LIKE '%error%')", :name=>"idx_saved_claims_partial_metadata_like_error_and_type", :algorithm=>:concurrently})
bin/rails aborted!
StandardError: An error has occurred, all later migrations canceled: (StandardError)

PG::ProgramLimitExceeded: ERROR: index row size 3064 exceeds btree version 4 maximum 2704 for index "idx_saved_claims_partial_metadata_like_error_and_type"
DETAIL: Index row references tuple (600210,11) in relation "saved_claims".
HINT: Values larger than 1/3 of a buffer page cannot be indexed.
Consider a function index of an MD5 hash of the value, or use full text indexing.
/app/db/migrate/20241204221534_add_indexes_to_saved_claims.rb:5:in `change'

Caused by:
ActiveRecord::StatementInvalid: PG::ProgramLimitExceeded: ERROR: index row size 3064 exceeds btree version 4 maximum 2704 for index "idx_saved_claims_partial_metadata_like_error_and_type" (ActiveRecord::StatementInvalid)
DETAIL: Index row references tuple (600210,11) in relation "saved_claims".
HINT: Values larger than 1/3 of a buffer page cannot be indexed.
Consider a function index of an MD5 hash of the value, or use full text indexing.
/app/db/migrate/20241204221534_add_indexes_to_saved_claims.rb:5:in `change'

Caused by:
PG::ProgramLimitExceeded: ERROR: index row size 3064 exceeds btree version 4 maximum 2704 for index "idx_saved_claims_partial_metadata_like_error_and_type" (PG::ProgramLimitExceeded)
DETAIL: Index row references tuple (600210,11) in relation "saved_claims".
HINT: Values larger than 1/3 of a buffer page cannot be indexed.
Consider a function index of an MD5 hash of the value, or use full text indexing.
/app/db/migrate/20241204221534_add_indexes_to_saved_claims.rb:5:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```