### PR TITLE
[API-43211] Add distributed tracing to POA request creation

### DIFF
--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
@@ -27,26 +27,33 @@ module ClaimsApi
       end
 
       def call
+        # https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#distributed-tracing
+        trace_digest = Datadog::Tracing.active_trace&.to_digest
+
         @vnp_proc_id = create_vnp_proc[:vnp_proc_id]
 
         # Parallelize create_vnp_form and create_vnp_ptcpnt
         form_promise = Concurrent::Promise.execute do
-          create_vnp_form
+          Datadog::Tracing.continue_trace!(trace_digest) do
+            create_vnp_form
+          end
         end
 
         ptcpnt_promise = Concurrent::Promise.execute do
-          create_vnp_ptcpnt(@veteran_participant_id)
+          Datadog::Tracing.continue_trace!(trace_digest) do
+            create_vnp_ptcpnt(@veteran_participant_id)
+          end
         end
 
         # Wait for both promises and store the participant ID
         form_promise.value!
         @veteran_vnp_ptcpnt_id = ptcpnt_promise.value![:vnp_ptcpnt_id]
 
-        create_vonapp_data(@form_data[:veteran], @veteran_vnp_ptcpnt_id)
+        create_vonapp_data(@form_data[:veteran], @veteran_vnp_ptcpnt_id, trace_digest)
 
         if @has_claimant
           @claimant_vnp_ptcpnt_id = create_vnp_ptcpnt(@claimant_participant_id)[:vnp_ptcpnt_id]
-          create_vonapp_data(@form_data[:claimant], @claimant_vnp_ptcpnt_id)
+          create_vonapp_data(@form_data[:claimant], @claimant_vnp_ptcpnt_id, trace_digest)
         end
 
         create_veteran_representative
@@ -54,26 +61,34 @@ module ClaimsApi
 
       private
 
-      def create_vonapp_data(person, vnp_ptcpnt_id)
+      def create_vonapp_data(person, vnp_ptcpnt_id, trace_digest) # rubocop:disable Metrics/MethodLength
         promises = []
 
         promises << Concurrent::Promise.execute do
-          create_vnp_person(person, vnp_ptcpnt_id)
+          Datadog::Tracing.continue_trace!(trace_digest) do
+            create_vnp_person(person, vnp_ptcpnt_id)
+          end
         end
 
         promises << Concurrent::Promise.execute do
-          create_vnp_mailing_address(person[:address], vnp_ptcpnt_id)
+          Datadog::Tracing.continue_trace!(trace_digest) do
+            create_vnp_mailing_address(person[:address], vnp_ptcpnt_id)
+          end
         end
 
         if person[:email]
           promises << Concurrent::Promise.execute do
-            create_vnp_email_address(person[:email], vnp_ptcpnt_id)
+            Datadog::Tracing.continue_trace!(trace_digest) do
+              create_vnp_email_address(person[:email], vnp_ptcpnt_id)
+            end
           end
         end
 
         if person[:phone]
           promises << Concurrent::Promise.execute do
-            create_vnp_phone(person[:phone][:areaCode], person[:phone][:phoneNumber], vnp_ptcpnt_id)
+            Datadog::Tracing.continue_trace!(trace_digest) do
+              create_vnp_phone(person[:phone][:areaCode], person[:phone][:phoneNumber], vnp_ptcpnt_id)
+            end
           end
         end
 


### PR DESCRIPTION
## Summary

We parallelized BGS calls in https://github.com/department-of-veterans-affairs/vets-api/pull/19633 but discovered Datadog creates new trace ids for the parallel requests. The result is we cannot see the parallel requests in the Datadog trace view (see ticket [comment](https://jira.devops.va.gov/browse/API-43211?focusedId=3467878&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3467878) for screenshot).

This PR attempts to continue the same Datadog trace for the parallel requests, allowing us to see all the requests in one waterfall view. See [ddtrace documentation](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#distributed-tracing) for the approach.

## Related issue(s)

[API-43211](https://jira.devops.va.gov/browse/API-43211)

## Testing done

- Manually submitted a POST /power-of-attorney-requests (see #19210 for details). Observed successful response.
- Weʼll need to merge this PR and observe the behavior in staging to verify the trace continuation. Low-risk changes since this endpoint is not used.
 
## Screenshots

N/A

## What areas of the site does it impact?

Power of attorney request creation

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A