### PR TITLE
Issue# 98709 & 98710 POA Request List and Detail endpoints

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -3,54 +3,21 @@
 module AccreditedRepresentativePortal
   module V0
     class PowerOfAttorneyRequestsController < ApplicationController
-      POA_REQUEST_ITEM_MOCK_DATA = {
-        status: 'Pending',
-        declinedReason: nil,
-        powerOfAttorneyCode: '091',
-        submittedAt: '2024-04-30T11:03:17Z',
-        acceptedOrDeclinedAt: nil,
-        isAddressChangingAuthorized: false,
-        isTreatmentDisclosureAuthorized: true,
-        veteran: {
-          firstName: 'Jon',
-          middleName: nil,
-          lastName: 'Smith',
-          participantId: '6666666666666'
-        },
-        representative: {
-          email: 'j2@example.com',
-          firstName: 'Jane',
-          lastName: 'Doe'
-        },
-        claimant: {
-          firstName: 'Sam',
-          lastName: 'Smith',
-          participantId: '777777777777777',
-          relationshipToVeteran: 'Child'
-        },
-        claimantAddress: {
-          city: 'Hartford',
-          state: 'CT',
-          zip: '06107',
-          country: 'GU',
-          militaryPostOffice: nil,
-          militaryPostalCode: nil
-        }
-      }.freeze
-
-      POA_REQUEST_LIST_MOCK_DATA = [
-        POA_REQUEST_ITEM_MOCK_DATA,
-        POA_REQUEST_ITEM_MOCK_DATA,
-        POA_REQUEST_ITEM_MOCK_DATA
-      ].freeze
-
       def index
-        render json: POA_REQUEST_LIST_MOCK_DATA
+        requests = PowerOfAttorneyRequest.includes(:resolution)
+        render json: PowerOfAttorneyRequestSerializer.new(requests).serializable_hash, status: :ok
       end
 
       def show
-        render json: POA_REQUEST_ITEM_MOCK_DATA
+        request = PowerOfAttorneyRequest.includes(:resolution).find(params[:id])
+        render json: PowerOfAttorneyRequestSerializer.new(request).serializable_hash, status: :ok
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: 'Record not found' }, status: :not_found
       end
+
+      private
+
+      def authenticate; end
     end
   end
 end

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -4,20 +4,16 @@ module AccreditedRepresentativePortal
   module V0
     class PowerOfAttorneyRequestsController < ApplicationController
       def index
-        requests = PowerOfAttorneyRequest.includes(:resolution)
-        render json: PowerOfAttorneyRequestSerializer.new(requests).serializable_hash, status: :ok
+        poa_requests = PowerOfAttorneyRequest.includes(:resolution)
+        render json: PowerOfAttorneyRequestSerializer.new(poa_requests).serializable_hash, status: :ok
       end
 
       def show
-        request = PowerOfAttorneyRequest.includes(:resolution).find(params[:id])
-        render json: PowerOfAttorneyRequestSerializer.new(request).serializable_hash, status: :ok
+        poa_request = PowerOfAttorneyRequest.includes(:resolution).find(params[:id])
+        render json: PowerOfAttorneyRequestSerializer.new(poa_request).serializable_hash, status: :ok
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'Record not found' }, status: :not_found
       end
-
-      private
-
-      def authenticate; end
     end
   end
 end

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -4,12 +4,12 @@ module AccreditedRepresentativePortal
   module V0
     class PowerOfAttorneyRequestsController < ApplicationController
       def index
-        poa_requests = PowerOfAttorneyRequest.includes(:resolution)
+        poa_requests = PowerOfAttorneyRequest.includes(resolution: :resolving).limit(100)
         render json: PowerOfAttorneyRequestSerializer.new(poa_requests).serializable_hash, status: :ok
       end
 
       def show
-        poa_request = PowerOfAttorneyRequest.includes(:resolution).find(params[:id])
+        poa_request = PowerOfAttorneyRequest.includes(resolution: :resolving).find(params[:id])
         render json: PowerOfAttorneyRequestSerializer.new(poa_request).serializable_hash, status: :ok
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'Record not found' }, status: :not_found

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_resolution_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_resolution_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestResolutionSerializer
+    include JSONAPI::Serializer
+
+    attribute :id
+
+    attribute :type do |object|
+      object.resolving_type.demodulize.underscore.split('_').last
+    end
+
+    attribute :decision_type, if: proc { |obj| obj.resolving.respond_to?(:type) } do |object|
+      object.resolving.type
+    end
+
+    attribute :reason
+
+    attribute :creator_id, if: proc { |obj| obj.resolving.respond_to?(:creator_id) } do |object|
+      object.resolving.creator_id
+    end
+
+    attribute :created_at do |object|
+      object.created_at.iso8601
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
@@ -4,7 +4,11 @@ module AccreditedRepresentativePortal
   class PowerOfAttorneyRequestSerializer
     include JSONAPI::Serializer
 
-    attributes :id, :claimant_id, :created_at
+    attributes :id, :claimant_id
+
+    attribute :created_at do |object|
+      object.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
+    end
 
     attribute :resolution do |object|
       next nil unless object.resolution
@@ -12,7 +16,7 @@ module AccreditedRepresentativePortal
       {
         id: object.resolution.id,
         type: object.resolution.resolving_type&.demodulize&.underscore,
-        created_at: object.resolution.created_at.iso8601,
+        created_at: object.resolution.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
         reason: object.resolution&.reason,
         creator_id: object.resolution.resolving.try(:creator_id)
       }.compact

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestSerializer
+    include JSONAPI::Serializer
+
+    attributes :id, :claimant_id, :created_at
+
+    attribute :resolution do |object|
+      next nil unless object.resolution
+
+      {
+        id: object.resolution.id,
+        type: object.resolution.resolving_type&.demodulize&.underscore,
+        created_at: object.resolution.created_at.iso8601,
+        reason: object.resolution&.reason,
+        creator_id: object.resolution.resolving.try(:creator_id)
+      }.compact
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
@@ -7,19 +7,15 @@ module AccreditedRepresentativePortal
     attributes :id, :claimant_id
 
     attribute :created_at do |object|
-      object.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
+      object.created_at.iso8601
     end
 
     attribute :resolution do |object|
-      next nil unless object.resolution
+      next nil if object.resolution.blank?
 
-      {
-        id: object.resolution.id,
-        type: object.resolution.resolving_type&.demodulize&.underscore,
-        created_at: object.resolution.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
-        reason: object.resolution&.reason,
-        creator_id: object.resolution.resolving.try(:creator_id)
-      }.compact
+      AccreditedRepresentativePortal::PowerOfAttorneyRequestResolutionSerializer.new(
+        object.resolution
+      ).serializable_hash[:data][:attributes]
     end
   end
 end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_decision.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_decision.rb
@@ -6,5 +6,13 @@ FactoryBot.define do
     id { Faker::Internet.uuid }
     association :creator, factory: :user_account
     type { 'Approval' }
+
+    trait :declination do
+      type { 'Declination' }
+    end
+
+    trait :approval do
+      type { 'Approval' }
+    end
   end
 end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     association :claimant, factory: :user_account
     id { Faker::Internet.uuid }
     created_at { Time.current }
+
+    trait :with_resolution do
+      resolution { create(:power_of_attorney_request_resolution, :with_decision) }
+    end
   end
 end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_request_resolution.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_request_resolution.rb
@@ -3,11 +3,15 @@
 FactoryBot.define do
   factory :power_of_attorney_request_resolution,
           class: 'AccreditedRepresentativePortal::PowerOfAttorneyRequestResolution' do
-    association :power_of_attorney_request, factory: :power_of_attorney_request
-    resolving_id { SecureRandom.uuid }
-    reason_ciphertext { 'Encrypted Reason' }
+    association :power_of_attorney_request
+    resolving_type { 'AccreditedRepresentativePortal::PowerOfAttorneyRequestExpiration' }
+    reason { 'Test reason for resolution' }
     created_at { Time.current }
     encrypted_kms_key { SecureRandom.hex(16) }
+
+    after(:build) do |resolution|
+      resolution.id ||= SecureRandom.random_number(1000)
+    end
 
     trait :with_expiration do
       resolving_type { 'AccreditedRepresentativePortal::PowerOfAttorneyRequestExpiration' }
@@ -16,7 +20,13 @@ FactoryBot.define do
 
     trait :with_decision do
       resolving_type { 'AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision' }
-      resolving { create(:power_of_attorney_request_decision) }
+      resolving { create(:power_of_attorney_request_decision, creator: create(:user_account)) }
+    end
+
+    trait :with_declination do
+      resolving_type { 'AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision' }
+      reason { "Didn't authorize treatment record disclosure" }
+      resolving { create(:power_of_attorney_request_decision, creator: create(:user_account)) }
     end
 
     trait :with_invalid_type do

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
@@ -55,18 +55,6 @@ RSpec.describe mod::PowerOfAttorneyRequestResolution, type: :model do
     end
   end
 
-<<<<<<< HEAD
-=======
-    it 'does not allow invalid resolving_type values' do
-      resolution = build(:power_of_attorney_request_resolution, :with_invalid_type)
-      resolution.resolving_type = 'AccreditedRepresentativePortal::InvalidType'
-
-      expect(resolution).not_to be_valid
-      expect(resolution.errors[:resolving_type]).to include('is not included in the list')
-    end
-  end
-
->>>>>>> 3815598394 ((fix) Apply requested PR changes; all specs passing)
   describe 'heterogeneous list behavior' do
     it 'conveniently returns heterogeneous lists' do
       travel_to Time.zone.parse('2024-11-25T09:46:24Z') do

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe mod::PowerOfAttorneyRequestResolution, type: :model do
     end
   end
 
+<<<<<<< HEAD
+=======
+    it 'does not allow invalid resolving_type values' do
+      resolution = build(:power_of_attorney_request_resolution, :with_invalid_type)
+      resolution.resolving_type = 'AccreditedRepresentativePortal::InvalidType'
+
+      expect(resolution).not_to be_valid
+      expect(resolution.errors[:resolving_type]).to include('is not included in the list')
+    end
+  end
+
+>>>>>>> 3815598394 ((fix) Apply requested PR changes; all specs passing)
   describe 'heterogeneous list behavior' do
     it 'conveniently returns heterogeneous lists' do
       travel_to Time.zone.parse('2024-11-25T09:46:24Z') do

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
                           .new(poa_requests)
                           .serializable_hash
 
-      expect(deep_stringify(parsed_response)).to eq(deep_stringify(expected_response))
+      expect(parsed_response.to_json).to eq(expected_response.to_json)
     end
   end
 
@@ -40,22 +40,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
                           .new(poa_request)
                           .serializable_hash
 
-      expect(deep_stringify(parsed_response)).to eq(deep_stringify(expected_response))
-    end
-  end
-
-  def deep_stringify(value)
-    case value
-    when Hash
-      value.each_with_object({}) do |(k, v), result|
-        result[k.to_s] = deep_stringify(v) # Stringify keys and recursively process values
-      end
-    when Array
-      value.map { |v| deep_stringify(v) } # Recursively process arrays
-    when Symbol
-      value.to_s # Convert symbols to strings
-    else
-      value # Leave other primitives (e.g., strings, numbers, nil) as is
+      expect(parsed_response.to_json).to eq(expected_response.to_json)
     end
   end
 end

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_resolution_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_resolution_serializer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../../rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestResolutionSerializer, type: :serializer do
+  describe 'serialization' do
+    subject { described_class.new(resolution).serializable_hash[:data][:attributes] }
+
+    let(:user) { create(:user_account) }
+    let(:resolution) do
+      create(:power_of_attorney_request_resolution, resolving: resolving, reason: 'Did not authorize')
+    end
+
+    context 'when resolving is a Decision' do
+      let(:resolving) { create(:power_of_attorney_request_decision, type: 'declination', creator: user) }
+
+      it 'serializes resolution with decision-specific fields' do
+        expect(subject).to eq(
+          id: resolution.id,
+          created_at: resolution.created_at.iso8601,
+          reason: 'Did not authorize',
+          type: 'decision',
+          decision_type: 'declination',
+          creator_id: user.id
+        )
+      end
+    end
+
+    context 'when resolving is an Expiration' do
+      let(:resolving) { create(:power_of_attorney_request_expiration) }
+
+      it 'serializes resolution with expiration-specific fields' do
+        expect(subject).to eq(
+          id: resolution.id,
+          created_at: resolution.created_at.iso8601,
+          reason: 'Did not authorize',
+          type: 'expiration'
+        )
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
@@ -1,75 +1,48 @@
 # frozen_string_literal: true
 
-# spec/serializers/power_of_attorney_request_serializer_spec.rb
-require 'rails_helper'
+require_relative '../../rails_helper'
 
-RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer do
-  subject { described_class.new(request).serializable_hash[:data][:attributes] }
+RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer, type: :serializer do
+  describe 'serialization' do
+    subject { described_class.new(poa_request).serializable_hash[:data][:attributes] }
 
-  let(:request) { create(:power_of_attorney_request, created_at: '2024-12-17T00:30:55Z') }
+    let(:claimant) { create(:user_account) }
+    let(:poa_request) { create(:power_of_attorney_request, claimant: claimant, resolution: resolution) }
 
-  context 'when resolution is nil' do
-    it 'returns the request without resolution' do
-      expect(subject).to eq({
-                              id: request.id,
-                              claimant_id: request.claimant_id,
-                              created_at: '2024-12-17T00:30:55.000Z',
-                              resolution: nil
-                            })
-    end
-  end
+    context 'when resolution exists' do
+      let(:resolution) do
+        create(:power_of_attorney_request_resolution,
+               resolving: create(:power_of_attorney_request_decision, type: 'declination'))
+      end
 
-  context 'when resolution is an expiration' do
-    let(:resolution) do
-      create(:power_of_attorney_request_resolution, :with_expiration, reason: 'Test reason for resolution')
-    end
-
-    before { request.update(resolution: resolution) }
-
-    it 'includes resolution details with type expiration and reason' do
-      expect(subject[:resolution]).to eq({
-                                           id: resolution.id,
-                                           type: 'power_of_attorney_request_expiration',
-                                           created_at: resolution.created_at.iso8601(3),
-                                           reason: 'Test reason for resolution'
-                                         })
-    end
-  end
-
-  context 'when resolution is a decision with creator_id' do
-    let(:resolution) do
-      create(:power_of_attorney_request_resolution, :with_decision)
+      it 'serializes POA request with resolution' do
+        expect(subject).to eq(
+          id: poa_request.id,
+          claimant_id: poa_request.claimant_id,
+          created_at: poa_request.created_at.iso8601,
+          resolution: {
+            id: resolution.id,
+            created_at: resolution.created_at.iso8601,
+            reason: resolution.reason,
+            type: 'decision',
+            decision_type: 'declination',
+            creator_id: resolution.resolving.creator_id
+          }
+        )
+      end
     end
 
-    before { request.update(resolution: resolution) }
+    context 'when resolution is absent' do
+      let(:resolution) { nil }
 
-    it 'includes resolution details with type decision and creator_id' do
-      expect(subject[:resolution]).to eq({
-                                           id: resolution.id,
-                                           type: 'power_of_attorney_request_decision',
-                                           created_at: resolution.created_at.iso8601(3),
-                                           reason: 'Test reason for resolution',
-                                           creator_id: resolution.resolving.creator_id
-                                         })
-    end
-  end
-
-  context 'when resolution is a declination with reason' do
-    let(:resolution) do
-      create(:power_of_attorney_request_resolution, :with_declination,
-             reason: "Didn't authorize treatment record disclosure")
-    end
-
-    before { request.update(resolution: resolution) }
-
-    it 'includes resolution details with type decision, reason, and creator_id' do
-      expect(subject[:resolution]).to eq({
-                                           id: resolution.id,
-                                           type: 'power_of_attorney_request_decision',
-                                           created_at: resolution.created_at.iso8601(3),
-                                           reason: "Didn't authorize treatment record disclosure",
-                                           creator_id: resolution.resolving.creator_id
-                                         })
+      it 'serializes POA request without resolution' do
+        expect(subject).to eq(
+          id: poa_request.id,
+          claimant_id: poa_request.claimant_id,
+          created_at: poa_request.created_at.iso8601,
+          resolution: nil
+        )
+      end
     end
   end
 end

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 # spec/serializers/power_of_attorney_request_serializer_spec.rb
 require 'rails_helper'
 
 RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer do
-  let(:request) { create(:power_of_attorney_request, created_at: '2024-12-17T00:30:55Z') }
-
   subject { described_class.new(request).serializable_hash[:data][:attributes] }
+
+  let(:request) { create(:power_of_attorney_request, created_at: '2024-12-17T00:30:55Z') }
 
   context 'when resolution is nil' do
     it 'returns the request without resolution' do
       expect(subject).to eq({
-        id: request.id,
-        claimant_id: request.claimant_id,
-        created_at: '2024-12-17T00:30:55Z',
-        resolution: nil
-      })
+                              id: request.id,
+                              claimant_id: request.claimant_id,
+                              created_at: '2024-12-17T00:30:55.000Z',
+                              resolution: nil
+                            })
     end
   end
 
@@ -26,11 +28,11 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer 
 
     it 'includes resolution details with type expiration and reason' do
       expect(subject[:resolution]).to eq({
-        id: resolution.id,
-        type: 'power_of_attorney_request_expiration',
-        created_at: resolution.created_at.iso8601,
-        reason: 'Test reason for resolution'
-      })
+                                           id: resolution.id,
+                                           type: 'power_of_attorney_request_expiration',
+                                           created_at: resolution.created_at.iso8601(3),
+                                           reason: 'Test reason for resolution'
+                                         })
     end
   end
 
@@ -43,12 +45,12 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer 
 
     it 'includes resolution details with type decision and creator_id' do
       expect(subject[:resolution]).to eq({
-        id: resolution.id,
-        type: 'power_of_attorney_request_decision',
-        created_at: resolution.created_at.iso8601,
-        reason: 'Test reason for resolution',
-        creator_id: resolution.resolving.creator_id
-      })
+                                           id: resolution.id,
+                                           type: 'power_of_attorney_request_decision',
+                                           created_at: resolution.created_at.iso8601(3),
+                                           reason: 'Test reason for resolution',
+                                           creator_id: resolution.resolving.creator_id
+                                         })
     end
   end
 
@@ -62,12 +64,12 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer 
 
     it 'includes resolution details with type decision, reason, and creator_id' do
       expect(subject[:resolution]).to eq({
-        id: resolution.id,
-        type: 'power_of_attorney_request_decision',
-        created_at: resolution.created_at.iso8601,
-        reason: "Didn't authorize treatment record disclosure",
-        creator_id: resolution.resolving.creator_id
-      })
+                                           id: resolution.id,
+                                           type: 'power_of_attorney_request_decision',
+                                           created_at: resolution.created_at.iso8601(3),
+                                           reason: "Didn't authorize treatment record disclosure",
+                                           creator_id: resolution.resolving.creator_id
+                                         })
     end
   end
 end

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
@@ -1,0 +1,73 @@
+# spec/serializers/power_of_attorney_request_serializer_spec.rb
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer do
+  let(:request) { create(:power_of_attorney_request, created_at: '2024-12-17T00:30:55Z') }
+
+  subject { described_class.new(request).serializable_hash[:data][:attributes] }
+
+  context 'when resolution is nil' do
+    it 'returns the request without resolution' do
+      expect(subject).to eq({
+        id: request.id,
+        claimant_id: request.claimant_id,
+        created_at: '2024-12-17T00:30:55Z',
+        resolution: nil
+      })
+    end
+  end
+
+  context 'when resolution is an expiration' do
+    let(:resolution) do
+      create(:power_of_attorney_request_resolution, :with_expiration, reason: 'Test reason for resolution')
+    end
+
+    before { request.update(resolution: resolution) }
+
+    it 'includes resolution details with type expiration and reason' do
+      expect(subject[:resolution]).to eq({
+        id: resolution.id,
+        type: 'power_of_attorney_request_expiration',
+        created_at: resolution.created_at.iso8601,
+        reason: 'Test reason for resolution'
+      })
+    end
+  end
+
+  context 'when resolution is a decision with creator_id' do
+    let(:resolution) do
+      create(:power_of_attorney_request_resolution, :with_decision)
+    end
+
+    before { request.update(resolution: resolution) }
+
+    it 'includes resolution details with type decision and creator_id' do
+      expect(subject[:resolution]).to eq({
+        id: resolution.id,
+        type: 'power_of_attorney_request_decision',
+        created_at: resolution.created_at.iso8601,
+        reason: 'Test reason for resolution',
+        creator_id: resolution.resolving.creator_id
+      })
+    end
+  end
+
+  context 'when resolution is a declination with reason' do
+    let(:resolution) do
+      create(:power_of_attorney_request_resolution, :with_declination,
+             reason: "Didn't authorize treatment record disclosure")
+    end
+
+    before { request.update(resolution: resolution) }
+
+    it 'includes resolution details with type decision, reason, and creator_id' do
+      expect(subject[:resolution]).to eq({
+        id: resolution.id,
+        type: 'power_of_attorney_request_decision',
+        created_at: resolution.created_at.iso8601,
+        reason: "Didn't authorize treatment record disclosure",
+        creator_id: resolution.resolving.creator_id
+      })
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the list and detail endpoints of POA Request API:

Serializer:
• Created PowerOfAttorneyRequestSerializer and PowerOfAttorneyRequestResolutionSerializer to format the JSON output in JSON:API standard.
• Includes flattened resolution details
Controller:
• Added PowerOfAttorneyRequestsController with index and show actions.
Specs:
• Added request specs to verify:
• GET /power_of_attorney_requests returns a list of requests.
• GET /power_of_attorney_requests/:id returns the details of a specific request.
• Added serializer specs to ensure accurate formatting of response data: