### PR TITLE
adds "remove_mhv_credential_content" toggle to features.yml

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -903,7 +903,7 @@ features:
     enable_in_development: true
   lighthouse_claims_api_v2_add_person_proxy:
     actor_type: user
-    description: Lighthouse Benefits Claims API v2 uses add_person_proxy service when target Veteran is missing a Participant ID 
+    description: Lighthouse Benefits Claims API v2 uses add_person_proxy service when target Veteran is missing a Participant ID
     enable_in_development: true
   lighthouse_claims_api_poa_dependent_claimants:
     actor_type: user
@@ -1357,8 +1357,11 @@ features:
     enable_in_development: true
   sign_in_modal_v2:
     actor_type: user
-    description: Enables new page design of Sign In modal and USiP
+    description: Enables new page design of Sign In modal and USiP (Identity)
     enable_in_development: false
+  remove_mhv_credential_content:
+    actor_type: user
+    description: Enables the content removal of the My HealtheVet credential (Identity)
   medical_copays_zero_debt:
     actor_type: user
     description: Enables zero debt balances feature on the medical copays application


### PR DESCRIPTION
## Summary
This PR adds the `remove_mhv_credential_content` Flipper feature toggle. This feature toggle will hide content as part of the MHV credential deprecation

## Related issue(s)
- JIRA VI-8

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
