### PR TITLE
[VI-910] Adding route to store user-input emails as a prerequisite for accessing MHV test accounts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -138,6 +138,7 @@ app/controllers/v0/search_controller.rb @department-of-veterans-affairs/va-api-e
 app/controllers/v0/search_typeahead_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/sign_in_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/terms_of_use_agreements_controller.rb @department-of-veterans-affairs/octo-identity
+app/controllers/v0/test_account_user_emails_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/trackings_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/triage_teams_controller.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/upload_supporting_evidences_controller.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1733,6 +1734,7 @@ spec/requests/v0/caregivers_assistance_claims_spec.rb @department-of-veterans-af
 spec/requests/v0/claim_documents_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/debts_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/disability_compensation_form_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/requests/v0/test_account_user_emails_spec.rb @department-of-veterans-affairs/octo-identity
 spec/requests/v1/higher_level_reviews @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 spec/requests/v1/notice_of_disagreements @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 spec/requests/v1/supplemental_claims @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/test_account_user_emails_controller.rb
+++ b/app/controllers/v0/test_account_user_emails_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V0
+  class TestAccountUserEmailsController < ApplicationController
+    service_tag 'identity'
+    skip_before_action :authenticate
+
+    NAMESPACE = 'test_account_user_email'
+    TTL = 2_592_000
+
+    def create
+      email_redis_key = SecureRandom.uuid
+      Rails.cache.write(email_redis_key, create_params, namespace: NAMESPACE, expires_in: TTL)
+
+      Rails.logger.info("[V0][TestAccountUserEmailsController] create, key:#{email_redis_key}")
+
+      render json: { test_account_user_email_uuid: email_redis_key }, status: :created
+    rescue
+      render json: { errors: 'invalid params' }, status: :bad_request
+    end
+
+    def create_params
+      params.require(:email)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,8 @@ Rails.application.routes.draw do
       resource :mhv_user_account, only: [:show], controller: 'user/mhv_user_accounts'
     end
 
+    resource :test_account_user_email, only: [:create]
+
     resource :veteran_onboarding, only: %i[show update]
 
     resource :education_benefits_claims, only: %i[create show] do

--- a/spec/requests/v0/test_account_user_emails_spec.rb
+++ b/spec/requests/v0/test_account_user_emails_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'V0::TestAccountUserEmails', type: :request do
+  describe 'POST #create' do
+    subject { post '/v0/test_account_user_email', params: }
+
+    let(:email) { 'some-email' }
+    let(:email_redis_key) { 'some-email-redis-key' }
+    let(:params) { { email: email } }
+    let(:rendered_error) { { 'errors' => 'invalid params' } }
+
+    before do
+      allow(SecureRandom).to receive(:uuid).and_return(email_redis_key)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    shared_context 'bad_request' do
+      it 'responds with bad request status' do
+        subject
+
+        assert_response :bad_request
+      end
+
+      it 'responds with error' do
+        subject
+
+        expect(JSON.parse(response.body)).to eq(rendered_error)
+      end
+    end
+
+    context 'when params does not include email' do
+      let(:params) { { some_params: 'some-params' } }
+
+      it_behaves_like 'bad_request'
+    end
+
+    context 'when params include email' do
+      let(:params) { { email: email } }
+
+      context 'and email param is empty' do
+        let(:email) { '' }
+
+        it_behaves_like 'bad_request'
+      end
+
+      context 'and email param is not empty' do
+        let(:email) { 'some-email' }
+        let(:expected_log_message) { "[V0][TestAccountUserEmailsController] create, key:#{email_redis_key}" }
+
+        it 'responds with created status' do
+          subject
+
+          assert_response :created
+        end
+
+        it 'responds with test_account_user_email_uuid' do
+          subject
+
+          expect(JSON.parse(response.body)['test_account_user_email_uuid']).to eq(email_redis_key)
+        end
+
+        it 'makes a create log to rails logger' do
+          subject
+
+          expect(Rails.logger).to have_received(:info).with(expected_log_message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- This PR adds a route that is callable with an email parameter 

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-910

## Testing done

- [ ] Called route with email param, confirmed it stored a redis value and returned a uuid
- [ ] Called route without email param, confirmed it responded with 'bad_request'

## What areas of the site does it impact?
Test Accounts

## Acceptance criteria

- [ ] Usage is `curl -X POST localhost:3000/v0/test_account_user_email  --data-binary '{"email": "email"}'`
- [ ] You'll get an invalid CSRF token error, so you probably need to call a 'GET' route on the backend and get a CSRF token to add to the request header (this is common to POST routes on vets-api, so you can also just add to the controller: `skip_before_action :verify_authenticity_token`, and not worry about it when testing this PR)
- [ ] Attempt with `email` param, empty `email` param, and arbitrary param

