### PR TITLE
[SIMPLE-FORMS] feat: Develop Data Purge Plan for FormSubmission Records

### DIFF
--- a/modules/simple_forms_api/docs/rfcs/0003-form-submission-purge-plan.md
+++ b/modules/simple_forms_api/docs/rfcs/0003-form-submission-purge-plan.md
@@ -6,33 +6,32 @@ Data Purge Plan for `FormSubmission` Records
 
 ## 2. Summary
 
-This document outlines a data purge plan for `FormSubmission` records stored in the VA.gov PostgreSQL database. The goal is to ensure compliance with best practices for handling Personally Identifiable Information (PII) and Protected Health Information (PHI) by removing sensitive data after a specified retention period while maintaining essential metadata for operational use. The purge process will also include deleting associated PDF backups stored in an AWS S3 bucket.
+This document outlines a data purge plan for `FormSubmission` records stored in the VA.gov PostgreSQL database. The goal is to ensure compliance with best practices for handling Personally Identifiable Information (PII) and Protected Health Information (PHI) by removing sensitive data after a specified retention period while maintaining essential metadata for operational use. The purge process includes deleting associated PDF backups stored in an AWS S3 bucket.
 
 ## 3. Background
 
-The `FormSubmission` table contains user-submitted data, including PII and PHI. Associated PDF backups are also stored in a team's S3 bucket. Current retention policies suggest removing user and form data after 60 days post-submission. While the form data is no longer required for operations, minimal metadata (`submission_date` and `benefits_intake_uuid`) will be retained for reporting and referencing. This purge process will help mitigate risks related to prolonged retention of sensitive data while maintaining functionality for users to download their PDF backups during the retention period.
+The `FormSubmission` table contains user-submitted data, including PII and PHI. Associated PDF backups are stored in an S3 bucket. Current retention policies suggest removing user and form data after 60 days post-submission. While the form data is no longer required for operations, minimal metadata (`submission_date` and `benefits_intake_uuid`) will be retained for reporting and referencing. This purge process mitigates risks associated with prolonged retention of sensitive data while maintaining essential operational functionality.
 
 ### 3.1 FormSubmission Status
 
-The status of a `FormSubmission` record is determined through a combination of attributes and a background job that queries the Lighthouse Benefits Intake API. This ensures the status is accurately updated, and appropriate actions are taken in response to errors or delays. The classification is as follows:
+The status of a `FormSubmission` record is determined by a combination of attributes and updates from the Lighthouse Benefits Intake API. The classifications are:
 
 1. **Expired**:
 
-   - Status is explicitly set to `'expired'`.
-   - OR, if no successful processing attempt is recorded within 10 days (`STALE_SLA`) of the latest `FormSubmissionAttempt` creation.
-   - Indicates that documents were not successfully uploaded within the expected window.
+   - Status is explicitly `'expired'`, or no successful processing attempt is recorded within 10 days (`STALE_SLA`) of the latest `FormSubmissionAttempt` creation.
+   - Indicates unsuccessful upload within the expected window.
 
 2. **Errored**:
 
-   - Status is set to `'error'`, signaling a failure during processing.
-   - Includes additional error details logged from the API response, such as error codes and descriptions.
+   - Status is `'error'`, signaling a failure during processing.
+   - Includes error codes and descriptions logged from the API response.
 
 3. **Successful**:
 
-   - Status is set to `'vbms'`, indicating the form submission has been successfully processed and uploaded into the Veteran's eFolder within the VBMS system.
+   - Status is `'vbms'`, indicating successful processing and upload to the Veteran's eFolder in VBMS.
 
 4. **Pending**:
-   - Any status that does not fall into the above categories is considered `'pending'`, representing submissions awaiting completion or further processing.
+   - Submissions not falling into the above categories remain `'pending'`, awaiting completion or further action.
 
 ### 3.2 Error Handling and Retry Mechanisms
 
@@ -40,22 +39,22 @@ To address potential errors or delays in processing:
 
 - **Error Detection**:
 
-  - The `BenefitsIntakeStatusJob` identifies errors during the batch processing of pending submissions by querying the API.
-  - If a submission's status is `'error'` or `'expired'`, detailed error messages are logged, including the error code and description.
+  - The `BenefitsIntakeStatusJob` identifies errors during batch processing of pending submissions.
+  - Errors are logged with details such as error codes and descriptions.
 
 - **Retries**:
 
-  - Submissions that encounter errors are not retried automatically (`Sidekiq.retry = false` for the job). However, a manual remediation process is in place:
-    - Notifications are sent to stakeholders, such as claimants, using email mechanisms tied to the form type.
-    - Failure logs and monitoring dashboards provide visibility into unresolved issues, enabling targeted reprocessing as necessary.
+  - Automatic retries are disabled (`Sidekiq.retry = false`). Manual remediation involves:
+    - Notifying claimants using email mechanisms tied to the form type.
+    - Monitoring unresolved issues via dashboards to enable targeted reprocessing.
 
 - **Monitoring and Alerts**:
 
-  - Metrics are captured for each submission's status update, including success, failure, and staleness. These metrics are monitored through a Datadog dashboard, allowing for proactive identification of systemic issues.
-  - Notifications are sent via associated monitoring services (e.g., Burials, Pensions, Dependents), ensuring team members are aware of silent failures or recurring errors.
+  - Metrics on success, failure, and staleness are captured and monitored through a Datadog dashboard.
+  - Alerts and notifications ensure timely resolution of silent failures or recurring errors.
 
 - **Fallback and Recovery**:
-  - If errors persist, claimants associated with failed submissions receive notifications, enabling them to take corrective action or contact support for resolution.
+  - Persistent errors trigger notifications to claimants for corrective action.
   - Records exceeding the SLA are flagged as `'stale'` for further investigation.
 
 ## 4. Proposal
@@ -64,40 +63,39 @@ To address potential errors or delays in processing:
 
 - **Retention Policy**:
 
-  - Purge sensitive data from `FormSubmission` records 60 days after the `updated_at` once `FormSubmission.submission_status` has been set to `vbms`.
+  - Purge sensitive data from `FormSubmission` records 60 days after `updated_at` when the status is `"vbms"`.
   - Retain:
-    - `submission_date` for operational timelines.
-    - `benefits_intake_uuid` for linking associated PDFs as well as historical lookups via the Benefits Intake API.
-  - Leave the `FormSubmission` record intact for future reference.
+    - `submission_date` for operational use.
+    - `benefits_intake_uuid` for linking PDFs and historical lookups.
+  - Keep the `FormSubmission` record intact for metadata and reference.
 
 - **PDF Purge**:
 
-  - Use `benefits_intake_uuid` to identify and delete PDFs from each team's AWS S3 bucket.
+  - Use `benefits_intake_uuid` to identify and delete associated PDFs from S3.
 
 - **Trigger for Purge**:
 
-  - Purge records where the status is `"vbms"`, marking the final stage of submission processing.
-  - For records not reaching `"vbms"`, resolve via manual remediation or notify users.
+  - Trigger for records with status `"vbms"`. For unresolved statuses, manual remediation or user notification will apply.
 
 - **Definition of "Purge"**:
-  - Replace the `form_data` field with `nil` or empty values to remove sensitive data while retaining the structure of the record for metadata purposes.
+  - Replace sensitive fields (e.g., `form_data`) with `nil` or empty values while retaining metadata for structure and reporting.
 
 ### 4.2. Job Implementation
 
 - **Scheduled Purge Job**:
 
-  - Utilize Sidekiq to run a background job daily during off-peak hours.
+  - Run a Sidekiq job daily during off-peak hours.
   - Job steps:
     1. Query `FormSubmission` records with an `updated_at` older than 60 days and a status of `"vbms"`.
-    2. Emit a `pii.deleting` event to notify subscribers before purging sensitive data.
+    2. Emit a `pii.deleting` event for pre-deletion notifications.
     3. Purge sensitive data from identified records.
     4. Delete associated PDFs from S3.
-    5. Emit a `pii.deleted` event to log and track the completion of the purge process.
+    5. Emit a `pii.deleted` event to track the purge completion.
 
-- **ActiveSupport Notifications for Deletion**:
+- **ActiveSupport Notifications**:
 
-  - **Pre-Deletion Notification**:
-    Emit an `ActiveSupport::Notification` event before purging sensitive data to allow subscribers to access any necessary information before it is deleted:
+  - **Pre-Deletion**:
+    Emit `pii.deleting` to allow subscribers to process or archive data before deletion:
 
     ```ruby
     ActiveSupport::Notifications.instrument(
@@ -111,10 +109,8 @@ To address potential errors or delays in processing:
     )
     ```
 
-    This ensures that subscribers can process or archive any data required before the deletion occurs.
-
-  - **Post-Deletion Notification**:
-    Emit a `pii.deleted` event to track and log the final completion of the purge process:
+  - **Post-Deletion**:
+    Emit `pii.deleted` to log the final deletion:
 
     ```ruby
     ActiveSupport::Notifications.instrument(
@@ -127,53 +123,47 @@ To address potential errors or delays in processing:
     )
     ```
 
-    This provides a clear audit trail and allows integration with downstream systems for cleanup or monitoring.
-
-  - **Benefits**:
-    - The `pii.deleting` event allows for any last-minute processing or backups by subscribing systems before sensitive data is purged.
-    - The `pii.deleted` event ensures accurate tracking of the purge process, enhancing transparency and system monitoring.
-
 ### 4.3. Testing Strategy
 
-- Create dummy records in the staging environment with varying submission dates and statuses for testing.
-- Validate that:
-  - Records with an `updated_at` older than 60 days and a `"vbms"` status are purged.
-  - PDFs are correctly identified and deleted from S3.
+- Create dummy records in staging with varying submission dates and statuses.
+- Validate:
+  - Records with `updated_at` older than 60 days and `"vbms"` status are purged.
+  - PDFs are correctly deleted from S3.
   - Records not reaching `"vbms"` are skipped.
-- Write assertions to ensure `submission_date` and `benefits_intake_uuid` retention for purged records.
+- Ensure retention of `submission_date` and `benefits_intake_uuid` for purged records.
 
 ### 4.4. Considerations for Delay Between Marking and Deleting
 
-- While the default approach is to delete records and PDFs immediately after they meet the criteria, consider the option to delay deletion by marking records for a brief period. This provides a buffer for potential recovery or downstream processing by other systems.
-- Explicit notifications or metrics can replace the need for marking if real-time tracking is implemented.
+- A brief delay for deletion (via marking) allows for recovery or downstream processing by other systems.
+- Explicit notifications or real-time metrics can replace marking if preferred.
 
 ### 4.5. Logging and Metrics
 
 - **Logs**:
 
-  - Record the number of records and PDFs purged in each job run:
+  - Record purged counts:
 
     ```plaintext
-      INFO: Purge job completed. Records purged: 123, PDFs deleted: 123.
+    INFO: Purge job completed. Records purged: 123, PDFs deleted: 123.
     ```
 
-  - Log errors and retries for failed operations.
+  - Log errors and retries for failures.
 
 - **Metrics**:
 
   - Monitor:
     - Job success rates.
-    - Time taken for each purge job.
-    - Size of the `FormSubmission` table and S3 bucket over time.
+    - Time taken per job run.
+    - `FormSubmission` table and S3 bucket size over time.
 
 - **Alerts**:
-  - Set up alerts for job failures or anomalies (e.g., low purge counts).
+  - Notify failures or anomalies (e.g., low purge counts).
 
 ### 4.6. Communication and Documentation
 
 - **Stakeholders**:
 
-  - Review by:
+  - Review:
     - VFS Platform team (AWS S3 Bucket)
     - Architecture Intent team (vets-api DB)
   - Inform:
@@ -181,25 +171,61 @@ To address potential errors or delays in processing:
     - Auth Experience team
 
 - **Documentation**:
-  - Document the purge process, triggers, and configurations in the project wiki.
+  - Maintain detailed purge process and configurations in the project wiki.
+
+### 4.7. Time to Transition to Success (VBMS)
+
+Based on current monitoring data, the time for `FormSubmission` records to transition to the `"vbms"` status varies across form types. The analysis below highlights both the average and maximum durations observed:
+
+#### **Average Time to Success**
+
+The average time for a form to reach the `"vbms"` status is as follows:
+
+- Most forms transition within **1 to 10 days**.
+- Certain forms experience longer average processing times. For example:
+  - **21P-0847**: **33 days**
+  - **21-0966**: **20 days**
+  - **21-0972**: **17 days**
+
+These longer averages are outliers compared to the typical processing duration for the majority of form submissions.
+
+#### **Maximum Time to Success**
+
+The maximum time observed for a form to transition to the `"vbms"` status can be significantly longer:
+
+- **40-10007**: **81.4 days** (Longest observed duration).
+- Several other forms exhibit maximum times between **40–46 days**:
+  - **21-0966**: **46.4 days**
+  - **21-4142**: **46.3 days**
+  - **686C-674**: **46.3 days**
+  - **21P-530V2**: **46.1 days**
+
+While such delays represent edge cases, they indicate the need for continued monitoring and remediation to address prolonged processing times.
+
+#### **Key Takeaway**
+
+- **Typical Transition Time**: Under **10 days** for most forms.
+- **Maximum Transition Time**: Up to **81.4 days** for outliers.
+
+These insights provide context for identifying patterns in form processing delays and inform future optimizations to ensure timely submissions.
 
 ## 5. Impact
 
-- **Data Security**: Reduces risks by removing sensitive PII/PHI from the database and S3.
-- **Operational Continuity**: Retains essential metadata for continued operational use.
-- **Resource Optimization**: Frees up database and S3 storage, improving system performance.
+- **Data Security**: Reduces risks by purging sensitive PII/PHI from storage.
+- **Operational Continuity**: Retains essential metadata for ongoing use.
+- **Resource Optimization**: Frees up storage, improving system performance.
 
 ## 6. Open Questions
 
-1. Should a delay between marking records for deletion and purging them be implemented to allow for recovery?
-2. Are there additional operational metrics or monitoring requirements we should consider?
-3. Are there concerns from the Auth Experience team regarding purge impacts on user-facing features?
+1. Should a delay for deletion be implemented for recovery purposes?
+2. Are additional operational metrics or monitoring requirements necessary?
+3. Could the purge impact user-facing features or the Auth Experience team's operations?
 
 ## 7. Feedback Request
 
-- Input on the proposed retention and purge plan.
-- Suggestions for metrics, monitoring, and alerting best practices.
-- Feedback on the job implementation strategy and delay mechanism.
+- Input on the retention and purge plan.
+- Suggestions for improving metrics, monitoring, and alerting.
+- Feedback on the job implementation strategy.
 
 ## 8. Appendices/References
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR introduces a detailed plan for purging `FormSubmission` records from our PostgreSQL database to comply with data retention policies. The plan outlines the process for safely deleting records and associated PDF files after a retention period of 60 days post-approval of the form submission.

## Related issue(s)

- [Develop Data Purge Plan for FormSubmission Records](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/860)
- No previous changes or bugs are directly linked to this implementation.

## Requested Feedback

I would appreciate feedback on the clarity and completeness of the purge plan. Specifically, are there any additional considerations or edge cases that we should account for in the implementation? Additionally, any insights on the integration with the status management team would be helpful.