### PR TITLE
Stamp watermark on PDF uploaded with Form Upload Flow

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -29,6 +29,9 @@ module SimpleFormsApi
 
       def upload_response
         file_path = find_attachment_path(params[:confirmation_code])
+        stamper = PdfStamper.new(stamped_template_path: file_path, current_loa: @current_user.loa[:current],
+                                 timestamp: Time.current)
+        stamper.stamp_pdf
         metadata = validated_metadata
         status, confirmation_number = upload_pdf(file_path, metadata)
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -7,6 +7,7 @@ module SimpleFormsApi
     attr_reader :stamped_template_path, :form, :loa, :timestamp
 
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
+    FORM_UPLOAD_SUBMISSION_TEXT = 'Submitted via VA.gov at '
 
     def initialize(stamped_template_path:, form: nil, current_loa: nil, timestamp: nil)
       @stamped_template_path = stamped_template_path
@@ -148,18 +149,30 @@ module SimpleFormsApi
     def get_auth_text_stamp
       current_time = "#{Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S')} "
       coords = [10, 10]
-      text = SUBMISSION_TEXT + current_time
+      submission_text = form ? SUBMISSION_TEXT : FORM_UPLOAD_SUBMISSION_TEXT
+      text = submission_text + current_time
       { coords:, text: }
     end
 
     def auth_text
-      case loa
-      when 3
-        'Signee signed with an identity-verified account.'
-      when 2
-        'Signee signed in but hasn’t verified their identity.'
+      if form
+        case loa
+        when 3
+          'Signee signed with an identity-verified account.'
+        when 2
+          'Signee signed in but hasn’t verified their identity.'
+        else
+          'Signee not signed in.'
+        end
       else
-        'Signee not signed in.'
+        case loa
+        when 3
+          'Signed in and submitted with an identity-verified account.'
+        when 2
+          'Signed in and submitted but has not verified their identity.'
+        else
+          'Signee not signed in.'
+        end
       end
     end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -8,7 +8,7 @@ module SimpleFormsApi
 
     SUBMISSION_TEXT = 'Signed electronically and submitted via VA.gov at '
 
-    def initialize(stamped_template_path:, form:, current_loa: nil, timestamp: nil)
+    def initialize(stamped_template_path:, form: nil, current_loa: nil, timestamp: nil)
       @stamped_template_path = stamped_template_path
       @form = form
       @loa = current_loa
@@ -45,7 +45,7 @@ module SimpleFormsApi
     end
 
     def all_form_stamps
-      form.desired_stamps + form.submission_date_stamps(timestamp)
+      form ? form.desired_stamps + form.submission_date_stamps(timestamp) : []
     end
 
     def stamp_form(desired_stamp)

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
     let(:metadata_file) { "#{file_seed}.SimpleFormsApi.metadata.json" }
     let(:file_seed) { 'tmp/some-unique-simple-forms-file-seed' }
     let(:random_string) { 'some-unique-simple-forms-file-seed' }
+    let(:pdf_path) { Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf') }
+    let(:pdf_stamper) { double(stamp_pdf: nil) }
+    let(:confirmation_code) { 'a-random-guid' }
+    let(:attachment) { double }
 
     before do
       VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
@@ -21,6 +25,10 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
       allow(Common::FileHelpers).to receive(:generate_clamav_temp_file).and_wrap_original do |original_method, *args|
         original_method.call(args[0], random_string)
       end
+      allow(SimpleFormsApi::PdfStamper).to receive(:new).with(stamped_template_path: pdf_path.to_s, current_loa: 3,
+                                                              timestamp: anything).and_return(pdf_stamper)
+      allow(attachment).to receive(:to_pdf).and_return(pdf_path)
+      allow(PersistentAttachment).to receive(:find_by).with(guid: confirmation_code).and_return(attachment)
     end
 
     after do
@@ -30,11 +38,15 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
     end
 
     it 'makes the request' do
-      pdf_path = Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf')
-      confirmation_code = 'a-random-guid'
-      attachment = double
-      allow(attachment).to receive(:to_pdf).and_return(pdf_path)
       expect(PersistentAttachment).to receive(:find_by).with(guid: confirmation_code).and_return(attachment)
+
+      post '/simple_forms_api/v1/submit_scanned_form', params: { form_number: '21-0779', confirmation_code: }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'stamps the pdf' do
+      expect(pdf_stamper).to receive(:stamp_pdf)
 
       post '/simple_forms_api/v1/submit_scanned_form', params: { form_number: '21-0779', confirmation_code: }
 

--- a/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
+++ b/modules/simple_forms_api/spec/services/pdf_stamper_spec.rb
@@ -66,6 +66,25 @@ describe SimpleFormsApi::PdfStamper do
           expect(File).to have_received(:rename).with(current_file_path, path)
         end
       end
+
+      context 'form is not specified' do
+        let(:instance) { described_class.new(stamped_template_path: path, current_loa: 3, timestamp: nil) }
+        let(:datestamp_instance) { double(run: 'current-file-path') }
+
+        before do
+          allow(File).to receive(:rename)
+          allow(File).to receive(:size).and_return(0, 1)
+          allow(PDFUtilities::DatestampPdf).to receive(:new).and_return(datestamp_instance)
+        end
+
+        it 'does not call stamp_form' do
+          allow(instance).to receive(:stamp_form)
+
+          instance.stamp_pdf
+
+          expect(instance).not_to have_received(:stamp_form)
+        end
+      end
     end
 
     describe 'stamping the authentication text' do


### PR DESCRIPTION
## Summary
This PR stamps a watermark at the bottom of a PDF uploaded through the Form Upload flow.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=83134526&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1473

## Screenshots
<img width="1106" alt="Screenshot 2024-12-17 at 10 35 07 AM" src="https://github.com/user-attachments/assets/78d25be0-9798-4591-9785-ccd630ee9dd1" />

