### PR TITLE
[VETS-API] Fix Rails 8 Deprecation warnings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -315,6 +315,7 @@ app/models/saved_claim/education_career_counseling_claim.rb @department-of-veter
 app/models/saved_claim/higher_level_review.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/notice_of_disagreement.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/supplemental_claim.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
+app/models/schema_contract/validation.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/secondary_appeal_form.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/sign_in @department-of-veterans-affairs/octo-identity
 app/models/single_logout_request.rb @department-of-veterans-affairs/octo-identity

--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -27,7 +27,7 @@ class AccreditedIndividual < ApplicationRecord
   validates :poa_code, length: { is: 3 }, allow_blank: true
   validates :individual_type, uniqueness: { scope: :registration_number }
 
-  enum individual_type: {
+  enum :individual_type, {
     'attorney' => 'attorney',
     'claims_agent' => 'claims_agent',
     'representative' => 'representative'

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -63,8 +63,8 @@ class Form526Submission < ApplicationRecord
   belongs_to :user_account, dependent: nil, optional: true
 
   validates(:auth_headers_json, presence: true)
-  enum backup_submitted_claim_status: { accepted: 0, rejected: 1, paranoid_success: 2 }
-  enum submit_endpoint: { evss: 0, claims_api: 1, benefits_intake_api: 2 }
+  enum :backup_submitted_claim_status, { accepted: 0, rejected: 1, paranoid_success: 2 }
+  enum :submit_endpoint, { evss: 0, claims_api: 1, benefits_intake_api: 2 }
 
   FORM_526 = 'form526'
   FORM_526_UPLOADS = 'form526_uploads'

--- a/app/models/form526_submission_remediation.rb
+++ b/app/models/form526_submission_remediation.rb
@@ -9,7 +9,7 @@ class Form526SubmissionRemediation < ApplicationRecord
 
   before_create :initialize_lifecycle
 
-  enum remediation_type: { manual: 0, ignored_as_duplicate: 1, email_notified: 2 }
+  enum :remediation_type, { manual: 0, ignored_as_duplicate: 1, email_notified: 2 }
 
   STATSD_KEY_PREFIX = 'form526_submission_remediation'
 

--- a/app/models/schema_contract/validation.rb
+++ b/app/models/schema_contract/validation.rb
@@ -14,7 +14,7 @@ module SchemaContract
     validates :response, presence: true
     validates :status, presence: true
 
-    enum status: { initialized: 0, success: 1, schema_errors_found: 2, schema_not_found: 3, error: 4 },
-         _default: :initialized
+    enum :status, { initialized: 0, success: 1, schema_errors_found: 2, schema_not_found: 3, error: 4 },
+         default: :initialized
   end
 end

--- a/app/models/terms_of_use_agreement.rb
+++ b/app/models/terms_of_use_agreement.rb
@@ -6,7 +6,7 @@ class TermsOfUseAgreement < ApplicationRecord
   belongs_to :user_account
 
   validates :agreement_version, :response, presence: true
-  enum response: { declined: 0, accepted: 1 }
+  enum :response, { declined: 0, accepted: 1 }
 
   default_scope { order(created_at: :asc) }
   scope :current, -> { where(agreement_version: CURRENT_VERSION) }

--- a/modules/debts_api/app/models/debts_api/v0/form5655_submission.rb
+++ b/modules/debts_api/app/models/debts_api/v0/form5655_submission.rb
@@ -6,7 +6,7 @@ module DebtsApi
   class V0::Form5655Submission < ApplicationRecord
     class StaleUserError < StandardError; end
     STATS_KEY = 'api.fsr_submission'
-    enum state: { unassigned: 0, in_progress: 1, submitted: 2, failed: 3 }
+    enum :state, { unassigned: 0, in_progress: 1, submitted: 2, failed: 3 }
 
     self.table_name = 'form5655_submissions'
     validates :user_uuid, presence: true

--- a/modules/representation_management/app/models/representation_management/flagged_veteran_representative_contact_data.rb
+++ b/modules/representation_management/app/models/representation_management/flagged_veteran_representative_contact_data.rb
@@ -4,7 +4,7 @@ module RepresentationManagement
   class FlaggedVeteranRepresentativeContactData < ApplicationRecord
     self.table_name = 'flagged_veteran_representative_contact_data'
 
-    enum flag_type: { phone_number: 'phone_number', email: 'email', address: 'address', other: 'other' }, _suffix: true
+    enum :flag_type, { phone_number: 'phone_number', email: 'email', address: 'address', other: 'other' }, suffix: true
     validates :ip_address, :representative_id, :flag_type, :flagged_value, presence: true
     validates :ip_address,
               uniqueness: { scope: %i[representative_id flag_type flagged_value_updated_at], message: 'Combination of ip_address, representative_id, flag_type, and flagged_value_updated_at must be unique' } # rubocop:disable Rails/I18nLocaleTexts,Layout/LineLength

--- a/modules/vye/app/models/vye/address_change.rb
+++ b/modules/vye/app/models/vye/address_change.rb
@@ -23,10 +23,7 @@ module Vye
     # The 'cached' enum is a special case where the record was created on the frontend
     # and sent to the backend, but the backend has not yet processed it.
     # So it will not have been reflected from the backend until the next pull.
-    enum(
-      origin: { frontend: 'frontend', cached: 'cached', backend: 'backend' },
-      _suffix: true
-    )
+    enum :origin, { frontend: 'frontend', cached: 'cached', backend: 'backend' }, suffix: true
 
     scope :backend, -> { where(origin: 'backend').limit(1) }
 

--- a/modules/vye/app/models/vye/award.rb
+++ b/modules/vye/app/models/vye/award.rb
@@ -5,10 +5,7 @@ module Vye
     belongs_to :user_info
     has_one :verification, dependent: :nullify
 
-    enum(
-      cur_award_ind: { current: 'C', future: 'F', past: 'P' },
-      _prefix: :award_ind
-    )
+    enum :cur_award_ind, { current: 'C', future: 'F', past: 'P' }, prefix: :award_ind
 
     validates(
       *%i[

--- a/modules/vye/app/models/vye/verification.rb
+++ b/modules/vye/app/models/vye/verification.rb
@@ -8,10 +8,7 @@ module Vye
 
     validates(:source_ind, presence: true)
 
-    enum(
-      source_ind: { web: 'W', phone: 'P' },
-      _prefix: :source
-    )
+    enum :source_ind, { web: 'W', phone: 'P' }, prefix: :source
 
     scope :export_ready, lambda {
       self


### PR DESCRIPTION
## Summary

- Fixes the following warning: `DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed in Rails 8.0.`
- more details [here](https://sparkrails.com/rails/2024/02/04/rails-7-adds-new-enum-syntax.html)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98790
