### PR TITLE
Mobile: Add past? as a parameter to if the appointment is cancellable

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -486,7 +486,7 @@ module VAOS
       # @param appt [Hash] the appointment to check
       # @return [Boolean] true if the appointment cannot be cancelled
       def cannot_be_cancelled?(appointment)
-        cnp?(appointment) || covid?(appointment) ||
+        cnp?(appointment) || covid?(appointment) || appointment[:start]&.to_datetime&.past? ||
           (cc?(appointment) && booked?(appointment)) || telehealth?(appointment)
       end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -19,24 +19,26 @@ describe VAOS::V2::AppointmentsService do
 
   let(:appt_med) do
     { kind: 'clinic', service_category: [{ coding:
-                 [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'REGULAR' }] }] }
+                                             [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'REGULAR' }] }] }
   end
   let(:appt_non) do
-    { kind: 'clinic', service_category: [{ coding:
-                 [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'SERVICE CONNECTED' }] }],
+    { kind: 'clinic', service_category: [
+                        { coding:
+                                                               [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'SERVICE CONNECTED' }] }
+                      ],
       service_type: 'SERVICE CONNECTED', service_types: [{ coding: [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'SERVICE CONNECTED' }] }] }
   end
   let(:appt_cnp) do
     { kind: 'clinic', service_category: [{ coding:
-                 [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'COMPENSATION & PENSION' }] }] }
+                                             [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'COMPENSATION & PENSION' }] }] }
   end
   let(:appt_cc) do
     { kind: 'cc', service_category: [{ coding:
-                 [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'REGULAR' }] }] }
+                                         [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'REGULAR' }] }] }
   end
   let(:appt_telehealth) do
     { kind: 'telehealth', service_category: [{ coding:
-                 [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'REGULAR' }] }] }
+                                                 [{ system: 'http://www.va.gov/terminology/vistadefinedterms/409_1', code: 'REGULAR' }] }] }
   end
   let(:appt_no_service_cat) { { kind: 'clinic' } }
 
@@ -369,6 +371,16 @@ describe VAOS::V2::AppointmentsService do
             expect(response[:data].size).to eq(4)
             expect(response[:data][0][:status]).to eq('proposed')
           end
+        end
+      end
+
+      context 'when an appointment is in the past' do
+        let(:appointment) { { status: 'booked', start: '2022-09-01T10:00:00-07:00' } }
+
+        it 'changes cancellable status to false' do
+          expect(subject.send(:cannot_be_cancelled?, appointment)).to be false
+          appointment[:start] = '2021-09-01T10:00:00-07:00'
+          expect(subject.send(:cannot_be_cancelled?, appointment)).to be true
         end
       end
 
@@ -1248,7 +1260,8 @@ describe VAOS::V2::AppointmentsService do
 
     it 'Modifies the appointment with service type(s) removed from appointment' do
       expect { subject.send(:remove_service_type, appt_non) }.to change(appt_non, :keys)
-        .from(%i[kind service_category service_type service_types])
+        .from(%i[kind service_category service_type
+                 service_types])
         .to(%i[kind service_category])
     end
   end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
This aligns backend with frontend by adding an extra check on If an appointment is cancellable based on if it's in the past

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/10326

## Testing done
Added extra test to ensure the change flips the boolean

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
