### PR TITLE
Add sortability to Vets::Collection

### DIFF
--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -5,9 +5,55 @@
 # sorted, filtered, or paginated.
 #
 
+require 'common/models/comparable/ascending'
+require 'common/models/comparable/descending'
+
 # This will be a replacement for Common::Collection
 module Vets
   class Collection
+    def initialize(records)
+      records = Array.wrap(records)
+      @model_class = records.first.class
 
+      unless records.all? { |record| record.is_a?(@model_class) }
+        raise ArgumentError, "All records must be instances of #{@model_class}"
+      end
+
+      @records = records.sort
+    end
+
+    def self.from_hashes(model_class, records)
+      raise ArgumentError, 'Expected an array of hashes' unless records.all? { |r| r.is_a?(Hash) }
+
+      records = records.map { |record| model_class.new(**record) }
+      new(records)
+    end
+
+    def order(clauses = {})
+      validate_sort_clauses(clauses)
+
+      @records.sort_by do |record|
+        clauses.map do |attribute, direction|
+          value = record.public_send(attribute)
+          direction == :asc ? Common::Ascending.new(value) : Common::Descending.new(value)
+        end
+      end
+    end
+
+    private
+
+    def validate_sort_clauses(clauses)
+      raise ArgumentError, "Order must have at least one sort clause" if clauses.empty?
+
+      clauses.each do |attribute, direction|
+        raise ArgumentError, "Attribute #{attribute} must be a symbol" unless attribute.is_a?(Symbol)
+
+        unless @records.first.respond_to?(attribute)
+          raise ArgumentError, "Attribute #{attribute} does not exist on the model"
+        end
+
+        raise ArgumentError, "Direction #{direction} must be :asc or :desc" unless %i[asc desc].include?(direction)
+      end
+    end
   end
 end

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -43,7 +43,7 @@ module Vets
     private
 
     def validate_sort_clauses(clauses)
-      raise ArgumentError, "Order must have at least one sort clause" if clauses.empty?
+      raise ArgumentError, 'Order must have at least one sort clause' if clauses.empty?
 
       clauses.each do |attribute, direction|
         raise ArgumentError, "Attribute #{attribute} must be a symbol" unless attribute.is_a?(Symbol)

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -4,14 +4,6 @@ require 'rails_helper'
 require 'vets/collection'
 
 RSpec.describe Vets::Collection do
-
-end
-# frozen_string_literal: true
-
-require 'rails_helper'
-require 'vets/collection'
-
-RSpec.describe Vets::Collection do
   let(:dummy_class) do
     Class.new do
       attr_accessor :name, :age
@@ -50,7 +42,7 @@ RSpec.describe Vets::Collection do
       hashes = [{ name: 'Alice', age: 30 }, { name: 'Bob', age: 25 }]
       collection = Vets::Collection.from_hashes(dummy_class, hashes)
 
-      expect(collection.instance_variable_get(:@records).map(&:name)).to eq(['Alice', 'Bob'])
+      expect(collection.instance_variable_get(:@records).map(&:name)).to eq(%w[Alice Bob])
     end
 
     it 'raises an error if any element is not a hash' do

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -6,3 +6,102 @@ require 'vets/collection'
 RSpec.describe Vets::Collection do
 
 end
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'vets/collection'
+
+RSpec.describe Vets::Collection do
+  let(:dummy_class) do
+    Class.new do
+      attr_accessor :name, :age
+
+      def initialize(name:, age:)
+        @name = name
+        @age = age
+      end
+
+      def <=>(other)
+        name <=> other.name
+      end
+    end
+  end
+
+  describe '#initialize' do
+    it 'initializes with sorted records' do
+      record1 = dummy_class.new(name: 'Bob', age: 25)
+      record2 = dummy_class.new(name: 'Alice', age: 30)
+
+      collection = Vets::Collection.new([record1, record2])
+      expect(collection.instance_variable_get(:@records)).to eq([record2, record1])
+    end
+
+    it 'raises an error if records are not all the same class' do
+      record1 = dummy_class.new(name: 'Alice', age: 30)
+      record2 = Object.new
+
+      expect { Vets::Collection.new([record1, record2]) }
+        .to raise_error(ArgumentError, "All records must be instances of #{dummy_class}")
+    end
+  end
+
+  describe '.from_hashes' do
+    it 'creates a collection from an array of hashes' do
+      hashes = [{ name: 'Alice', age: 30 }, { name: 'Bob', age: 25 }]
+      collection = Vets::Collection.from_hashes(dummy_class, hashes)
+
+      expect(collection.instance_variable_get(:@records).map(&:name)).to eq(['Alice', 'Bob'])
+    end
+
+    it 'raises an error if any element is not a hash' do
+      hashes = [{ name: 'Alice', age: 30 }, 'invalid']
+
+      expect { Vets::Collection.from_hashes(dummy_class, hashes) }
+        .to raise_error(ArgumentError, 'Expected an array of hashes')
+    end
+  end
+
+  describe '#order' do
+    let(:record1) { dummy_class.new(name: 'Alice', age: 30) }
+    let(:record2) { dummy_class.new(name: 'Bob', age: 25) }
+    let(:record3) { dummy_class.new(name: 'Charlie', age: 35) }
+    let(:record4) { dummy_class.new(name: 'David', age: 25) }
+
+    let(:collection) { Vets::Collection.new([record4, record1, record2, record3]) }
+
+    it 'returns records sorted by the specified attribute in ascending order' do
+      sorted = collection.order(name: :asc)
+      expect(sorted).to eq([record1, record2, record3, record4])
+    end
+
+    it 'returns records sorted by the specified attribute in descending order' do
+      sorted = collection.order(name: :desc)
+      expect(sorted).to eq([record4, record3, record2, record1])
+    end
+
+    it 'handles sorting by multiple attributes' do
+      sorted = collection.order(age: :asc, name: :desc)
+      expect(sorted).to eq([record4, record2, record1, record3])
+    end
+
+    it 'raises an error if an attribute is not a symbol' do
+      expect { collection.order('name' => :asc) }
+        .to raise_error(ArgumentError, 'Attribute name must be a symbol')
+    end
+
+    it 'raises an error if an attribute does not exist' do
+      expect { collection.order(nonexistent: :asc) }
+        .to raise_error(ArgumentError, 'Attribute nonexistent does not exist on the model')
+    end
+
+    it 'raises an error if the direction is invalid' do
+      expect { collection.order(name: :invalid) }
+        .to raise_error(ArgumentError, 'Direction invalid must be :asc or :desc')
+    end
+
+    it 'raises an error if no clauses are provided' do
+      expect { collection.order }
+        .to raise_error(ArgumentError, 'Order must have at least one sort clause')
+    end
+  end
+end


### PR DESCRIPTION
Note: there's a linting failure for a rails upgrade... that will be addressed in sjc-vets-collection

## Summary

- This requires Vets::Models be Sortable, but these files will be merged in a different PR
-  So it's blocked until Sortable is merged 

## Related issue(s)

- Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/99123
- Blocking PR: https://github.com/department-of-veterans-affairs/vets-api/pull/19827

## Testing done

- [ ] New tests added

## Acceptance criteria

- [ ] Copies sorting functionality of Common::Collection

