### PR TITLE
Use FileUtils.mv instead of File.rename to handle cross-filesystem file manipulation

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pdf_utilities/datestamp_pdf'
+require 'fileutils'
 
 module SimpleFormsApi
   class PdfStamper
@@ -64,7 +65,7 @@ module SimpleFormsApi
 
     def stamp_all_pages(desired_stamp, append_to_stamp: nil)
       current_file_path = call_datestamp_pdf(desired_stamp[:coords], desired_stamp[:text], append_to_stamp)
-      File.rename(current_file_path, stamped_template_path)
+      FileUtils.mv(current_file_path, stamped_template_path)
     end
 
     def verified_multistamp(stamp, page_configuration)
@@ -93,7 +94,7 @@ module SimpleFormsApi
 
     def multistamp_cleanup(out_path)
       Common::FileHelpers.delete_file_if_exists(stamped_template_path)
-      File.rename(out_path, stamped_template_path)
+      FileUtils.mv(out_path, stamped_template_path)
     end
 
     def verify


### PR DESCRIPTION
## Summary
This PR uses `FileUtils.mv` instead of `File.rename` in the Simple Forms PDF Stamper. We were seeing errors on staging stemming from trying to rename files across filesystems. `FileUtils.mv` should be able to handle this.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=88752628&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1892
