### PR TITLE
Isolate DR engine tests from main test context

### DIFF
--- a/modules/decision_reviews/spec/dr_spec_helper.rb
+++ b/modules/decision_reviews/spec/dr_spec_helper.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['RACK_ENV'] ||= 'test' # Shrine uses this to determine log levels
+require File.expand_path('../../../config/environment', __dir__)
+# Prevent database truncation if the environment is production
+abort('The Rails environment is running in production mode!') if Rails.env.production?
+require 'statsd-instrument'
+require 'statsd/instrument/matchers'
+require 'rspec/rails'
+require 'webmock/rspec'
+require 'shoulda/matchers'
+require 'support/stub_va_profile'
+require 'support/mpi/stub_mpi'
+require 'support/factory_bot'
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+# Helper function for testing changes to the global Settings object
+# Pass in the particular settings object that you want to change,
+# along with temporary values that should be set on that object.
+# For example,
+#
+# with_settings(Settings.some_group, {foo: 'temp1', bar: 'temp2'}) do
+#   expect(something).to equal(2)
+# end
+def with_settings(settings, temp_values)
+  old_settings = temp_values.keys.index_with { |k| settings[k] }
+
+  # The `Config` object doesn't support `.merge!`, so manually copy
+  # the updated values.
+  begin
+    temp_values.each do |k, v|
+      settings[k] = v
+    end
+
+    yield
+  ensure
+    old_settings.each do |k, v|
+      settings[k] = v
+    end
+  end
+end
+
+ActiveRecord::Migration.maintain_test_schema!
+
+FactoryBot::SyntaxRunner.class_eval do
+  include RSpec::Mocks::ExampleMethods
+end
+
+RSpec.configure do |config|
+  # Adding support for url_helper
+  config.include Rails.application.routes.url_helpers
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, remove the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = true
+
+  config.infer_spec_type_from_file_location!
+
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+  # arbitrary gems may also be filtered via:
+  # config.filter_gems_from_backtrace("gem name")
+
+  config.include StatsD::Instrument::Matchers
+end
+
+Gem::Deprecate.skip = true
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/modules/decision_reviews/spec/lib/v1/service_spec.rb
+++ b/modules/decision_reviews/spec/lib/v1/service_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 require 'decision_reviews/v1/service'
 
 describe DecisionReviews::V1::Service do

--- a/modules/decision_reviews/spec/sidekiq/delete_saved_claim_records_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/delete_saved_claim_records_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/sidekiq_helper'
 
 RSpec.describe DecisionReviews::DeleteSavedClaimRecordsJob, type: :job do
   subject { described_class }

--- a/modules/decision_reviews/spec/sidekiq/failure_notification_email_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/failure_notification_email_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/sidekiq_helper'
 require 'decision_review_v1/service'
 
 RSpec.describe DecisionReviews::FailureNotificationEmailJob, type: :job do

--- a/modules/decision_reviews/spec/sidekiq/form4142_submit_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/form4142_submit_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/sidekiq_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 require 'decision_reviews/v1/service'
 require 'decision_reviews/v1/helpers'
 

--- a/modules/decision_reviews/spec/sidekiq/hlr_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/hlr_status_updater_job_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require './modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs'
+require './modules/decision_reviews/spec/support/engine_shared_examples_for_status_updater_jobs'
 
 RSpec.describe DecisionReviews::HlrStatusUpdaterJob, type: :job do
   subject { described_class }

--- a/modules/decision_reviews/spec/sidekiq/nod_email_loader_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/nod_email_loader_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/sidekiq_helper'
 
 RSpec.describe DecisionReviews::NodEmailLoaderJob, type: :job do
   subject { described_class }

--- a/modules/decision_reviews/spec/sidekiq/nod_send_email_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/nod_send_email_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/sidekiq_helper'
 require 'decision_review_v1/service'
 
 RSpec.describe DecisionReviews::NodSendEmailJob, type: :job do

--- a/modules/decision_reviews/spec/sidekiq/nod_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/nod_status_updater_job_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require './modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs'
+require './modules/decision_reviews/spec/support/engine_shared_examples_for_status_updater_jobs'
 
 RSpec.describe DecisionReviews::NodStatusUpdaterJob, type: :job do
   subject { described_class }

--- a/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require './modules/decision_reviews/spec/sidekiq/engine_shared_examples_for_status_updater_jobs'
+require './modules/decision_reviews/spec/support/engine_shared_examples_for_status_updater_jobs'
 
 RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
   subject { described_class }

--- a/modules/decision_reviews/spec/sidekiq/submit_upload_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/submit_upload_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/sidekiq_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe DecisionReviews::SubmitUpload, type: :job do
   subject { described_class }

--- a/modules/decision_reviews/spec/spec_helper.rb
+++ b/modules/decision_reviews/spec/spec_helper.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Configure Rails Envinronment
-ENV['RAILS_ENV'] = 'test'
-
-require 'rspec/rails'
-
-RSpec.configure { |config| config.use_transactional_fixtures = true }

--- a/modules/decision_reviews/spec/support/engine_shared_examples_for_status_updater_jobs.rb
+++ b/modules/decision_reviews/spec/support/engine_shared_examples_for_status_updater_jobs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/sidekiq_helper'
 require 'decision_reviews/v1/service'
 
 ENGINE_SUBCLASS_INFO = {

--- a/modules/decision_reviews/spec/support/pdf_helper.rb
+++ b/modules/decision_reviews/spec/support/pdf_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'support/pdf_fill_helper'
+
+RSpec.configure do |config|
+  %i[model controller request].each do |type|
+    config.include PdfFillHelper, type:
+  end
+end

--- a/modules/decision_reviews/spec/support/sidekiq_helper.rb
+++ b/modules/decision_reviews/spec/support/sidekiq_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'sidekiq/semantic_logging'
+require 'sidekiq/error_tag'
+require 'sidekiq/testing'
+
+Sidekiq::Testing.fake!
+Sidekiq::Testing.server_middleware do |chain|
+  chain.add Sidekiq::SemanticLogging
+  chain.add SidekiqStatsInstrumentation::ServerMiddleware
+  chain.add Sidekiq::ErrorTag
+end
+
+RSpec.configure do |config|
+  config.before do
+    Sidekiq::Job.clear_all
+  end
+end

--- a/modules/decision_reviews/spec/support/vcr_helper.rb
+++ b/modules/decision_reviews/spec/support/vcr_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'support/vcr'
+require 'support/vcr_multipart_matcher_helper'
+
+VCR::MATCH_EVERYTHING = { match_requests_on: %i[method uri headers body] }.freeze
+
+module VCR
+  def self.all_matches
+    %i[method uri body]
+  end
+end
+
+VCR.configure(&:configure_rspec_metadata!)
+
+VCR.configure do |c|
+  c.before_record(:force_utf8) do |interaction|
+    interaction.response.body.force_encoding('UTF-8')
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
- don't use the general `rails_helper`
- only require test support and configuration needed by the engine
- *(Which team do you work for, does your team own the maintenance of this component?)*
- Decision Reviews, yes

## Related issue(s)

No ticket

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
The test in the DR engine were using the main app `rails_helper`. This led to some file loading and namespace collision. The goal is to isolate the engine from the main app as much as possible
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Test run without flaky failures or warnings about re-definition

## What areas of the site does it impact?
DR engine tests

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature