### PR TITLE
96412 use current user's icn for calling EPS methods

### DIFF
--- a/modules/vaos/app/services/eps/appointment_service.rb
+++ b/modules/vaos/app/services/eps/appointment_service.rb
@@ -7,7 +7,7 @@ module Eps
     #
     # @return OpenStruct response from EPS appointments endpoint
     #
-    def get_appointments(patient_id:)
+    def get_appointments
       response = perform(:get, "/#{config.base_path}/appointments?patientId=#{patient_id}",
                          {}, headers)
       OpenStruct.new(response.body)

--- a/modules/vaos/app/services/eps/base_service.rb
+++ b/modules/vaos/app/services/eps/base_service.rb
@@ -57,6 +57,10 @@ module Eps
       { 'Content-Type' => 'application/x-www-form-urlencoded' }
     end
 
+    def patient_id
+      @patient_id ||= user.icn
+    end
+
     class TokenError < StandardError; end
   end
 end

--- a/modules/vaos/spec/services/eps/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/eps/appointment_service_spec.rb
@@ -5,18 +5,18 @@ require 'rails_helper'
 describe Eps::AppointmentService do
   subject(:service) { described_class.new(user) }
 
-  let(:user) { double('User', account_uuid: '1234') }
+  let(:icn) { '123ICN' }
+  let(:user) { double('User', account_uuid: '1234', icn:) }
   let(:successful_appt_response) do
     double('Response', status: 200, body: { 'count' => 1,
                                             'appointments' => [
                                               {
                                                 'id' => 'test-id',
                                                 'state' => 'booked',
-                                                'patientId' => patient_id
+                                                'patientId' => icn
                                               }
                                             ] })
   end
-  let(:patient_id) { 'test-patient-id' }
   let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   describe 'get_appointments' do
@@ -33,7 +33,7 @@ describe Eps::AppointmentService do
       it 'returns the appointments scheduled' do
         exp_response = OpenStruct.new(successful_appt_response.body)
 
-        expect(service.get_appointments(patient_id:)).to eq(exp_response)
+        expect(service.get_appointments).to eq(exp_response)
       end
     end
 
@@ -51,7 +51,7 @@ describe Eps::AppointmentService do
       end
 
       it 'throws exception' do
-        expect { service.get_appointments(patient_id:) }.to raise_error(Common::Exceptions::BackendServiceException,
+        expect { service.get_appointments }.to raise_error(Common::Exceptions::BackendServiceException,
                                                                         /VA900/)
       end
     end

--- a/modules/vaos/spec/services/eps/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/eps/appointment_service_spec.rb
@@ -52,7 +52,7 @@ describe Eps::AppointmentService do
 
       it 'throws exception' do
         expect { service.get_appointments }.to raise_error(Common::Exceptions::BackendServiceException,
-                                                                        /VA900/)
+                                                           /VA900/)
       end
     end
   end


### PR DESCRIPTION
## Summary
Minor update to use current user's ICN to call EPS methods, rather than requiring a patient_id be passed in as argument.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/96412

## Testing done

- [x] *New code is covered by unit tests*
## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
