### PR TITLE
Fix future date for valid_service_info_for_bdd

### DIFF
--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
@@ -471,6 +471,8 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
   end
 
   describe 'validation for BDD_PROGRAM claim' do
+    future_date = "#{Time.current.year + 1}-12-20"
+
     let(:valid_service_info_for_bdd) do
       {
         'servicePeriods' => [
@@ -478,7 +480,7 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
             'serviceBranch' => 'Air Force Reserves',
             'serviceComponent' => 'Reserves',
             'activeDutyBeginDate' => '2015-11-14',
-            'activeDutyEndDate' => '2024-12-20'
+            'activeDutyEndDate' => future_date
           }
         ],
         'reservesNationalGuardService' => {
@@ -497,7 +499,7 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
         },
         'federalActivation' => {
           'activationDate' => '2023-10-01',
-          'anticipatedSeparationDate' => '2024-12-20'
+          'anticipatedSeparationDate' => future_date
         }
       }
     end


### PR DESCRIPTION
## Summary

- [disability_compensation_validation_spec.rb#L481](https://github.com/department-of-veterans-affairs/vets-api/blame/master/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb#L481)
- `anticipatedSeparationDate` must be a future date for the tests to pass
- I made the date dynamic to ensure it always passes

## Related issue(s)

- n/a

## Testing done

- [x] test pass

## Acceptance criteria

- [x]  `anticipatedSeparationDate` is always in the future 
- [x]  `activeDutyEndDate` == `anticipatedSeparationDate`
- [x] tests pass
