### PR TITLE
API-42933-vnp-ptcpnt-phone-standardization 

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -509,15 +509,6 @@ module ClaimsApi
             bean: VnpPtcpntPhoneWebServiceBean::DEFINITION,
             path: 'VnpPtcpntPhoneService'
           )
-
-        module FindPersonBySSN
-          DEFINITION =
-            Action.new(
-              service: VnpPtcpntPhoneService::DEFINITION,
-              name: 'vnpPtcpntPhoneCreate',
-              key: 'return'
-            )
-        end
       end
 
       ##
@@ -540,15 +531,6 @@ module ClaimsApi
             bean: VnpPtcpntWebServiceBean::DEFINITION,
             path: 'VnpPtcpntService'
           )
-
-        module VnpPtcpntCreate
-          DEFINITION =
-            Action.new(
-              service: VnpPtcpntService::DEFINITION,
-              name: 'vnpPtcpntCreate',
-              key: 'return'
-            )
-        end
       end
     end
   end

--- a/modules/claims_api/spec/lib/claims_api/find_definition_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/find_definition_spec.rb
@@ -114,34 +114,6 @@ describe ClaimsApi::LocalBGSRefactored::FindDefinition do
           expect(parsed_result['service']['bean']['namespaces']['target']).to eq 'http://ptcpntAddrsService.services.vonapp.vba.va.gov/'
         end
       end
-
-      context 'VnpPtcpntPhoneWebServiceBean' do
-        let(:endpoint) { 'VnpPtcpntPhoneWebServiceBean/VnpPtcpntPhoneService' }
-        let(:action) { 'vnpPtcpntPhoneCreate' }
-        let(:key) { 'return' }
-
-        it 'response with the correct attributes' do
-          result = subject.for_action(endpoint, action)
-          parsed_result = JSON.parse(result.to_json)
-          expect(parsed_result['service']['bean']['path']).to eq 'VnpPtcpntPhoneWebServiceBean'
-          expect(parsed_result['service']['path']).to eq 'VnpPtcpntPhoneService'
-          expect(parsed_result['service']['bean']['namespaces']['target']).to eq 'http://ptcpntPhoneService.services.vonapp.vba.va.gov/'
-        end
-      end
-
-      context 'VnpPtcpntWebServiceBean' do
-        let(:endpoint) { 'VnpPtcpntWebServiceBean/VnpPtcpntService' }
-        let(:action) { 'vnpPtcpntCreate' }
-        let(:key) { 'return' }
-
-        it 'response with the correct attributes' do
-          result = subject.for_action(endpoint, action)
-          parsed_result = JSON.parse(result.to_json)
-          expect(parsed_result['service']['bean']['path']).to eq 'VnpPtcpntWebServiceBean'
-          expect(parsed_result['service']['path']).to eq 'VnpPtcpntService'
-          expect(parsed_result['service']['bean']['namespaces']['target']).to eq 'http://ptcpntService.services.vonapp.vba.va.gov/'
-        end
-      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Removes actions from the definitions file for vnpPtcpntPhone and vnpPtcpnt. 
- Removes the corresponding tests in the find_defintions_spec.

## Related issue(s)

- [API-42933](https://jira.devops.va.gov/browse/API-42933)
- [API-42933](https://jira.devops.va.gov/browse/API-42933)

## Testing done

- [x] {{uri}}/services/claims/v2/veterans/{{veteran_id}}/power-of-attorney-request in dev
- [ ] {{uri}}/services/claims/v2/veterans/{{veteran_id}}/power-of-attorney-request in staging


## What areas of the site does it impact?
	modified:   modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
	modified:   modules/claims_api/spec/lib/claims_api/find_definition_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature