### PR TITLE
[API-43131] Validate 526 v1 disabilitiesʼ classification code end date

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
@@ -414,20 +414,20 @@ module ClaimsApi
     end
 
     def validate_form_526_disability_classification_code!
-      form_attributes['disabilities'].each do |disability|
+      form_attributes['disabilities'].each_with_index do |disability, index|
         classification_code = disability['classificationCode']
         next if classification_code.nil? || classification_code.blank?
 
         if bgs_classification_ids.include?(classification_code)
-          validate_form_526_disability_classification_code_end_date!(classification_code)
+          validate_form_526_disability_classification_code_end_date!(classification_code, index)
         else
-          raise ::Common::Exceptions::InvalidFieldValue.new('disabilities.classificationCode',
+          raise ::Common::Exceptions::InvalidFieldValue.new("disabilities.#{index}.classificationCode",
                                                             classification_code)
         end
       end
     end
 
-    def validate_form_526_disability_classification_code_end_date!(classification_code)
+    def validate_form_526_disability_classification_code_end_date!(classification_code, index)
       brd_disability = brd_disabilities.find { |d| d[:id] == classification_code.to_i }
       end_date_time = brd_disability[:endDateTime] if brd_disability
 
@@ -435,7 +435,7 @@ module ClaimsApi
 
       return if Date.parse(end_date_time) >= Time.zone.today
 
-      raise ::Common::Exceptions::InvalidFieldValue.new('disabilities.classificationCode', classification_code)
+      raise ::Common::Exceptions::InvalidFieldValue.new("disabilities.#{index}.classificationCode", classification_code)
     end
 
     def bgs_classification_ids

--- a/modules/claims_api/spec/requests/v1/forms/526_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           end
         end
 
-        context "when 'treatments[].center.country' is too long'" do
+        context "when 'treatments[].center.country' is too long" do
           let(:treated_disability_names) { ['PTSD (post traumatic stress disorder)'] }
 
           it 'returns a bad request' do
@@ -1286,7 +1286,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
       end
 
       context 'when consumer is representative' do
-        it 'returns an unprocessible entity status' do
+        it 'returns an unprocessable entity status' do
           mock_acg(scopes) do |auth_header|
             VCR.use_cassette('claims_api/brd/countries') do
               post path, params: data, headers: headers.merge(auth_header)
@@ -1391,7 +1391,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           stub_mpi(build(:mpi_profile, birls_id: nil, birth_date: '19560506'))
         end
 
-        it 'returns an unprocessible entity status' do
+        it 'returns an unprocessable entity status' do
           mock_acg(scopes) do |auth_header|
             VCR.use_cassette('claims_api/brd/countries') do
               post path, params: data, headers: headers.merge(auth_header)
@@ -1407,7 +1407,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         stub_mpi(build(:mpi_profile, birls_id: nil, birth_date: '19560506'))
       end
 
-      it 'returns an unprocessible entity status' do
+      it 'returns an unprocessable entity status' do
         mock_acg(scopes) do |auth_header|
           VCR.use_cassette('claims_api/brd/countries') do
             VCR.use_cassette('claims_api/bgs/claims/claims') do
@@ -1992,7 +1992,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           context "when 'amount' is below the minimum" do
             let(:military_retired_payment_amount) { 0 }
 
-            it 'responds with an unprocessible entity' do
+            it 'responds with an unprocessable entity' do
               mock_acg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/brd/countries') do
                   json_data = JSON.parse data
@@ -2008,7 +2008,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           context "when 'amount' is above the maximum" do
             let(:military_retired_payment_amount) { 1_000_000 }
 
-            it 'responds with an unprocessible entity' do
+            it 'responds with an unprocessable entity' do
               mock_acg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/bgs/claims/claims') do
                   VCR.use_cassette('claims_api/brd/countries') do
@@ -2059,7 +2059,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
                 }
               end
 
-              it 'responds with an unprocessible entity' do
+              it 'responds with an unprocessable entity' do
                 mock_acg(scopes) do |auth_header|
                   VCR.use_cassette('claims_api/brd/countries') do
                     json_data = JSON.parse data
@@ -2122,7 +2122,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           context "when 'amount' is below the minimum" do
             let(:separation_payment_amount) { 0 }
 
-            it 'responds with an unprocessible entity' do
+            it 'responds with an unprocessable entity' do
               mock_acg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/brd/countries') do
                   json_data = JSON.parse data
@@ -2138,7 +2138,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           context "when 'amount' is above the maximum" do
             let(:separation_payment_amount) { 1_000_000 }
 
-            it 'responds with an unprocessible entity' do
+            it 'responds with an unprocessable entity' do
               mock_acg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/bgs/claims/claims') do
                   VCR.use_cassette('claims_api/brd/countries') do
@@ -2272,7 +2272,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         end
       end
 
-      context "when 'disabilites.secondaryDisabilities.classificationCode' is invalid" do
+      context "when 'disabilities.secondaryDisabilities.classificationCode' is invalid" do
         let(:classification_type_codes) { [{ clsfcn_id: '1111' }] }
 
         [true, false].each do |flipped|
@@ -2318,7 +2318,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         end
       end
 
-      context "when 'disabilites.secondaryDisabilities.classificationCode' does not match name" do
+      context "when 'disabilities.secondaryDisabilities.classificationCode' does not match name" do
         let(:classification_type_codes) { [{ clsfcn_id: '1111' }] }
 
         [true, false].each do |flipped|
@@ -2364,7 +2364,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         end
       end
 
-      context "when 'disabilites.secondaryDisabilities.approximateBeginDate' is present" do
+      context "when 'disabilities.secondaryDisabilities.approximateBeginDate' is present" do
         it 'raises an exception if date is invalid' do
           mock_acg(scopes) do |auth_header|
             VCR.use_cassette('claims_api/brd/countries') do
@@ -2420,7 +2420,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         end
       end
 
-      context "when 'disabilites.secondaryDisabilities.classificationCode' is not present" do
+      context "when 'disabilities.secondaryDisabilities.classificationCode' is not present" do
         it 'raises an exception if name is not valid structure' do
           mock_acg(scopes) do |auth_header|
             VCR.use_cassette('claims_api/brd/countries') do
@@ -2477,7 +2477,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
       end
     end
 
-    describe "'disabilites' validations" do
+    describe "'disabilities' validations" do
       describe "'disabilities.classificationCode' validations" do
         [true, false].each do |flipped|
           context "when feature flag is #{flipped}" do
@@ -2490,11 +2490,16 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
                 expect_any_instance_of(BGS::StandardDataService)
                   .to receive(:get_contention_classification_type_code_list).and_return(classification_type_codes)
               end
+
+              allow_any_instance_of(ClaimsApi::DisabilityCompensationValidations)
+                .to receive(:brd_disabilities).and_return([{
+                                                            id: 1111, endDateTime: 1.year.from_now.iso8601
+                                                          }])
             end
 
             let(:classification_type_codes) { [{ clsfcn_id: '1111' }] }
 
-            context "when 'disabilites.classificationCode' is valid" do
+            context "when 'disabilities.classificationCode' is valid and expires in the future" do
               it 'returns a successful response' do
                 mock_acg(scopes) do |auth_header|
                   VCR.use_cassette('claims_api/bgs/claims/claims') do
@@ -2517,11 +2522,42 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
               end
             end
 
-            context "when 'disabilites.classificationCode' is invalid" do
+            context "when 'disabilities.classificationCode' is valid but expires in the past" do
+              before do
+                allow_any_instance_of(ClaimsApi::DisabilityCompensationValidations)
+                  .to receive(:brd_disabilities).and_return([{
+                                                              id: 1111,
+                                                              endDateTime: 1.year.ago.iso8601
+                                                            }])
+              end
+
+              it 'responds with a bad request' do
+                mock_acg(scopes) do |auth_header|
+                  VCR.use_cassette('claims_api_bgs/claims/claims') do
+                    VCR.use_cassette('claims_api/brd/countries') do
+                      json_data = JSON.parse data
+                      params = json_data
+                      disabilities = [
+                        {
+                          disabilityActionType: 'NEW',
+                          name: 'PTSD (post traumatic stress disorder)',
+                          classificationCode: '1111'
+                        }
+                      ]
+                      params['data']['attributes']['disabilities'] = disabilities
+                      post path, params: params.to_json, headers: headers.merge(auth_header)
+                      expect(response).to have_http_status(:bad_request)
+                    end
+                  end
+                end
+              end
+            end
+
+            context "when 'disabilities.classificationCode' is invalid" do
               it 'responds with a bad request' do
                 mock_acg(scopes) do |auth_header|
                   VCR.use_cassette('claims_api/brd/countries') do
-                    VCR.use_cassette('claims_api/bgs/stadard_service_data') do
+                    VCR.use_cassette('claims_api/bgs/standard_service_data') do
                       json_data = JSON.parse data
                       params = json_data
                       disabilities = [
@@ -2544,9 +2580,9 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
       end
 
       describe "'disabilities.ratedDisabilityId' validations" do
-        context "when 'disabilites.disabilityActionType' equals 'INCREASE'" do
+        context "when 'disabilities.disabilityActionType' equals 'INCREASE'" do
           context "and 'disabilities.ratedDisabilityId' is not provided" do
-            it 'returns an unprocessible entity status' do
+            it 'returns an unprocessable entity status' do
               mock_acg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/bgs/claims/claims') do
                   VCR.use_cassette('claims_api/brd/countries') do
@@ -2593,7 +2629,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           end
 
           context "and 'disabilities.diagnosticCode' is not provided" do
-            it 'returns an unprocessible entity status' do
+            it 'returns an unprocessable entity status' do
               mock_acg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/brd/countries') do
                   json_data = JSON.parse data
@@ -2614,10 +2650,10 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           end
         end
 
-        context "when 'disabilites.disabilityActionType' equals 'NONE'" do
-          context "and 'disabilites.secondaryDisabilities' is defined" do
-            context "and 'disabilites.diagnosticCode is not provided" do
-              it 'returns an unprocessible entity status' do
+        context "when 'disabilities.disabilityActionType' equals 'NONE'" do
+          context "and 'disabilities.secondaryDisabilities' is defined" do
+            context "and 'disabilities.diagnosticCode is not provided" do
+              it 'returns an unprocessable entity status' do
                 mock_acg(scopes) do |auth_header|
                   VCR.use_cassette('claims_api/bgs/claims/claims') do
                     VCR.use_cassette('claims_api/brd/countries') do
@@ -2648,7 +2684,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           end
         end
 
-        context "when 'disabilites.disabilityActionType' equals value other than 'INCREASE'" do
+        context "when 'disabilities.disabilityActionType' equals value other than 'INCREASE'" do
           context "and 'disabilities.ratedDisabilityId' is not provided" do
             it 'responds with a 200' do
               mock_acg(scopes) do |auth_header|
@@ -2674,7 +2710,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         end
       end
 
-      describe "'disabilites.approximateBeginDate' validations" do
+      describe "'disabilities.approximateBeginDate' validations" do
         let(:disabilities) do
           [
             {
@@ -2727,7 +2763,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         end
       end
 
-      describe "'disabilites.specialIssues' validations" do
+      describe "'disabilities.specialIssues' validations" do
         let(:disabilities) do
           [
             {
@@ -2882,7 +2918,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
           end
         end
 
-        context "when 'specialIssues' are provided for some 'disabilites'" do
+        context "when 'specialIssues' are provided for some 'disabilities'" do
           let(:disabilities) do
             [
               {


### PR DESCRIPTION
## Summary

In v1 526 validation, check the disabilitiesʼ classification code expiration dates. If the code is expired, raise an exception.

## Related issue(s)

[API-43131](https://jira.devops.va.gov/browse/API-43131)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?

v1 526 submission validation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
