### PR TITLE
VEBT-894 - handle 404 error for 22-10203 SCO email

### DIFF
--- a/app/sidekiq/education_form/send_school_certifying_officials_email.rb
+++ b/app/sidekiq/education_form/send_school_certifying_officials_email.rb
@@ -32,12 +32,10 @@ module EducationForm
     private
 
     def get_institution(facility_code)
-      begin
-        GI::Client.new.get_institution_details_v0({ id: facility_code }).body[:data][:attributes]
-      rescue Common::Exceptions::RecordNotFound
-        StatsD.increment("#{stats_key}.skipped.institution_not_approved")
-        nil
-      end
+      GI::Client.new.get_institution_details_v0({ id: facility_code }).body[:data][:attributes]
+    rescue Common::Exceptions::RecordNotFound
+      StatsD.increment("#{stats_key}.skipped.institution_not_approved")
+      nil
     end
 
     def school_changed?

--- a/app/sidekiq/education_form/send_school_certifying_officials_email.rb
+++ b/app/sidekiq/education_form/send_school_certifying_officials_email.rb
@@ -32,7 +32,12 @@ module EducationForm
     private
 
     def get_institution(facility_code)
-      GI::Client.new.get_institution_details_v0({ id: facility_code }).body[:data][:attributes]
+      begin
+        GI::Client.new.get_institution_details_v0({ id: facility_code }).body[:data][:attributes]
+      rescue Common::Exceptions::RecordNotFound
+        StatsD.increment("#{stats_key}.skipped.institution_not_approved")
+        nil
+      end
     end
 
     def school_changed?


### PR DESCRIPTION

## Summary

- *This work is behind a feature toggle (flipper): NO*
- VEBT-894 - handle 404 error for 22-10203 SCO email
- *(If bug, how to reproduce)* N/A
-  add error handling
- VEBT
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- [vebt-894](https://jira.devops.va.gov/browse/VEBT-894)

From ticket:
Description

Fixing a school certifying officials email datadog error.  The error is /app/lib/common/client/base.rb:115:in `rescue in request': BackendServiceException: {:status=>404, :detail=>"Record not found", :code=>"GI404", :source=>"Record not found"} (GI::ServiceException)

## Testing done

- [x] *New code is covered by unit tests*
- 404 error thrown for SCO email when facility code is not an approved institution
- submit a 10203 form

## What areas of the site does it impact?
submission of 10203 form SCO email

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)

