### PR TITLE
EDM-269/update post911 sob statsd prefix

### DIFF
--- a/app/controllers/v1/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v1/post911_gi_bill_statuses_controller.rb
@@ -9,8 +9,7 @@ module V1
     include SentryLogging
     service_tag 'gibill-statement'
 
-    STATSD_GI_BILL_TOTAL_KEY = 'api.lighthouse.gi_bill_status.total'
-    STATSD_GI_BILL_FAIL_KEY = 'api.lighthouse.gi_bill_status.fail'
+    STATSD_KEY_PREFIX = 'api.post911_gi_bill_status'
 
     def show
       response = service.get_gi_bill_status
@@ -20,7 +19,7 @@ module V1
     rescue => e
       handle_error(e)
     ensure
-      StatsD.increment(STATSD_GI_BILL_TOTAL_KEY)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.total")
     end
 
     private
@@ -28,7 +27,7 @@ module V1
     def handle_error(e)
       status = e.errors.first[:status].to_i
       log_vet_not_found(@current_user, Time.now.in_time_zone('Eastern Time (US & Canada)')) if status == 404
-      StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ["error:#{status}"])
+      StatsD.increment("#{STATSD_KEY_PREFIX}.fail", tags: ["error:#{status}"])
       render json: { errors: e.errors }, status: status || :internal_server_error
     end
 

--- a/spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb
+++ b/spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe V1::Post911GIBillStatusesController, type: :controller do
       sign_in_as(valid_user)
 
       VCR.use_cassette('lighthouse/benefits_education/gi_bill_status/200_response') do
-        expect(StatsD).to receive(:increment).with(V1::Post911GIBillStatusesController::STATSD_GI_BILL_TOTAL_KEY)
+        expect(StatsD).to receive(:increment).with("#{V1::Post911GIBillStatusesController::STATSD_KEY_PREFIX}.total")
         expect(StatsD).to receive(:increment).with(
           "api.external_http_request.#{BenefitsEducation::Configuration.instance.service_name}.success", 1, anything
         )
@@ -42,9 +42,9 @@ RSpec.describe V1::Post911GIBillStatusesController, type: :controller do
 
     it 'returns a 404 when vet isn\'t found' do
       VCR.use_cassette('lighthouse/benefits_education/gi_bill_status/404_response') do
-        expect(StatsD).to receive(:increment).with(V1::Post911GIBillStatusesController::STATSD_GI_BILL_FAIL_KEY,
+        expect(StatsD).to receive(:increment).with("#{V1::Post911GIBillStatusesController::STATSD_KEY_PREFIX}.fail",
                                                    tags: ['error:404'])
-        expect(StatsD).to receive(:increment).with(V1::Post911GIBillStatusesController::STATSD_GI_BILL_TOTAL_KEY)
+        expect(StatsD).to receive(:increment).with("#{V1::Post911GIBillStatusesController::STATSD_KEY_PREFIX}.total")
         expect do
           get :show
         end.to change(PersonalInformationLog, :count)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)* Updated the statsd prefix in preparation for integration of Post-911 Statement of Benefits tool with DGIB data. Tool no longer exclusively serves data from Light House.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)* I removed reference to Lighthouse from statsd prefix because tool will no longer exclusively serve lighthouse data
- *(Which team do you work for, does your team own the maintenance of this component?)* Education Data Migration (EDM)
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://jira.devops.va.gov/browse/EDM-269

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
Post-911 Statement of Benefits

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature