### PR TITLE
VACMS-11589 Remove facilities_ppms_suppress_all flipper (unused)

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -605,9 +605,6 @@ features:
     actor_type: user
     description: Enables the Dispute Debt feature
     enable_in_development: true
-  facilities_ppms_suppress_all:
-    actor_type: user
-    description: Hide all ppms search options
   facilities_ppms_suppress_pharmacies:
     actor_type: user
     description: Front End Flag to suppress the ability to search for pharmacies


### PR DESCRIPTION
## Summary

Remove an unused flipper: `facilities_ppms_suppress_all`.

Github-wide search for the flipper: https://github.com/search?q=org%3Adepartment-of-veterans-affairs%20facilities_ppms_suppress_all&type=code

The flipper is off in all environments:

[Production](https://api.va.gov/flipper/features)
[Staging](https://staging-api.va.gov/flipper/features)
[Dev](https://dev-api.va.gov/flipper/features)

PR that removes the code using the flipper: https://github.com/department-of-veterans-affairs/vets-website/pull/33551

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11589