### PR TITLE
EDM/Remove mock logic for gids flight programs

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -942,13 +942,6 @@
   :base_uri: <%= "#{URI(Settings.gids.url).host}:#{URI(Settings.gids.url).port}" %>
   :endpoints:
     - :method: :get
-      :path: "/gids/v0/institution_programs"
-      :file_path: "gids/programs"
-      # Mock only enabled when filtering by flight programs, see: lib/gi/search_client.rb
-      :cache_multiple_responses:
-        :uid_location: query
-        :uid_locator: type
-    - :method: :get
       :path: "/gids/v1/lce"
       :file_path: "gids/lce"
       :cache_multiple_responses:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -475,8 +475,6 @@ gids:
   url: https://dev.va.gov/gids
   open_timeout: 1
   read_timeout: 1
-  search:
-    use_mocks: false
   lce:
     use_mocks: false
 

--- a/lib/gi/search_client.rb
+++ b/lib/gi/search_client.rb
@@ -14,10 +14,6 @@ module GI
     end
 
     def get_institution_program_search_results_v0(params = {})
-      # Mock response if querying for flight school programs
-      # TO-DO: Remove after flight school program data becomes accessible
-      config.instance_variable_set(:@program_type_flight, true) if params[:type] == 'FLGT'
-
       response = perform(:get, 'v0/institution_programs', params)
       gids_response(response)
     end

--- a/lib/gi/search_configuration.rb
+++ b/lib/gi/search_configuration.rb
@@ -4,14 +4,5 @@ module GI
   class SearchConfiguration < GI::Configuration
     self.read_timeout = Settings.gids.search&.read_timeout || 4
     self.open_timeout = Settings.gids.search&.open_timeout || 4
-
-    # Mock response if querying for flight school programs
-    # TO-DO: Remove after flight school program data becomes accessible
-    def use_mocks?
-      return false unless instance_variable_defined?(:@program_type_flight)
-
-      querying_by_flight = remove_instance_variable(:@program_type_flight)
-      (querying_by_flight && Settings.gids.search.use_mocks) || false
-    end
   end
 end


### PR DESCRIPTION
Remove temporary logic to mock requests to v0/gi/institution_programs/search filtered by flight program type