### PR TITLE
appointments - parse out correct id when bad provider data is given

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1662,9 +1662,6 @@ features:
   mobile_v2_contact_info:
     actor_type: user
     description: For mobile app, enables ContactInformationV2 Service.
-  appointment_provider_id_logging:
-    actor_type: user
-    description: For mobile app, logs provider id for debugging
   mobile_push_register_logging:
     actor_type: user
     description: For mobile app, logs push register errors for debugging

--- a/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe 'Mobile::V0::Appointments::VAOSV2', type: :request do
         end
 
         context 'when provider id is formatted incorrectly' do
-          it 'sets provider to null' do
+          it 'parses out correct id and makes successful provider call' do
             VCR.use_cassette('mobile/appointments/VAOS_v2/get_clinics_200', match_requests_on: %i[method uri]) do
               VCR.use_cassette('mobile/appointments/VAOS_v2/get_facilities_200', match_requests_on: %i[method uri]) do
                 VCR.use_cassette('mobile/appointments/VAOS_v2/get_appointments_with_mixed_provider_types_bad_id',
@@ -300,7 +300,7 @@ RSpec.describe 'Mobile::V0::Appointments::VAOSV2', type: :request do
             appointment_with_practitioner_list = appointments.find { |appt| appt['id'] == '76133' }
 
             expect(appointment_without_provider['attributes']['healthcareProvider']).to be_nil
-            expect(proposed_cc_appointment_with_provider['attributes']['healthcareProvider']).to eq(nil)
+            expect(proposed_cc_appointment_with_provider['attributes']['healthcareProvider']).to eq('DEHGHAN, AMIR')
             expect(appointment_with_practitioner_list['attributes']['healthcareProvider']).to eq('MATTHEW ENGHAUSER')
           end
         end

--- a/modules/vaos/app/services/vaos/v2/appointment_provider_name.rb
+++ b/modules/vaos/app/services/vaos/v2/appointment_provider_name.rb
@@ -37,7 +37,7 @@ module VAOS
 
       def find_practitioner_id(practitioner)
         practitioner[:identifier]&.each do |i|
-          return i[:value] if i[:system].include? 'us-npi'
+          return i[:value].tr('^0-9', '') if i[:system].include? 'us-npi'
         end
         nil
       end
@@ -47,14 +47,7 @@ module VAOS
         provider_data&.name&.strip&.presence
       rescue Common::Exceptions::BackendServiceException
         NPI_NOT_FOUND_MSG
-      rescue URI::InvalidURIError => e
-        if Flipper.enabled?(:appointment_provider_id_logging, @user)
-          PersonalInformationLog.create!(
-            data: { icn: @user.icn, message: e.message, backtrace: e.backtrace },
-            error_class: 'Appointment Provider URI Error'
-          )
-        end
-
+      rescue URI::InvalidURIError
         nil
       end
 

--- a/modules/vaos/app/services/vaos/v2/appointment_provider_name.rb
+++ b/modules/vaos/app/services/vaos/v2/appointment_provider_name.rb
@@ -37,7 +37,7 @@ module VAOS
 
       def find_practitioner_id(practitioner)
         practitioner[:identifier]&.each do |i|
-          return i[:value].tr('^0-9', '') if i[:system].include? 'us-npi'
+          return i[:value]&.tr('^0-9', '') if i[:system].include? 'us-npi'
         end
         nil
       end


### PR DESCRIPTION
## Summary
appointments - parse out correct id when bad provider data is given

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/10341

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
