### PR TITLE
DBEX/97932: log started form version in show action

### DIFF
--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -8,11 +8,11 @@ module V0
       if form_for_user
         # get IPF
         data = data_and_metadata_with_updated_rated_disabilities
-        log_started_form_version(data, "get IPF")
+        log_started_form_version(data, 'get IPF')
       else
         # create IPF
         data = camelized_prefill_for_user
-        log_started_form_version(data, "create IPF")
+        log_started_form_version(data, 'create IPF')
       end
       render json: data
     end
@@ -72,25 +72,23 @@ module V0
     # temp: for https://github.com/department-of-veterans-affairs/va.gov-team/issues/97932
     # tracking down a possible issue with prefill
     def log_started_form_version(data, location)
-      begin
-        cloned_data = data.deep_dup
-        cloned_data_as_json = cloned_data.as_json.deep_transform_keys { |k| k.camelize(:lower) }
+      cloned_data = data.deep_dup
+      cloned_data_as_json = cloned_data.as_json.deep_transform_keys { |k| k.camelize(:lower) }
 
-        if cloned_data_as_json['formData'].present?
-          started_form_version = cloned_data_as_json['formData']['startedFormVersion']
-          message = "Form526 InProgressForm startedFormVersion = #{started_form_version} #{location}"
-          Rails.logger.info(message)
-        end
-
-        if started_form_version.blank?
-          raise Common::Exceptions::ServiceError.new(
-            detail: "no startedFormVersion detected in #{location}",
-            source: 'DisabilityCompensationInProgressFormsController#show'
-          )
-        end
-      rescue => e
-        Rails.logger.error("Form526 InProgressForm startedFormVersion retrieval failed #{location} #{e.message}")
+      if cloned_data_as_json['formData'].present?
+        started_form_version = cloned_data_as_json['formData']['startedFormVersion']
+        message = "Form526 InProgressForm startedFormVersion = #{started_form_version} #{location}"
+        Rails.logger.info(message)
       end
+
+      if started_form_version.blank?
+        raise Common::Exceptions::ServiceError.new(
+          detail: "no startedFormVersion detected in #{location}",
+          source: 'DisabilityCompensationInProgressFormsController#show'
+        )
+      end
+    rescue => e
+      Rails.logger.error("Form526 InProgressForm startedFormVersion retrieval failed #{location} #{e.message}")
     end
   end
 end

--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -6,10 +6,15 @@ module V0
 
     def show
       if form_for_user
-        render json: data_and_metadata_with_updated_rated_disabilities
+        # get IPF
+        data = data_and_metadata_with_updated_rated_disabilities
+        log_started_form_version(data, "get IPF")
       else
-        render json: camelized_prefill_for_user
+        # create IPF
+        data = camelized_prefill_for_user
+        log_started_form_version(data, "create IPF")
       end
+      render json: data
     end
 
     private
@@ -62,6 +67,30 @@ module V0
         rated_disability_id = rd['rated_disability_id'] || rd['ratedDisabilityId']
         "#{diagnostic_code}#{rated_disability_id}#{rd['name']}"
       end&.sort
+    end
+
+    # temp: for https://github.com/department-of-veterans-affairs/va.gov-team/issues/97932
+    # tracking down a possible issue with prefill
+    def log_started_form_version(data, location)
+      begin
+        cloned_data = data.deep_dup
+        cloned_data_as_json = cloned_data.as_json.deep_transform_keys { |k| k.camelize(:lower) }
+
+        if cloned_data_as_json['formData'].present?
+          started_form_version = cloned_data_as_json['formData']['startedFormVersion']
+          message = "Form526 InProgressForm startedFormVersion = #{started_form_version} #{location}"
+          Rails.logger.info(message)
+        end
+
+        if started_form_version.blank?
+          raise Common::Exceptions::ServiceError.new(
+            detail: "no startedFormVersion detected in #{location}",
+            source: 'DisabilityCompensationInProgressFormsController#show'
+          )
+        end
+      rescue => e
+        Rails.logger.error("Form526 InProgressForm startedFormVersion retrieval failed #{location} #{e.message}")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO* behind a rescue
- logs form version from the retrieval of IPF and prefill

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97932

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

