### PR TITLE
Add filterable to Vets::Model

### DIFF
--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -16,7 +16,7 @@ module Vets
       def attribute(name, klass, **options)
         default = options[:default]
         array = options[:array] || false
-        filterable = options[:filterable]
+        filterable = options[:filterable] || false
 
         attributes[name] = { type: klass, default:, array:, filterable: }
 
@@ -29,8 +29,14 @@ module Vets
         ancestors.select { |klass| klass.respond_to?(:attributes) }.flat_map { |klass| klass.attributes.keys }.uniq
       end
 
+      # Lists the attributes that are filterable
       def filterable_attributes
-        @filterable_attributes ||= attributes.each_with_object({}) do |attribute, hash|
+        @filterable_attributes ||= attributes.select { |_, options| !!options[:filterable] }.keys
+      end
+
+      # Creates a param hash for filterable
+      def filterable_params
+        @filterable_params ||= attributes.each_with_object({}) do |attribute, hash|
 
           name = attribute.first
           options = attribute.second

--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -9,8 +9,9 @@ module Vets
     end
 
     module ClassMethods
+      # rubocop:disable ThreadSafety/ClassInstanceVariable
       def attributes
-        @attributes ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+        @attributes ||= {}
       end
 
       def attribute(name, klass, **options)
@@ -31,19 +32,20 @@ module Vets
 
       # Lists the attributes that are filterable
       def filterable_attributes
-        @filterable_attributes ||= attributes.select { |_, options| !!options[:filterable] }.keys
+        @filterable_attributes ||= attributes.select { |_, options| options[:filterable] }.keys
       end
 
       # Creates a param hash for filterable
       def filterable_params
         @filterable_params ||= attributes.each_with_object({}) do |attribute, hash|
-
           name = attribute.first
           options = attribute.second
 
           hash[name.to_s] = options[:filterable] if options[:filterable]
         end.with_indifferent_access
       end
+
+      # rubocop:enable ThreadSafety/ClassInstanceVariable
 
       private
 

--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -9,9 +9,8 @@ module Vets
     end
 
     module ClassMethods
-      # rubocop:disable ThreadSafety/ClassInstanceVariable
       def attributes
-        @attributes ||= {}
+        @attributes ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
       end
 
       def attribute(name, klass, **options)
@@ -32,20 +31,18 @@ module Vets
 
       # Lists the attributes that are filterable
       def filterable_attributes
-        @filterable_attributes ||= attributes.select { |_, options| options[:filterable] }.keys
+        attributes.select { |_, options| options[:filterable] }.keys
       end
 
       # Creates a param hash for filterable
       def filterable_params
-        @filterable_params ||= attributes.each_with_object({}) do |attribute, hash|
+        attributes.each_with_object({}) do |attribute, hash|
           name = attribute.first
           options = attribute.second
 
           hash[name.to_s] = options[:filterable] if options[:filterable]
         end.with_indifferent_access
       end
-
-      # rubocop:enable ThreadSafety/ClassInstanceVariable
 
       private
 

--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -16,8 +16,9 @@ module Vets
       def attribute(name, klass, **options)
         default = options[:default]
         array = options[:array] || false
+        filterable = options[:filterable]
 
-        attributes[name] = { type: klass, default:, array: }
+        attributes[name] = { type: klass, default:, array:, filterable: }
 
         define_getter(name, default)
         define_setter(name, klass, array)
@@ -26,6 +27,16 @@ module Vets
       def attribute_set
         # grabs attribute keys from parent classes
         ancestors.select { |klass| klass.respond_to?(:attributes) }.flat_map { |klass| klass.attributes.keys }.uniq
+      end
+
+      def filterable_attributes
+        @filterable_attributes ||= attributes.each_with_object({}) do |attribute, hash|
+
+          name = attribute.first
+          options = attribute.second
+
+          hash[name.to_s] = options[:filterable] if options[:filterable]
+        end.with_indifferent_access
       end
 
       private

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -62,11 +62,11 @@ RSpec.describe Vets::Attributes do
   describe '.attributes' do
     it 'returns a hash of the attribute definitions' do
       expected_attributes = {
-        name: { type: String, default: 'Unknown', array: false },
-        age: { type: Integer, default: nil, array: false },
-        tags: { type: String, default: nil, array: true },
-        categories: { type: FakeCategory, default: nil, array: true },
-        created_at: { type: DateTime, default: :current_time, array: false }
+        name: { type: String, default: 'Unknown', array: false, filterable: false },
+        age: { type: Integer, default: nil, array: false, filterable: %w(eq lteq gteq) },
+        tags: { type: String, default: nil, array: true, filterable: false },
+        categories: { type: FakeCategory, default: nil, array: true, filterable: false },
+        created_at: { type: DateTime, default: :current_time, array: false, filterable: %w(eq not_eq) }
       }
       expect(DummyModel.attributes).to eq(expected_attributes)
     end
@@ -84,12 +84,18 @@ RSpec.describe Vets::Attributes do
   end
 
   describe '.filterable_attributes' do
-    it 'returns a hash of the attribute with the filterable option' do
-      filterable_attributes = {
+    it 'returns an of the attribute with the filterable option' do
+      expect(DummyModel.filterable_attributes).to eq([:age, :created_at])
+    end
+  end
+
+  describe '.filterable_params' do
+    it 'returns a hash of the attribute with the filterable option for param filter' do
+      filterable_params = {
         'age' => %w[eq lteq gteq],
         'created_at' => %w[eq not_eq]
       }
-      expect(DummyModel.filterable_attributes).to eq(filterable_attributes)
+      expect(DummyModel.filterable_params).to eq(filterable_params)
     end
   end
 end

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -63,10 +63,10 @@ RSpec.describe Vets::Attributes do
     it 'returns a hash of the attribute definitions' do
       expected_attributes = {
         name: { type: String, default: 'Unknown', array: false, filterable: false },
-        age: { type: Integer, default: nil, array: false, filterable: %w(eq lteq gteq) },
+        age: { type: Integer, default: nil, array: false, filterable: %w[eq lteq gteq] },
         tags: { type: String, default: nil, array: true, filterable: false },
         categories: { type: FakeCategory, default: nil, array: true, filterable: false },
-        created_at: { type: DateTime, default: :current_time, array: false, filterable: %w(eq not_eq) }
+        created_at: { type: DateTime, default: :current_time, array: false, filterable: %w[eq not_eq] }
       }
       expect(DummyModel.attributes).to eq(expected_attributes)
     end
@@ -85,7 +85,7 @@ RSpec.describe Vets::Attributes do
 
   describe '.filterable_attributes' do
     it 'returns an of the attribute with the filterable option' do
-      expect(DummyModel.filterable_attributes).to eq([:age, :created_at])
+      expect(DummyModel.filterable_attributes).to eq(%i[age created_at])
     end
   end
 

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -24,10 +24,10 @@ class DummyModel < DummyParentModel
   include Vets::Attributes
 
   attribute :name, String, default: 'Unknown'
-  attribute :age, Integer, array: false
+  attribute :age, Integer, array: false, filterable: %w[eq lteq gteq]
   attribute :tags, String, array: true
   attribute :categories, FakeCategory, array: true
-  attribute :created_at, DateTime, default: :current_time
+  attribute :created_at, DateTime, default: :current_time, filterable: %w[eq not_eq]
 
   def current_time
     DateTime.new(2024, 9, 25, 10, 30, 0)
@@ -80,6 +80,16 @@ RSpec.describe Vets::Attributes do
 
     it 'includes an array of attributes from ancestors' do
       expect(DummyModel.attribute_set).to include(:updated_at)
+    end
+  end
+
+  describe '.filterable_attributes' do
+    it 'returns a hash of the attribute with the filterable option' do
+      filterable_attributes = {
+        'age' => %w[eq lteq gteq],
+        'created_at' => %w[eq not_eq]
+      }
+      expect(DummyModel.filterable_attributes).to eq(filterable_attributes)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add filterability by attributes 
- Add filterable attribute list
- Add filterable param list (for use with controllers)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98688

## Testing done

- [ ] Manual testing
- [ ] New test added

## Acceptance criteria

- [ ]  Matches functionality of `Common::Base`

