### PR TITLE
Add pagination info to Vets::Model

### DIFF
--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -14,6 +14,7 @@ module Vets
     include ActiveModel::Model
     include ActiveModel::Serializers::JSON
     include Vets::Attributes
+    include Vets::Model::Pagination
 
     included do
       extend ActiveModel::Naming

--- a/lib/vets/model/pagination.rb
+++ b/lib/vets/model/pagination.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#
+# Pagination allows Vets::Model models to set pagination info
+# for that model class.
+#
+# class User
+#   include Vets::Model
+#
+#   attr_accessor :name, :age
+#
+#   set_pagination per_page: 21, max_per_page: 41
+#
+#   ...
+# end
+#
+# User.per_page
+# => 21
+#
+# User.max_per_page
+# => 41
+#
+
+module Vets
+  module Model
+    module Pagination
+      DEFAULT_PER_PAGE = 10
+      DEFAULT_MAX_PER_PAGE = 100
+
+      def self.included(base)
+        base.extend ClassMethods
+        base.private_class_method :set_pagination
+      end
+
+      module ClassMethods
+        # rubocop:disable ThreadSafety/ClassInstanceVariable
+        def set_pagination(per_page:, max_per_page:)
+          @per_page = per_page
+          @max_per_page = max_per_page
+        end
+
+        # Provide default values if set_pagination has not been called
+        def per_page
+          @per_page || DEFAULT_PER_PAGE
+        end
+
+        def max_per_page
+          @max_per_page || DEFAULT_MAX_PER_PAGE
+        end
+        # rubocop:enable ThreadSafety/ClassInstanceVariable
+      end
+    end
+  end
+end

--- a/spec/lib/vets/model/pagination_spec.rb
+++ b/spec/lib/vets/model/pagination_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'vets/model/pagination'
+
+RSpec.describe 'Vets::Model::Pagination' do
+  let(:user_class) do
+    Class.new do
+      include Vets::Model::Pagination
+
+      attr_accessor :name, :age
+
+      set_pagination per_page: 20, max_per_page: 40
+    end
+  end
+
+  describe 'when included in a model' do
+    it 'sets the correct per_page value' do
+      expect(user_class.per_page).to eq(20)
+    end
+
+    it 'sets the correct max_per_page value' do
+      expect(user_class.max_per_page).to eq(40)
+    end
+
+    it 'defaults to per_page = 10 when no pagination is set' do
+      dummy_class = Class.new do
+        include Vets::Model::Pagination
+      end
+
+      expect(dummy_class.per_page).to eq(10)
+    end
+
+    it 'defaults to max_per_page = 100 when no pagination is set' do
+      dummy_class = Class.new do
+        include Vets::Model::Pagination
+      end
+
+      expect(dummy_class.max_per_page).to eq(100)
+    end
+
+    it 'does not allow calling set_pagination directly from outside the class' do
+      expect do
+        user_class.set_pagination(per_page: 30, max_per_page: 60)
+      end.to raise_error(NoMethodError, /private method `set_pagination' called/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `per_page` and `max_per_page` to Vets::Model
- Add class method to set the above variables

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98688

## Testing done

- [ ] Manual testing
- [ ] New spec for module

## Acceptance criteria

- [ ]  Models only set pagination info via class definition 
- [ ]  Pagination info has the same default as `Common::Base`