### PR TITLE
Add 21-509 min and max pages to Form Upload flow

### DIFF
--- a/app/models/persistent_attachments/va_form.rb
+++ b/app/models/persistent_attachments/va_form.rb
@@ -9,7 +9,8 @@ class PersistentAttachments::VAForm < PersistentAttachment
     { max_pages: 10, min_pages: 1 }
   ).merge(
     {
-      '21-0779' => { max_pages: 4, min_pages: 2 }
+      '21-0779' => { max_pages: 4, min_pages: 2 },
+      '21-509' => { max_pages: 4, min_pages: 2 }
     }
   )
 

--- a/spec/models/persistent_attachments/va_form_spec.rb
+++ b/spec/models/persistent_attachments/va_form_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe PersistentAttachments::VAForm, :uploader_helpers do
       end
     end
 
+    context 'form_id 21-509' do
+      before { instance.form_id = '21-509' }
+
+      it 'returns 4' do
+        expect(instance.max_pages).to eq 4
+      end
+    end
+
     context 'default' do
       it 'returns 10' do
         expect(instance.max_pages).to eq 10
@@ -40,6 +48,14 @@ RSpec.describe PersistentAttachments::VAForm, :uploader_helpers do
   describe '#min_pages' do
     context 'form_id 21-0779' do
       before { instance.form_id = '21-0779' }
+
+      it 'returns 2' do
+        expect(instance.min_pages).to eq 2
+      end
+    end
+
+    context 'form_id 21-509' do
+      before { instance.form_id = '21-509' }
 
       it 'returns 2' do
         expect(instance.min_pages).to eq 2


### PR DESCRIPTION
## Summary
This PR adds the min and max page count for 21-509 to the `VAForm` Persistent attachment class. This will enable the FE to display warnings if the user uploads a doc with too few or too many pages.
