### PR TITLE
chore: Check for existence of saved_claims indexes before creating

### DIFF
--- a/db/migrate/20241209231104_add_indexes_to_saved_claims.rb
+++ b/db/migrate/20241209231104_add_indexes_to_saved_claims.rb
@@ -2,7 +2,12 @@ class AddIndexesToSavedClaims < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :saved_claims, [:id], where: "(metadata LIKE '%error%')", name: "index_partial_saved_claims_on_id_metadata_like_error", algorithm: :concurrently
-    add_index :saved_claims, :delete_date, algorithm: :concurrently
+    unless index_exists?(:saved_claims, [:id], name: "index_partial_saved_claims_on_id_metadata_like_error")
+      add_index :saved_claims, [:id], where: "(metadata LIKE '%error%')", name: "index_partial_saved_claims_on_id_metadata_like_error", algorithm: :concurrently
+    end
+
+    unless index_exists?(:saved_claims, :delete_date)
+      add_index :saved_claims, :delete_date, algorithm: :concurrently
+    end
   end
 end


### PR DESCRIPTION
- Prevents migration errors caused by duplicate index creation in dev/staging

![Screenshot 2024-12-12 at 09 28 44@2x](https://github.com/user-attachments/assets/2967f33b-c0fb-4a75-99ad-d38dc88f8797)