### PR TITLE
[10-10EZ] Add VANotify Callbacks to Failure email

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -259,7 +259,7 @@ class HealthCareApplication < ApplicationRecord
   end
 
   def log_async_submission_failure
-    log_zero_silent_failures
+    log_zero_silent_failures unless Flipper.enabled?(:hca_zero_silent_failures)
     StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.failed_wont_retry")
     StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.failed_wont_retry_short_form") if short_form?
     log_submission_failure_details
@@ -295,11 +295,7 @@ class HealthCareApplication < ApplicationRecord
     api_key = Settings.vanotify.services.health_apps_1010.api_key
 
     salutation = first_name ? "Dear #{first_name}," : ''
-    VANotify::EmailJob.perform_async(
-      email,
-      template_id,
-      { 'salutation' => salutation },
-      api_key,
+    metadata =
       {
         callback_metadata: {
           notification_type: 'error',
@@ -307,7 +303,11 @@ class HealthCareApplication < ApplicationRecord
           statsd_tags: DD_ZSF_TAGS
         }
       }
-    )
+
+    params = [email, template_id, { 'salutation' => salutation }, api_key]
+    params << metadata if Flipper.enabled?(:hca_zero_silent_failures)
+
+    VANotify::EmailJob.perform_async(*params)
     StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.submission_failure_email_sent")
   rescue => e
     log_exception_to_sentry(e)

--- a/config/features.yml
+++ b/config/features.yml
@@ -128,6 +128,9 @@ features:
   hca_retrieve_facilities_without_repopulating:
     actor_type: user
     description: Constrain facilities endpoint to only return existing facilities values - even if the table is empty, do not rerun the Job to populate it.
+  hca_zero_silent_failures:
+    actor_type: user
+    description: Pass callback metadata to vanotify sidekiq job
   cg1010_oauth_2_enabled:
     actor_type: user
     description: Use OAuth 2.0 Authentication for 10-10CG Form Mulesoft integration.

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -545,6 +545,7 @@ RSpec.describe HealthCareApplication, type: :model do
 
     before do
       allow(VANotify::EmailJob).to receive(:perform_async)
+      allow(Flipper).to receive(:enabled?).with(:hca_zero_silent_failures).and_return(false)
     end
 
     describe '#send_failure_email' do
@@ -560,18 +561,32 @@ RSpec.describe HealthCareApplication, type: :model do
               {
                 'salutation' => "Dear #{health_care_application.parsed_form['veteranFullName']['first']},"
               },
-              api_key,
-              {
+              api_key
+            ]
+          end
+
+          let(:standard_error) { StandardError.new('Test error') }
+
+          context ':hca_zero_silent_failures enabled' do
+            before do
+              allow(Flipper).to receive(:enabled?).with(:hca_zero_silent_failures).and_return(true)
+            end
+
+            let(:template_params_with_callback_metadata) do
+              template_params << {
                 callback_metadata: {
                   notification_type: 'error',
                   form_number: form_id,
                   statsd_tags: zsf_tags
                 }
               }
-            ]
-          end
+            end
 
-          let(:standard_error) { StandardError.new('Test error') }
+            it 'sends a failure email to the email address provided on the form with callback metadata' do
+              subject
+              expect(VANotify::EmailJob).to have_received(:perform_async).with(*template_params_with_callback_metadata)
+            end
+          end
 
           it 'sends a failure email to the email address provided on the form' do
             subject
@@ -601,18 +616,34 @@ RSpec.describe HealthCareApplication, type: :model do
                 {
                   'salutation' => ''
                 },
-                api_key,
-                {
+                api_key
+              ]
+            end
+
+            let(:standard_error) { StandardError.new('Test error') }
+
+            context ':hca_zero_silent_failures enabled' do
+              before do
+                allow(Flipper).to receive(:enabled?).with(:hca_zero_silent_failures).and_return(true)
+              end
+
+              let(:template_params_no_name_with_callback_metadata) do
+                template_params_no_name << {
                   callback_metadata: {
                     notification_type: 'error',
                     form_number: form_id,
                     statsd_tags: zsf_tags
                   }
                 }
-              ]
-            end
+              end
 
-            let(:standard_error) { StandardError.new('Test error') }
+              it 'sends a failure email to the email address provided on the form with callback metadata' do
+                subject
+                expect(VANotify::EmailJob).to have_received(:perform_async).with(
+                  *template_params_no_name_with_callback_metadata
+                )
+              end
+            end
 
             it 'sends a failure email without personalisations to the email address provided on the form' do
               subject

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe HealthCareApplication, type: :model do
     short_form
   end
   let(:inelig_character_of_discharge) { HCA::EnrollmentEligibility::Constants::INELIG_CHARACTER_OF_DISCHARGE }
+  let(:statsd_key_prefix) { HCA::Service::STATSD_KEY_PREFIX }
+  let(:zsf_tags) { described_class::DD_ZSF_TAGS }
+  let(:form_id) { described_class::FORM_ID }
 
   describe 'LOCKBOX' do
     it 'can encrypt strings over 4kb' do
@@ -419,7 +422,7 @@ RSpec.describe HealthCareApplication, type: :model do
           expect do
             described_class.new(form: { mothersMaidenName: 'm' }.to_json).process!
           end.to raise_error(Common::Exceptions::ValidationErrors)
-        end.to trigger_statsd_increment('api.1010ez.validation_error_short_form')
+        end.to trigger_statsd_increment("#{statsd_key_prefix}.validation_error_short_form")
       end
 
       it 'triggers statsd' do
@@ -427,7 +430,7 @@ RSpec.describe HealthCareApplication, type: :model do
           expect do
             described_class.new(form: {}.to_json).process!
           end.to raise_error(Common::Exceptions::ValidationErrors)
-        end.to trigger_statsd_increment('api.1010ez.validation_error')
+        end.to trigger_statsd_increment("#{statsd_key_prefix}.validation_error")
       end
     end
 
@@ -501,7 +504,7 @@ RSpec.describe HealthCareApplication, type: :model do
           end
 
           it 'increments statsd' do
-            expect(StatsD).to receive(:increment).with('api.1010ez.sync_submission_failed')
+            expect(StatsD).to receive(:increment).with("#{statsd_key_prefix}.sync_submission_failed")
 
             expect do
               health_care_application.process!
@@ -515,8 +518,8 @@ RSpec.describe HealthCareApplication, type: :model do
             end
 
             it 'increments statsd and short_form statsd' do
-              expect(StatsD).to receive(:increment).with('api.1010ez.sync_submission_failed')
-              expect(StatsD).to receive(:increment).with('api.1010ez.sync_submission_failed_short_form')
+              expect(StatsD).to receive(:increment).with("#{statsd_key_prefix}.sync_submission_failed")
+              expect(StatsD).to receive(:increment).with("#{statsd_key_prefix}.sync_submission_failed_short_form")
 
               expect do
                 health_care_application.process!
@@ -557,7 +560,14 @@ RSpec.describe HealthCareApplication, type: :model do
               {
                 'salutation' => "Dear #{health_care_application.parsed_form['veteranFullName']['first']},"
               },
-              api_key
+              api_key,
+              {
+                callback_metadata: {
+                  notification_type: 'error',
+                  form_number: form_id,
+                  statsd_tags: zsf_tags
+                }
+              }
             ]
           end
 
@@ -575,7 +585,7 @@ RSpec.describe HealthCareApplication, type: :model do
           end
 
           it 'increments statsd' do
-            expect { subject }.to trigger_statsd_increment('api.1010ez.submission_failure_email_sent')
+            expect { subject }.to trigger_statsd_increment("#{statsd_key_prefix}.submission_failure_email_sent")
           end
 
           context 'without first name' do
@@ -591,7 +601,14 @@ RSpec.describe HealthCareApplication, type: :model do
                 {
                   'salutation' => ''
                 },
-                api_key
+                api_key,
+                {
+                  callback_metadata: {
+                    notification_type: 'error',
+                    form_number: form_id,
+                    statsd_tags: zsf_tags
+                  }
+                }
               ]
             end
 
@@ -652,7 +669,7 @@ RSpec.describe HealthCareApplication, type: :model do
 
     describe '#log_async_submission_failure' do
       it 'triggers failed_wont_retry statsd' do
-        expect { subject }.to trigger_statsd_increment('api.1010ez.failed_wont_retry')
+        expect { subject }.to trigger_statsd_increment("#{statsd_key_prefix}.failed_wont_retry")
       end
 
       it 'triggers zero silent failures statsd' do
@@ -666,8 +683,8 @@ RSpec.describe HealthCareApplication, type: :model do
         end
 
         it 'triggers statsd' do
-          expect { subject }.to trigger_statsd_increment('api.1010ez.failed_wont_retry')
-            .and trigger_statsd_increment('api.1010ez.failed_wont_retry_short_form')
+          expect { subject }.to trigger_statsd_increment("#{statsd_key_prefix}.failed_wont_retry")
+            .and trigger_statsd_increment("#{statsd_key_prefix}.failed_wont_retry_short_form")
         end
       end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Added VANotify callbacks to the 10-10EZ Submission Failure email. The callbacks increment relevant statsD metrics and logs for success/failure, and we will be adding monitors in datadog for these metrics. 
- 10-10 Health Apps
- Behind new `hca_zero_silent_failures` toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93247

## Testing done

- [x] New code is covered by unit tests
- We will validate that the relevant vanotify statsD metrics are incremented with our email tags in staging

## What areas of the site does it impact?
10-10EZ

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

