### PR TITLE
[VI-740] Skipping mhv account creation during auth custom type in payload attributes

### DIFF
--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -113,7 +113,7 @@ module SAML
                    "#{base_redirect_url}/terms-of-use"
                  end
 
-      if current_application.in?(SKIP_MHV_ACCOUNT_CREATION_CLIENTS)
+      if current_application.in?(SKIP_MHV_ACCOUNT_CREATION_CLIENTS) || @tracker&.payload_attr(:type) == 'custom'
         base_url = add_query(base_url, { skip_mhv_account_creation: true })
       end
 


### PR DESCRIPTION
## Summary

- This PR skips the mhv account creation API during SSOe authentication if `custom` is the type of authentication in the requested SAML attributes


## What areas of the site does it impact?
Authentication