### PR TITLE
[10-10EZ] Remove view:email_confirmation check from HCA:: LogEmailDiffJob since attribute is no longer used

### DIFF
--- a/app/sidekiq/hca/log_email_diff_job.rb
+++ b/app/sidekiq/hca/log_email_diff_job.rb
@@ -22,9 +22,8 @@ module HCA
 
       parsed_form = JSON.parse(in_progress_form.form_data)
       form_email = parsed_form['email']
-      email_confirmation = parsed_form['view:email_confirmation']
 
-      return if form_email.blank? || form_email != email_confirmation
+      return if form_email.blank?
 
       user = User.find(user_uuid)
       va_profile_email = user.va_profile_email
@@ -45,9 +44,8 @@ module HCA
 
       parsed_form = JSON.parse(in_progress_form.form_data)
       form_email = parsed_form['email']
-      email_confirmation = parsed_form['view:email_confirmation']
 
-      return if form_email.blank? || form_email != email_confirmation
+      return if form_email.blank?
 
       user = User.find(user_uuid)
       va_profile_email = user.va_profile_email

--- a/spec/factories/in_progress_forms/in_progress_forms.rb
+++ b/spec/factories/in_progress_forms/in_progress_forms.rb
@@ -228,7 +228,6 @@ FactoryBot.define do
       form_data do
         {
           "email": 'email@email.com',
-          "view:email_confirmation": 'email@email.com',
           "veteran_address": { "street": 'hgjghj', "city": 'hjkhjk', "postal_code": '44444', "country": 'USA',
                                "state": 'AL' },
           "view:does_mailing_match_home_address": true,

--- a/spec/sidekiq/hca/log_email_diff_job_spec.rb
+++ b/spec/sidekiq/hca/log_email_diff_job_spec.rb
@@ -47,16 +47,6 @@ RSpec.describe HCA::LogEmailDiffJob, type: :job do
       end
 
       context 'when form email is present' do
-        context 'when email confirmation is different' do
-          before do
-            in_progress_form.update!(
-              form_data: JSON.parse(in_progress_form.form_data).except('view:email_confirmation').to_json
-            )
-          end
-
-          expect_does_nothing
-        end
-
         context 'when va profile email is different' do
           expect_email_tag('different')
         end
@@ -136,16 +126,6 @@ RSpec.describe HCA::LogEmailDiffJob, type: :job do
       end
 
       context 'when form email is present' do
-        context 'when email confirmation is different' do
-          before do
-            in_progress_form.update!(
-              form_data: JSON.parse(in_progress_form.form_data).except('view:email_confirmation').to_json
-            )
-          end
-
-          expect_does_nothing
-        end
-
         context 'when va profile email is different' do
           expect_email_tag('different')
         end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- When refactoring the `HCA::LogEmailDiffJob` to no longer use redis, we discovered it was using an old attribute to validate if the email should be logged as same/different. This attribute was causing it to always return early in the job, thus never actually logging if the email was the same/different between the form and the profile. Removing this check from the job should make the metric start incrementing. 
- 10-10 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94285

## Testing done

- [x] *New code is covered by unit tests*
- [ ] We will manually validate the metric is being logged again once it is merged in

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10 EZ

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
