### PR TITLE
dbex/97932-claims-api: set claims api only

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -122,7 +122,7 @@ module V0
         saved_claim_id: saved_claim.id,
         auth_headers_json: auth_headers.to_json,
         form_json: saved_claim.to_submission_data(@current_user),
-        submit_endpoint: includes_toxic_exposure? ? 'claims_api' : 'evss'
+        submit_endpoint: 'claims_api'
       ) { |sub| sub.add_birls_ids @current_user.birls_id }
 
       if missing_disabilities?(submission)
@@ -159,11 +159,6 @@ module V0
 
     def stats_key
       'api.disability_compensation'
-    end
-
-    def includes_toxic_exposure?
-      # any form that has a startedFormVersion (whether it is '2019' or '2022') will go through the Toxic Exposure flow
-      form_content['form526']['startedFormVersion']
     end
 
     def missing_disabilities?(submission)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- all submissions go through lighthouse

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97932

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

