### PR TITLE
8: [ART] POA request representative

### DIFF
--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -26,7 +26,8 @@ class AccreditedIndividual < ApplicationRecord
   has_many :power_of_attorney_requests,
            as: :power_of_attorney_holder,
            inverse_of: :power_of_attorney_holder,
-           class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest'
+           class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest',
+           dependent: :restrict_with_exception
 
   validates :ogc_id, :registration_number, :individual_type, presence: true
   validates :poa_code, length: { is: 3 }, allow_blank: true

--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -23,6 +23,11 @@ class AccreditedIndividual < ApplicationRecord
   has_many :accreditations, dependent: :destroy
   has_many :accredited_organizations, through: :accreditations
 
+  has_many :power_of_attorney_requests,
+           as: :power_of_attorney_holder,
+           inverse_of: :power_of_attorney_holder,
+           class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest'
+
   validates :ogc_id, :registration_number, :individual_type, presence: true
   validates :poa_code, length: { is: 3 }, allow_blank: true
   validates :individual_type, uniqueness: { scope: :registration_number }

--- a/app/models/accredited_organization.rb
+++ b/app/models/accredited_organization.rb
@@ -22,7 +22,8 @@ class AccreditedOrganization < ApplicationRecord
   has_many :power_of_attorney_requests,
            as: :power_of_attorney_holder,
            inverse_of: :power_of_attorney_holder,
-           class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest'
+           class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest',
+           dependent: :restrict_with_exception
 
   validates :ogc_id, :poa_code, presence: true
   validates :poa_code, length: { is: 3 }

--- a/app/models/accredited_organization.rb
+++ b/app/models/accredited_organization.rb
@@ -19,6 +19,11 @@ class AccreditedOrganization < ApplicationRecord
   has_many :accreditations, dependent: :destroy
   has_many :accredited_individuals, through: :accreditations
 
+  has_many :power_of_attorney_requests,
+           as: :power_of_attorney_holder,
+           inverse_of: :power_of_attorney_holder,
+           class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequest'
+
   validates :ogc_id, :poa_code, presence: true
   validates :poa_code, length: { is: 3 }
   validates :poa_code, uniqueness: true

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -4,17 +4,28 @@ module AccreditedRepresentativePortal
   module V0
     class PowerOfAttorneyRequestsController < ApplicationController
       def index
-        poa_requests = PowerOfAttorneyRequest.includes(resolution: :resolving).limit(100)
+        poa_requests = poa_requests_rel.limit(100)
         serializer = PowerOfAttorneyRequestSerializer.new(poa_requests)
         render json: serializer.serializable_hash, status: :ok
       end
 
       def show
-        poa_request = PowerOfAttorneyRequest.includes(resolution: :resolving).find(params[:id])
+        poa_request = poa_requests_rel.find(params[:id])
         serializer = PowerOfAttorneyRequestSerializer.new(poa_request)
         render json: serializer.serializable_hash, status: :ok
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'Record not found' }, status: :not_found
+      end
+
+      private
+
+      def poa_requests_rel
+        PowerOfAttorneyRequest.includes(
+          :power_of_attorney_form,
+          :power_of_attorney_holder,
+          :accredited_individual,
+          resolution: :resolving
+        )
       end
     end
   end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
@@ -10,13 +10,18 @@ module AccreditedRepresentativePortal
     belongs_to :claimant, class_name: 'UserAccount'
 
     has_one :power_of_attorney_form,
-            class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyForm',
             inverse_of: :power_of_attorney_request,
             required: true
 
     has_one :resolution,
             class_name: 'AccreditedRepresentativePortal::PowerOfAttorneyRequestResolution',
             inverse_of: :power_of_attorney_request
+
+    belongs_to :power_of_attorney_holder,
+               inverse_of: :power_of_attorney_requests,
+               polymorphic: true
+
+    belongs_to :accredited_individual
 
     before_validation :set_claimant_type
 

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
@@ -23,5 +23,17 @@ module AccreditedRepresentativePortal
         .new(poa_request.resolution)
         .serializable_hash
     end
+
+    attribute :power_of_attorney_holder do |poa_request|
+      PowerOfAttorneyHolderSerializer
+        .new(poa_request.power_of_attorney_holder)
+        .serializable_hash
+    end
+
+    attribute :accredited_individual do |poa_request|
+      AccreditedIndividualSerializer
+        .new(poa_request.accredited_individual)
+        .serializable_hash
+    end
   end
 end

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/accredited_individual_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/accredited_individual_serializer.rb
@@ -10,7 +10,7 @@ module AccreditedRepresentativePortal
           poa_holder.last_name
         ]
 
-        parts.reject(&:blank?).join(' ')
+        parts.compact_blank.join(' ')
       end
     end
   end

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/accredited_individual_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/accredited_individual_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestSerializer
+    class AccreditedIndividualSerializer < ApplicationSerializer
+      attribute :full_name do |poa_holder|
+        parts = [
+          poa_holder.first_name,
+          poa_holder.middle_initial,
+          poa_holder.last_name
+        ]
+
+        parts.reject(&:blank?).join(' ')
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/power_of_attorney_holder_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/power_of_attorney_holder_serializer.rb
@@ -24,7 +24,7 @@ module AccreditedRepresentativePortal
             poa_holder.last_name
           ]
 
-          parts.reject(&:blank?).join(' ')
+          parts.compact_blank.join(' ')
         end
       end
     end

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/power_of_attorney_holder_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer/power_of_attorney_holder_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestSerializer
+    class PowerOfAttorneyHolderSerializer < ApplicationSerializer
+      attribute :type do |poa_holder|
+        case poa_holder
+        when AccreditedIndividual
+          "accredited_#{poa_holder.individual_type}"
+        when AccreditedOrganization
+          'veteran_service_organization'
+        end
+      end
+
+      with_options if: proc { |poa_holder| poa_holder.is_a?(AccreditedOrganization) } do
+        attribute :name
+      end
+
+      with_options if: proc { |poa_holder| poa_holder.is_a?(AccreditedIndividual) } do
+        attribute :full_name do |poa_holder|
+          parts = [
+            poa_holder.first_name,
+            poa_holder.middle_initial,
+            poa_holder.last_name
+          ]
+
+          parts.reject(&:blank?).join(' ')
+        end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     association :claimant, factory: :user_account
     association :power_of_attorney_form, strategy: :build
 
-    association :power_of_attorney_holder, factory: [:accredited_organization, :with_representatives]
+    association :power_of_attorney_holder, factory: %i[accredited_organization with_representatives]
     accredited_individual { power_of_attorney_holder.accredited_individuals.first }
 
     trait :with_acceptance do

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
@@ -5,6 +5,9 @@ FactoryBot.define do
     association :claimant, factory: :user_account
     association :power_of_attorney_form, strategy: :build
 
+    association :power_of_attorney_holder, factory: [:accredited_organization, :with_representatives]
+    accredited_individual { power_of_attorney_holder.accredited_individuals.first }
+
     trait :with_acceptance do
       resolution { create(:power_of_attorney_request_resolution, :acceptance) }
     end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -95,7 +95,10 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             },
             'accredited_individual' => {
               'id' => poa_requests[0].accredited_individual.id,
-              'full_name' => "#{poa_requests[0].accredited_individual.first_name} #{poa_requests[0].accredited_individual.last_name}",
+              'full_name' => [
+                poa_requests[0].accredited_individual.first_name,
+                poa_requests[0].accredited_individual.last_name
+              ].join(' ')
             },
             'resolution' => nil
           },
@@ -161,7 +164,10 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             },
             'accredited_individual' => {
               'id' => poa_requests[1].accredited_individual.id,
-              'full_name' => "#{poa_requests[1].accredited_individual.first_name} #{poa_requests[1].accredited_individual.last_name}",
+              'full_name' => [
+                poa_requests[1].accredited_individual.first_name,
+                poa_requests[1].accredited_individual.last_name
+              ].join(' ')
             },
             'resolution' => {
               'id' => poa_requests[1].resolution.id,
@@ -233,7 +239,10 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             },
             'accredited_individual' => {
               'id' => poa_requests[2].accredited_individual.id,
-              'full_name' => "#{poa_requests[2].accredited_individual.first_name} #{poa_requests[2].accredited_individual.last_name}",
+              'full_name' => [
+                poa_requests[2].accredited_individual.first_name,
+                poa_requests[2].accredited_individual.last_name
+              ].join(' ')
             },
             'resolution' => {
               'id' => poa_requests[2].resolution.id,
@@ -306,7 +315,10 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             },
             'accredited_individual' => {
               'id' => poa_requests[3].accredited_individual.id,
-              'full_name' => "#{poa_requests[3].accredited_individual.first_name} #{poa_requests[3].accredited_individual.last_name}",
+              'full_name' => [
+                poa_requests[3].accredited_individual.first_name,
+                poa_requests[3].accredited_individual.last_name
+              ].join(' ')
             },
             'resolution' => {
               'id' => poa_requests[3].resolution.id,
@@ -397,7 +409,10 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
           },
           'accredited_individual' => {
             'id' => poa_request.accredited_individual.id,
-            'full_name' => "#{poa_request.accredited_individual.first_name} #{poa_request.accredited_individual.last_name}",
+            'full_name' => [
+              poa_request.accredited_individual.first_name,
+              poa_request.accredited_individual.last_name
+            ].join(' ')
           }
         }
       )

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
   end
 
   describe 'GET /accredited_representative_portal/v0/power_of_attorney_requests' do
-    it 'returns the list of power of attorney requests', skip: 'temporarily for a migration' do
+    it 'returns the list of power of attorney requests' do
       poa_requests
 
       get('/accredited_representative_portal/v0/power_of_attorney_requests')
@@ -88,6 +88,15 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
                 'email' => 'veteran@example.com'
               }
             },
+            'power_of_attorney_holder' => {
+              'id' => poa_requests[0].power_of_attorney_holder.id,
+              'type' => 'veteran_service_organization',
+              'name' => poa_requests[0].power_of_attorney_holder.name
+            },
+            'accredited_individual' => {
+              'id' => poa_requests[0].accredited_individual.id,
+              'full_name' => "#{poa_requests[0].accredited_individual.first_name} #{poa_requests[0].accredited_individual.last_name}",
+            },
             'resolution' => nil
           },
           {
@@ -144,6 +153,15 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
                 'phone' => '1234567890',
                 'email' => 'veteran@example.com'
               }
+            },
+            'power_of_attorney_holder' => {
+              'id' => poa_requests[1].power_of_attorney_holder.id,
+              'type' => 'veteran_service_organization',
+              'name' => poa_requests[1].power_of_attorney_holder.name
+            },
+            'accredited_individual' => {
+              'id' => poa_requests[1].accredited_individual.id,
+              'full_name' => "#{poa_requests[1].accredited_individual.first_name} #{poa_requests[1].accredited_individual.last_name}",
             },
             'resolution' => {
               'id' => poa_requests[1].resolution.id,
@@ -207,6 +225,15 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
                 'phone' => '1234567890',
                 'email' => 'veteran@example.com'
               }
+            },
+            'power_of_attorney_holder' => {
+              'id' => poa_requests[2].power_of_attorney_holder.id,
+              'type' => 'veteran_service_organization',
+              'name' => poa_requests[2].power_of_attorney_holder.name
+            },
+            'accredited_individual' => {
+              'id' => poa_requests[2].accredited_individual.id,
+              'full_name' => "#{poa_requests[2].accredited_individual.first_name} #{poa_requests[2].accredited_individual.last_name}",
             },
             'resolution' => {
               'id' => poa_requests[2].resolution.id,
@@ -272,6 +299,15 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
                 'email' => 'veteran@example.com'
               }
             },
+            'power_of_attorney_holder' => {
+              'id' => poa_requests[3].power_of_attorney_holder.id,
+              'type' => 'veteran_service_organization',
+              'name' => poa_requests[3].power_of_attorney_holder.name
+            },
+            'accredited_individual' => {
+              'id' => poa_requests[3].accredited_individual.id,
+              'full_name' => "#{poa_requests[3].accredited_individual.first_name} #{poa_requests[3].accredited_individual.last_name}",
+            },
             'resolution' => {
               'id' => poa_requests[3].resolution.id,
               'type' => 'expiration',
@@ -284,7 +320,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
   end
 
   describe 'GET /accredited_representative_portal/v0/power_of_attorney_requests/:id' do
-    it 'returns the details of a specific power of attorney request', skip: 'temporarily for a migration' do
+    it 'returns the details of a specific power of attorney request' do
       get("/accredited_representative_portal/v0/power_of_attorney_requests/#{poa_request.id}")
 
       parsed_response = JSON.parse(response.body)
@@ -353,6 +389,15 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'creator_id' => poa_request.resolution.resolving.creator_id,
             'reason' => 'Didn\'t authorize treatment record disclosure',
             'decision_type' => 'declination'
+          },
+          'power_of_attorney_holder' => {
+            'id' => poa_request.power_of_attorney_holder.id,
+            'type' => 'veteran_service_organization',
+            'name' => poa_request.power_of_attorney_holder.name
+          },
+          'accredited_individual' => {
+            'id' => poa_request.accredited_individual.id,
+            'full_name' => "#{poa_request.accredited_individual.first_name} #{poa_request.accredited_individual.last_name}",
           }
         }
       )


### PR DESCRIPTION

**Add Power of Attorney Representative Support to Accredited Representative Portal**

Description:
This PR introduces enhancements to the Accredited Representative Portal to support Power of Attorney (POA) request representatives (accredited individuals and organizations). The key changes include:

Key Changes:
	1.	Model Changes:
	•	Added new references and associations for power_of_attorney_requests to support representatives (accredited_individuals and accredited_organizations).
	•	Updated the PowerOfAttorneyRequest model with new relationships (belongs_to and has_one) and validations for claimant data.
	•	Added a mechanism to handle the claimant type (dependent or veteran) during record creation.
	2.	Controllers
	•	Minor modification to how querying is handled in the POA requests controller.
	3.	Serializers
	•	Added new serializers to handle changes in data presentation.
  	4.	Specs
	•	Updated specs and factories to properly test the models and serializer changes
