### PR TITLE
Update VetVerificationStatusesController to use existing settings

### DIFF
--- a/app/controllers/v0/profile/vet_verification_statuses_controller.rb
+++ b/app/controllers/v0/profile/vet_verification_statuses_controller.rb
@@ -7,8 +7,7 @@ module V0
       before_action { authorize :lighthouse, :access? }
 
       def show
-        access_token = settings.access_token
-        response = service.get_vet_verification_status(@current_user.icn, access_token.client_id, access_token.rsa_key)
+        response = service.get_vet_verification_status(@current_user.icn)
         response['data']['id'] = ''
 
         render json: response
@@ -18,10 +17,6 @@ module V0
 
       def service
         @service ||= VeteranVerification::Service.new
-      end
-
-      def settings
-        Settings.lighthouse.veteran_verification['status']
       end
     end
   end

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -246,12 +246,6 @@ lighthouse:
         client_id: abc123456
         rsa_key: path/to/key
       use_mocks: false
-    status:
-      host: https://sandbox-api.va.gov
-      access_token:
-        client_id: ~
-        rsa_key: ~
-      use_mocks: false
   benefits_claims:
     host: https://sandbox-api.va.gov
     aud_claim_url: https://deptva-eval.okta.com/oauth2/ausi3u00gw66b9Ojk2p7/v1/token


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change updates the new `VetVerificationStatusesController` to use existing settings for veteran verification. We believed that we would receive new credentials for the Lighthouse API team for this endpoint, but they instead told us to use existing credentials. This change reflects that decision. This is a new vets-api endpoint with no FE implementation currently, so no feature toggle needed. 
- I work on the IIR Product team and we currently own this feature.

## Related issue(s)

- [1249](https://github.com/department-of-veterans-affairs/va-iir/issues/1249)

## Testing done

- [x] *New code is covered by unit tests*
- The way this was previously setup was for the controller to look in a new place for API credentials.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
