### PR TITLE
MHV-65160 Handle missing EDIPI

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/medical_records/military_service_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/military_service_controller.rb
@@ -12,9 +12,7 @@ module MyHealth
         # @return [String] military service record in text format
         #
         def index
-          if @current_user.nil? || @current_user.edipi.blank?
-            raise MissingEdipiError, 'No EDIPI found for the current user'
-          end
+          raise MissingEdipiError, 'No EDIPI found for the current user' if @current_user.edipi.blank?
 
           resource = phrmgr_client.get_military_service(@current_user.edipi)
           render json: resource.to_json

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/military_service_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/military_service_controller.rb
@@ -4,11 +4,22 @@ module MyHealth
   module V1
     module MedicalRecords
       class MilitaryServiceController < MrController
-        # Gets a user's military service record
+        class MissingEdipiError < StandardError; end
+
+        ##
+        # Get a user's military service record
+        #
         # @return [String] military service record in text format
+        #
         def index
+          if @current_user.nil? || @current_user.edipi.blank?
+            raise MissingEdipiError, 'No EDIPI found for the current user'
+          end
+
           resource = phrmgr_client.get_military_service(@current_user.edipi)
           render json: resource.to_json
+        rescue MissingEdipiError => e
+          render json: { error: e }, status: :bad_request
         end
       end
     end


### PR DESCRIPTION
## Summary

- A user might be missing an EDIPI. If this is the case, return an informative error to the frontend so it can be handled there.

## Related issue(s)

### [MHV-65160](https://jira.devops.va.gov/browse/MHV-65160) - Resolve appointments/Military service call issues ###

## Testing done

- [ ] *New code is covered by unit tests*
- User without an EDIPI would get a 404 error because the upstream API was called without the URL param.
- To verify, see that a call to the military service API returns an informative 400 or a 200 in normal scenarios.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
