### PR TITLE
99310-Implement-POA-Establishment-Method-In-Lighthouse-API-Client

### DIFF
--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -170,6 +170,37 @@ module BenefitsClaims
       handle_error(e, lighthouse_client_id, endpoint)
     end
 
+    def submit2122(body,lighthouse_client_id = nil, lighthouse_rsa_key_path = nil )
+      path = "#{@icn}/2122"
+      endpoint = '{icn}/2122'
+
+      request_body = {
+        data: {
+          attributes: body
+        }
+      }
+
+      response = config.post( 
+        path, 
+        request_body.to_json,
+        lighthouse_client_id,
+        lighthouse_rsa_key_path
+      )
+
+      if response["data"]
+        return response["data"]
+      elsif response["message"]
+        return response["message"]
+      elsif response["errors"]
+        return response["errors"]
+      else
+        return response
+      end
+
+    rescue  Faraday::ClientError, Faraday::ServerError => e
+      handle_error(e, lighthouse_client_id, endpoint)
+    end
+
     private
 
     def build_request_body(body, transaction_id = "vagov-#{SecureRandom}")

--- a/spec/lib/lighthouse/benefits_claims/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/service_spec.rb
@@ -216,6 +216,88 @@ RSpec.describe BenefitsClaims::Service do
           end
         end
       end
+
+      describe '#submit2122' do
+        body =  {
+          "veteran": {
+            "address": {
+              "addressLine1": "123",
+              "city": "city",
+              "stateCode": "OR",
+              "countryCode": "US",
+              "zipCode": "12345"
+            }
+          },
+          "serviceOrganization": {
+            "poaCode": "083",
+            "registrationNumber": "999999999999"
+          }
+        }
+
+        lighthouse_client_id = "abcdefgh"
+
+        context 'when there is valid params' do
+          it "returns data" do
+            response = @service.submit2122(body, lighthouse_client_id)
+            data = JSON.parse(response.body)["data"]
+            expect(response.status).to eq(202)
+            expect(data["id"]).to eq("20da46c4-10d5-4985-8113-db92597ac85f")
+            expect(data["attributes"]["name"]).to eq("083 - DISABLED AMERICAN VETERANS")
+            expect(data["attributes"]["phoneNumber"]).to eq("555-555-5555")
+          end
+        end
+
+        context 'when you are not authorized' do
+          it "returns a 401 error" do
+            response = @service.submit2122(body)
+            errors = JSON.parse(response.body)["errors"]
+            expect(response.status).to eq(401)
+            expect(errors[0]["title"]).to eq("Not authorized")
+            expect(errors[0]["status"]).to eq("401")
+            expect(errors[0]["detail"]).to eq("Not authorized")
+          end
+        end
+
+        context 'when the resource does not exist' do
+          it "returns a 404 error" do
+            invalid_body = body.dup
+            invalid_body["serviceOrganization"]["poaCode"] = "082"
+            invalid_body["serviceOrganization"]["registrationNumber"] = "999999999998"
+            response = @service.submit2122(invalid_body, lighthouse_client_id)
+            errors = JSON.parse(response.body)["errors"]
+            expect(response.status).to eq(404)
+            expect(errors[0]["title"]).to eq("Resource not found")
+            expect(errors[0]["status"]).to eq("404")
+            expect(errors[0]["detail"]).to eq("Could not find an Accredited Representative with registration number: 999999999998 and poa code: 082")
+          end
+        end
+
+        context 'when the payload has incorrect params' do
+          it "returns a 422 error" do
+            invalid_body = body.dup
+            invalid_body["serviceOrganization"].delete(:poaCode)
+            response = @service.submit2122(invalid_body, lighthouse_client_id)
+            errors = JSON.parse(response.body)["errors"]
+            expect(response.status).to eq(422)
+            expect(errors[0]["title"]).to eq("Unprocessable entity")
+            expect(errors[0]["status"]).to eq("422")
+            expect(errors[0]["detail"]).to eq("The property /serviceOrganization did not contain the required key poaCode")
+            expect(errors[0]["source"]["pointer"]).to eq("data/attributes/serviceOrganization")
+          end
+        end
+
+        context 'when the payload is too big' do
+          it "returns a 413 error" do
+            invalid_body = body.dup
+            extra_chars = "A" * 200 
+            invalid_body["serviceOrganization"]["registrationNumber"] += extra_chars
+            response = @service.submit2122(invalid_body, lighthouse_client_id)
+            body = JSON.parse(response.body)
+            expect(response.status).to eq(413)
+            expect(body["message"]).to eq("Request size limit exceeded")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *Work this ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/99310*
- *It adds an ability to submit a 2122 form to Lighthouse*
- *I couldn't figure out VCR. Once access comes through, I'll take some free time so I can finish the ticket fully*
- *I used these docs from lighthouse as my guide - https://developer.va.gov/explore/api/benefits-claims/docs?version=current *

## Related issue(s)

It is related to this ticket which I will work on and finish soon - https://github.com/department-of-veterans-affairs/va.gov-team/issues/99465

## Testing done

- [ ] *New code is covered by unit tests*
- Will work on VCR cassettes more later


## Acceptance criteria

- [ ] *Handle responses, including error responses, following the conventions of sibling endpoint methods*
