### PR TITLE
Add dirty module to Vets::Model

### DIFF
--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -30,9 +30,6 @@ module Vets
       self.class.attribute_set.each do |attr_name|
         instance_variable_set("@#{attr_name}", nil) unless instance_variable_defined?("@#{attr_name}")
       end
-
-      # required for Vets::Model::Dirty
-      @original_attributes = attribute_values.dup
     end
 
     # Acts as ActiveRecord::Base#attributes which is needed for serialization
@@ -60,15 +57,6 @@ module Vets
           value
         end
       end
-    end
-  end
-end
-
-module Vets
-  module Model
-    def initialize(params = {})
-      super(params)
-      @original_attributes = attribute_values
     end
   end
 end

--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'vets/attributes'
+require 'vets/model/dirty'
 
 # This will be moved after virtus is removed
 module Bool; end
@@ -14,6 +15,7 @@ module Vets
     include ActiveModel::Model
     include ActiveModel::Serializers::JSON
     include Vets::Attributes
+    include Vets::Model::Dirty
 
     included do
       extend ActiveModel::Naming
@@ -28,6 +30,9 @@ module Vets
       self.class.attribute_set.each do |attr_name|
         instance_variable_set("@#{attr_name}", nil) unless instance_variable_defined?("@#{attr_name}")
       end
+
+      # required for Vets::Model::Dirty
+      @original_attributes = attribute_values.dup
     end
 
     # Acts as ActiveRecord::Base#attributes which is needed for serialization
@@ -55,6 +60,15 @@ module Vets
           value
         end
       end
+    end
+  end
+end
+
+module Vets
+  module Model
+    def initialize(params = {})
+      super(params)
+      @original_attributes = attribute_values
     end
   end
 end

--- a/lib/vets/model/dirty.rb
+++ b/lib/vets/model/dirty.rb
@@ -6,8 +6,8 @@
 module Vets
   module Model
     module Dirty
-      def initialize(*args, **kwargs)
-        super(*args, **kwargs) if defined?(super)
+      def initialize(*, **)
+        super(*, **) if defined?(super)
         @original_attributes = attribute_values.dup
       end
 

--- a/lib/vets/model/dirty.rb
+++ b/lib/vets/model/dirty.rb
@@ -12,8 +12,8 @@ module Vets
         attr_reader :original_attributes
       end
 
-      def initialize(*args, **kwargs)
-        super(*args, **kwargs) if defined?(super)
+      def initialize(*, **)
+        super(*, **) if defined?(super)
         @original_attributes = attribute_values.dup
       end
 

--- a/lib/vets/model/dirty.rb
+++ b/lib/vets/model/dirty.rb
@@ -6,6 +6,12 @@
 module Vets
   module Model
     module Dirty
+      extend ActiveSupport::Concern
+
+      included do
+        attr_reader :original_attributes
+      end
+
       def initialize(*, **)
         super(*, **) if defined?(super)
         @original_attributes = attribute_values.dup
@@ -25,8 +31,6 @@ module Vets
           result[key] = [original_value, current_value] if original_value != current_value
         end
       end
-
-      attr_reader :original_attributes
     end
   end
 end

--- a/lib/vets/model/dirty.rb
+++ b/lib/vets/model/dirty.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Intended to only be used with Vets::Model
+# inspired by ActiveModel::Dirty
+
+module Vets
+  module Model
+    module Dirty
+      def initialize(*args, **kwargs)
+        super(*args, **kwargs) if defined?(super)
+        @original_attributes = attribute_values.dup
+      end
+
+      def changed?
+        changes.any?
+      end
+
+      def changed
+        changes.keys
+      end
+
+      def changes
+        attribute_values.each_with_object({}) do |(key, current_value), result|
+          original_value = @original_attributes[key]
+          result[key] = [original_value, current_value] if original_value != current_value
+        end
+      end
+
+      attr_reader :original_attributes
+    end
+  end
+end

--- a/lib/vets/model/dirty.rb
+++ b/lib/vets/model/dirty.rb
@@ -12,8 +12,8 @@ module Vets
         attr_reader :original_attributes
       end
 
-      def initialize(*, **)
-        super(*, **) if defined?(super)
+      def initialize(*args, **kwargs)
+        super(*args, **kwargs) if defined?(super)
         @original_attributes = attribute_values.dup
       end
 

--- a/spec/lib/vets/model/dirty_spec.rb
+++ b/spec/lib/vets/model/dirty_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Vets::Model::Dirty do
     it 'returns a list of all changed attributes after multiple changes' do
       user.name = 'Bob'
       user.email = 'bob@example.com'
-      expect(user.changed).to match_array(['name', 'email'])
+      expect(user.changed).to match_array(%w[name email])
     end
   end
 
@@ -60,13 +60,13 @@ RSpec.describe Vets::Model::Dirty do
 
     it 'returns the changes with the original and current values when an attribute has been changed' do
       user.name = 'Bob'
-      expect(user.changes).to eq({ 'name' => ['Alice', 'Bob'] })
+      expect(user.changes).to eq({ 'name' => %w[Alice Bob] })
     end
 
     it 'returns changes for multiple attributes' do
       user.name = 'Bob'
       user.email = 'bob@example.com'
-      expect(user.changes).to include('name' => ['Alice', 'Bob'])
+      expect(user.changes).to include('name' => %w[Alice Bob])
       expect(user.changes).to include('email' => ['alice@example.com', 'bob@example.com'])
     end
 

--- a/spec/lib/vets/model/dirty_spec.rb
+++ b/spec/lib/vets/model/dirty_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'vets/model'
+require 'vets/model/dirty'
+
+RSpec.describe Vets::Model::Dirty do
+  let(:user_class) do
+    Class.new do
+      include Vets::Model
+
+      attr_accessor :name, :email
+
+      def self.attribute_set
+        %i[name email]
+      end
+    end
+  end
+
+  let(:user) { user_class.new(name: 'Alice', email: 'alice@example.com') }
+
+  describe '#changed?' do
+    it 'returns false when no changes have been made' do
+      expect(user.changed?).to eq(false)
+    end
+
+    it 'returns true when an attribute has been changed' do
+      user.name = 'Bob'
+      expect(user.changed?).to eq(true)
+    end
+
+    it 'returns false when changes are reverted back to original values' do
+      user.name = 'Bob'
+      user.name = 'Alice'
+      expect(user.changed?).to eq(false)
+    end
+  end
+
+  describe '#changed' do
+    it 'returns an empty array when no changes have been made' do
+      expect(user.changed).to eq([])
+    end
+
+    it 'returns a list of changed attributes when changes have been made' do
+      user.name = 'Bob'
+      expect(user.changed).to eq(['name'])
+    end
+
+    it 'returns a list of all changed attributes after multiple changes' do
+      user.name = 'Bob'
+      user.email = 'bob@example.com'
+      expect(user.changed).to match_array(['name', 'email'])
+    end
+  end
+
+  describe '#changes' do
+    it 'returns an empty hash when no changes have been made' do
+      expect(user.changes).to eq({})
+    end
+
+    it 'returns the changes with the original and current values when an attribute has been changed' do
+      user.name = 'Bob'
+      expect(user.changes).to eq({ 'name' => ['Alice', 'Bob'] })
+    end
+
+    it 'returns changes for multiple attributes' do
+      user.name = 'Bob'
+      user.email = 'bob@example.com'
+      expect(user.changes).to include('name' => ['Alice', 'Bob'])
+      expect(user.changes).to include('email' => ['alice@example.com', 'bob@example.com'])
+    end
+
+    it 'returns an empty hash if changes are reverted' do
+      user.name = 'Bob'
+      user.name = 'Alice'
+      expect(user.changes).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add methods for use with Vets::Model via Vets::Model::Dirty
    - `changed?`: returns an array with the name of the attributes with unsaved changes.
    - `changed`: returns true if any of the attributes has unsaved changes, false otherwise.
    - `changes`: returns a hash of changed attributes indicating their original and new values
- The changes track only the original value and the current value

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98688

## Testing done

- [ ] Manual testing
- [ ] New spec for module

## Acceptance criteria

- [ ]  Instances with Vets::Model can track changes 
- [ ]  The functionality matches methods in `Common::Base`