### PR TITLE
98848 Use `FileUtils.mv` over `File.rename` to account for external device error - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -4,7 +4,7 @@ module IvcChampva
   module Attachments
     attr_accessor :form_id, :uuid, :data
 
-    def handle_attachments(file_path)
+    def handle_attachments(file_path) # rubocop:disable Metrics/MethodLength
       file_paths = [file_path]
       attachments = get_attachments
 
@@ -28,6 +28,7 @@ module IvcChampva
           FileUtils.mv(attachment, new_file_path) # Performs a copy automatically if mv fails
         else
           File.rename(attachment, new_file_path)
+        end
 
         file_paths << new_file_path
       end

--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -22,7 +22,13 @@ module IvcChampva
                           File.join(File.dirname(attachment), new_file_name)
                         end
 
-        File.rename(attachment, new_file_path)
+        if Flipper.enabled?(:champva_pdf_decrypt, @current_user)
+          # Use FileUtils.mv to handle `Errno::EXDEV` error since encrypted PDFs
+          # get stashed in the clamav_tmp dir which is a different device on staging, apparently
+          FileUtils.mv(attachment, new_file_path) # Performs a copy automatically if mv fails
+        else
+          File.rename(attachment, new_file_path)
+
         file_paths << new_file_path
       end
 


### PR DESCRIPTION
## Summary

This PR fixes an issue regarding moving decrypted/unlocked PDFs.

When a user uploads an encrypted PDF, we call a method to unlock it that relies on `Common::FileHelpers::generate_clamav_temp_file` - this method stores the file in a `clamav_tmp` directory. This is fine when developing locally, but on staging that directory is apparently on a different device, which causes our later `File.rename` call to fail as such:

![Screenshot 2024-12-13 at 07 56 38](https://github.com/user-attachments/assets/1d67ff51-b718-48a8-be29-5b4324dede13)

To account for this, rather than using `File.rename`, the code now uses `FileUtils.mv` which should automatically fall back to a copy operation if the move fails due to being on an external device.

- Adds a new `FileUtils.mv` call behind feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98848

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

IVC CHAMPVA forms 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
