### PR TITLE
API-42308-prevent-wsdl-call-fix

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -108,7 +108,7 @@ module ClaimsApi
       ##
       # EBenefitsBnftClaimStatusWebServiceBean
       #
-      module EBenefitsBnftClaimStatusWebService
+      module EBenefitsBenefitClaimStatusWebServiceBean
         DEFINITION =
           Bean.new(
             path: 'EBenefitsBnftClaimStatusWebServiceBean',
@@ -116,6 +116,14 @@ module ClaimsApi
               target: 'http://claimstatus.services.ebenefits.vba.va.gov/',
               data: nil
             )
+          )
+      end
+
+      module EBenefitsBenefitClaimStatusWebService
+        DEFINITION =
+          Service.new(
+            bean: EBenefitsBenefitClaimStatusWebServiceBean::DEFINITION,
+            path: 'EBenefitsBnftClaimStatusWebService'
           )
       end
 


### PR DESCRIPTION
## Summary
* Reverts some changes made to the definitions file to avoid Calling for the WSDL when making a request to the 
EBenefitsBnftClaimStatusWebServiceBean/EBenefitsBnftClaimStatusWebService

## Related issue(s)
[API-43374](https://jira.devops.va.gov/browse/API-43374)

## Testing done
* V2 Claims Index hit can be used to test, but anything that uses `find_benefit_claims_status_by_ptcpnt_id` should be good.  Then watch the log out
* What we _do not_ want to see is the WSDL get call in the logout like below
<img width="1065" alt="Screenshot 2024-12-13 at 3 26 38 PM" src="https://github.com/user-attachments/assets/20a13cb3-c304-45ab-b996-610d49f090b6" />

* What we do want to see
<img width="1070" alt="Screenshot 2024-12-13 at 3 27 23 PM" src="https://github.com/user-attachments/assets/6e9892da-e7e9-4005-a873-4fc2f340a1d2" />


## What areas of the site does it impact?
modified:   modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
