### PR TITLE
95915 Add pega notification email workflow - IVC CHAMPVA forms

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1361,6 +1361,7 @@ vanotify:
     ivc_champva:
       api_key: fake_secret
       failure_email_threshold_days: 7
+      pega_inbox_address: fake_email_address
       template_id:
         form_10_10d_email: form_10_10d_email
         form_10_10d_failure_email: form_10_10d_failure_email

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -77,7 +77,8 @@ module IvcChampva
             form_number: form.form_number,
             file_count: fetch_forms_by_uuid(form_uuid).where('file_name LIKE ?', '%supporting_doc%').count,
             pega_status: form.pega_status,
-            created_at: form.created_at.strftime('%B %d, %Y')
+            created_at: form.created_at.strftime('%B %d, %Y'),
+            form_uuid: form.form_uuid
           }
 
         ActiveRecord::Base.transaction do

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -80,8 +80,7 @@ module IvcChampva
     # @param form_data [hash] hash of form details (see `send_failure_email`)
     # @param form [IvcChampvaForm] form object in question
     def send_zsf_notification_to_pega(form)
-      # form_data = construct_email_payload(form, 'PEGA-TEAM-ZSF')
-      form_data = construct_email_payload(form, '10-7959F-1-FAILURE')
+      form_data = construct_email_payload(form, 'PEGA-TEAM-ZSF')
       form_data = form_data.merge({
                                     email: Settings.vanotify.services.ivc_champva.pega_inbox_address
                                   })

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -29,9 +29,10 @@ module IvcChampva
             template_id = "#{form[:form_number]}-FAILURE"
             send_failure_email(form, template_id)
             if Flipper.enabled?(:champva_enhanced_monitor_logging, @current_user)
-              additional_context = { form_id: form[:form_number] }
+              additional_context = { form_id: form[:form_number], form_uuid: form[:form_uuid] }
               monitor.log_silent_failure_avoided(additional_context)
               monitor.track_missing_status_email_sent(form[:form_number])
+              send_zsf_notification_to_pega(form)
             end
           end
         end
@@ -44,31 +45,55 @@ module IvcChampva
       Rails.logger.error e.backtrace.join("\n")
     end
 
-    def fetch_forms_by_uuid(form_uuid)
-      @fetch_forms_by_uuid ||= IvcChampvaForm.where(form_uuid:)
+    def construct_email_payload(form, template_id)
+      { email: form.email,
+        first_name: form.first_name,
+        last_name: form.last_name,
+        form_number: form.form_number,
+        file_count: nil,
+        pega_status: form.pega_status,
+        created_at: form.created_at.strftime('%B %d, %Y'),
+        template_id: template_id,
+        form_uuid: form.form_uuid }
     end
 
+    # Sends an email to user notifying them of their submission's failure
+    #
+    # @param form [IvcChampvaForm] form object in question
+    # @param template_id [string] key for template to use in `IvcChampva::Email::EMAIL_TEMPLATE_MAP`
     def send_failure_email(form, template_id)
-      form_data =
-        {
-          email: form.email,
-          first_name: form.first_name,
-          last_name: form.last_name,
-          form_number: form.form_number,
-          file_count: nil,
-          pega_status: form.pega_status,
-          created_at: form.created_at.strftime('%B %d, %Y'),
-          template_id: template_id
-        }
+      form_data = construct_email_payload(form, template_id)
       ActiveRecord::Base.transaction do
         if IvcChampva::Email.new(form_data).send_email
           fetch_forms_by_uuid(form[:form_uuid]).update_all(email_sent: true) # rubocop:disable Rails/SkipsModelValidations
         else
-          additional_context = { form_id: form[:form_number] }
+          additional_context = { form_id: form[:form_number], form_uuid: form[:form_uuid] }
           monitor.log_silent_failure(additional_context)
           raise ActiveRecord::Rollback, 'Pega Status Update/Action Required Email send failure'
         end
       end
+    end
+
+    # Fires off a notification email to Pega so they know a user has been
+    # notified of a failed submission.
+    #
+    # @param form_data [hash] hash of form details (see `send_failure_email`)
+    # @param form [IvcChampvaForm] form object in question
+    def send_zsf_notification_to_pega(form)
+      # form_data = construct_email_payload(form, 'PEGA-TEAM-ZSF')
+      form_data = construct_email_payload(form, '10-7959F-1-FAILURE')
+      form_data = form_data.merge({
+                                    email: Settings.vanotify.services.ivc_champva.pega_inbox_address
+                                  })
+      if IvcChampva::Email.new(form_data).send_email
+        monitor.track_send_zsf_notification_to_pega(form_data[:form_uuid])
+      else
+        monitor.track_failed_send_zsf_notification_to_pega(form_data[:form_uuid])
+      end
+    end
+
+    def fetch_forms_by_uuid(form_uuid)
+      @fetch_forms_by_uuid ||= IvcChampvaForm.where(form_uuid:)
     end
 
     ##

--- a/modules/ivc_champva/app/services/ivc_champva/email.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/email.rb
@@ -33,7 +33,8 @@ module IvcChampva
             'last_name' => data[:last_name],
             'file_count' => data[:file_count],
             'pega_status' => data[:pega_status],
-            'date_submitted' => data[:created_at]
+            'date_submitted' => data[:created_at],
+            'form_uuid' => data[:form_uuid]
           },
           Settings.vanotify.services.ivc_champva.api_key
         )

--- a/modules/ivc_champva/lib/ivc_champva/monitor.rb
+++ b/modules/ivc_champva/lib/ivc_champva/monitor.rb
@@ -42,5 +42,23 @@ module IvcChampva
                     "#{STATS_KEY}.form_missing_status_email_sent",
                     call_location: caller_locations.first, **additional_context)
     end
+
+    def track_send_zsf_notification_to_pega(form_uuid)
+      additional_context = {
+        form_uuid:
+      }
+      track_request('info', "IVC ChampVA Forms - alerted Pega of ZSF email sent for submission #{form_uuid}",
+                    "#{STATS_KEY}.send_zsf_notification_to_pega",
+                    call_location: caller_locations.first, **additional_context)
+    end
+
+    def track_failed_send_zsf_notification_to_pega(form_uuid)
+      additional_context = {
+        form_uuid:
+      }
+      track_request('warn', "IVC ChampVA Forms - could not alert Pega of ZSF email sent for submission #{form_uuid}",
+                    "#{STATS_KEY}.failed_send_zsf_notification_to_pega",
+                    call_location: caller_locations.first, **additional_context)
+    end
   end
 end

--- a/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
@@ -5,11 +5,16 @@ require 'rails_helper'
 RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
   let!(:one_week_ago) { 1.week.ago.utc }
   let!(:forms) { create_list(:ivc_champva_form, 3, pega_status: nil, created_at: one_week_ago) }
+  let!(:job) { IvcChampva::MissingFormStatusJob.new }
 
   before do
     allow(Settings.ivc_forms.sidekiq.missing_form_status_job).to receive(:enabled).and_return(true)
     allow(StatsD).to receive(:gauge)
     allow(StatsD).to receive(:increment)
+
+    allow(IvcChampva::Email).to receive(:new).and_return(double(send_email: true))
+    allow(job).to receive(:monitor).and_return(double(track_send_zsf_notification_to_pega: nil,
+                                                      track_failed_send_zsf_notification_to_pega: nil))
   end
 
   it 'sends the count of forms to DataDog' do
@@ -24,5 +29,28 @@ RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
     expect(Rails.logger).to receive(:error).twice
 
     IvcChampva::MissingFormStatusJob.new.perform
+  end
+
+  context 'when send_zsf_notification_to_pega is successful' do
+    it 'logs a successful notification send to Pega' do
+      job.send_zsf_notification_to_pega(forms[0])
+
+      # Expect our monitor to track the successful send
+      expect(job.monitor).to have_received(:track_send_zsf_notification_to_pega).with(forms[0].form_uuid)
+    end
+  end
+
+  context 'when send_zsf_notification_to_pega fails' do
+    before do
+      # Sending the email should fail in this case
+      allow(IvcChampva::Email).to receive(:new).and_return(double(send_email: false))
+    end
+
+    it 'logs a failed notification send to Pega' do
+      job.send_zsf_notification_to_pega(forms[0])
+
+      # Expect our monitor to track the failed send
+      expect(job.monitor).to have_received(:track_failed_send_zsf_notification_to_pega).with(forms[0].form_uuid)
+    end
   end
 end

--- a/modules/ivc_champva/spec/services/email_spec.rb
+++ b/modules/ivc_champva/spec/services/email_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe IvcChampva::Email, type: :service do
             'last_name' => data[:last_name],
             'file_count' => data[:file_count],
             'pega_status' => data[:pega_status],
-            'date_submitted' => data[:created_at]
+            'date_submitted' => data[:created_at],
+            'form_uuid' => data[:form_uuid]
           },
           Settings.vanotify.services.ivc_champva.api_key
         )

--- a/modules/ivc_champva/spec/services/monitor_spec.rb
+++ b/modules/ivc_champva/spec/services/monitor_spec.rb
@@ -53,5 +53,31 @@ RSpec.describe IvcChampva::Monitor do
         monitor.track_missing_status_email_sent(payload[:form_id])
       end
     end
+
+    describe '#track_send_zsf_notification_to_pega' do
+      it 'logs sidekiq success' do
+        payload = {
+          form_uuid: '12345678-1234-5678-1234-567812345678'
+        }
+
+        expect(monitor).to receive(:track_send_zsf_notification_to_pega).with(
+          payload[:form_uuid]
+        )
+        monitor.track_send_zsf_notification_to_pega(payload[:form_uuid])
+      end
+    end
+
+    describe '#track_failed_send_zsf_notification_to_pega' do
+      it 'logs sidekiq success' do
+        payload = {
+          form_uuid: '12345678-1234-5678-1234-567812345678'
+        }
+
+        expect(monitor).to receive(:track_failed_send_zsf_notification_to_pega).with(
+          payload[:form_uuid]
+        )
+        monitor.track_failed_send_zsf_notification_to_pega(payload[:form_uuid])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds an email trigger to alert the downstream Pega service when we've fired a ZSF email off to a user. It lets the Pega team keep abreast of any issues to which users have been alerted.

- Adds logic to send Pega an email
- Adds new logging metrics to the `IvcChampva::Monitor` class

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95915

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

`IvcChampva` module only

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
