### PR TITLE
Recover tests lost during refactor

### DIFF
--- a/modules/decision_reviews/spec/factories/secondary_appeal_forms.rb
+++ b/modules/decision_reviews/spec/factories/secondary_appeal_forms.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :secondary_appeal_form4142_module, class: 'SecondaryAppealForm' do
+    guid { SecureRandom.uuid }
+    form_id { '21-4142' }
+    form do
+      {
+        veteran: {
+          fullName: {
+            first: 'Person',
+            last: 'McPerson'
+          },
+          dateOfBirth: '1983-01-23',
+          ssn: '111223333',
+          address: {},
+          homePhone: '123-456-7890'
+        },
+        patientIdentification: {
+          isRequestingOwnMedicalRecords: true
+
+        },
+        providerFacility: [{
+          providerFacilityName: 'provider 1',
+          treatmentDateRange: [
+            {
+              from: '1980-1-1',
+              to: '1985-1-1'
+            },
+            {
+              from: '1986-1-1',
+              to: '1987-1-1'
+            }
+          ],
+          providerFacilityAddress: {
+            street: '123 Main Street',
+            street2: '1B',
+            city: 'Baltimore',
+            state: 'MD',
+            country: 'USA',
+            postalCode: '21200-1111'
+          }
+        }],
+        preparerIdentification: {
+          relationshipToVeteran: 'self'
+        },
+        acknowledgeToReleaseInformation: true,
+        limitedConsent: 'some string',
+        privacyAgreementAccepted: true
+      }.to_json
+    end
+    delete_date { nil }
+    appeal_submission { create(:appeal_submission_module) }
+  end
+end

--- a/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
@@ -16,6 +16,167 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
 
       include_examples 'engine status updater job with base forms', SavedClaim::SupplementalClaim
       include_examples 'engine status updater job when forms include evidence', SavedClaim::SupplementalClaim
+
+      context 'SavedClaim records are present with completed status in LH and have associated secondary forms' do
+        let(:benefits_intake_service) { instance_double(BenefitsIntake::Service) }
+        let!(:secondary_form1) { create(:secondary_appeal_form4142_module, guid: SecureRandom.uuid) }
+        let!(:secondary_form2) { create(:secondary_appeal_form4142_module, guid: SecureRandom.uuid) }
+        let!(:secondary_form3) { create(:secondary_appeal_form4142_module, guid: SecureRandom.uuid) }
+        let!(:secondary_form_with_delete_date) do
+          create(:secondary_appeal_form4142_module, guid: SecureRandom.uuid, delete_date: 10.days.from_now)
+        end
+        let!(:saved_claim1) do
+          SavedClaim::SupplementalClaim.create(guid: secondary_form1.appeal_submission.submitted_appeal_uuid,
+                                               form: '{}')
+        end
+        let!(:saved_claim2) do
+          SavedClaim::SupplementalClaim.create(guid: secondary_form2.appeal_submission.submitted_appeal_uuid,
+                                               form: '{}')
+        end
+        let!(:saved_claim3) do
+          SavedClaim::SupplementalClaim.create(guid: secondary_form3.appeal_submission.submitted_appeal_uuid,
+                                               form: '{}')
+        end
+        let!(:saved_claim4) do
+          SavedClaim::SupplementalClaim
+            .create(guid: secondary_form_with_delete_date.appeal_submission.submitted_appeal_uuid, form: '{}')
+        end
+
+        let(:upload_response_4142_vbms) do
+          response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json'))
+          instance_double(Faraday::Response, body: response)
+        end
+
+        let(:upload_response_4142_processing) do
+          response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json'))
+          response['data']['attributes']['status'] = 'processing'
+          instance_double(Faraday::Response, body: response)
+        end
+
+        let(:upload_response_4142_error) do
+          response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json'))
+          response['data']['attributes']['status'] = 'error'
+          response['data']['attributes']['detail'] = 'Invalid PDF'
+          instance_double(Faraday::Response, body: response)
+        end
+
+        before do
+          allow(DecisionReviews::V1::Service).to receive(:new).and_return(service)
+          allow(BenefitsIntake::Service).to receive(:new).and_return(benefits_intake_service)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim1.guid).and_return(response_complete)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim2.guid).and_return(response_complete)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim3.guid).and_return(response_complete)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim4.guid).and_return(response_complete)
+
+          allow(StatsD).to receive(:increment)
+          allow(Rails.logger).to receive(:info)
+        end
+
+        it 'does NOT check status for 4142 records that already have a delete_date' do
+          expect(benefits_intake_service).to receive(:get_status).with(uuid: secondary_form1.guid)
+          expect(benefits_intake_service).to receive(:get_status).with(uuid: secondary_form2.guid)
+          expect(benefits_intake_service).to receive(:get_status).with(uuid: secondary_form3.guid)
+          expect(benefits_intake_service).not_to receive(:get_status)
+            .with(uuid: secondary_form_with_delete_date.guid)
+          subject.new.perform
+        end
+
+        context 'updating 4142 information' do
+          let(:frozen_time) { DateTime.new(2024, 1, 1).utc }
+
+          before do
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form1.guid).and_return(upload_response_4142_vbms)
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form2.guid).and_return(upload_response_4142_processing)
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form3.guid).and_return(upload_response_4142_error)
+          end
+
+          it 'updates the status and sets delete_date if appropriate' do
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+            end
+            expect(secondary_form1.reload.status).to include('vbms')
+            expect(secondary_form1.reload.status_updated_at).to eq frozen_time
+            expect(secondary_form1.reload.delete_date).to eq frozen_time + 59.days
+
+            expect(secondary_form2.reload.status).to include('processing')
+            expect(secondary_form2.reload.status_updated_at).to eq frozen_time
+            expect(secondary_form2.reload.delete_date).to be_nil
+
+            expect(secondary_form3.reload.status).to include('error')
+            expect(secondary_form3.reload.status_updated_at).to eq frozen_time
+            expect(secondary_form3.reload.delete_date).to be_nil
+          end
+
+          it 'logs ands increments metrics for updates to the 4142 status' do
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+            end
+
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.delete_date_update')
+              .exactly(1).time
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.status', tags: ['status:vbms'])
+              .exactly(1).time
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.status',
+                    tags: ['status:processing'])
+              .exactly(1).time
+
+            expect(Rails.logger).to have_received(:info)
+              .with('DecisionReviews::SavedClaimScStatusUpdaterJob secondary form status error', anything)
+          end
+
+          context 'when the 4142 status is unchanged' do
+            let(:previous_status) do
+              {
+                'status' => 'processing'
+              }
+            end
+
+            before do
+              secondary_form2.update!(status: previous_status.to_json, status_updated_at: frozen_time - 3.days)
+            end
+
+            it 'does not log or increment metrics for a status change' do
+              Timecop.freeze(frozen_time) do
+                subject.new.perform
+              end
+
+              expect(secondary_form2.reload.status_updated_at).to eq frozen_time
+              expect(StatsD).not_to have_received(:increment)
+                .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.status',
+                      tags: ['status:processing'])
+            end
+          end
+
+          context 'when at least one secondary form is not in vbms status' do
+            it 'does not set the delete_date for the related SavedCalim::SupplementlClaim' do
+              Timecop.freeze(frozen_time) do
+                subject.new.perform
+              end
+
+              expect(saved_claim1.reload.delete_date).to eq frozen_time + 59.days
+              expect(saved_claim2.delete_date).to be_nil
+            end
+          end
+        end
+
+        context 'with 4142 flag disabled' do
+          before do
+            Flipper.disable :decision_review_track_4142_submissions
+          end
+
+          it 'does not query SecondaryAppealForm records' do
+            expect(SecondaryAppealForm).not_to receive(:where)
+
+            subject.new.perform
+          end
+        end
+      end
     end
 
     context 'with flag disabled' do

--- a/spec/sidekiq/decision_review/sc_status_updater_job_spec.rb
+++ b/spec/sidekiq/decision_review/sc_status_updater_job_spec.rb
@@ -17,6 +17,167 @@ RSpec.describe DecisionReview::ScStatusUpdaterJob, type: :job do
 
       include_examples 'status updater job with base forms', SavedClaim::SupplementalClaim
       include_examples 'status updater job when forms include evidence', SavedClaim::SupplementalClaim
+
+      context 'SavedClaim records are present with completed status in LH and have associated secondary forms' do
+        let(:benefits_intake_service) { instance_double(BenefitsIntake::Service) }
+        let!(:secondary_form1) { create(:secondary_appeal_form4142, guid: SecureRandom.uuid) }
+        let!(:secondary_form2) { create(:secondary_appeal_form4142, guid: SecureRandom.uuid) }
+        let!(:secondary_form3) { create(:secondary_appeal_form4142, guid: SecureRandom.uuid) }
+        let!(:secondary_form_with_delete_date) do
+          create(:secondary_appeal_form4142, guid: SecureRandom.uuid, delete_date: 10.days.from_now)
+        end
+        let!(:saved_claim1) do
+          SavedClaim::SupplementalClaim.create(guid: secondary_form1.appeal_submission.submitted_appeal_uuid,
+                                               form: '{}')
+        end
+        let!(:saved_claim2) do
+          SavedClaim::SupplementalClaim.create(guid: secondary_form2.appeal_submission.submitted_appeal_uuid,
+                                               form: '{}')
+        end
+        let!(:saved_claim3) do
+          SavedClaim::SupplementalClaim.create(guid: secondary_form3.appeal_submission.submitted_appeal_uuid,
+                                               form: '{}')
+        end
+        let!(:saved_claim4) do
+          SavedClaim::SupplementalClaim
+            .create(guid: secondary_form_with_delete_date.appeal_submission.submitted_appeal_uuid, form: '{}')
+        end
+
+        let(:upload_response_4142_vbms) do
+          response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json'))
+          instance_double(Faraday::Response, body: response)
+        end
+
+        let(:upload_response_4142_processing) do
+          response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json'))
+          response['data']['attributes']['status'] = 'processing'
+          instance_double(Faraday::Response, body: response)
+        end
+
+        let(:upload_response_4142_error) do
+          response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json'))
+          response['data']['attributes']['status'] = 'error'
+          response['data']['attributes']['detail'] = 'Invalid PDF'
+          instance_double(Faraday::Response, body: response)
+        end
+
+        before do
+          allow(DecisionReviewV1::Service).to receive(:new).and_return(service)
+          allow(BenefitsIntake::Service).to receive(:new).and_return(benefits_intake_service)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim1.guid).and_return(response_complete)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim2.guid).and_return(response_complete)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim3.guid).and_return(response_complete)
+          allow(service).to receive(:get_supplemental_claim).with(saved_claim4.guid).and_return(response_complete)
+
+          allow(StatsD).to receive(:increment)
+          allow(Rails.logger).to receive(:info)
+        end
+
+        it 'does NOT check status for 4142 records that already have a delete_date' do
+          expect(benefits_intake_service).to receive(:get_status).with(uuid: secondary_form1.guid)
+          expect(benefits_intake_service).to receive(:get_status).with(uuid: secondary_form2.guid)
+          expect(benefits_intake_service).to receive(:get_status).with(uuid: secondary_form3.guid)
+          expect(benefits_intake_service).not_to receive(:get_status)
+            .with(uuid: secondary_form_with_delete_date.guid)
+          subject.new.perform
+        end
+
+        context 'updating 4142 information' do
+          let(:frozen_time) { DateTime.new(2024, 1, 1).utc }
+
+          before do
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form1.guid).and_return(upload_response_4142_vbms)
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form2.guid).and_return(upload_response_4142_processing)
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form3.guid).and_return(upload_response_4142_error)
+          end
+
+          it 'updates the status and sets delete_date if appropriate' do
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+            end
+            expect(secondary_form1.reload.status).to include('vbms')
+            expect(secondary_form1.reload.status_updated_at).to eq frozen_time
+            expect(secondary_form1.reload.delete_date).to eq frozen_time + 59.days
+
+            expect(secondary_form2.reload.status).to include('processing')
+            expect(secondary_form2.reload.status_updated_at).to eq frozen_time
+            expect(secondary_form2.reload.delete_date).to be_nil
+
+            expect(secondary_form3.reload.status).to include('error')
+            expect(secondary_form3.reload.status_updated_at).to eq frozen_time
+            expect(secondary_form3.reload.delete_date).to be_nil
+          end
+
+          it 'logs ands increments metrics for updates to the 4142 status' do
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+            end
+
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.delete_date_update')
+              .exactly(1).time
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.status', tags: ['status:vbms'])
+              .exactly(1).time
+            expect(StatsD).to have_received(:increment)
+              .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.status',
+                    tags: ['status:processing'])
+              .exactly(1).time
+
+            expect(Rails.logger).to have_received(:info)
+              .with('DecisionReview::SavedClaimScStatusUpdaterJob secondary form status error', anything)
+          end
+
+          context 'when the 4142 status is unchanged' do
+            let(:previous_status) do
+              {
+                'status' => 'processing'
+              }
+            end
+
+            before do
+              secondary_form2.update!(status: previous_status.to_json, status_updated_at: frozen_time - 3.days)
+            end
+
+            it 'does not log or increment metrics for a status change' do
+              Timecop.freeze(frozen_time) do
+                subject.new.perform
+              end
+
+              expect(secondary_form2.reload.status_updated_at).to eq frozen_time
+              expect(StatsD).not_to have_received(:increment)
+                .with('worker.decision_review.saved_claim_sc_status_updater_secondary_form.status',
+                      tags: ['status:processing'])
+            end
+          end
+
+          context 'when at least one secondary form is not in vbms status' do
+            it 'does not set the delete_date for the related SavedCalim::SupplementlClaim' do
+              Timecop.freeze(frozen_time) do
+                subject.new.perform
+              end
+
+              expect(saved_claim1.reload.delete_date).to eq frozen_time + 59.days
+              expect(saved_claim2.delete_date).to be_nil
+            end
+          end
+        end
+
+        context 'with 4142 flag disabled' do
+          before do
+            Flipper.disable :decision_review_track_4142_submissions
+          end
+
+          it 'does not query SecondaryAppealForm records' do
+            expect(SecondaryAppealForm).not_to receive(:where)
+
+            subject.new.perform
+          end
+        end
+      end
     end
 
     context 'with flag disabled' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Previous refactor accidentally deleted a block of tests. This PR adds them back
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews, yes

## Related issue(s)

No ticket, noticed during another bug fix

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Checking status of 4142 forms submitted with Supplemental Claim was not tested
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Break 4142 status checks, see tests fail correctly

## What areas of the site does it impact?
Test for one Decision Review background job

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature