### PR TITLE
DBEX/97336: filter complete claims from open claims list

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -69,7 +69,9 @@ module Form526ClaimFastTrackingConcern
   # Fetch all claims from EVSS
   # @return [Boolean] whether there are any open EP 020's
   def pending_eps?
-    pending = open_claims.any? { |claim| claim['base_end_product_code'] == '020' }
+    pending = open_claims.any? do |claim|
+      claim['base_end_product_code'] == '020' && claim['status'].upcase != 'COMPLETE'
+    end
     save_metadata(offramp_reason: 'pending_ep') if pending
     pending
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- Lighthouse open claims implementation returns everything in a list
- we only filter by certain statuses from the LH Provider 
    - `FILTERED_STATUSES = %w[CANCELED ERRORED PENDING].freeze`
- this removes the COMPLETED claims from the "open_claims" list, as those EPs are not "pending" for the "pending_eps?" check

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97336

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

