### PR TITLE
Update mapping to properly check `nonGroup` field - form 10-7959a

### DIFF
--- a/modules/ivc_champva/app/form_mappings/vha_10_7959a.json.erb
+++ b/modules/ivc_champva/app/form_mappings/vha_10_7959a.json.erb
@@ -24,7 +24,7 @@
   "form1[0].#subform[0].#area[0].OutsdWrkAccdnt[0]":                          "<%= ['true', true].include?(form.data.dig('claims', 0, 'claim_is_auto_related')) ? 0 : 1 %>",
   "form1[0].#subform[0].PtntCverage[0]":                                      "<%= ['true', true].include?(form.data.dig('has_ohi')) ? 0 : 1 %>",
   "form1[0].#subform[0].#area[1].RadioButtonList[0]":                         "<%= form.data.dig('policies', 0, 'type') === 'group' ? 1 :
-                                                                                   form.data.dig('policies', 0, 'type') === 'non_group' ? 2 :
+                                                                                   form.data.dig('policies', 0, 'type') === 'nonGroup' ? 2 :
                                                                                    form.data.dig('policies', 0, 'type') === 'medicare' ? 3 :
                                                                                    form.data.dig('policies', 0, 'type') === 'other' ? 4 : 0 %>",
   "form1[0].#subform[0].#area[1].SpecifyOtherPrimaryHealthInsurance[0]":      "<%= form.data.dig('policies', 0, 'other_type') %>",


### PR DESCRIPTION
## Summary

This PR updates the JSON erb mapping so that the "Non group" insurance checkbox on form 10-7959a gets checked correctly.

Previously, the mapping was attempting to use the key `non_group`, which did not exist and caused the form to erroneously check the 'other' box. Updating the mapping here fixes the issue of the checkbox not being checked properly.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/33552

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

| | |
|-|-|
|Before|![Screenshot 2024-12-12 at 16 50 25](https://github.com/user-attachments/assets/3b24f3db-ae90-492b-8a4a-4edb8facbfb9)|
|After|![Screenshot 2024-12-12 at 16 50 02](https://github.com/user-attachments/assets/083e9ecc-ca8f-4cb2-803b-1be2e026e04a)|

## What areas of the site does it impact?

IVC CHAMPVA form 10-7959a only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

NA