### PR TITLE
MHV-65081 Check patient_id is present before making calls

### DIFF
--- a/lib/medical_records/bb_internal/client.rb
+++ b/lib/medical_records/bb_internal/client.rb
@@ -322,6 +322,13 @@ module BBInternal
     end
 
     ##
+    # Overriding MHVSessionBasedClient's method to ensure the thread blocks if patient ID is not yet set.
+    #
+    def invalid?(session)
+      super(session) || session.patient_id.blank?
+    end
+
+    ##
     # Overriding MHVSessionBasedClient's method so we can get the patientId and store it as well.
     #
     def get_session

--- a/spec/lib/medical_records/bb_internal/client_spec.rb
+++ b/spec/lib/medical_records/bb_internal/client_spec.rb
@@ -419,4 +419,35 @@ describe BBInternal::Client do
       end
     end
   end
+
+  describe '#invalid?' do
+    let(:session_data) { OpenStruct.new(patient_id: patient_id, expired?: session_expired) }
+
+    context 'when session is expired' do
+      let(:session_expired) { true }
+      let(:patient_id) { '12345' }
+
+      it 'returns true' do
+        expect(client.send(:invalid?, session_data)).to be true
+      end
+    end
+
+    context 'when session has no patient_id' do
+      let(:session_expired) { false }
+      let(:patient_id) { nil }
+
+      it 'returns true' do
+        expect(client.send(:invalid?, session_data)).to be true
+      end
+    end
+
+    context 'when session is valid' do
+      let(:session_expired) { false }
+      let(:patient_id) { '12345' }
+
+      it 'returns false' do
+        expect(client.send(:invalid?, session_data)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- The call to retrieve images was not blocking while the authentication call was completing.
- We needed to update the block condition to check for patient_id, which is required by the images call.

## Related issue(s)

### [MHV-65081](https://jira.devops.va.gov/browse/MHV-65081) - Error on first load of images, upon refresh it works ###
<img width="520" alt="image" src="https://github.com/user-attachments/assets/fc0b671f-9061-4bc4-ac85-f16fa2dc8f40" />


## Testing done

- [x] *New code is covered by unit tests*
- Old behavior - first time calling radiology or images API would yield a 404
- To verify, start a fresh MR session and see that radiology and images API calls work on the first try

## Screenshots
Here's the call. Note that before, the radiology call would have returned a 404 as there was no patient ID.
<img width="278" alt="image" src="https://github.com/user-attachments/assets/9754e244-e0d5-4259-81aa-5488984de9fb" />


## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
