### PR TITLE
Reduce modality error log to info

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -770,8 +770,7 @@ module VAOS
           modality = telehealth_modality(appointment)
         elsif appointment[:kind] == 'phone'
           modality = 'vaPhone'
-        elsif appointment[:kind] ==
-              'cc'
+        elsif appointment[:kind] == 'cc'
           modality = 'communityCare'
         end
 

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -770,11 +770,12 @@ module VAOS
           modality = telehealth_modality(appointment)
         elsif appointment[:kind] == 'phone'
           modality = 'vaPhone'
-        elsif appointment[:kind] == 'cc'
+        elsif appointment[:kind] ==
+              'cc'
           modality = 'communityCare'
         end
 
-        Rails.logger.error("VAOS appointment id #{appointment[:id]} modality cannot be determined.") if modality.nil?
+        Rails.logger.info("VAOS appointment id #{appointment[:id]} modality cannot be determined.") if modality.nil?
 
         appointment[:modality] = modality
       end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1730,12 +1730,12 @@ describe VAOS::V2::AppointmentsService do
     end
 
     it 'logs failure to determine modality' do
-      allow(Rails.logger).to receive(:error).at_least(:once)
+      allow(Rails.logger).to receive(:info).at_least(:once)
       appt = FactoryBot.build(:appointment_form_v2, :va_proposed_valid_reason_code_text).attributes
       appt[:kind] = 'none'
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to be_nil
-      expect(Rails.logger).to have_received(:error).at_least(:once)
+      expect(Rails.logger).to have_received(:info).at_least(:once)
     end
 
     it 'requires appointment' do


### PR DESCRIPTION
## Summary

- Hotfix for large number of modality errors, see [conversation on Slack](https://dsva.slack.com/archives/CMNQT72LX/p1734727335423249)

## Related issue(s)

- N/A

## Testing done

- [x] Updated unit test
- [x] Tested locally: 
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e7bee5f3-de71-4a0b-8a5e-58f01c26bdeb" />


## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
