### PR TITLE
(stats) add StatsD gauge for Lighthouse API response length

### DIFF
--- a/lib/lighthouse/veterans_health/client.rb
+++ b/lib/lighthouse/veterans_health/client.rb
@@ -109,6 +109,11 @@ module Lighthouse
         return first_response unless next_page
 
         first_response.body['entry'] = collect_all_entries(next_page, first_response.body['entry'])
+
+        StatsD.gauge('api.lighthouse.something.goes.here.vitals_gauge',
+                     first_response.length,
+                     tags: %w[mhv mhv-accelerated-delivery])
+
         first_response
       end
 


### PR DESCRIPTION
## Summary

- Adds a gauge to StatsD for the Lighthouse API response length.


## Related issue(s)

- Issue logged in slack canvas

## Testing done

- [ ] None yet? 

## What areas of the site does it impact?

MHV - MR

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
