### PR TITLE
VACMS-11595, 11594: remove unused feature flippers

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -615,16 +615,9 @@ features:
     actor_type: user
     description: Send only lat/long values (no bounding box or address) to the API when querying for facilities.
     enable_in_development: true
-  facility_locator_ppms_legacy_urgent_care_to_pos_locator:
-    actor_type: user
-    description: force the legacy urgent care path to use the new POS locator
   facility_locator_predictive_location_search:
     actor_type: user
     description: Use predictive location search in the Facility Locator UI
-  facility_locator_pull_operating_status_from_lighthouse:
-    actor_type: user
-    description: A fast and dirty way to get the operating status from lighthouse
-    enable_in_development: true
   facility_locator_rails_engine:
     actor_type: user
     description: Use rails engine routes for all Facility Locator API calls


### PR DESCRIPTION
## Summary
Remove two unused feature flippers:

- `facility_locator_ppms_legacy_urgent_care_to_pos_locator`
- `facility_locator_pull_operating_status_from_lighthouse`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11594
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11595

## Testing done

- [Github-wide search for `facility_locator_ppms_legacy_urgent_care_to_pos_locator`](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+facility_locator_ppms_legacy_urgent_care_to_pos_locator&type=code) shows only one result in vets-api (other than archived/test repos)
- [Github-wide search for `facility_locator_pull_operating_status_from_lighthouse`](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+facility_locator_pull_operating_status_from_lighthouse&type=code) shows only one result in vets-api (other than archived/test repos)

Flipper Admins:

### Dev
<img width="863" alt="Screenshot 2024-12-13 at 10 04 46 AM" src="https://github.com/user-attachments/assets/ac5725a9-1969-42a1-bc34-962cc9884fa8" />
<img width="862" alt="Screenshot 2024-12-13 at 10 06 04 AM" src="https://github.com/user-attachments/assets/372b0fc1-7fa0-4161-8a8a-8ec9633c6a26" />

### Staging
<img width="862" alt="Screenshot 2024-12-13 at 10 05 00 AM" src="https://github.com/user-attachments/assets/42b0be14-9b16-4d50-aab7-6b022282c384" />
<img width="868" alt="Screenshot 2024-12-13 at 10 06 11 AM" src="https://github.com/user-attachments/assets/043027b1-2a8e-4e1e-966a-ba5b3948f21f" />

### Production
<img width="863" alt="Screenshot 2024-12-13 at 10 05 15 AM" src="https://github.com/user-attachments/assets/358cd720-5a12-4f0c-8b60-ac3f70748562" />
<img width="860" alt="Screenshot 2024-12-13 at 10 06 18 AM" src="https://github.com/user-attachments/assets/14132da5-569e-437b-8afe-17bd7068b2f6" />


