### PR TITLE
98402: Add partial index and delete_date index to SavedClaim for DR sidekiq job queries

### DIFF
--- a/db/migrate/20241209231104_add_indexes_to_saved_claims.rb
+++ b/db/migrate/20241209231104_add_indexes_to_saved_claims.rb
@@ -1,0 +1,8 @@
+class AddIndexesToSavedClaims < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :saved_claims, [:id], where: "(metadata LIKE '%error%')", name: "index_partial_saved_claims_on_id_metadata_like_error", algorithm: :concurrently
+    add_index :saved_claims, :delete_date, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_04_222335) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_09_231104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1093,8 +1093,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_04_222335) do
     t.text "metadata"
     t.datetime "metadata_updated_at"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
+    t.index ["delete_date"], name: "index_saved_claims_on_delete_date"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true
     t.index ["id", "type"], name: "index_saved_claims_on_id_and_type"
+    t.index ["id"], name: "index_partial_saved_claims_on_id_metadata_like_error", where: "(metadata ~~ '%error%'::text)"
   end
 
   create_table "schema_contract_validations", force: :cascade do |t|


### PR DESCRIPTION
## Summary
This adds indexes to SavedClaim to help address slow queries and query timeouts for the Decision Review sidekiq jobs.

This PR addresses an issue with an index added in #19758 which blocked production deploys so it was reverted in #19790. The previous index erroneously used a large text field as the column for the index key, and is now using the column id instead.

`PG::ProgramLimitExceeded: ERROR: index row size 3064 exceeds btree version 4 maximum 2704 for index "idx_saved_claims_partial_metadata_like_error_and_type"`

This is owned by the Benefits Decision Review team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/98402
#19758
#19790

## Testing done
Tested locally and manually in staging

## What areas of the site does it impact?
This impacts the `saved_claims` table.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
