### PR TITLE
[vi-694] update mhv_correlation_id 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1233,6 +1233,7 @@ spec/factories/message_drafts.rb @department-of-veterans-affairs/vfs-mhv-secure-
 spec/factories/message_threads.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/messages.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/messaging_preferences.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/factories/mhv_user_accounts.rb @department-of-veterans-affairs/octo-identity
 spec/factories/military_service_episodes.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/mpi @department-of-veterans-affairs/octo-identity
 spec/factories/mvi_profile_relationships.rb @department-of-veterans-affairs/octo-identity

--- a/app/controllers/concerns/exception_handling.rb
+++ b/app/controllers/concerns/exception_handling.rb
@@ -83,7 +83,7 @@ module ExceptionHandling
     # Add additional user specific context to the logs
     if exception.is_a?(Common::Exceptions::BackendServiceException) && current_user.present?
       extra[:icn] = current_user.icn
-      extra[:mhv_correlation_id] = current_user.mhv_correlation_id
+      extra[:mhv_credential_uuid] = current_user.mhv_credential_uuid
     end
     va_exception_info = { va_exception_errors: va_exception.errors.map(&:to_hash) }
     log_exception_to_sentry(exception, extra.merge(va_exception_info))

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -374,7 +374,7 @@ module V1
                 else
                   exc.message
                 end
-      conditional_log_message_to_sentry(message, level, context, code)
+      conditional_log_message_to_sentry(message, level, context)
       Rails.logger.info("SessionsController version:v1 saml_callback failure, user_uuid=#{@current_user&.uuid}")
 
       unless performed?
@@ -393,14 +393,11 @@ module V1
     end
     # rubocop:enable Metrics/ParameterLists
 
-    def conditional_log_message_to_sentry(message, level, context, code)
-      # If our error is that we have multiple mhv ids, this is a case where we won't log in the user,
-      # but we give them a path to resolve this. So we don't want to throw an error, and we don't want
-      # to pollute Sentry with this condition, but we will still log in case we want metrics in
-      # Cloudwatch or any other log aggregator. Additionally, if the user has an invalid message timestamp
+    def conditional_log_message_to_sentry(message, level, context)
+      # If the user has an invalid message timestamp
       # error, this means they have waited too long in the log in page to progress, so it's not really an
       # appropriate Sentry error
-      if code == SAML::UserAttributeError::MULTIPLE_MHV_IDS_CODE || invalid_message_timestamp_error?(message)
+      if invalid_message_timestamp_error?(message)
         Rails.logger.warn("SessionsController version:v1 context:#{context} message:#{message}")
       else
         log_message_to_sentry(message, level, extra_context: context)

--- a/app/models/mhv_user_account.rb
+++ b/app/models/mhv_user_account.rb
@@ -10,6 +10,7 @@ class MHVUserAccount
   attribute :patient, :boolean
   attribute :sm_account_created, :boolean
   attribute :message, :string
+  alias_attribute :id, :user_profile_id
 
   validates :user_profile_id, presence: true
   validates :premium, :champ_va, :patient, :sm_account_created, inclusion: { in: [true, false] }

--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -29,7 +29,7 @@ class UserIdentity < Common::RedisStore
   attribute :verified_at # Login.gov IAL2 verification timestamp
   attribute :sec_id
   attribute :mhv_icn # only needed by B/E not serialized in user_serializer
-  attribute :mhv_correlation_id # this is the cannonical version of MHV Correlation ID, provided by MHV sign-in users
+  attribute :mhv_credential_uuid
   attribute :mhv_account_type # this is only available for MHV sign-in users
   attribute :edipi # this is only available for dslogon users
   attribute :sign_in, Hash # original sign_in (see sso_service#mergable_identity_attributes)

--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -48,7 +48,7 @@ module Login
       check_id_mismatch(current_user.identity.icn, current_user.mpi_icn, 'User Identity & MPI ICN values conflict')
       check_id_mismatch(current_user.identity.edipi, current_user.edipi_mpi,
                         'User Identity & MPI EDIPI values conflict')
-      check_id_mismatch(current_user.identity.mhv_correlation_id, current_user.mpi_mhv_correlation_id,
+      check_id_mismatch(current_user.identity.mhv_credential_uuid, current_user.mpi_mhv_correlation_id,
                         'User Identity & MPI MHV Correlation ID values conflict')
     end
 

--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -5,7 +5,7 @@ module Login
     def initialize(user)
       @login_type = user.sign_in&.dig(:service_name)
       @auth_broker = user.sign_in&.dig(:auth_broker)
-      @mhv_uuid = user.mhv_correlation_id
+      @mhv_uuid = user.mhv_credential_uuid
       @idme_uuid = user.idme_uuid
       @dslogon_uuid = user.edipi
       @logingov_uuid = user.logingov_uuid

--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -15,7 +15,7 @@ module SignIn
                 :ssn,
                 :mhv_icn,
                 :edipi,
-                :mhv_correlation_id
+                :mhv_credential_uuid
 
     def initialize(user_attributes:)
       @idme_uuid = user_attributes[:idme_uuid]
@@ -31,7 +31,7 @@ module SignIn
       @ssn = user_attributes[:ssn]
       @mhv_icn = user_attributes[:mhv_icn]
       @edipi = user_attributes[:edipi]
-      @mhv_correlation_id = user_attributes[:mhv_correlation_id]
+      @mhv_credential_uuid = user_attributes[:mhv_credential_uuid]
     end
 
     def perform
@@ -59,8 +59,9 @@ module SignIn
       check_lock_flag(mpi_response_profile.id_theft_flag, 'Theft Flag', Constants::ErrorCode::MPI_LOCKED_ACCOUNT)
       check_lock_flag(mpi_response_profile.deceased_date, 'Death Flag', Constants::ErrorCode::MPI_LOCKED_ACCOUNT)
       check_id_mismatch(mpi_response_profile.edipis, 'EDIPI', Constants::ErrorCode::MULTIPLE_EDIPI)
-      check_id_mismatch(mpi_response_profile.mhv_iens, 'MHV_ID', Constants::ErrorCode::MULTIPLE_MHV_IEN)
       check_id_mismatch(mpi_response_profile.participant_ids, 'CORP_ID', Constants::ErrorCode::MULTIPLE_CORP_ID)
+      check_id_mismatch(mpi_response_profile.mhv_iens, 'MHV_ID', Constants::ErrorCode::MULTIPLE_MHV_IEN,
+                        raise_error: false)
     end
 
     def add_mpi_user
@@ -108,7 +109,7 @@ module SignIn
     def validate_credential_attributes
       if mhv_auth?
         credential_attribute_check(:icn, mhv_icn)
-        credential_attribute_check(:mhv_uuid, mhv_correlation_id)
+        credential_attribute_check(:mhv_uuid, mhv_credential_uuid)
       else
         credential_attribute_check(:dslogon_uuid, edipi) if dslogon_auth?
         credential_attribute_check(:last_name, last_name) unless auto_uplevel
@@ -154,26 +155,26 @@ module SignIn
       handle_error("#{attribute_description} Detected", code, error: Errors::MPILockedAccountError) if attribute
     end
 
-    def check_id_mismatch(id_array, id_description, code)
+    def check_id_mismatch(id_array, id_description, code, raise_error: true)
       if id_array && id_array.compact.uniq.size > 1
         handle_error("User attributes contain multiple distinct #{id_description} values",
                      code,
-                     error: Errors::MPIMalformedAccountError)
+                     error: Errors::MPIMalformedAccountError, raise_error:)
       end
     end
 
-    def handle_error(error_message, error_code, error: nil)
+    def handle_error(error_message, error_code, error: nil, raise_error: true)
       sign_in_logger.info('attribute validator error', { errors: error_message,
                                                          credential_uuid:,
                                                          mhv_icn:,
                                                          type: service_name }.compact)
-      raise error.new message: error_message, code: error_code if error
+      raise error.new message: error_message, code: error_code if error && raise_error
     end
 
     def mpi_response_profile
       @mpi_response_profile ||=
-        if mhv_correlation_id
-          mpi_service.find_profile_by_identifier(identifier: mhv_correlation_id,
+        if mhv_credential_uuid
+          mpi_service.find_profile_by_identifier(identifier: mhv_credential_uuid,
                                                  identifier_type: MPI::Constants::MHV_UUID)&.profile
         elsif idme_uuid
           mpi_service.find_profile_by_identifier(identifier: idme_uuid,

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -9,7 +9,7 @@ module SignIn
                 :all_credential_emails,
                 :verified_icn,
                 :edipi,
-                :mhv_correlation_id,
+                :mhv_credential_uuid,
                 :request_ip,
                 :first_name,
                 :last_name
@@ -21,7 +21,7 @@ module SignIn
       @credential_email = user_attributes[:csp_email]
       @all_credential_emails = user_attributes[:all_csp_emails]
       @edipi = user_attributes[:edipi]
-      @mhv_correlation_id = user_attributes[:mhv_correlation_id]
+      @mhv_credential_uuid = user_attributes[:mhv_credential_uuid]
       @verified_icn = verified_icn
       @request_ip = request_ip
       @first_name = user_attributes[:first_name]
@@ -71,7 +71,7 @@ module SignIn
                                                  logingov_uuid:,
                                                  sign_in:,
                                                  edipi:,
-                                                 mhv_correlation_id:,
+                                                 mhv_credential_uuid:,
                                                  icn: verified_icn })
     end
 

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -11,7 +11,7 @@ module SAML
       include Identity::Parsers::GCIds
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name gender ssn birth_date
                                    uuid idme_uuid logingov_uuid verified_at sec_id mhv_icn
-                                   mhv_correlation_id mhv_account_type edipi loa sign_in multifactor icn].freeze
+                                   mhv_credential_uuid mhv_account_type edipi loa sign_in multifactor icn].freeze
       INBOUND_AUTHN_CONTEXT = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password'
 
       attr_reader :attributes, :authn_context, :tracker_uuid, :warnings
@@ -95,7 +95,7 @@ module SAML
         safe_attr('va_eauth_icn')
       end
 
-      def mhv_correlation_id
+      def mhv_credential_uuid
         safe_attr('va_eauth_mhvuuid') || mvi_ids[:mhv_ien]
       end
 
@@ -215,7 +215,7 @@ module SAML
         check_id_mismatch([safe_attr('va_eauth_icn'), safe_attr('va_eauth_mhvicn')], :mhv_icn_mismatch)
         check_id_mismatch(mvi_ids[:vba_corp_ids], :multiple_corp_ids)
         check_id_mismatch(edipi_ids[:edipis], :multiple_edipis)
-        check_id_mismatch(mhv_iens, :multiple_mhv_ids)
+        check_id_mismatch(mhv_iens, :multiple_mhv_ids, raise_error: false)
         if sec_id_mismatch?
           log_message_to_sentry('User attributes contains multiple sec_id values',
                                 'warn',
@@ -259,22 +259,25 @@ module SAML
       def mhv_outbound_redirect(mismatched_ids_error)
         return false if mismatched_ids_error[:tag] == :multiple_edipis
 
-        @mhv_outbound_redirect ||= %w[mhv myvahealth].include?(tracker&.payload_attr(:application))
+        %w[mhv myvahealth].include?(tracker&.payload_attr(:application))
       end
 
-      def check_id_mismatch(ids, multiple_ids_error_type)
+      def check_id_mismatch(ids, multiple_ids_error_type, raise_error: true)
         return if ids.blank?
+        return if ids.compact.uniq.count <= 1
 
-        if ids.reject(&:nil?).uniq.size > 1
-          mismatched_ids_error = SAML::UserAttributeError::ERRORS[multiple_ids_error_type]
-          error_data = { mismatched_ids: ids, icn: mhv_icn }
-          Rails.logger.warn("[SAML::UserAttributes::SSOe] #{mismatched_ids_error[:message]}, #{error_data}")
-          unless mhv_outbound_redirect(mismatched_ids_error)
-            raise SAML::UserAttributeError.new(message: mismatched_ids_error[:message],
-                                               code: mismatched_ids_error[:code],
-                                               tag: mismatched_ids_error[:tag])
-          end
-        end
+        mismatched_ids_error = SAML::UserAttributeError::ERRORS[multiple_ids_error_type]
+        error_data = { mismatched_ids: ids, icn: mhv_icn }
+
+        Rails.logger.warn("[SAML::UserAttributes::SSOe] #{mismatched_ids_error[:message]}", error_data)
+
+        return if mhv_outbound_redirect(mismatched_ids_error) || !raise_error
+
+        raise SAML::UserAttributeError.new(
+          message: mismatched_ids_error[:message],
+          code: mismatched_ids_error[:code],
+          tag: mismatched_ids_error[:tag]
+        )
       end
 
       def sec_id_mismatch?

--- a/lib/sign_in/idme/service.rb
+++ b/lib/sign_in/idme/service.rb
@@ -126,7 +126,7 @@ module SignIn
 
       def mhv_attributes(user_info)
         {
-          mhv_correlation_id: user_info.mhv_uuid,
+          mhv_credential_uuid: user_info.mhv_uuid,
           mhv_icn: user_info.mhv_icn,
           mhv_assurance: user_info.mhv_assurance
         }

--- a/modules/mocked_authentication/spec/lib/credential/service_spec.rb
+++ b/modules/mocked_authentication/spec/lib/credential/service_spec.rb
@@ -322,7 +322,7 @@ describe MockedAuthentication::Credential::Service do
             credential_aal_highest: 2,
             credential_ial_highest: 'classic_loa3',
             email:,
-            mhv_uuid: mhv_correlation_id,
+            mhv_uuid: mhv_credential_uuid,
             mhv_icn:,
             mhv_assurance:,
             level_of_assurance: 3,
@@ -333,7 +333,7 @@ describe MockedAuthentication::Credential::Service do
           }
         )
       end
-      let(:mhv_correlation_id) { 'some-mhv-correlation-id' }
+      let(:mhv_credential_uuid) { 'some-mhv-credential-uuid' }
       let(:mhv_icn) { 'some-mhv-icn' }
       let(:mhv_assurance) { 'some-mhv-assurance' }
       let(:aud) { 'some-aud' }
@@ -351,7 +351,7 @@ describe MockedAuthentication::Credential::Service do
           authn_context:,
           auto_uplevel:,
           mhv_icn:,
-          mhv_correlation_id:,
+          mhv_credential_uuid:,
           mhv_assurance:
         }
       end

--- a/spec/factories/mhv_user_accounts.rb
+++ b/spec/factories/mhv_user_accounts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :mhv_user_account do
+    user_profile_id { '12345678' }
+    premium { true }
+    champ_va { true }
+    patient { true }
+    sm_account_created { true }
+    message { 'Success' }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,9 +27,10 @@ FactoryBot.define do
       icn { '123498767V234859' }
       mhv_icn { nil }
       multifactor { false }
-      mhv_ids { [] }
-      active_mhv_ids { [] }
-      mhv_correlation_id { Faker::Number.number(digits: 9) }
+      mhv_ids { [mhv_credential_uuid] }
+      active_mhv_ids { [mhv_credential_uuid] }
+      mhv_correlation_id { mhv_credential_uuid }
+      mhv_credential_uuid { Faker::Number.number(digits: 9) }
       mhv_account_type { nil }
       edipi { '384759483' }
       va_patient { nil }
@@ -86,7 +87,7 @@ FactoryBot.define do
           mhv_icn:,
           loa:,
           multifactor:,
-          mhv_correlation_id:,
+          mhv_credential_uuid:,
           mhv_account_type:,
           edipi:,
           sign_in: }
@@ -119,6 +120,10 @@ FactoryBot.define do
                            vha_facility_hash:,
                            vet360_id: }
         build(:mpi_profile, mpi_attributes)
+      end
+
+      mhv_user_account do
+        build(:mhv_user_account)
       end
     end
 

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe SAML::User do
           verified_at: nil,
           sec_id: nil,
           mhv_icn: nil,
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: nil,
           edipi: nil,
           loa: { current: 1, highest: 1 },
@@ -160,7 +160,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '123123123',
           mhv_icn: '1200049153V217987',
-          mhv_correlation_id: '123456',
+          mhv_credential_uuid: '123456',
           mhv_account_type: nil,
           edipi: nil,
           uuid: 'aa478abc-e494-4af1-9f87-d002f8fe1cda',
@@ -200,7 +200,7 @@ RSpec.describe SAML::User do
           gender: nil,
           ssn: nil,
           mhv_icn: nil,
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: nil,
           edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
@@ -235,7 +235,7 @@ RSpec.describe SAML::User do
           gender: nil,
           ssn: nil,
           mhv_icn: nil,
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: nil,
           edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
@@ -271,7 +271,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '666271152',
           mhv_icn: '1008830476V316605',
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: nil,
           edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
@@ -311,7 +311,7 @@ RSpec.describe SAML::User do
           gender: nil,
           ssn: nil,
           mhv_icn: nil,
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: 'Advanced',
           uuid: '881571066e5741439652bc80759dd88c',
           email: 'alexmac_0@example.com',
@@ -352,7 +352,7 @@ RSpec.describe SAML::User do
           gender: 'F',
           ssn: '230595111',
           mhv_icn: '1013183292V131165',
-          mhv_correlation_id: '15001594',
+          mhv_credential_uuid: '15001594',
           mhv_account_type: 'Advanced',
           uuid: '881571066e5741439652bc80759dd88c',
           email: 'alexmac_0@example.com',
@@ -388,7 +388,7 @@ RSpec.describe SAML::User do
           gender: nil,
           ssn: nil,
           mhv_icn: nil,
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: 'Basic',
           uuid: '72782a87a807407f83e8a052d804d7f7',
           email: 'pv+mhvtestb@example.com',
@@ -427,7 +427,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '666811850',
           mhv_icn: '1012853550V207686',
-          mhv_correlation_id: '12345748',
+          mhv_credential_uuid: '12345748',
           mhv_account_type: 'Premium',
           uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           email: 'k+tristanmhv@example.com',
@@ -467,7 +467,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '666811850',
           mhv_icn: '1012853550V207686',
-          mhv_correlation_id: '12345748',
+          mhv_credential_uuid: '12345748',
           mhv_account_type: 'Premium',
           uuid: nil,
           email: 'k+tristanmhv@example.com',
@@ -497,7 +497,7 @@ RSpec.describe SAML::User do
 
         it 'resolves mhv id' do
           expect(subject.to_hash).to include(
-            mhv_correlation_id: '999888'
+            mhv_credential_uuid: '999888'
           )
         end
 
@@ -516,7 +516,7 @@ RSpec.describe SAML::User do
 
         it 'resolves mhv id' do
           expect(subject.to_hash).to include(
-            mhv_correlation_id: mhv_ien
+            mhv_credential_uuid: mhv_ien
           )
         end
 
@@ -535,7 +535,7 @@ RSpec.describe SAML::User do
 
         it 'resolves mhv id' do
           expect(subject.to_hash).to include(
-            mhv_correlation_id: mhv_ien
+            mhv_credential_uuid: mhv_ien
           )
         end
 
@@ -544,7 +544,7 @@ RSpec.describe SAML::User do
         end
       end
 
-      context 'with mismatching identifiers' do
+      context 'with multiple mhv id values identifiers' do
         let(:mhv_uuid) { '999888' }
         let(:mhv_ien) { '888777' }
         let(:mhv_icn) { '123456789V98765431' }
@@ -557,29 +557,26 @@ RSpec.describe SAML::User do
         let(:expected_error) { SAML::UserAttributeError::ERRORS[:multiple_mhv_ids] }
         let(:expected_error_data) { { mismatched_ids: [mhv_ien, mhv_uuid], icn: mhv_icn } }
         let(:expected_error_message) { expected_error[:message] }
-        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}, #{expected_error_data}" }
+        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}" }
 
         it 'resolves mhv id from credential provider' do
           expect(subject.to_hash).to include(
-            mhv_correlation_id: mhv_uuid
+            mhv_credential_uuid: mhv_uuid
           )
         end
 
         context 'normal validation flow' do
-          it 'does not validate and throws an error' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
-            expect { subject.validate! }.to raise_error { |error|
-              expect(error).to be_a(SAML::UserAttributeError)
-              expect(error.message).to eq(expected_error_message)
-            }
+          it 'logs a warning and doesnt raise an error' do
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
+            expect { subject.validate! }.not_to raise_error
           end
         end
 
         context 'MHV outbound-redirect flow' do
           let(:client_id) { 'mhv' }
 
-          it 'does not validate and logs a Sentry warning' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
+          it 'logs a warning and doesnt raise an error' do
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
             expect { subject.validate! }.not_to raise_error
           end
         end
@@ -595,11 +592,11 @@ RSpec.describe SAML::User do
         end
         let(:expected_error_data) { { mismatched_ids: [va_eauth_icn, va_eauth_mhvicn], icn: va_eauth_icn } }
         let(:expected_error_message) { SAML::UserAttributeError::ERRORS[:mhv_icn_mismatch][:message] }
-        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}, #{expected_error_data}" }
+        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}" }
 
         context 'normal validation flow' do
           it 'does not validate' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
             expect { subject.validate! }.to raise_error { |error|
               expect(error).to be_a(SAML::UserAttributeError)
               expect(error.message).to eq(expected_error_message)
@@ -611,7 +608,7 @@ RSpec.describe SAML::User do
           let(:client_id) { 'myvahealth' }
 
           it 'does not validate and logs a Sentry warning' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
             expect { subject.validate! }.not_to raise_error
           end
         end
@@ -634,7 +631,7 @@ RSpec.describe SAML::User do
 
           it 'de-duplicates values' do
             expect(subject.to_hash).to include(
-              mhv_correlation_id: '888777'
+              mhv_credential_uuid: '888777'
             )
           end
 
@@ -649,7 +646,7 @@ RSpec.describe SAML::User do
 
           it 'de-duplicates values' do
             expect(subject.to_hash).to include(
-              mhv_correlation_id: '888777'
+              mhv_credential_uuid: '888777'
             )
           end
 
@@ -664,7 +661,7 @@ RSpec.describe SAML::User do
 
           it 'de-duplicates values' do
             expect(subject.to_hash).to include(
-              mhv_correlation_id: nil
+              mhv_credential_uuid: nil
             )
           end
 
@@ -680,7 +677,7 @@ RSpec.describe SAML::User do
 
           it 'de-duplicates values' do
             expect(subject.to_hash).to include(
-              mhv_correlation_id: '888777'
+              mhv_credential_uuid: '888777'
             )
           end
 
@@ -696,15 +693,11 @@ RSpec.describe SAML::User do
           let(:expected_error) { SAML::UserAttributeError::ERRORS[:multiple_mhv_ids] }
           let(:expected_error_data) { { mismatched_ids: [first_ien, second_ien], icn: mhv_icn } }
           let(:expected_error_message) { expected_error[:message] }
-          let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}, #{expected_error_data}" }
+          let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}" }
 
-          it 'does not validate' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
-            expect { subject.validate! }
-              .to raise_error { |error|
-                expect(error).to be_a(SAML::UserAttributeError)
-                expect(error.message).to eq(expected_error_message)
-              }
+          it 'logs a warning but does not raise an error' do
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
+            expect { subject.validate! }.not_to raise_error
           end
         end
 
@@ -715,15 +708,11 @@ RSpec.describe SAML::User do
           let(:expected_error) { SAML::UserAttributeError::ERRORS[:multiple_mhv_ids] }
           let(:expected_error_data) { { mismatched_ids: [first_ien, second_ien], icn: mhv_icn } }
           let(:expected_error_message) { expected_error[:message] }
-          let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}, #{expected_error_data}" }
+          let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}" }
 
-          it 'does not validate' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
-            expect { subject.validate! }
-              .to raise_error { |error|
-                expect(error).to be_a(SAML::UserAttributeError)
-                expect(error.message).to eq(expected_error_message)
-              }
+          it 'logs a warning but does not raise an error' do
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
+            expect { subject.validate! }.not_to raise_error
           end
         end
       end
@@ -776,11 +765,11 @@ RSpec.describe SAML::User do
         let(:expected_error) { SAML::UserAttributeError::ERRORS[:multiple_corp_ids] }
         let(:expected_error_data) { { mismatched_ids: [first_corp_id, second_corp_id], icn: mhv_icn } }
         let(:expected_error_message) { expected_error[:message] }
-        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}, #{expected_error_data}" }
+        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}" }
 
         context 'regular auth flow' do
           it 'does not validate and prevents login' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
             expect { subject.validate! }
               .to raise_error { |error|
                     expect(error).to be_a(SAML::UserAttributeError)
@@ -793,7 +782,7 @@ RSpec.describe SAML::User do
           let(:client_id) { 'mhv' }
 
           it 'logs a Sentry warning and allows login' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
             expect { subject.validate! }.not_to raise_error
           end
         end
@@ -802,7 +791,7 @@ RSpec.describe SAML::User do
           let(:client_id) { 'test application' }
 
           it 'does not validate and prevents login' do
-            expect(Rails.logger).to receive(:warn).with(expected_log)
+            expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
             expect { subject.validate! }
               .to raise_error { |error|
                     expect(error).to be_a(SAML::UserAttributeError)
@@ -828,10 +817,10 @@ RSpec.describe SAML::User do
         let(:expected_error) { SAML::UserAttributeError::ERRORS[:multiple_edipis] }
         let(:expected_error_data) { { mismatched_ids: [first_edipi, second_edipi], icn: mhv_icn } }
         let(:expected_error_message) { expected_error[:message] }
-        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}, #{expected_error_data}" }
+        let(:expected_log) { "[SAML::UserAttributes::SSOe] #{expected_error_message}" }
 
         it 'does not validate' do
-          expect(Rails.logger).to receive(:warn).with(expected_log)
+          expect(Rails.logger).to receive(:warn).with(expected_log, expected_error_data)
           expect { subject.validate! }
             .to raise_error { |error|
                   expect(error).to be_a(SAML::UserAttributeError)
@@ -888,7 +877,7 @@ RSpec.describe SAML::User do
           gender: nil,
           ssn: nil,
           mhv_icn: nil,
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: nil,
           uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           email: 'kam+tristanmhv@adhocteam.us',
@@ -928,7 +917,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '666016789',
           mhv_icn: '1013173963V366678',
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: nil,
           uuid: '363761e8857642f7b77ef7d99200e711',
           email: 'iam.tester@example.com',
@@ -968,7 +957,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '796123607',
           mhv_icn: '1012740600V714187',
-          mhv_correlation_id: '14384899',
+          mhv_credential_uuid: '14384899',
           mhv_account_type: nil,
           uuid: '1655c16aa0784dbe973814c95bd69177',
           email: 'Test0206@gmail.com',
@@ -1007,7 +996,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '796123607',
           mhv_icn: '1012740600V714187',
-          mhv_correlation_id: '14384899',
+          mhv_credential_uuid: '14384899',
           mhv_account_type: nil,
           uuid: '1655c16aa0784dbe973814c95bd69177',
           email: 'Test0206@gmail.com',
@@ -1063,7 +1052,7 @@ RSpec.describe SAML::User do
           gender: 'F',
           ssn: '101174874',
           mhv_icn: '1012779219V964737',
-          mhv_correlation_id: nil,
+          mhv_credential_uuid: nil,
           mhv_account_type: nil,
           uuid: nil,
           email: nil,
@@ -1116,7 +1105,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '666872589',
           mhv_icn: '1013062086V794840',
-          mhv_correlation_id: '15093546',
+          mhv_credential_uuid: '15093546',
           mhv_account_type: nil,
           uuid: '53f065475a794e14a32d707bfd9b215f',
           email: nil,
@@ -1154,7 +1143,7 @@ RSpec.describe SAML::User do
           gender: 'M',
           ssn: '666271152',
           mhv_icn: '1012827134V054550',
-          mhv_correlation_id: '10894456',
+          mhv_credential_uuid: '10894456',
           mhv_account_type: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
           email: 'vets.gov.user+262@gmail.com',

--- a/spec/lib/sign_in/idme/service_spec.rb
+++ b/spec/lib/sign_in/idme/service_spec.rb
@@ -456,7 +456,7 @@ describe SignIn::Idme::Service do
             credential_aal_highest: 2,
             credential_ial_highest: 'classic_loa3',
             email:,
-            mhv_uuid: mhv_correlation_id,
+            mhv_uuid: mhv_credential_uuid,
             mhv_icn:,
             mhv_assurance:,
             level_of_assurance: 3,
@@ -467,12 +467,12 @@ describe SignIn::Idme::Service do
           }
         )
       end
-      let(:mhv_correlation_id) { 'some-mhv-correlation-id' }
+      let(:mhv_credential_uuid) { 'some-mhv-credential-uuid' }
       let(:mhv_icn) { 'some-mhv-icn' }
       let(:mhv_assurance) { 'some-mhv-assurance' }
       let(:expected_attributes) do
         expected_standard_attributes.merge({ mhv_icn:,
-                                             mhv_correlation_id:,
+                                             mhv_credential_uuid:,
                                              mhv_assurance: })
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -495,31 +495,57 @@ RSpec.describe User, type: :model do
           end
         end
 
-        context 'MHV ids' do
-          let(:user) { build(:user, :loa3, mhv_correlation_id: nil, participant_id:) }
-          let(:participant_id) { 'some_mpi_participant_id' }
+        describe '#mhv_correlation_id' do
+          let(:user) { build(:user, :loa3, mpi_profile:) }
+          let(:mhv_user_account) { build(:mhv_user_account, user_profile_id: mhv_account_id) }
+          let(:mpi_profile) { build(:mpi_profile, active_mhv_ids:) }
+          let(:mhv_account_id) { 'some-id' }
+          let(:active_mhv_ids) { [mhv_account_id] }
 
-          context 'when mhv ids are nil' do
-            let(:participant_id) { nil }
+          context 'when mhv_user_account is present' do
+            before do
+              allow(user).to receive(:mhv_user_account).and_return(mhv_user_account)
+            end
 
-            it 'has a mhv correlation id of nil' do
-              expect(user.mhv_correlation_id).to be_nil
+            it 'returns the user_profile_id from the mhv_user_account' do
+              expect(user.mhv_correlation_id).to eq(mhv_account_id)
             end
           end
 
-          context 'when there are mhv ids' do
-            it 'fetches mhv correlation id from MPI' do
-              expect(user.mhv_correlation_id).to eq(user.send(:mpi_profile).mhv_ids.first)
-              expect(user.mhv_correlation_id).to eq(user.send(:mpi_profile).active_mhv_ids.first)
+          context 'when mhv_user_account is not present' do
+            before do
+              allow(user).to receive(:mhv_user_account).and_return(nil)
             end
 
-            it 'fetches mhv_ids from MPI' do
-              expect(user.mhv_ids).to be(user.send(:mpi_profile).mhv_ids)
+            context 'when the user has one active_mhv_ids' do
+              it 'returns the active_mhv_id' do
+                expect(user.mhv_correlation_id).to eq(active_mhv_ids.first)
+              end
             end
 
-            it 'fetches active_mhv_ids from MPI' do
-              expect(user.active_mhv_ids).to be(user.send(:mpi_profile).active_mhv_ids)
+            context 'when the user has multiple active_mhv_ids' do
+              let(:active_mhv_ids) { %w[some-id another-id] }
+
+              it 'returns nil' do
+                expect(user.mhv_correlation_id).to be_nil
+              end
             end
+          end
+        end
+
+        describe '#mhv_ids' do
+          let(:user) { build(:user, :loa3) }
+
+          it 'fetches mhv_ids from MPI' do
+            expect(user.mhv_ids).to be(user.send(:mpi_profile).mhv_ids)
+          end
+        end
+
+        describe '#active_mhv_ids' do
+          let(:user) { build(:user, :loa3) }
+
+          it 'fetches active_mhv_ids from MPI' do
+            expect(user.active_mhv_ids).to be(user.send(:mpi_profile).active_mhv_ids)
           end
         end
 
@@ -1079,18 +1105,18 @@ RSpec.describe User, type: :model do
       described_class.new(
         build(:user, :loa3,
               idme_uuid:, logingov_uuid:,
-              edipi:, mhv_correlation_id:, authn_context:)
+              edipi:, mhv_credential_uuid:, authn_context:)
       )
     end
     let(:user_verifier_object) do
       OpenStruct.new({ idme_uuid:, logingov_uuid:, sign_in: user.identity_sign_in,
-                       edipi:, mhv_correlation_id: })
+                       edipi:, mhv_credential_uuid: })
     end
     let(:authn_context) { LOA::IDME_LOA1_VETS }
     let(:logingov_uuid) { 'some-logingov-uuid' }
     let(:idme_uuid) { 'some-idme-uuid' }
     let(:edipi) { 'some-edipi' }
-    let(:mhv_correlation_id) { 'some-mhv-correlation-id' }
+    let(:mhv_credential_uuid) { 'some-mhv-credential-uuid' }
     let!(:user_verification) { Login::UserVerifier.new(user_verifier_object).perform }
     let!(:user_account) { user_verification&.user_account }
 
@@ -1102,14 +1128,14 @@ RSpec.describe User, type: :model do
       context 'when user is logged in with mhv' do
         let(:authn_context) { 'myhealthevet' }
 
-        context 'and there is an mhv_correlation_id' do
-          it 'returns user verification with a matching mhv_correlation_id' do
-            expect(user.user_verification.mhv_uuid).to eq(mhv_correlation_id)
+        context 'and there is an mhv_credential_uuid' do
+          it 'returns user verification with a matching mhv_credential_uuid' do
+            expect(user.user_verification.mhv_uuid).to eq(mhv_credential_uuid)
           end
         end
 
-        context 'and there is not an mhv_correlation_id' do
-          let(:mhv_correlation_id) { nil }
+        context 'and there is not an mhv_credential_uuid' do
+          let(:mhv_credential_uuid) { nil }
 
           context 'and user has an idme_uuid' do
             let(:idme_uuid) { 'some-idme-uuid' }
@@ -1305,8 +1331,8 @@ RSpec.describe User, type: :model do
         let(:expected_log_message) { '[User] mhv_user_account error' }
         let(:expected_log_payload) { { error_message: /#{expected_error_message}/, icn: user.icn } }
 
-        it 'logs and re-raises the error' do
-          expect { user.mhv_user_account }.to raise_error(MHV::UserAccount::Errors::UserAccountError)
+        it 'logs and returns nil' do
+          expect(user.mhv_user_account).to be_nil
           expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
         end
       end

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'the v0 API documentation', type: %i[apivore request], order: :de
     let(:headers) { { '_headers' => { 'Cookie' => sign_in(mhv_user, nil, true) } } }
 
     before do
-      create(:mhv_user_verification, mhv_uuid: mhv_user.mhv_correlation_id)
+      create(:mhv_user_verification, mhv_uuid: mhv_user.mhv_credential_uuid)
     end
 
     describe 'backend statuses' do

--- a/spec/requests/v0/user_spec.rb
+++ b/spec/requests/v0/user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'V0::User', type: :request do
     let(:mhv_user) { build(:user, :mhv) }
     let(:v0_user_request_headers) { {} }
     let(:edipi) { '1005127153' }
-    let!(:mhv_user_verification) { create(:mhv_user_verification, mhv_uuid: mhv_user.mhv_correlation_id) }
+    let!(:mhv_user_verification) { create(:mhv_user_verification, mhv_uuid: mhv_user.mhv_credential_uuid) }
 
     before do
       allow(SM::Client).to receive(:new).and_return(authenticated_client)
@@ -134,7 +134,7 @@ RSpec.describe 'V0::User', type: :request do
     end
 
     context 'with missing MHV accounts' do
-      let(:mhv_user) { build(:user, :mhv, mhv_ids: nil, active_mhv_ids: nil, mhv_correlation_id: nil) }
+      let(:mhv_user) { build(:user, :mhv, mhv_ids: nil, active_mhv_ids: nil, mhv_credential_uuid: nil) }
       let!(:mhv_user_verification) { create(:mhv_user_verification, backing_idme_uuid: mhv_user.idme_uuid) }
 
       before do

--- a/spec/services/login/after_login_actions_spec.rb
+++ b/spec/services/login/after_login_actions_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Login::AfterLoginActions do
       end
 
       context 'MHV correlation id validation' do
-        let(:expected_identity_value) { loa3_user.identity.mhv_correlation_id }
+        let(:expected_identity_value) { loa3_user.identity.mhv_credential_uuid }
         let(:expected_mpi_value) { loa3_user.mpi_mhv_correlation_id }
         let(:validation_id) { 'MHV Correlation ID' }
 

--- a/spec/services/login/user_verifier_spec.rb
+++ b/spec/services/login/user_verifier_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Login::UserVerifier do
         {
           edipi: edipi_identifier,
           sign_in: { service_name: login_value, auth_broker: },
-          mhv_correlation_id: mhv_correlation_id_identifier,
+          mhv_credential_uuid: mhv_credential_uuid_identifier,
           idme_uuid: idme_uuid_identifier,
           logingov_uuid: logingov_uuid_identifier,
           icn:,
@@ -22,7 +22,7 @@ RSpec.describe Login::UserVerifier do
     end
     let(:auth_broker) { 'some-auth-broker' }
     let(:edipi_identifier) { 'some-edipi' }
-    let(:mhv_correlation_id_identifier) { 'some-correlation-id' }
+    let(:mhv_credential_uuid_identifier) { 'some-credential=uuid' }
     let(:idme_uuid_identifier) { 'some-idme-uuid' }
     let(:logingov_uuid_identifier) { 'some-logingov-uuid' }
     let(:locked) { false }
@@ -42,7 +42,7 @@ RSpec.describe Login::UserVerifier do
     shared_examples 'user_verification with nil credential identifier' do
       let(:authn_identifier) { nil }
       let(:edipi_identifier) { authn_identifier }
-      let(:mhv_correlation_id_identifier) { authn_identifier }
+      let(:mhv_credential_uuid_identifier) { authn_identifier }
       let(:idme_uuid_identifier) { authn_identifier }
       let(:logingov_uuid_identifier) { authn_identifier }
       let(:expected_log) { "[Login::UserVerifier] Nil identifier for type=#{authn_identifier_type}" }
@@ -391,7 +391,7 @@ RSpec.describe Login::UserVerifier do
 
     context 'when user credential is mhv' do
       let(:login_value) { SignIn::Constants::Auth::MHV }
-      let(:authn_identifier) { user_identity.mhv_correlation_id }
+      let(:authn_identifier) { user_identity.mhv_credential_uuid }
       let(:authn_identifier_type) { :mhv_uuid }
       let(:backing_idme_uuid) { idme_uuid_identifier }
       let(:linked_user_verification_type) { :mhv_user_verification }
@@ -410,7 +410,7 @@ RSpec.describe Login::UserVerifier do
       context 'when credential identifier is nil' do
         let(:authn_identifier) { nil }
         let(:edipi_identifier) { authn_identifier }
-        let(:mhv_correlation_id_identifier) { authn_identifier }
+        let(:mhv_credential_uuid_identifier) { authn_identifier }
         let(:idme_uuid_identifier) { authn_identifier }
         let(:logingov_uuid_identifier) { authn_identifier }
         let(:expected_log) { "[Login::UserVerifier] Nil identifier for type=#{authn_identifier_type}" }

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Users::Profile do
 
       context 'mhv user' do
         let(:user) { create(:user, :mhv) }
-        let!(:user_verification) { create(:mhv_user_verification, mhv_uuid: user.mhv_correlation_id) }
+        let!(:user_verification) { create(:mhv_user_verification, mhv_uuid: user.mhv_credential_uuid) }
 
         it 'includes sign_in' do
           expect(profile[:sign_in]).to eq(service_name: SAML::User::MHV_ORIGINAL_CSID,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
- update `mhv_correlation_id` to pull from `mhv_user_account` if it exists otherwise pull from `mpi.active_mhv_ids` if there is only one.
- update `mhv_correlation_id` from the saml and login user attributes to `mhv_credential_uuid`
- don't block users from logging in if they have multiple `mhv_ids`

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-694

## Testing 
- test ssoe and sis login
- test logging in with users that have multiple `mhv_ids` (vets.gov.user+11@gmail.com)
  - these should not be blocked

## What areas of the site does it impact?
Authentication, mhv_correlation_id

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

