### PR TITLE
Dr engine controllers retry

### DIFF
--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/appeals_base_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/appeals_base_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'caseflow/service'
+require 'decision_reviews/v1/service'
+
+module DecisionReviews
+  module V1
+    class AppealsBaseController < ApplicationController
+      include FailedRequestLoggable
+      before_action { authorize :appeals, :access? }
+
+      private
+
+      def decision_review_service
+        pp 'HERE'
+        DecisionReviews::V1::Service.new
+      end
+
+      def request_body_hash
+        @request_body_hash ||= get_hash_from_request_body
+      end
+
+      def get_hash_from_request_body
+        # rubocop:disable Style/ClassEqualityComparison
+        # testing string b/c NullIO class doesn't always exist
+        raise request_body_is_not_a_hash_error if request.body.class.name == 'Puma::NullIO'
+        # rubocop:enable Style/ClassEqualityComparison
+
+        body = JSON.parse request.body.string
+        raise request_body_is_not_a_hash_error unless body.is_a?(Hash)
+
+        body
+      rescue JSON::ParserError
+        raise request_body_is_not_a_hash_error
+      end
+
+      def request_body_is_not_a_hash_error
+        DecisionReviewV1::ServiceException.new key: 'DR_REQUEST_BODY_IS_NOT_A_HASH'
+      end
+
+      def request_body_debug_data
+        {
+          request_body_class_name: request.try(:body).class.name,
+          request_body_string: request.try(:body).try(:string)
+        }
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/higher_level_reviews/contestable_issues_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/higher_level_reviews/contestable_issues_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DecisionReviews
+  module V1
+    module HigherLevelReviews
+      class ContestableIssuesController < AppealsBaseController
+        service_tag 'higher-level-review'
+
+        def index
+          ci = decision_review_service
+               .get_higher_level_review_contestable_issues(user: current_user, benefit_type: params[:benefit_type])
+               .body
+          render json: merge_legacy_appeals(ci)
+        rescue => e
+          log_exception_to_personal_information_log(
+            e,
+            error_class: "#{self.class.name}#index exception #{e.class} (HLR_V1)",
+            benefit_type: params[:benefit_type]
+          )
+          raise
+        end
+
+        private
+
+        def merge_legacy_appeals(contestable_issues)
+          # Fetch Legacy Appels and combine with CIs
+          ci_la = nil
+          begin
+            la = decision_review_service
+                 .get_legacy_appeals(user: current_user)
+                 .body
+            # punch in an empty LA section if no LAs for user to distinguish no LAs from a LA call fail
+            la['data'] = [{ type: 'legacyAppeal', attributes: { issues: [] } }] if la['data'].empty?
+            ci_la = { data: contestable_issues['data'] + la['data'] }
+          rescue => e
+            # If LA fails keep going Legacy Appeals are not critical, return original contestable_issues
+            log_exception_to_personal_information_log(
+              e,
+              error_class: "#{self.class.name}#index exception #{e.class} (HLR_V1_LEGACY_APPEALS)",
+              benefit_type: params[:benefit_type]
+            )
+            contestable_issues
+          else
+            ci_la
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/higher_level_reviews_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/higher_level_reviews_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'decision_reviews/saved_claim/service'
+
+module DecisionReviews
+  module V1
+    class HigherLevelReviewsController < AppealsBaseController
+      include DecisionReviews::SavedClaim::Service
+      service_tag 'higher-level-review'
+
+      def show
+        render json: decision_review_service.get_higher_level_review(params[:id]).body
+      rescue => e
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'show', exception_class: e.class), id: params[:id]
+        )
+        raise
+      end
+
+      def create
+        hlr_response_body = decision_review_service
+                            .create_higher_level_review(request_body: request_body_hash, user: @current_user)
+                            .body
+        submitted_appeal_uuid = hlr_response_body.dig('data', 'id')
+        ActiveRecord::Base.transaction do
+          AppealSubmission.create!(user_uuid: @current_user.uuid, user_account: @current_user.user_account,
+                                   type_of_appeal: 'HLR', submitted_appeal_uuid:)
+
+          store_saved_claim(claim_class: ::SavedClaim::HigherLevelReview, form: request_body_hash.to_json,
+                            guid: submitted_appeal_uuid)
+
+          # Clear in-progress form since submit was successful
+          InProgressForm.form_for_user('20-0996', current_user)&.destroy!
+        end
+        render json: hlr_response_body
+      rescue => e
+        ::Rails.logger.error(
+          message: "Exception occurred while submitting Higher Level Review: #{e.message}",
+          backtrace: e.backtrace
+        )
+
+        handle_personal_info_error(e)
+      end
+
+      private
+
+      def error_class(method:, exception_class:)
+        "#{self.class.name}##{method} exception #{exception_class} (HLR_V1)"
+      end
+
+      def handle_personal_info_error(e)
+        request = begin
+          { body: request_body_hash }
+        rescue
+          request_body_debug_data
+        end
+
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'create', exception_class: e.class), request:
+        )
+        raise
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/notice_of_disagreements/contestable_issues_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/notice_of_disagreements/contestable_issues_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DecisionReviews
+  module V1
+    module NoticeOfDisagreements
+      class ContestableIssuesController < AppealsBaseController
+        service_tag 'board-appeal'
+
+        def index
+          render json: decision_review_service
+            .get_notice_of_disagreement_contestable_issues(user: current_user)
+            .body
+        rescue => e
+          log_exception_to_personal_information_log e,
+                                                    error_class:
+                                                    "#{self.class.name}#index exception #{e.class} (NOD_V1)"
+          raise
+        end
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/notice_of_disagreements_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/notice_of_disagreements_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module DecisionReviews
+  module V1
+    class NoticeOfDisagreementsController < AppealsBaseController
+      service_tag 'board-appeal'
+
+      def show
+        render json: decision_review_service.get_notice_of_disagreement(params[:id]).body
+      rescue => e
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'show', exception_class: e.class), id: params[:id]
+        )
+        raise
+      end
+
+      def create
+        nod_response_body = AppealSubmission.submit_nod(
+          current_user: @current_user,
+          request_body_hash:,
+          decision_review_service:
+        )
+
+        render json: nod_response_body
+      rescue => e
+        ::Rails.logger.error(
+          message: "Exception occurred while submitting Notice Of Disagreement: #{e.message}",
+          backtrace: e.backtrace
+        )
+        handle_personal_info_error(e)
+      end
+
+      private
+
+      def error_class(method:, exception_class:)
+        "#{self.class.name}##{method} exception #{exception_class} (NOD_V1)"
+      end
+
+      def handle_personal_info_error(e)
+        request = begin
+          { body: request_body_hash }
+        rescue
+          request_body_debug_data
+        end
+
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'create', exception_class: e.class), request:
+        )
+        raise
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/supplemental_claims/contestable_issues_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/supplemental_claims/contestable_issues_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DecisionReviews
+  module V1
+    module SupplementalClaims
+      class ContestableIssuesController < AppealsBaseController
+        service_tag 'appeal-application'
+
+        def index
+          ci = decision_review_service
+               .get_supplemental_claim_contestable_issues(user: current_user, benefit_type: params[:benefit_type])
+               .body
+          render json: merge_legacy_appeals(ci)
+        rescue => e
+          log_exception_to_personal_information_log e,
+                                                    error_class: "#{self.class.name}#index exception #{e.class} (SC_V1)"
+          raise
+        end
+
+        def merge_legacy_appeals(contestable_issues)
+          # Fetch Legacy Appels and combine with CIs
+          ci_la = nil
+          begin
+            la = decision_review_service
+                 .get_legacy_appeals(user: current_user)
+                 .body
+            # punch in an empty LA section if no LAs for user to distinguish no LAs from a LA call fail
+            la['data'] = [{ type: 'legacyAppeal', attributes: { issues: [] } }] if la['data'].empty?
+            ci_la = { data: contestable_issues['data'] + la['data'] }
+          rescue => e
+            # If LA fails keep going Legacy Appeals are not critical, return original contestable_issues
+            log_exception_to_personal_information_log(
+              e,
+              error_class: "#{self.class.name}#index exception #{e.class} (SC_V1_LEGACY_APPEALS)",
+              benefit_type: params[:benefit_type]
+            )
+            contestable_issues
+          else
+            ci_la
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/supplemental_claims_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/supplemental_claims_controller.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'decision_reviews/v1//constants'
+require 'decision_reviews/v1/helpers'
+require 'decision_reviews/saved_claim/service'
+module DecisionReviews
+  module V1
+    class SupplementalClaimsController < AppealsBaseController
+      include DecisionReviews::V1::Helpers
+      include DecisionReviews::SavedClaim::Service
+      service_tag 'appeal-application'
+
+      def show
+        render json: decision_review_service.get_supplemental_claim(params[:id]).body
+      rescue => e
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'show', exception_class: e.class), id: params[:id]
+        )
+        raise
+      end
+
+      def create
+        process_submission
+      rescue => e
+        ::Rails.logger.error(
+          message: "Exception occurred while submitting Supplemental Claim: #{e.message}",
+          backtrace: e.backtrace
+        )
+        handle_personal_info_error(e)
+      end
+
+      private
+
+      def post_create_log_msg(appeal_submission_id:, submitted_appeal_uuid:)
+        {
+          message: 'Supplemental Claim Appeal Record Created',
+          appeal_submission_id:,
+          lighthouse_submission: {
+            id: submitted_appeal_uuid
+          }
+        }
+      end
+
+      def handle_4142(request_body:, form4142:, appeal_submission_id:, submitted_appeal_uuid:) # rubocop:disable Naming/VariableNumber
+        return if form4142.blank?
+
+        rejiggered_payload = get_and_rejigger_required_info(request_body:, form4142:, user: @current_user)
+        jid = decision_review_service.queue_form4142(appeal_submission_id:, rejiggered_payload:, submitted_appeal_uuid:)
+        log_form4142_job_queued(appeal_submission_id, submitted_appeal_uuid, jid)
+      end
+
+      def log_form4142_job_queued(appeal_submission_id, submitted_appeal_uuid, jid)
+        ::Rails.logger.info({
+                              form_id: DecisionReviews::V1::FORM4142_ID,
+                              parent_form_id: DecisionReviews::V1::SUPP_CLAIM_FORM_ID,
+                              message: 'Supplemental Claim Form4142 queued.',
+                              jid:,
+                              appeal_submission_id:,
+                              lighthouse_submission: {
+                                id: submitted_appeal_uuid
+                              }
+                            })
+      end
+
+      def submit_evidence(sc_evidence, appeal_submission_id, submitted_appeal_uuid)
+        # I know I could just use `appeal_submission.enqueue_uploads` here, but I want to return the jids to log, so
+        # replicating instead. There is some duplicate code but I want them jids in the logs.
+        jids = decision_review_service.queue_submit_evidence_uploads(sc_evidence, appeal_submission_id)
+        ::Rails.logger.info({
+                              form_id: DecisionReviews::V1::SUPP_CLAIM_FORM_ID,
+                              message: 'Supplemental Claim Evidence jobs created.',
+                              appeal_submission_id:,
+                              lighthouse_submission: {
+                                id: submitted_appeal_uuid
+                              },
+                              evidence_upload_job_ids: jids
+                            })
+      end
+
+      def handle_personal_info_error(e)
+        request = begin
+          { body: request_body_hash }
+        rescue
+          request_body_debug_data
+        end
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'create', exception_class: e.class), request:
+        )
+        raise
+      end
+
+      def process_submission
+        req_body_obj = request_body_hash.is_a?(String) ? JSON.parse(request_body_hash) : request_body_hash
+        saved_claim_request_body = req_body_obj.to_json # serialize before request body is modified
+        form4142 = req_body_obj.delete('form4142')
+        sc_evidence = req_body_obj.delete('additionalDocuments')
+        zip_from_frontend = req_body_obj.dig('data', 'attributes', 'veteran', 'address', 'zipCode5')
+
+        sc_response = decision_review_service.create_supplemental_claim(request_body: req_body_obj, user: @current_user)
+        submitted_appeal_uuid = sc_response.body.dig('data', 'id')
+
+        ActiveRecord::Base.transaction do
+          appeal_submission_id = create_appeal_submission(submitted_appeal_uuid, zip_from_frontend)
+          handle_saved_claim(form: saved_claim_request_body, guid: submitted_appeal_uuid, form4142:)
+
+          ::Rails.logger.info(post_create_log_msg(appeal_submission_id:, submitted_appeal_uuid:))
+          handle_4142(request_body: req_body_obj, form4142:, appeal_submission_id:, submitted_appeal_uuid:)
+          submit_evidence(sc_evidence, appeal_submission_id, submitted_appeal_uuid) if sc_evidence.present?
+
+          # Only destroy InProgressForm after evidence upload step
+          # so that we still have references if a fatal error occurs before this step
+          clear_in_progress_form
+        end
+        render json: sc_response.body, status: sc_response.status
+      end
+
+      def create_appeal_submission(submitted_appeal_uuid, backup_zip)
+        upload_metadata = DecisionReviews::V1::Service.file_upload_metadata(
+          @current_user, backup_zip
+        )
+        create_params = {
+          user_uuid: @current_user.uuid,
+          user_account: @current_user.user_account,
+          type_of_appeal: 'SC',
+          submitted_appeal_uuid:,
+          upload_metadata:
+        }
+        appeal_submission = AppealSubmission.create!(create_params)
+        appeal_submission.id
+      end
+
+      def handle_saved_claim(form:, guid:, form4142:)
+        uploaded_forms = []
+        uploaded_forms << '21-4142' if form4142.present?
+        store_saved_claim(claim_class: ::SavedClaim::SupplementalClaim, form:, guid:, uploaded_forms:)
+      end
+
+      def clear_in_progress_form
+        InProgressForm.form_for_user('20-0995', @current_user)&.destroy!
+      end
+
+      def error_class(method:, exception_class:)
+        "#{self.class.name}##{method} exception #{exception_class} (SC_V1)"
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/app/controllers/decision_reviews/v2/higher_level_reviews_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v2/higher_level_reviews_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'decision_reviews/saved_claim/service'
+require_relative '../v1/appeals_base_controller'
+
+module DecisionReviews
+  module V2
+    class HigherLevelReviewsController < V1::AppealsBaseController
+      include DecisionReviews::SavedClaim::Service
+      service_tag 'higher-level-review'
+
+      def show
+        render json: decision_review_service.get_higher_level_review(params[:id]).body
+      rescue => e
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'show', exception_class: e.class), id: params[:id]
+        )
+        raise
+      end
+
+      def create
+        hlr_response_body = decision_review_service
+                            .create_higher_level_review(request_body: request_body_hash, user: @current_user,
+                                                        version: 'V2')
+                            .body
+        submitted_appeal_uuid = hlr_response_body.dig('data', 'id')
+        ActiveRecord::Base.transaction do
+          AppealSubmission.create!(user_uuid: @current_user.uuid, user_account: @current_user.user_account,
+                                   type_of_appeal: 'HLR', submitted_appeal_uuid:)
+
+          store_saved_claim(claim_class: ::SavedClaim::HigherLevelReview, form: request_body_hash.to_json,
+                            guid: submitted_appeal_uuid)
+
+          # Clear in-progress form since submit was successful
+          InProgressForm.form_for_user('20-0996', current_user)&.destroy!
+        end
+        render json: hlr_response_body
+      rescue => e
+        ::Rails.logger.error(
+          message: "Exception occurred while submitting Higher Level Review: #{e.message}",
+          backtrace: e.backtrace
+        )
+
+        handle_personal_info_error(e)
+      end
+
+      private
+
+      def error_class(method:, exception_class:)
+        "#{self.class.name}##{method} exception #{exception_class} (HLR_V2)"
+      end
+
+      def handle_personal_info_error(e)
+        request = begin
+          { body: request_body_hash }
+        rescue
+          request_body_debug_data
+        end
+
+        log_exception_to_personal_information_log(
+          e, error_class: error_class(method: 'create', exception_class: e.class), request:
+        )
+        raise
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/config/routes.rb
+++ b/modules/decision_reviews/config/routes.rb
@@ -1,4 +1,24 @@
 # frozen_string_literal: true
 
 DecisionReviews::Engine.routes.draw do
+  namespace :v1, defaults: { format: 'json' } do
+    namespace :higher_level_reviews do
+      get 'contestable_issues(/:benefit_type)', to: 'contestable_issues#index'
+    end
+    resources :higher_level_reviews, only: %i[create show]
+
+    namespace :notice_of_disagreements do
+      get 'contestable_issues', to: 'contestable_issues#index'
+    end
+    resources :notice_of_disagreements, only: %i[create show]
+
+    namespace :supplemental_claims do
+      get 'contestable_issues(/:benefit_type)', to: 'contestable_issues#index'
+    end
+    resources :supplemental_claims, only: %i[create show]
+  end
+
+  namespace :v2, defaults: { format: 'json' } do
+    resources :higher_level_reviews, only: %i[create show]
+  end
 end

--- a/modules/decision_reviews/lib/decision_reviews/saved_claim/service.rb
+++ b/modules/decision_reviews/lib/decision_reviews/saved_claim/service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module DecisionReviews
+  ##
+  # Service for persisting Decision Review SavedClaim
+  #
+  module SavedClaim
+    module Service
+      VALID_CLASS = [
+        ::SavedClaim::HigherLevelReview,
+        ::SavedClaim::NoticeOfDisagreement,
+        ::SavedClaim::SupplementalClaim
+      ].freeze
+
+      def store_saved_claim(claim_class:, form:, guid:, uploaded_forms: [])
+        raise "Invalid class type '#{claim_class}'" unless VALID_CLASS.include? claim_class
+
+        claim = claim_class.new(form:, guid:, uploaded_forms:)
+        claim.save!
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/lib/decision_reviews/v1/service.rb
+++ b/modules/decision_reviews/lib/decision_reviews/v1/service.rb
@@ -36,11 +36,11 @@ module DecisionReviews
       # @param user [User] Veteran who the form is in regard to
       # @return [Faraday::Response]
       #
-      def create_higher_level_review(request_body:, user:)
+      def create_higher_level_review(request_body:, user:, version: 'V1')
         with_monitoring_and_error_handling do
           headers = create_higher_level_review_headers(user)
           common_log_params = { key: :overall_claim_submission, form_id: '996', user_uuid: user.uuid,
-                                downstream_system: 'Lighthouse' }
+                                downstream_system: 'Lighthouse', params: { version: } }
           begin
             response = perform :post, 'higher_level_reviews', request_body, headers
             log_formatted(**common_log_params.merge(is_success: true, status_code: response.status,
@@ -51,7 +51,7 @@ module DecisionReviews
           end
           raise_schema_error_unless_200_status response.status
           validate_against_schema json: response.body, schema: HLR_CREATE_RESPONSE_SCHEMA,
-                                  append_to_error_class: ' (HLR_V1)'
+                                  append_to_error_class: " (HLR_#{version}})"
           response
         end
       end

--- a/modules/decision_reviews/spec/requests/v1/higher_level_reviews/contestable_issues_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/higher_level_reviews/contestable_issues_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe 'DecisionReviews::V1::HigherLevelReviews::ContestableIssues', type: :request do
+  let(:user) { build(:user, :loa3) }
+  let(:success_log_args) do
+    {
+      message: 'Get contestable issues success!',
+      user_uuid: user.uuid,
+      action: 'Get contestable issues',
+      form_id: '996',
+      upstream_system: 'Lighthouse',
+      downstream_system: nil,
+      is_success: true,
+      http: {
+        status_code: 200,
+        body: '[Redacted]'
+      }
+    }
+  end
+  let(:error_log_args) do
+    {
+      message: 'Get contestable issues failure!',
+      user_uuid: user.uuid,
+      action: 'Get contestable issues',
+      form_id: '996',
+      upstream_system: 'Lighthouse',
+      downstream_system: nil,
+      is_success: false,
+      http: {
+        status_code: 404,
+        body: anything
+      }
+    }
+  end
+
+  before { sign_in_as(user) }
+
+  describe '#index' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::HigherLevelReviews::ContestableIssuesController#index exception % (HLR_V1)' # rubocop:disable Layout/LineLength
+    end
+
+    subject { get '/decision_reviews/v1/higher_level_reviews/contestable_issues/compensation' }
+
+    it 'fetches issues that the Veteran could contest via a higher-level review' do
+      VCR.use_cassette('decision_review/HLR-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
+        VCR.use_cassette('decision_review/HLR-GET-LEGACY_APPEALS-RESPONSE-200_V1') do
+          allow(Rails.logger).to receive(:info)
+          expect(Rails.logger).to receive(:info).with(success_log_args)
+          subject
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)['data']).to be_an Array
+          expect(JSON.parse(response.body)['data'].length).to be 4
+        end
+      end
+    end
+
+    it 'fetches issues that the Veteran could contest via a higher-level review, but empty Legacy Appeals' do
+      VCR.use_cassette('decision_review/HLR-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
+        VCR.use_cassette('decision_review/HLR-GET-LEGACY_APPEALS-RESPONSE-200-EMPTY_V1') do
+          subject
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)['data']).to be_an Array
+          expect(JSON.parse(response.body)['data'].length).to be 4
+        end
+      end
+    end
+
+    it 'adds to the PersonalInformationLog when an exception is thrown' do
+      VCR.use_cassette('decision_review/HLR-GET-CONTESTABLE-ISSUES-RESPONSE-404_V1') do
+        expect(personal_information_logs.count).to be 0
+        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error).with(error_log_args)
+        subject
+        expect(personal_information_logs.count).to be 1
+        pil = personal_information_logs.first
+        expect(pil.data['user']).to be_truthy
+        expect(pil.data['error']).to be_truthy
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/spec/requests/v1/higher_level_reviews_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/higher_level_reviews_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe 'DecisonReviews::V1::HigherLevelReviews', type: :request do
+  let(:user) { build(:user, :loa3) }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:success_log_args) do
+    {
+      message: 'Overall claim submission success!',
+      user_uuid: user.uuid,
+      action: 'Overall claim submission',
+      form_id: '996',
+      upstream_system: nil,
+      downstream_system: 'Lighthouse',
+      is_success: true,
+      http: {
+        status_code: 200,
+        body: '[Redacted]'
+      },
+      version: 'V1'
+    }
+  end
+  let(:error_log_args) do
+    {
+      message: 'Overall claim submission failure!',
+      user_uuid: user.uuid,
+      action: 'Overall claim submission',
+      form_id: '996',
+      upstream_system: nil,
+      downstream_system: 'Lighthouse',
+      is_success: false,
+      http: {
+        status_code: 422,
+        body: response_error_body
+      },
+      version: 'V1'
+    }
+  end
+
+  let(:response_error_body) do
+    {
+      'errors' => [{ 'title' => 'Missing required fields',
+                     'detail' => 'One or more expected fields were not found',
+                     'code' => '145',
+                     'source' => { 'pointer' => '/' },
+                     'status' => '422',
+                     'meta' => { 'missing_fields' => %w[data included] } }]
+    }
+  end
+
+  let(:extra_error_log_message) do
+    'BackendServiceException: {:source=>"Common::Client::Errors::ClientError raised in DecisionReviews::V1::Service", :code=>"DR_422"}' # rubocop:disable Layout/LineLength
+  end
+
+  before { sign_in_as(user) }
+
+  describe '#create' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::HigherLevelReviewsController#create exception % (HLR_V1)'
+    end
+
+    subject do
+      post '/decision_reviews/v1/higher_level_reviews',
+           params: VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY_V1').to_json,
+           headers:
+    end
+
+    it 'creates an HLR' do
+      VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200_V1') do
+        # Create an InProgressForm
+        in_progress_form = create(:in_progress_form, user_uuid: user.uuid, form_id: '20-0996')
+        expect(in_progress_form).not_to be_nil
+
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(success_log_args)
+        allow(StatsD).to receive(:increment)
+        expect(StatsD).to receive(:increment).with('decision_review.form_996.overall_claim_submission.success')
+
+        subject
+        expect(response).to be_successful
+        appeal_uuid = JSON.parse(response.body)['data']['id']
+        expect(AppealSubmission.where(submitted_appeal_uuid: appeal_uuid).first).to be_truthy
+        # InProgressForm should be destroyed after successful submission
+        in_progress_form = InProgressForm.find_by(user_uuid: user.uuid, form_id: '20-0996')
+        expect(in_progress_form).to be_nil
+        # SavedClaim should be created with request data
+        saved_claim = SavedClaim::HigherLevelReview.find_by(guid: appeal_uuid)
+        expect(saved_claim.form).to eq(VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY_V1').to_json)
+      end
+    end
+
+    context 'when an error occurs with the api call' do
+      it 'adds to the PersonalInformationLog' do
+        VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-422_V1') do
+          expect(personal_information_logs.count).to be 0
+
+          allow(Rails.logger).to receive(:error)
+          expect(Rails.logger).to receive(:error).with(error_log_args)
+          expect(Rails.logger).to receive(:error).with(
+            message: "Exception occurred while submitting Higher Level Review: #{extra_error_log_message}",
+            backtrace: anything
+          )
+          expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
+          allow(StatsD).to receive(:increment)
+          expect(StatsD).to receive(:increment).with('decision_review.form_996.overall_claim_submission.failure')
+
+          subject
+          expect(personal_information_logs.count).to be 1
+          pil = personal_information_logs.first
+          %w[
+            first_name last_name birls_id icn edipi mhv_correlation_id
+            participant_id vet360_id ssn assurance_level birth_date
+          ].each { |key| expect(pil.data['user'][key]).to be_truthy }
+          %w[message backtrace key response_values original_status original_body]
+            .each { |key| expect(pil.data['error'][key]).to be_truthy }
+          expect(pil.data['additional_data']['request']['body']).not_to be_empty
+        end
+      end
+    end
+
+    context 'when an error occurs in the transaction' do
+      shared_examples 'rolledback transaction' do |model|
+        before do
+          allow_any_instance_of(model).to receive(:save!).and_raise(ActiveModel::Error) # stub a model error
+        end
+
+        it 'rollsback transaction' do
+          VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200_V1') do
+            expect(subject).to eq 500
+
+            # check that transaction rolled back / records were not persisted
+            expect(AppealSubmission.count).to eq 0
+            expect(SavedClaim.count).to eq 0
+          end
+        end
+      end
+
+      context 'for AppealSubmission' do
+        it_behaves_like 'rolledback transaction', AppealSubmission
+      end
+
+      context 'for SavedClaim' do
+        it_behaves_like 'rolledback transaction', SavedClaim
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/spec/requests/v1/notice_of_disagreements/contestable_issues_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/notice_of_disagreements/contestable_issues_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe 'DecisionReviews::V1::NoticeOfDisagreements::ContestableIssues', type: :request do
+  let(:user) { build(:user, :loa3) }
+
+  before { sign_in_as(user) }
+
+  describe '#index' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::NoticeOfDisagreements::ContestableIssuesController#index exception % (NOD_V1)' # rubocop:disable Layout/LineLength
+    end
+
+    subject { get '/decision_reviews/v1/notice_of_disagreements/contestable_issues' }
+
+    it 'fetches issues that the Veteran could contest via a notice of disagreement' do
+      VCR.use_cassette('decision_review/NOD-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
+        subject
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)['data']).to be_an Array
+      end
+    end
+
+    it 'adds to the PersonalInformationLog when an exception is thrown' do
+      VCR.use_cassette('decision_review/NOD-GET-CONTESTABLE-ISSUES-RESPONSE-404_V1') do
+        expect(personal_information_logs.count).to be 0
+        subject
+        expect(personal_information_logs.count).to be 1
+        pil = personal_information_logs.first
+        expect(pil.data['user']).to be_truthy
+        expect(pil.data['error']).to be_truthy
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/spec/requests/v1/notice_of_disagreements_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/notice_of_disagreements_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe 'DecisionReviews::V1::NoticeOfDisagreements', type: :request do
+  let(:user) do
+    build(:user,
+          :loa3,
+          mhv_correlation_id: 'some-mhv_correlation_id',
+          birls_id: 'some-birls_id',
+          participant_id: 'some-participant_id',
+          vet360_id: 'some-vet360_id')
+  end
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  let(:error_log_args) do
+    {
+      message: 'Overall claim submission failure!',
+      user_uuid: user.uuid,
+      action: 'Overall claim submission',
+      form_id: '10182',
+      upstream_system: nil,
+      downstream_system: 'Lighthouse',
+      is_success: false,
+      http: {
+        status_code: 422,
+        body: response_error_body
+      }
+    }
+  end
+
+  let(:response_error_body) do
+    {
+      'errors' => [{ 'title' => 'Missing required fields',
+                     'detail' => 'One or more expected fields were not found',
+                     'code' => '145',
+                     'source' => { 'pointer' => '/data/attributes' },
+                     'status' => '422',
+                     'meta' => { 'missing_fields' => ['boardReviewOption'] } }]
+    }
+  end
+
+  before { sign_in_as(user) }
+
+  describe '#create' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::NoticeOfDisagreementsController#create exception % (NOD_V1)'
+    end
+
+    subject do
+      post '/decision_reviews/v1/notice_of_disagreements',
+           params: test_request_body.to_json,
+           headers:
+    end
+
+    let(:extra_error_log_message) do
+      'BackendServiceException: {:source=>"Common::Client::Errors::ClientError raised in DecisionReviews::V1::Service", :code=>"DR_422"}' # rubocop:disable Layout/LineLength
+    end
+
+    let(:test_request_body) do
+      JSON.parse Rails.root.join('spec', 'fixtures', 'notice_of_disagreements',
+                                 'valid_NOD_create_request.json').read
+    end
+
+    it 'creates an NOD and logs to StatsD and logger' do
+      VCR.use_cassette('decision_review/NOD-CREATE-RESPONSE-200_V1') do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with({
+                                                      message: 'Overall claim submission success!',
+                                                      user_uuid: user.uuid,
+                                                      action: 'Overall claim submission',
+                                                      form_id: '10182',
+                                                      upstream_system: nil,
+                                                      downstream_system: 'Lighthouse',
+                                                      is_success: true,
+                                                      http: {
+                                                        status_code: 200,
+                                                        body: '[Redacted]'
+                                                      }
+                                                    })
+        allow(StatsD).to receive(:increment)
+        expect(StatsD).to receive(:increment).with('decision_review.form_10182.overall_claim_submission.success')
+        previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
+        # Create an InProgressForm
+        in_progress_form = create(:in_progress_form, user_uuid: user.uuid, form_id: '10182')
+        expect(in_progress_form).not_to be_nil
+        subject
+        expect(response).to be_successful
+        parsed_response = JSON.parse(response.body)
+        id = parsed_response['data']['id']
+        expect(previous_appeal_submission_ids).not_to include id
+        appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+        expect(appeal_submission.type_of_appeal).to eq('NOD')
+        # AppealSubmissionUpload should be created for each form attachment
+        appeal_submission_uploads = AppealSubmissionUpload.where(appeal_submission:)
+        expect(appeal_submission_uploads.count).to eq 1
+        # Evidence upload job should have been enqueued
+        expect(DecisionReview::SubmitUpload).to have_enqueued_sidekiq_job(appeal_submission_uploads.first.id)
+        # InProgressForm should be destroyed after successful submission
+        in_progress_form = InProgressForm.find_by(user_uuid: user.uuid, form_id: '10182')
+        expect(in_progress_form).to be_nil
+        # SavedClaim should be created with request data
+        saved_claim = SavedClaim::NoticeOfDisagreement.find_by(guid: id)
+        expect(JSON.parse(saved_claim.form)).to eq(test_request_body)
+      end
+    end
+
+    it 'adds to the PersonalInformationLog when an exception is thrown and logs to StatsD and logger' do
+      VCR.use_cassette('decision_review/NOD-CREATE-RESPONSE-422_V1') do
+        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error).with(error_log_args)
+        expect(Rails.logger).to receive(:error).with(
+          message: "Exception occurred while submitting Notice Of Disagreement: #{extra_error_log_message}",
+          backtrace: anything
+        )
+        expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
+        allow(StatsD).to receive(:increment)
+        expect(StatsD).to receive(:increment).with('decision_review.form_10182.overall_claim_submission.failure')
+        expect(personal_information_logs.count).to be 0
+        subject
+        expect(personal_information_logs.count).to be 1
+        pil = personal_information_logs.first
+        %w[
+          first_name last_name birls_id icn edipi mhv_correlation_id
+          participant_id vet360_id ssn assurance_level birth_date
+        ].each { |key| expect(pil.data['user'][key]).to be_truthy }
+        %w[message backtrace key response_values original_status original_body]
+          .each { |key| expect(pil.data['error'][key]).to be_truthy }
+        expect(pil.data['additional_data']['request']['body']).not_to be_empty
+
+        # check that transaction rolled back / records were not persisted / evidence upload job was not queued up
+        expect(AppealSubmission.count).to eq 0
+        expect(AppealSubmissionUpload.count).to eq 0
+        expect(DecisionReview::SubmitUpload).not_to have_enqueued_sidekiq_job(anything)
+
+        expect(SavedClaim.count).to eq 0
+      end
+    end
+
+    context 'when an error occurs in wrapped code' do
+      shared_examples 'rolledback transaction' do |model|
+        before do
+          allow_any_instance_of(model).to receive(:save!).and_raise(ActiveModel::Error) # stub a model error
+        end
+
+        it 'rollsback transaction' do
+          VCR.use_cassette('decision_review/NOD-CREATE-RESPONSE-200_V1') do
+            expect(subject).to eq 500
+            # check that transaction rolled back / records were not persisted / evidence upload job was not queued up
+            expect(AppealSubmission.count).to eq 0
+            expect(AppealSubmissionUpload.count).to eq 0
+            expect(DecisionReview::SubmitUpload).not_to have_enqueued_sidekiq_job(anything)
+            expect(SavedClaim.count).to eq 0
+          end
+        end
+      end
+
+      context 'for AppealSubmission' do
+        it_behaves_like 'rolledback transaction', AppealSubmission
+      end
+
+      context 'for SavedClaim' do
+        it_behaves_like 'rolledback transaction', SavedClaim
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/spec/requests/v1/supplemental_claims/contestable_issues_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/supplemental_claims/contestable_issues_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe 'DecisionReviews::V1::SupplementalClaims::ContestableIssues', type: :request do
+  let(:user) { build(:user, :loa3) }
+  let(:success_log_args) do
+    {
+      message: 'Get contestable issues success!',
+      user_uuid: user.uuid,
+      action: 'Get contestable issues',
+      form_id: '995',
+      upstream_system: 'Lighthouse',
+      downstream_system: nil,
+      is_success: true,
+      http: {
+        status_code: 200,
+        body: '[Redacted]'
+      }
+    }
+  end
+  let(:error_log_args) do
+    {
+      message: 'Get contestable issues failure!',
+      user_uuid: user.uuid,
+      action: 'Get contestable issues',
+      form_id: '995',
+      upstream_system: 'Lighthouse',
+      downstream_system: nil,
+      is_success: false,
+      http: {
+        status_code: 404,
+        body: anything
+      }
+    }
+  end
+
+  before { sign_in_as(user) }
+
+  describe '#index' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::SupplementalClaims::ContestableIssuesController#index exception % (SC_V1)' # rubocop:disable Layout/LineLength
+    end
+
+    subject { get '/decision_reviews/v1/supplemental_claims/contestable_issues/compensation' }
+
+    it 'fetches issues that the Veteran could contest via a supplemental claim' do
+      VCR.use_cassette('decision_review/SC-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(success_log_args)
+        subject
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)['data']).to be_an Array
+      end
+    end
+
+    it 'adds to the PersonalInformationLog when an exception is thrown' do
+      VCR.use_cassette('decision_review/SC-GET-CONTESTABLE-ISSUES-RESPONSE-404_V1') do
+        expect(personal_information_logs.count).to be 0
+        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error).with(error_log_args)
+        subject
+        expect(personal_information_logs.count).to be 1
+        pil = personal_information_logs.first
+        expect(pil.data['user']).to be_truthy
+        expect(pil.data['error']).to be_truthy
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe 'DecisionReviews::V1::SupplementalClaims', type: :request do
+  let(:user) { build(:user, :loa3) }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:success_log_args) do
+    {
+      message: 'Overall claim submission success!',
+      user_uuid: user.uuid,
+      action: 'Overall claim submission',
+      form_id: '995',
+      upstream_system: nil,
+      downstream_system: 'Lighthouse',
+      is_success: true,
+      http: {
+        status_code: 200,
+        body: '[Redacted]'
+      }
+    }
+  end
+  let(:error_log_args) do
+    {
+      message: 'Overall claim submission failure!',
+      user_uuid: user.uuid,
+      action: 'Overall claim submission',
+      form_id: '995',
+      upstream_system: nil,
+      downstream_system: 'Lighthouse',
+      is_success: false,
+      http: {
+        status_code: 422,
+        body: response_error_body
+      }
+    }
+  end
+  let(:extra_error_log_message) do
+    'BackendServiceException: ' \
+      '{:source=>"Common::Client::Errors::ClientError raised in DecisionReviews::V1::Service", :code=>"DR_422"}'
+  end
+
+  let(:response_error_body) do
+    {
+      'errors' => [{ 'title' => 'Missing required fields',
+                     'detail' => 'One or more expected fields were not found',
+                     'code' => '145',
+                     'source' => { 'pointer' => '/data/attributes' },
+                     'status' => '422',
+                     'meta' => { 'missing_fields' => ['form5103Acknowledged'] } }]
+    }
+  end
+
+  before { sign_in_as(user) }
+
+  describe '#create' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::SupplementalClaimsController#create exception % (SC_V1)'
+    end
+
+    subject do
+      post '/decision_reviews/v1/supplemental_claims',
+           params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY_V1').to_json,
+           headers:
+    end
+
+    it 'creates a supplemental claim' do
+      VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-200_V1') do
+        # Create an InProgressForm
+        in_progress_form = create(:in_progress_form, user_uuid: user.uuid, form_id: '20-0995')
+        expect(in_progress_form).not_to be_nil
+        previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
+
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(success_log_args)
+        allow(StatsD).to receive(:increment)
+        expect(StatsD).to receive(:increment).with('decision_review.form_995.overall_claim_submission.success')
+
+        subject
+        expect(response).to be_successful
+        parsed_response = JSON.parse(response.body)
+        id = parsed_response['data']['id']
+        expect(previous_appeal_submission_ids).not_to include id
+        appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+        expect(appeal_submission.type_of_appeal).to eq('SC')
+        # InProgressForm should be destroyed after successful submission
+        in_progress_form = InProgressForm.find_by(user_uuid: user.uuid, form_id: '20-0995')
+        expect(in_progress_form).to be_nil
+        # SavedClaim should be created with request data
+        saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
+        expect(saved_claim.form).to eq(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY_V1').to_json)
+        expect(saved_claim.uploaded_forms).to be_empty
+      end
+    end
+
+    it 'adds to the PersonalInformationLog when an exception is thrown' do
+      VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-422_V1') do
+        expect(personal_information_logs.count).to be 0
+        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error).with(error_log_args)
+        expect(Rails.logger).to receive(:error).with(
+          message: "Exception occurred while submitting Supplemental Claim: #{extra_error_log_message}",
+          backtrace: anything
+        )
+        expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
+        allow(StatsD).to receive(:increment)
+        expect(StatsD).to receive(:increment).with('decision_review.form_995.overall_claim_submission.failure')
+
+        subject
+        expect(personal_information_logs.count).to be 1
+        pil = personal_information_logs.first
+        %w[
+          first_name last_name birls_id icn edipi mhv_correlation_id
+          participant_id vet360_id ssn assurance_level birth_date
+        ].each { |key| expect(pil.data['user'][key]).to be_truthy }
+        %w[message backtrace key response_values original_status original_body]
+          .each { |key| expect(pil.data['error'][key]).to be_truthy }
+        expect(pil.data['additional_data']['request']['body']).not_to be_empty
+      end
+    end
+  end
+
+  describe '#create with 4142' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::SupplementalClaimsController#create exception % (SC_V1)'
+    end
+
+    context 'when tracking 4142 is enabled' do
+      subject do
+        post '/decision_reviews/v1/supplemental_claims',
+             params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
+             headers:
+      end
+
+      before do
+        Flipper.enable(:decision_review_track_4142_submissions)
+      end
+
+      it 'creates a supplemental claim and queues and saves a 4142 form when 4142 info is provided' do
+        VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
+              expect { subject }.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
+              expect(response).to be_successful
+              parsed_response = JSON.parse(response.body)
+              id = parsed_response['data']['id']
+              expect(previous_appeal_submission_ids).not_to include id
+              appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+              expect(appeal_submission.type_of_appeal).to eq('SC')
+              expect do
+                DecisionReview::Form4142Submit.drain
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(-1)
+
+              # SavedClaim should be created with request data and list of uploaded forms
+              request_body = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json)
+              saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
+              expect(saved_claim.form).to eq(request_body.to_json)
+              expect(saved_claim.uploaded_forms).to contain_exactly '21-4142'
+
+              # SecondaryAppealForm should be created with 4142 data and user data
+              expected_form4142_data = VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV')['form4142']
+              veteran_data = {
+                'vaFileNumber' => '796111863',
+                'veteranSocialSecurityNumber' => '796111863',
+                'veteranFullName' => {
+                  'first' => 'abraham',
+                  'middle' => nil,
+                  'last' => 'lincoln'
+                },
+                'veteranDateOfBirth' => '1809-02-12',
+                'veteranAddress' => { 'addressLine1' => '123  Main St', 'city' => 'New York', 'countryCodeISO2' => 'US',
+                                      'zipCode5' => '30012', 'country' => 'US', 'postalCode' => '30012' },
+                'email' => 'josie@example.com',
+                'veteranPhone' => '5558001111'
+              }
+              expected_form4142_data_with_user = veteran_data.merge(expected_form4142_data)
+              saved4142 = SecondaryAppealForm.last
+              saved_4142_json = JSON.parse(saved4142.form)
+              expect(saved_4142_json).to eq(expected_form4142_data_with_user)
+              expect(saved4142.form_id).to eq('21-4142')
+              expect(saved4142.appeal_submission.id).to eq(appeal_submission.id)
+            end
+          end
+        end
+      end
+    end
+
+    context 'when tracking 4142 is disabled' do
+      before do
+        Flipper.disable(:decision_review_track_4142_submissions)
+      end
+
+      it 'creates a supplemental claim and queues a 4142 form when 4142 info is provided' do
+        VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              previous_appeal_submission_ids = AppealSubmission.all.pluck :submitted_appeal_uuid
+              expect do
+                post '/decision_reviews/v1/supplemental_claims',
+                     params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
+                     headers:
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
+              expect(response).to be_successful
+              parsed_response = JSON.parse(response.body)
+              id = parsed_response['data']['id']
+              expect(previous_appeal_submission_ids).not_to include id
+              appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+              expect(appeal_submission.type_of_appeal).to eq('SC')
+              expect do
+                DecisionReview::Form4142Submit.drain
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(-1)
+
+              # SavedClaim should be created with request data and list of uploaded forms
+              request_body = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json)
+              saved_claim = SavedClaim::SupplementalClaim.find_by(guid: id)
+              expect(saved_claim.form).to eq(request_body.to_json)
+              expect(saved_claim.uploaded_forms).to contain_exactly '21-4142'
+            end
+          end
+        end
+      end
+
+      it 'does not persist a SecondaryAppealForm for the 4142' do
+        VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-4142-200_V1') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+            VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+              expect do
+                post '/decision_reviews/v1/supplemental_claims',
+                     params: VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').to_json,
+                     headers:
+              end.to change(DecisionReview::Form4142Submit.jobs, :size).by(1)
+              expect do
+                DecisionReview::Form4142Submit.drain
+              end.not_to change(SecondaryAppealForm, :count)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#create with uploads' do
+    # Create evidence files objs
+
+    subject do
+      post '/decision_reviews/v1/supplemental_claims',
+           params: example_payload.to_json,
+           headers:
+    end
+
+    let(:example_payload) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV') }
+
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V1::SupplementalClaimsController#create exception % (SC_V1)'
+    end
+
+    it 'creates a supplemental claim and queues evidence jobs when additionalDocuments info is provided' do
+      VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-UPLOADS-200_V1') do
+        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+            VCR.use_cassette('decision_review/SC-GET-UPLOAD-URL-200_V1') do
+              expect { subject }.to change(DecisionReview::SubmitUpload.jobs, :size).by(2)
+              expect(response).to be_successful
+              parsed_response = JSON.parse(response.body)
+              id = parsed_response['data']['id']
+              appeal_submission = AppealSubmission.find_by(submitted_appeal_uuid: id)
+              expect(appeal_submission.type_of_appeal).to eq('SC')
+            end
+          end
+        end
+      end
+    end
+
+    context 'when an error occurs in the transaction' do
+      shared_examples 'rolledback transaction' do |model|
+        before do
+          allow_any_instance_of(model).to receive(:save!).and_raise(ActiveModel::Error) # stub a model error
+        end
+
+        it 'rollsback transaction' do
+          VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-WITH-UPLOADS-200_V1') do
+            expect(subject).to eq 500
+
+            # check that transaction rolled back / records were not persisted / evidence upload job was not queued up
+            expect(AppealSubmission.count).to eq 0
+            expect(AppealSubmissionUpload.count).to eq 0
+            expect(DecisionReview::SubmitUpload).not_to have_enqueued_sidekiq_job(anything)
+            expect(SavedClaim.count).to eq 0
+            expect(SecondaryAppealForm.count).to eq 0
+          end
+        end
+      end
+
+      context 'for AppealSubmission' do
+        it_behaves_like 'rolledback transaction', AppealSubmission
+      end
+
+      context 'for SavedClaim' do
+        it_behaves_like 'rolledback transaction', SavedClaim
+      end
+    end
+  end
+end

--- a/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
+++ b/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
@@ -51,15 +51,15 @@ RSpec.describe 'DecisionReviews::V2::HigherLevelReviews', type: :request do
   end
 
   let(:extra_error_log_message) do
-    'BackendServiceException: {:source=>"Common::Client::Errors::ClientError raised in DecisionReviews::V1::Service", ' \
-      ':code=>"DR_422"}'
+    'BackendServiceException: {:source=>"Common::Client::Errors::ClientError raised in DecisionReviews::V1::Service", :code=>"DR_422"}' # rubocop:disable Layout/LineLength
   end
 
   before { sign_in_as(user) }
 
   describe '#create' do
     def personal_information_logs
-      PersonalInformationLog.where 'error_class like ?', 'DecisionReviews::V2::HigherLevelReviewsController#create exception % (HLR_V2)'
+      PersonalInformationLog.where 'error_class like ?',
+                                   'DecisionReviews::V2::HigherLevelReviewsController#create exception % (HLR_V2)'
     end
 
     subject do

--- a/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
+++ b/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe 'DecisionReviews::V2::HigherLevelReviews', type: :request do
+  let(:user) { build(:user, :loa3) }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:success_log_args) do
+    {
+      message: 'Overall claim submission success!',
+      user_uuid: user.uuid,
+      action: 'Overall claim submission',
+      form_id: '996',
+      upstream_system: nil,
+      downstream_system: 'Lighthouse',
+      is_success: true,
+      http: {
+        status_code: 200,
+        body: '[Redacted]'
+      },
+      version: 'V2'
+    }
+  end
+  let(:error_log_args) do
+    {
+      message: 'Overall claim submission failure!',
+      user_uuid: user.uuid,
+      action: 'Overall claim submission',
+      form_id: '996',
+      upstream_system: nil,
+      downstream_system: 'Lighthouse',
+      is_success: false,
+      http: {
+        status_code: 422,
+        body: response_error_body
+      },
+      version: 'V2'
+    }
+  end
+
+  let(:response_error_body) do
+    {
+      'errors' => [{ 'title' => 'Missing required fields',
+                     'detail' => 'One or more expected fields were not found',
+                     'code' => '145',
+                     'source' => { 'pointer' => '/' },
+                     'status' => '422',
+                     'meta' => { 'missing_fields' => %w[data included] } }]
+    }
+  end
+
+  let(:extra_error_log_message) do
+    'BackendServiceException: {:source=>"Common::Client::Errors::ClientError raised in DecisionReviews::V1::Service", ' \
+      ':code=>"DR_422"}'
+  end
+
+  before { sign_in_as(user) }
+
+  describe '#create' do
+    def personal_information_logs
+      PersonalInformationLog.where 'error_class like ?', 'DecisionReviews::V2::HigherLevelReviewsController#create exception % (HLR_V2)'
+    end
+
+    subject do
+      post '/decision_reviews/v2/higher_level_reviews',
+           params: VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY_V1').to_json,
+           headers:
+    end
+
+    it 'creates an HLR' do
+      VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200_V1') do
+        # Create an InProgressForm
+        in_progress_form = create(:in_progress_form, user_uuid: user.uuid, form_id: '20-0996')
+        expect(in_progress_form).not_to be_nil
+
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(success_log_args)
+        allow(StatsD).to receive(:increment)
+        expect(StatsD).to receive(:increment).with('decision_review.form_996.overall_claim_submission.success')
+
+        subject
+        expect(response).to be_successful
+        appeal_uuid = JSON.parse(response.body)['data']['id']
+        expect(AppealSubmission.where(submitted_appeal_uuid: appeal_uuid).first).to be_truthy
+        # InProgressForm should be destroyed after successful submission
+        in_progress_form = InProgressForm.find_by(user_uuid: user.uuid, form_id: '20-0996')
+        expect(in_progress_form).to be_nil
+        # SavedClaim should be created with request data
+        saved_claim = SavedClaim::HigherLevelReview.find_by(guid: appeal_uuid)
+        expect(saved_claim.form).to eq(VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY_V1').to_json)
+      end
+    end
+
+    context 'when an error occurs with the api call' do
+      it 'adds to the PersonalInformationLog' do
+        VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-422_V1') do
+          expect(personal_information_logs.count).to be 0
+
+          allow(Rails.logger).to receive(:error)
+          expect(Rails.logger).to receive(:error).with(error_log_args)
+          expect(Rails.logger).to receive(:error).with(
+            message: "Exception occurred while submitting Higher Level Review: #{extra_error_log_message}",
+            backtrace: anything
+          )
+          expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
+          allow(StatsD).to receive(:increment)
+          expect(StatsD).to receive(:increment).with('decision_review.form_996.overall_claim_submission.failure')
+
+          subject
+          expect(personal_information_logs.count).to be 1
+          pil = personal_information_logs.first
+          %w[
+            first_name last_name birls_id icn edipi mhv_correlation_id
+            participant_id vet360_id ssn assurance_level birth_date
+          ].each { |key| expect(pil.data['user'][key]).to be_truthy }
+          %w[message backtrace key response_values original_status original_body]
+            .each { |key| expect(pil.data['error'][key]).to be_truthy }
+          expect(pil.data['additional_data']['request']['body']).not_to be_empty
+        end
+      end
+    end
+
+    context 'when an error occurs in the transaction' do
+      shared_examples 'rolledback transaction' do |model|
+        before do
+          allow_any_instance_of(model).to receive(:save!).and_raise(ActiveModel::Error) # stub a model error
+        end
+
+        it 'rollsback transaction' do
+          VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200_V1') do
+            expect(subject).to eq 500
+
+            # check that transaction rolled back / records were not persisted
+            expect(AppealSubmission.count).to eq 0
+            expect(SavedClaim.count).to eq 0
+          end
+        end
+      end
+
+      context 'for AppealSubmission' do
+        it_behaves_like 'rolledback transaction', AppealSubmission
+      end
+
+      context 'for SavedClaim' do
+        it_behaves_like 'rolledback transaction', SavedClaim
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Next step in process of isolating decision reviews code in new engine in modules folder. This PR only duplicates existing controllers, routes, tests, and services/utilities in the engine. They are not yet used.
- *(Which team do you work for, does your team own the maintenance of this component?)*
- Decision Reviews, yes

## Related issue(s)

[- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/98358)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Duplicates existing routes and controller behavior in the engine. Never used.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Ensure duplicated specs run, and fail correctly if the engine versions of the controllers are changed. Test engine endpoints in staging, ensure the behavior is the same

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Controllers and routes for the decision reviews functionality are duplicated in engine context.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
