### PR TITLE
Api 42375 add person proxy target veteran

### DIFF
--- a/modules/claims_api/app/models/claims_api/veteran.rb
+++ b/modules/claims_api/app/models/claims_api/veteran.rb
@@ -68,6 +68,10 @@ module ClaimsApi
       @mpi ||= MPIData.for_user(self)
     end
 
+    def mpi_no_cache
+      MPIData.for_user(self)
+    end
+
     def mpi_record?(user_key: uuid)
       mpi&.mvi_response(user_key:)&.ok?
     end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
- This is WIP and not meant for review, more for visibility and because I will have to hand this off

## Related issue(s)
* [API-42375](https://jira.devops.va.gov/browse/API-42375)

## Testing Notes
* Run a V1 or V2 submission.  I used 526 but anything that relies on `target_veteran` should be fair game.
* Go into redis and find the key generated (it will use the ICN of the test vet you used)
    *  `Keys *`
    * Should see something along the lines of `"mpi-profile-response:1012845028V591200"` but with your test vet's ICN
    * Print out that value (you need to remove the `participant_id` from it for testing)
        * `GET mpi-profile-response:1012845028V591200`
        * That will print out a string, copy that string and remove the `participant_id` value, should be set to `"\"\`, you can leave the `paarticipant_ids` value as is, at least for this testing.
        * Once you have removed the participant_id you can set the value again for that key using the adjusted string
            * `SET mpi-profile-response:1012845028V591200` (remember to use your test vet's ICN)
* With that in place your submission should now trigger the code to run `add_person_proxy`
    * As it currently sits this will not update the cache
    * If you log out from `/lib/common/models/concerns/cache_aside.rb` in the `cache` method you see the key being used, unless it matches the ICN for the test user it will not properly find the Redis key you want to update.
    * This is because in `/app/models/mpi_data.rb` [the value being passed in ](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/mpi_data.rb#L239)to `cache` from `add_ids` is a `user_uuid` not the ICN (log them out and verify they are not matching).
        * *That is kind of the point of failure here* since it will not update the redis cache.  However, if you hard code your vet ICN in as the `key` in cache and run this code you will be able to go back in and then see that the redis cache does get updated and has the `participant_id`.   You can also change the argument in the `cache` method and in place of `user_uuid` put `get_user_key`.

```mermaid
flowchart TD
    A[target_veteran.rb#build_target_veteran] --> B[mpi_data#add_person_proxy]
    B[mpi_data#add_person_proxy] --> C[mpi_data#add_ids]
    C[mpi_data#add_ids] --> |The _key_ argument sent here from add_ids to cache is *ssn*, needs to be *participant_id* to properly update the Redis cache correctly| D[cache_aside#cache]
    D[cache_aside#cache] --> |Where the Redis Cache gets updated| E[cache_aside#set_attribute]
```

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
