### PR TITLE
Replace Virtus with Vets::Model on DisabilityCompensation

### DIFF
--- a/lib/disability_compensation/providers/brd/lighthouse_brd_provider.rb
+++ b/lib/disability_compensation/providers/brd/lighthouse_brd_provider.rb
@@ -25,7 +25,7 @@ class LighthouseBRDProvider
   def transform(data)
     separation_locations = data['items'].map do |intake_site|
       DisabilityCompensation::ApiProvider::SeparationLocation.new(
-        code: intake_site['id'],
+        code: intake_site['id'].to_s,
         description: intake_site['description']
       )
     end

--- a/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider.rb
+++ b/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider.rb
@@ -48,7 +48,7 @@ class LighthouseRatedDisabilitiesProvider
           hyphenated_diagnostic_code: rated_disability['hyph_diagnostic_type_code'].presence&.to_i,
           effective_date: rated_disability['effective_date'],
           rated_disability_id: rated_disability['disability_rating_id'],
-          rating_decision_id: 0,
+          rating_decision_id: 0.to_s,
           rating_percentage: rated_disability['rating_percentage'],
           # TODO: figure out if this is important
           related_disability_date: DateTime.now

--- a/lib/disability_compensation/responses/claims_service_response.rb
+++ b/lib/disability_compensation/responses/claims_service_response.rb
@@ -1,32 +1,31 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     # Used in conjunction with the PPIU/Direct Deposit Provider
     class ClaimPhaseDates
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :phase_change_date, String
     end
 
     class Claim
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :id, String
       attribute :base_end_product_code, String
-      attribute :development_letter_sent, Boolean
+      attribute :development_letter_sent, Bool
       attribute :status, String
       attribute :claim_date, String
       attribute :claim_phase_dates, ClaimPhaseDates
     end
 
     class ClaimsServiceResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :open_claims, Array[DisabilityCompensation::ApiProvider::Claim]
+      attribute :open_claims, DisabilityCompensation::ApiProvider::Claim, array: true
     end
   end
 end

--- a/lib/disability_compensation/responses/intake_sites_response.rb
+++ b/lib/disability_compensation/responses/intake_sites_response.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class SeparationLocation
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :code, String
       attribute :description, String
     end
 
     class IntakeSitesResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :separation_locations, Array[DisabilityCompensation::ApiProvider::SeparationLocation]
+      attribute :separation_locations, DisabilityCompensation::ApiProvider::SeparationLocation, array: true
       attribute :status, Integer
 
       def cache?

--- a/lib/disability_compensation/responses/intent_to_files_response.rb
+++ b/lib/disability_compensation/responses/intent_to_files_response.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class IntentToFile
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       # The spelling of these status types has been validated with the partner team
       STATUS_TYPES = %w[
@@ -26,10 +27,9 @@ module DisabilityCompensation
     end
 
     class IntentToFilesResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :intent_to_file, Array[DisabilityCompensation::ApiProvider::IntentToFile]
+      attribute :intent_to_file, DisabilityCompensation::ApiProvider::IntentToFile, array: true
     end
   end
 end

--- a/lib/disability_compensation/responses/payment_information_response.rb
+++ b/lib/disability_compensation/responses/payment_information_response.rb
@@ -1,25 +1,26 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class ControlInformation
-      include Virtus.model
+      include Vets::Model
 
-      attribute :can_update_address, Boolean
-      attribute :corp_avail_indicator, Boolean
-      attribute :corp_rec_found_indicator, Boolean
-      attribute :has_no_bdn_payments_indicator, Boolean
-      attribute :identity_indicator, Boolean
-      attribute :is_competent_indicator, Boolean
-      attribute :index_indicator, Boolean
-      attribute :no_fiduciary_assigned_indicator, Boolean
-      attribute :not_deceased_indicator, Boolean
+      attribute :can_update_address, Bool
+      attribute :corp_avail_indicator, Bool
+      attribute :corp_rec_found_indicator, Bool
+      attribute :has_no_bdn_payments_indicator, Bool
+      attribute :identity_indicator, Bool
+      attribute :is_competent_indicator, Bool
+      attribute :index_indicator, Bool
+      attribute :no_fiduciary_assigned_indicator, Bool
+      attribute :not_deceased_indicator, Bool
     end
 
     class PaymentAccount
-      include Virtus.model
+      include Vets::Model
       include ActiveModel::Validations
-      include ActiveModel::Serialization
 
       attribute :account_type, String
       attribute :financial_institution_name, String
@@ -28,7 +29,7 @@ module DisabilityCompensation
     end
 
     class PaymentAddress
-      include Virtus.model
+      include Vets::Model
 
       attribute :type, String
       attribute :address_effective_date, DateTime
@@ -46,8 +47,7 @@ module DisabilityCompensation
 
     # Used in conjunction with the PPIU/Direct Deposit Provider
     class PaymentInformation
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :control_information, DisabilityCompensation::ApiProvider::ControlInformation
       attribute :payment_account, DisabilityCompensation::ApiProvider::PaymentAccount
@@ -56,10 +56,9 @@ module DisabilityCompensation
     end
 
     class PaymentInformationResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :responses, Array[DisabilityCompensation::ApiProvider::PaymentInformation]
+      attribute :responses, DisabilityCompensation::ApiProvider::PaymentInformation, array: true
     end
   end
 end

--- a/lib/disability_compensation/responses/rated_disabilities_response.rb
+++ b/lib/disability_compensation/responses/rated_disabilities_response.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class SpecialIssue
-      include Virtus.model
+      include Vets::Model
 
       attribute :code, String
       attribute :name, String
     end
 
     class RatedDisability
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :decision_code, String
       attribute :decision_text, String
@@ -24,14 +25,13 @@ module DisabilityCompensation
       attribute :rating_percentage, Integer
       attribute :maximum_rating_percentage, Integer
       attribute :related_disability_date, DateTime
-      attribute :special_issues, Array[DisabilityCompensation::ApiProvider::SpecialIssue]
+      attribute :special_issues, DisabilityCompensation::ApiProvider::SpecialIssue, array: true
     end
 
     class RatedDisabilitiesResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :rated_disabilities, Array[DisabilityCompensation::ApiProvider::RatedDisability]
+      attribute :rated_disabilities, DisabilityCompensation::ApiProvider::RatedDisability, array: true
     end
   end
 end

--- a/spec/lib/disability_compensation/providers/claims_service/lighthouse_claims_service_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/claims_service/lighthouse_claims_service_provider_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe LighthouseClaimsServiceProvider do
   it 'retrieves claim service from the Lighthouse API' do
     VCR.use_cassette('lighthouse/claims/200_response') do
       response = @provider.all_claims('', '')
-      expect(response['open_claims'].length).to eq(1)
+      expect(response.open_claims.length).to eq(1)
     end
   end
 

--- a/spec/lib/disability_compensation/providers/intent_to_file/lighthouse_intent_to_file_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/intent_to_file/lighthouse_intent_to_file_provider_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe LighthouseIntentToFileProvider do
   it 'retrieves intent to file from the Lighthouse API' do
     VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response') do
       response = provider.get_intent_to_file('compensation', '', '')
-      expect(response['intent_to_file'].length).to eq(1)
+      expect(response.intent_to_file.length).to eq(1)
     end
   end
 
@@ -32,8 +32,8 @@ RSpec.describe LighthouseIntentToFileProvider do
     VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_compensation_200_response') do
       response = provider.create_intent_to_file('compensation', '', '')
       expect(response).to be_an_instance_of(DisabilityCompensation::ApiProvider::IntentToFilesResponse)
-      expect(response['intent_to_file'][0]['type']).to eq('compensation')
-      expect(response['intent_to_file'][0]['id']).to be_present
+      expect(response.intent_to_file[0].type).to eq('compensation')
+      expect(response.intent_to_file[0].id).to be_present
     end
   end
 
@@ -41,8 +41,8 @@ RSpec.describe LighthouseIntentToFileProvider do
     VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_survivor_200_response') do
       response = provider.create_intent_to_file('survivor', '', '')
       expect(response).to be_an_instance_of(DisabilityCompensation::ApiProvider::IntentToFilesResponse)
-      expect(response['intent_to_file'][0]['type']).to eq('survivor')
-      expect(response['intent_to_file'][0]['id']).to be_present
+      expect(response.intent_to_file[0].type).to eq('survivor')
+      expect(response.intent_to_file[0].id).to be_present
     end
   end
 

--- a/spec/lib/disability_compensation/providers/rated_disabilities/evss_rated_disabilities_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/rated_disabilities/evss_rated_disabilities_provider_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe EvssRatedDisabilitiesProvider do
     VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
       provider = EvssRatedDisabilitiesProvider.new(auth_headers)
       response = provider.get_rated_disabilities('', '')
-      expect(response['rated_disabilities'].length).to eq(2)
+      expect(response.rated_disabilities.length).to eq(2)
     end
   end
 

--- a/spec/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe LighthouseRatedDisabilitiesProvider do
   it 'retrieves rated disabilities from the Lighthouse API' do
     VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_response') do
       response = @provider.get_rated_disabilities('', '')
-      expect(response['rated_disabilities'].length).to eq(1)
+      expect(response.rated_disabilities.length).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Summary

- Virtus is discontinued and needs to be removed. 
- Replace Virtus models with `Vets::Model` for DisabilityCompensation
- Another minor update to the spec was required to use dot notation

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92441

## Testing done

- [x] manually comparing the previous and new ControlInformation & PaymentInformationResponse object

## Acceptance criteria

- [x] virtus models are inlcude Vets::Model module
- [x] model(s) don't use the virtus gem