### PR TITLE
[10-10CG] Add callbacks to VANotify usage in 10-10CG Submission Job

### DIFF
--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -73,8 +73,6 @@ module Form1010cg
           return
         end
 
-        StatsD.increment('silent_failure_avoided', tags: DD_ZSF_TAGS)
-
         parsed_form = claim.parsed_form
         first_name = parsed_form.dig('veteran', 'fullName', 'first')
         email = parsed_form.dig('veteran', 'email')

--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -5,10 +5,23 @@ require 'sidekiq/monitored_worker'
 module Form1010cg
   class SubmissionJob
     STATSD_KEY_PREFIX = "#{Form1010cg::Auditor::STATSD_KEY_PREFIX}.async.".freeze
+    SERVICE = 'caregiver-application'
+    FUNCTION_NAME = '10-10CG async form submission'
+
     DD_ZSF_TAGS = [
-      'caregiver-application',
-      'function: 10-10CG async form submission'
+      SERVICE,
+      "function: #{FUNCTION_NAME}"
     ].freeze
+
+    CALLBACK_METADATA = {
+      callback_metadata: {
+        notification_type: 'error',
+        form_number: '10-10CG',
+        statsd_tags: { service: SERVICE,
+                       function: FUNCTION_NAME }
+      }
+    }.freeze
+
     include Sidekiq::Job
     include Sidekiq::MonitoredWorker
     include SentryLogging
@@ -19,7 +32,6 @@ module Form1010cg
 
     sidekiq_retries_exhausted do |msg, _e|
       StatsD.increment("#{STATSD_KEY_PREFIX}failed_no_retries_left", tags: ["claim_id:#{msg['args'][0]}"])
-      StatsD.increment('silent_failure_avoided_no_confirmation', tags: DD_ZSF_TAGS)
 
       claim = SavedClaim::CaregiversAssistanceClaim.find(msg['args'][0])
       send_failure_email(claim)
@@ -49,8 +61,6 @@ module Form1010cg
       end
     rescue CARMA::Client::MuleSoftClient::RecordParseError
       StatsD.increment("#{STATSD_KEY_PREFIX}record_parse_error", tags: ["claim_id:#{claim_id}"])
-      StatsD.increment('silent_failure_avoided_no_confirmation', tags: DD_ZSF_TAGS)
-
       self.class.send_failure_email(claim)
     rescue => e
       log_exception_to_sentry(e)
@@ -59,25 +69,40 @@ module Form1010cg
       raise
     end
 
-    def self.send_failure_email(claim)
-      return unless Flipper.enabled?(:caregiver_use_va_notify_on_submission_failure)
-      return unless claim.parsed_form.dig('veteran', 'email')
+    class << self
+      def send_failure_email(claim)
+        unless can_send_failure_email?(claim)
+          StatsD.increment('silent_failure_avoided_no_confirmation', tags: DD_ZSF_TAGS)
+          return
+        end
 
-      parsed_form = claim.parsed_form
-      first_name = parsed_form.dig('veteran', 'fullName', 'first')
-      email = parsed_form.dig('veteran', 'email')
-      template_id = Settings.vanotify.services.health_apps_1010.template_id.form1010_cg_failure_email
-      api_key = Settings.vanotify.services.health_apps_1010.api_key
-      salutation = first_name ? "Dear #{first_name}," : ''
+        StatsD.increment('silent_failure_avoided', tags: DD_ZSF_TAGS)
 
-      VANotify::EmailJob.perform_async(
-        email,
-        template_id,
-        { 'salutation' => salutation },
-        api_key
-      )
+        parsed_form = claim.parsed_form
+        first_name = parsed_form.dig('veteran', 'fullName', 'first')
+        email = parsed_form.dig('veteran', 'email')
+        template_id = Settings.vanotify.services.health_apps_1010.template_id.form1010_cg_failure_email
+        api_key = Settings.vanotify.services.health_apps_1010.api_key
+        salutation = first_name ? "Dear #{first_name}," : ''
 
-      StatsD.increment("#{STATSD_KEY_PREFIX}submission_failure_email_sent")
+        VANotify::EmailJob.perform_async(
+          email,
+          template_id,
+          { 'salutation' => salutation },
+          api_key,
+          CALLBACK_METADATA
+        )
+
+        StatsD.increment("#{STATSD_KEY_PREFIX}submission_failure_email_sent")
+      end
+
+      private
+
+      def can_send_failure_email?(claim)
+        Flipper.enabled?(:caregiver_use_va_notify_on_submission_failure) && claim.parsed_form.dig(
+          'veteran', 'email'
+        )
+      end
     end
   end
 end

--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -5,20 +5,17 @@ require 'sidekiq/monitored_worker'
 module Form1010cg
   class SubmissionJob
     STATSD_KEY_PREFIX = "#{Form1010cg::Auditor::STATSD_KEY_PREFIX}.async.".freeze
-    SERVICE = 'caregiver-application'
-    FUNCTION_NAME = '10-10CG async form submission'
 
     DD_ZSF_TAGS = [
-      SERVICE,
-      "function: #{FUNCTION_NAME}"
+      'service:caregiver-application',
+      'function: 10-10CG async form submission'
     ].freeze
 
     CALLBACK_METADATA = {
       callback_metadata: {
         notification_type: 'error',
         form_number: '10-10CG',
-        statsd_tags: { service: SERVICE,
-                       function: FUNCTION_NAME }
+        statsd_tags: DD_ZSF_TAGS
       }
     }.freeze
 
@@ -72,7 +69,7 @@ module Form1010cg
     class << self
       def send_failure_email(claim)
         unless can_send_failure_email?(claim)
-          StatsD.increment('silent_failure_avoided_no_confirmation', tags: DD_ZSF_TAGS)
+          StatsD.increment('silent_failure', tags: DD_ZSF_TAGS)
           return
         end
 

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Form1010cg::SubmissionJob do
               "#{statsd_key_prefix}failed_no_retries_left",
               tags: ["claim_id:#{claim.id}"]
             )
-            expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: zsf_tags)
+            expect(StatsD).to receive(:increment).with('silent_failure', tags: zsf_tags)
             expect(VANotify::EmailJob).not_to receive(:perform_async)
           end
         end
@@ -118,7 +118,7 @@ RSpec.describe Form1010cg::SubmissionJob do
               "#{statsd_key_prefix}failed_no_retries_left",
               tags: ["claim_id:#{claim.id}"]
             )
-            expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: zsf_tags)
+            expect(StatsD).to receive(:increment).with('silent_failure', tags: zsf_tags)
             expect(VANotify::EmailJob).not_to receive(:perform_async)
           end
         end
@@ -142,7 +142,7 @@ RSpec.describe Form1010cg::SubmissionJob do
             callback_metadata: {
               notification_type: 'error',
               form_number: claim.form_id,
-              statsd_tags: { service: 'caregiver-application', function: '10-10CG async form submission' }
+              statsd_tags: zsf_tags
             }
           }
         ]
@@ -253,7 +253,7 @@ RSpec.describe Form1010cg::SubmissionJob do
             expect do
               job.perform(claim.id)
             end.to trigger_statsd_increment('api.form1010cg.async.record_parse_error', tags: ["claim_id:#{claim.id}"])
-              .and trigger_statsd_increment('silent_failure_avoided_no_confirmation', tags: zsf_tags)
+              .and trigger_statsd_increment('silent_failure', tags: zsf_tags)
 
             expect(SavedClaim.exists?(id: claim.id)).to eq(true)
             expect(VANotify::EmailJob).not_to receive(:perform_async)
@@ -274,7 +274,7 @@ RSpec.describe Form1010cg::SubmissionJob do
           expect do
             job.perform(claim.id)
           end.to trigger_statsd_increment('api.form1010cg.async.record_parse_error', tags: ["claim_id:#{claim.id}"])
-            .and trigger_statsd_increment('silent_failure_avoided_no_confirmation', tags: zsf_tags)
+            .and trigger_statsd_increment('silent_failure', tags: zsf_tags)
 
           expect(SavedClaim.exists?(id: claim.id)).to eq(true)
           expect(VANotify::EmailJob).not_to receive(:perform_async)

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -137,7 +137,14 @@ RSpec.describe Form1010cg::SubmissionJob do
           {
             'salutation' => "Dear #{claim.parsed_form.dig('veteran', 'fullName', 'first')},"
           },
-          api_key
+          api_key,
+          {
+            callback_metadata: {
+              notification_type: 'error',
+              form_number: claim.form_id,
+              statsd_tags: { service: 'caregiver-application', function: '10-10CG async form submission' }
+            }
+          }
         ]
       end
 
@@ -230,7 +237,7 @@ RSpec.describe Form1010cg::SubmissionJob do
               tags: ["claim_id:#{claim.id}"]
             )
             expect(StatsD).to receive(:increment).with(
-              'silent_failure_avoided_no_confirmation', tags: zsf_tags
+              'silent_failure_avoided', tags: zsf_tags
             )
 
             job.perform(claim.id)

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -236,9 +236,6 @@ RSpec.describe Form1010cg::SubmissionJob do
               "#{statsd_key_prefix}record_parse_error",
               tags: ["claim_id:#{claim.id}"]
             )
-            expect(StatsD).to receive(:increment).with(
-              'silent_failure_avoided', tags: zsf_tags
-            )
 
             job.perform(claim.id)
           end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Added callbacks to the VANotify implementation for submission failure emails to update statsD metrics with email delivery status information. We are using the default implementation from the VANotify team. Also updated which metrics are incremented when we have a submission that does not have an email or the flipper toggle is turned off.
- Sending the email is still behind the `caregiver_use_va_notify_on_submission_failure` toggle.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95342

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
none

## What areas of the site does it impact?
10-10CG Submission Job

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

