### PR TITLE
Differentiate engine version of shared examples

### DIFF
--- a/modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs.rb
+++ b/modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'decision_reviews/v1/service'
 
-SUBCLASS_INFO = {
+ENGINE_SUBCLASS_INFO = {
   SavedClaim::SupplementalClaim => { service_method: 'get_supplemental_claim',
                                      evidence_service_method: 'get_supplemental_claim_upload',
                                      statsd_prefix: 'worker.decision_review.saved_claim_sc_status_updater',
@@ -21,7 +21,7 @@ SUBCLASS_INFO = {
                                         service_tag: 'service:board-appeal' }
 }.freeze
 
-RSpec.shared_context 'status updater job context' do |subclass|
+RSpec.shared_context 'engine status updater job context' do |subclass|
   subject { described_class }
 
   let(:service) { instance_double(DecisionReviews::V1::Service) }
@@ -29,15 +29,15 @@ RSpec.shared_context 'status updater job context' do |subclass|
   let(:guid1) { SecureRandom.uuid }
   let(:guid2) { SecureRandom.uuid }
   let(:guid3) { SecureRandom.uuid }
-  let(:other_subclass1) { SUBCLASS_INFO.keys.excluding(subclass)[0] }
-  let(:other_subclass2) { SUBCLASS_INFO.keys.excluding(subclass)[1] }
-  let(:service_method) { SUBCLASS_INFO[subclass][:service_method].to_sym }
-  let(:other_service_method1) { SUBCLASS_INFO[other_subclass1][:service_method].to_sym }
-  let(:other_service_method2) { SUBCLASS_INFO[other_subclass2][:service_method].to_sym }
+  let(:other_subclass1) { ENGINE_SUBCLASS_INFO.keys.excluding(subclass)[0] }
+  let(:other_subclass2) { ENGINE_SUBCLASS_INFO.keys.excluding(subclass)[1] }
+  let(:service_method) { ENGINE_SUBCLASS_INFO[subclass][:service_method].to_sym }
+  let(:other_service_method1) { ENGINE_SUBCLASS_INFO[other_subclass1][:service_method].to_sym }
+  let(:other_service_method2) { ENGINE_SUBCLASS_INFO[other_subclass2][:service_method].to_sym }
 
-  let(:statsd_prefix) { SUBCLASS_INFO[subclass][:statsd_prefix] }
-  let(:log_prefix) { SUBCLASS_INFO[subclass][:log_prefix] }
-  let(:service_tag) { SUBCLASS_INFO[subclass][:service_tag] }
+  let(:statsd_prefix) { ENGINE_SUBCLASS_INFO[subclass][:statsd_prefix] }
+  let(:log_prefix) { ENGINE_SUBCLASS_INFO[subclass][:log_prefix] }
+  let(:service_tag) { ENGINE_SUBCLASS_INFO[subclass][:service_tag] }
 
   let(:response_complete) do
     response = JSON.parse(VetsJsonSchema::EXAMPLES.fetch('HLR-SHOW-RESPONSE-200_V2').to_json) # deep copy
@@ -62,7 +62,7 @@ RSpec.shared_context 'status updater job context' do |subclass|
   end
 end
 
-RSpec.shared_examples 'status updater job with base forms' do |subclass|
+RSpec.shared_examples 'engine status updater job with base forms' do |subclass|
   context 'SavedClaim records are present' do
     before do
       subclass.create(guid: guid1, form: '{}')
@@ -206,7 +206,7 @@ RSpec.shared_examples 'status updater job with base forms' do |subclass|
   end
 end
 
-RSpec.shared_examples 'status updater job when forms include evidence' do |subclass|
+RSpec.shared_examples 'engine status updater job when forms include evidence' do |subclass|
   let(:upload_response_vbms) do
     response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_upload_show_response_200.json'))
     instance_double(Faraday::Response, body: response)
@@ -226,7 +226,7 @@ RSpec.shared_examples 'status updater job when forms include evidence' do |subcl
     instance_double(Faraday::Response, body: response)
   end
 
-  let(:evidence_service_method) { SUBCLASS_INFO[subclass][:evidence_service_method].to_sym }
+  let(:evidence_service_method) { ENGINE_SUBCLASS_INFO[subclass][:evidence_service_method].to_sym }
 
   context 'SavedClaim records are present with completed status in LH and have associated evidence uploads' do
     let(:guid4) { SecureRandom.uuid }

--- a/modules/decision_reviews/spec/sidekiq/hlr_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/hlr_status_updater_job_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './modules/decision_reviews/spec/sidekiq/shared_examples_for_status_updater_jobs'
+require './modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs'
 
 RSpec.describe DecisionReviews::HlrStatusUpdaterJob, type: :job do
   subject { described_class }
 
-  include_context 'status updater job context', SavedClaim::HigherLevelReview
+  include_context 'engine status updater job context', SavedClaim::HigherLevelReview
 
   describe 'perform' do
     context 'with flag enabled', :aggregate_failures do
@@ -14,7 +14,7 @@ RSpec.describe DecisionReviews::HlrStatusUpdaterJob, type: :job do
         Flipper.enable :decision_review_saved_claim_hlr_status_updater_job_enabled
       end
 
-      include_examples 'status updater job with base forms', SavedClaim::HigherLevelReview
+      include_examples 'engine status updater job with base forms', SavedClaim::HigherLevelReview
     end
 
     context 'with flag disabled' do

--- a/modules/decision_reviews/spec/sidekiq/nod_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/nod_status_updater_job_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './modules/decision_reviews/spec/sidekiq/shared_examples_for_status_updater_jobs'
+require './modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs'
 
 RSpec.describe DecisionReviews::NodStatusUpdaterJob, type: :job do
   subject { described_class }
 
-  include_context 'status updater job context', SavedClaim::NoticeOfDisagreement
+  include_context 'engine status updater job context', SavedClaim::NoticeOfDisagreement
 
   describe 'perform' do
     context 'with flag enabled', :aggregate_failures do
@@ -14,8 +14,8 @@ RSpec.describe DecisionReviews::NodStatusUpdaterJob, type: :job do
         Flipper.enable :decision_review_saved_claim_nod_status_updater_job_enabled
       end
 
-      include_examples 'status updater job with base forms', SavedClaim::NoticeOfDisagreement
-      include_examples 'status updater job when forms include evidence', SavedClaim::NoticeOfDisagreement
+      include_examples 'engine status updater job with base forms', SavedClaim::NoticeOfDisagreement
+      include_examples 'engine status updater job when forms include evidence', SavedClaim::NoticeOfDisagreement
     end
 
     context 'with flag disabled' do

--- a/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './modules/decision_reviews/spec/sidekiq/shared_examples_for_status_updater_jobs'
+require './modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs'
 
 RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
   subject { described_class }
 
-  include_context 'status updater job context', SavedClaim::SupplementalClaim
+  include_context 'engine status updater job context', SavedClaim::SupplementalClaim
 
   describe 'perform' do
     context 'with flag enabled', :aggregate_failures do
@@ -14,8 +14,8 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
         Flipper.enable :decision_review_saved_claim_sc_status_updater_job_enabled
       end
 
-      include_examples 'status updater job with base forms', SavedClaim::SupplementalClaim
-      include_examples 'status updater job when forms include evidence', SavedClaim::SupplementalClaim
+      include_examples 'engine status updater job with base forms', SavedClaim::SupplementalClaim
+      include_examples 'engine status updater job when forms include evidence', SavedClaim::SupplementalClaim
     end
 
     context 'with flag disabled' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Fixing flaky tests, no implementation changes
- *(If bug, how to reproduce)*
Flaky tests. Run `bundle exec rspec --color spec/sidekiq/decision_review/*  modules/decision_reviews/spec/sidekiq/*` to trigger
- *(What is the solution, why is this the solution?)*
- sometimes file load order during test was causing shared examples in the module to overwrite shared examples in the main app, or vice versa. No longer sharing names
- *(Which team do you work for, does your team own the maintenance of this component?)*
- Decision Reviews, yes

## Related issue(s)

No ticket

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Shared examples in main app and module had the same names. Rspec doesn't respect the module isolation so they were overwriting each other

## What areas of the site does it impact?
Decision Reviews module test code

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature