### PR TITLE
[96836] Appoint a Rep prefill fixups

### DIFF
--- a/app/models/form_profiles/va_2122.rb
+++ b/app/models/form_profiles/va_2122.rb
@@ -22,7 +22,7 @@ class FormProfiles::VA2122 < FormProfile
     {
       version: 0,
       prefill: true,
-      returnUrl: '/claimant-information'
+      returnUrl: '/claimant-type'
     }
   end
 

--- a/app/models/form_profiles/va_2122a.rb
+++ b/app/models/form_profiles/va_2122a.rb
@@ -22,7 +22,7 @@ class FormProfiles::VA2122a < FormProfile
     {
       version: 0,
       prefill: true,
-      returnUrl: '/claimant-information'
+      returnUrl: '/claimant-type'
     }
   end
 

--- a/config/form_profile_mappings/21-22.yml
+++ b/config/form_profile_mappings/21-22.yml
@@ -11,7 +11,6 @@ militaryInformation:
   serviceDateRange:
     from: [military_information, last_entry_date]
     to: [military_information, last_discharge_date]
-vaFileNumber: [veteran_information, va_file_number]
 identityValidation:
   hasICN: [identity_validation, has_icn]
   hasParticipantId: [identity_validation, has_participant_id]

--- a/config/form_profile_mappings/21-22A.yml
+++ b/config/form_profile_mappings/21-22A.yml
@@ -11,7 +11,6 @@ militaryInformation:
   serviceDateRange:
     from: [military_information, last_entry_date]
     to: [military_information, last_discharge_date]
-vaFileNumber: [veteran_information, va_file_number]
 identityValidation:
   hasICN: [identity_validation, has_icn]
   hasParticipantId: [identity_validation, has_participant_id]


### PR DESCRIPTION
## Summary

- This pr fixes the default return url for Appoint a Rep prefill
- This pr removes incorrect prefill attributes

## Related issue(s)

- [96836](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96836)

## Testing done

- [x] *New code is covered by unit tests*
- Prefill with vets-website running locally is working

## What areas of the site does it impact?
Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature