### PR TITLE
96446 add EPS get provider slots method

### DIFF
--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -34,5 +34,38 @@ module Eps
 
       OpenStruct.new(response.body)
     end
+
+    # Retrieves available slots for a specific provider.
+    #
+    # @param provider_id [String] The unique identifier of the provider
+    # @param opts [Hash] Optional parameters for the request
+    # @option opts [String] :nextToken Token for pagination of results
+    # @option opts [String] :appointmentTypeId Required if nextToken is not provided. The type of appointment
+    # @option opts [String] :startOnOrAfter Required if nextToken is not provided. Start of the time range
+    #   (ISO 8601 format)
+    # @option opts [String] :startBefore Required if nextToken is not provided. End of the time range
+    #   (ISO 8601 format)
+    # @option opts [Hash] Additional optional parameters will be passed through to the request
+    #
+    # @raise [ArgumentError] If nextToken is not provided and any of appointmentTypeId, startOnOrAfter, or
+    #   startBefore are missing
+    #
+    # @return [OpenStruct] Response containing available slots
+    #
+    def get_provider_slots(provider_id, opts = {})
+      params = if opts[:nextToken]
+                 { nextToken: opts[:nextToken] }
+               else
+                 required_params = %i[appointmentTypeId startOnOrAfter startBefore]
+                 missing_params = required_params - opts.keys
+
+                 raise ArgumentError, "Missing required parameters: #{missing_params.join(', ')}" if missing_params.any?
+
+                 opts
+               end
+
+      response = perform(:get, "/#{config.base_path}/provider-services/#{provider_id}/slots", params, headers)
+      OpenStruct.new(response.body)
+    end
   end
 end

--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -53,6 +53,8 @@ module Eps
     # @return [OpenStruct] Response containing available slots
     #
     def get_provider_slots(provider_id, opts = {})
+      raise ArgumentError, 'provider_id is required and cannot be blank' if provider_id.blank?
+
       params = if opts[:nextToken]
                  { nextToken: opts[:nextToken] }
                else

--- a/modules/vaos/spec/services/eps/provider_service_spec.rb
+++ b/modules/vaos/spec/services/eps/provider_service_spec.rb
@@ -125,4 +125,100 @@ describe Eps::ProviderService do
       end
     end
   end
+
+  describe '#get_provider_slots' do
+    let(:provider_id) { '9mN718pH' }
+    let(:required_params) do
+      {
+        appointmentTypeId: 'type123',
+        startOnOrAfter: '2024-01-01T00:00:00Z',
+        startBefore: '2024-01-02T00:00:00Z'
+      }
+    end
+    let(:valid_response) do
+      double('Response', status: 200, body: { count: 1,
+                                              slots: [
+                                                { id: 'slot1', providerServiceId: '9mN718pH' },
+                                                { id: 'slot2', providerServiceId: '9mN718pH' }
+                                              ] })
+    end
+
+    context 'when nextToken is provided' do
+      it 'makes request with nextToken parameter' do
+        next_token = 'token123'
+        expect_any_instance_of(VAOS::SessionService).to receive(:perform)
+          .with(:get, "/#{config.base_path}/provider-services/#{provider_id}/slots", { nextToken: next_token }, headers)
+          .and_return(OpenStruct.new(valid_response.body))
+
+        service.get_provider_slots(provider_id, nextToken: next_token)
+      end
+    end
+
+    context 'when required and additional parameters are provided' do
+      it 'makes request with all parameters' do
+        params_with_extra = required_params.merge(appointmentId: 'id123')
+
+        expect_any_instance_of(VAOS::SessionService).to receive(:perform)
+          .with(:get, "/#{config.base_path}/provider-services/#{provider_id}/slots", params_with_extra, headers)
+          .and_return(valid_response)
+
+        service.get_provider_slots(provider_id, params_with_extra)
+      end
+    end
+
+    context 'when required parameters are missing' do
+      it 'raises ArgumentError when appointmentTypeId is missing' do
+        expect do
+          service.get_provider_slots(provider_id, required_params.except(:appointmentTypeId))
+        end.to raise_error(ArgumentError, /Missing required parameters: appointmentTypeId/)
+      end
+
+      it 'raises ArgumentError when startOnOrAfter is missing' do
+        expect do
+          service.get_provider_slots(provider_id, required_params.except(:startOnOrAfter))
+        end.to raise_error(ArgumentError, /Missing required parameters: startOnOrAfter/)
+      end
+
+      it 'raises ArgumentError when startBefore is missing' do
+        expect do
+          service.get_provider_slots(provider_id, required_params.except(:startBefore))
+        end.to raise_error(ArgumentError, /Missing required parameters: startBefore/)
+      end
+
+      it 'raises ArgumentError when multiple required parameters are missing' do
+        expect do
+          service.get_provider_slots(provider_id, required_params.except(:startOnOrAfter, :startBefore))
+        end.to raise_error(ArgumentError, /Missing required parameters: startOnOrAfter, startBefore/)
+      end
+    end
+
+    context 'when required parameters are provided and request is successful' do
+      before do
+        allow_any_instance_of(VAOS::SessionService).to receive(:perform).and_return(valid_response)
+      end
+
+      it 'returns an OpenStruct with the response body' do
+        result = service.get_provider_slots(provider_id, required_params)
+
+        expect(result).to eq(OpenStruct.new(valid_response.body))
+      end
+    end
+
+    context 'when the request fails' do
+      let(:response) { double('Response', status: 500, body: 'Unknown service exception') }
+      let(:exception) do
+        Common::Exceptions::BackendServiceException.new(nil, {}, response.status, response.body)
+      end
+
+      before do
+        allow_any_instance_of(VAOS::SessionService).to receive(:perform).and_raise(exception)
+      end
+
+      it 'raises an error' do
+        expect do
+          service.get_provider_slots(provider_id, required_params)
+        end.to raise_error(Common::Exceptions::BackendServiceException, /VA900/)
+      end
+    end
+  end
 end

--- a/modules/vaos/spec/services/eps/provider_service_spec.rb
+++ b/modules/vaos/spec/services/eps/provider_service_spec.rb
@@ -143,6 +143,26 @@ describe Eps::ProviderService do
                                               ] })
     end
 
+    context 'when provider_id is invalid' do
+      it 'raises ArgumentError when provider_id is nil' do
+        expect do
+          service.get_provider_slots(nil, nextToken: 'token123')
+        end.to raise_error(ArgumentError, 'provider_id is required and cannot be blank')
+      end
+
+      it 'raises ArgumentError when provider_id is empty' do
+        expect do
+          service.get_provider_slots('', nextToken: 'token123')
+        end.to raise_error(ArgumentError, 'provider_id is required and cannot be blank')
+      end
+
+      it 'raises ArgumentError when provider_id is blank' do
+        expect do
+          service.get_provider_slots('   ', nextToken: 'token123')
+        end.to raise_error(ArgumentError, 'provider_id is required and cannot be blank')
+      end
+    end
+
     context 'when nextToken is provided' do
       it 'makes request with nextToken parameter' do
         next_token = 'token123'


### PR DESCRIPTION
## Summary

This PR adds a method to get the provider slots based on the parameters provided. If nextToken is provided, it is used to fetch the slots. If not, other parameters are passed as is to the underlying wellhive api method, and results are returned.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/96446

## Testing done
- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
