### PR TITLE
98397-Implement-POA-Request-Decision-Create-Endpoint

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -62,7 +62,7 @@ module AccreditedRepresentativePortal
 
         creator_id = @current_user.id
 
-        type = power_of_attorney_request_params[:declination_reason].present? ? "Declination" :  "Acceptance"
+        type = power_of_attorney_request_params[:declination_reason].present? ? "Rejection" :  "Approval"
         decision = PowerOfAttorneyRequestDecision.new(type:, creator_id:)
 
         ActiveRecord::Base.transaction do

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -3,6 +3,8 @@
 module AccreditedRepresentativePortal
   module V0
     class PowerOfAttorneyRequestsController < ApplicationController
+      before_action :set_power_of_attorney_request, only: [:decision, :get_decision]
+
       POA_REQUEST_ITEM_MOCK_DATA = {
         status: 'Pending',
         declinedReason: nil,
@@ -50,6 +52,66 @@ module AccreditedRepresentativePortal
 
       def show
         render json: POA_REQUEST_ITEM_MOCK_DATA
+      end
+
+      def decision
+        if @power_of_attorney_request.resolution.present?
+          render json: { error: 'Resolution already exists' }, status: :unprocessable_entity
+          return
+        end
+
+        creator_id = @current_user.id
+
+        type = power_of_attorney_request_params[:declination_reason].present? ? "Declination" :  "Acceptance"
+        decision = PowerOfAttorneyRequestDecision.new(type:, creator_id:)
+
+        ActiveRecord::Base.transaction do
+          if decision.save
+            resolution = PowerOfAttorneyRequestResolution.new(
+              power_of_attorney_request: @power_of_attorney_request,
+              resolving: decision,
+              reason: power_of_attorney_request_params[:declination_reason]
+            )
+
+            if resolution.save
+              render json: decision, status: :ok
+            else
+              raise ActiveRecord::Rollback
+              render json: { error: 'Failed to create resolution' }, status: :unprocessable_entity
+            end
+          else
+            render json: { error: 'Failed to create decision' }, status: :unprocessable_entity
+          end
+        end
+      end
+
+      def get_decision
+        resolution = @power_of_attorney_request.resolution
+        if resolution.blank?
+          # should this error or just say Resolution not found and be status ok?
+          render json: { error: 'Resolution Not Found' }, status: :not_found
+          return
+        end
+
+        resolving_class = resolution.resolving_type.constantize
+        outcome = resolving_class.find_by(id: resolution.resolving_id)
+        if outcome.blank?
+          render json: { error: 'Outcome Not Found' }, status: :not_found
+          return
+        end
+
+        render json: outcome, status: :ok
+      end
+
+      private 
+
+      def set_power_of_attorney_request
+        @power_of_attorney_request = PowerOfAttorneyRequest.find_by(id: params[:power_of_attorney_request_id])
+        render json: { error: 'Not Found' }, status: :not_found unless @power_of_attorney_request
+      end
+
+      def power_of_attorney_request_params
+        params.require(:decision).permit(:declination_reason)
       end
     end
   end

--- a/modules/accredited_representative_portal/config/routes.rb
+++ b/modules/accredited_representative_portal/config/routes.rb
@@ -7,6 +7,9 @@ AccreditedRepresentativePortal::Engine.routes.draw do
     post 'form21a', to: 'form21a#submit'
 
     resources :in_progress_forms, only: %i[update show destroy]
-    resources :power_of_attorney_requests, only:  %i[index show]
+    resources :power_of_attorney_requests, only: [:index, :show] do
+      post 'decision', to: 'power_of_attorney_requests#decision'
+      get 'decision', to: 'power_of_attorney_requests#get_decision'
+    end
   end
 end


### PR DESCRIPTION

## Summary

PR for this ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/98743?issue=department-of-veterans-affairs%7Cva.gov-team%7C98397

@current_user is currently an issue. I'm not sure if that is because of access issues. I used UserAccount.first locally when testing


## Testing done

- [ ] *New code is covered by unit tests*
- I ran post, get, post, get methods for the same Request. Matches what one would expect for results

## Acceptance criteria

- [ ]  Check the result of GET -> POST -> GET -> POSTexpected
- [ ] Request spec for the above outcomes and in particular a lifecycle oriented test with the following sequence GET -> POST -> GET -> POST to demonstrate the validation logic around just 1 resolution

